### PR TITLE
fix(ci): harden report and core workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,13 @@ jobs:
           PY
       - name: Check release workflow input safety
         run: python3 scripts/tests/test_release_tag_workflow_safety.py
+      - name: Install actionlint
+        run: |
+          mkdir -p "$RUNNER_TEMP/actionlint-bin"
+          GOBIN="$RUNNER_TEMP/actionlint-bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          echo "$RUNNER_TEMP/actionlint-bin" >> "$GITHUB_PATH"
+      - name: Check report workflow hardening
+        run: python3 scripts/tests/test_workflow_report_hardening.py
       - name: Check formatting
         run: cargo xtask fmt
       - name: Check API error response shape (issue #3505)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
 
           # Directly-touched crates (no downstream fan-out — on purpose).
           DIRECT=$(printf '%s\n' "$CHANGED" \
-            | sed -n 's|^crates/\([^/]*\)/.*|\1|p' \
+            | sed -n 's|^crates/\([A-Za-z0-9_-][A-Za-z0-9_-]*\)/.*|\1|p' \
             | sort -u | tr '\n' ' ')
 
           # xtask isn't under `crates/`, so the regex above misses it.
@@ -246,9 +246,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Reject static/react/ in PR
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Only flag added or modified files (not deletions — cleanup PRs are OK)
-          ADDED=$(git diff --diff-filter=AM --name-only origin/${{ github.base_ref }}...HEAD -- 'crates/librefang-api/static/react/' || true)
+          ADDED=$(git diff --diff-filter=AM --name-only "origin/${BASE_REF}...HEAD" -- 'crates/librefang-api/static/react/' || true)
           if [ -n "$ADDED" ]; then
             echo "::error::PR adds/modifies dashboard build artifacts (static/react/). These are auto-built by CI — remove them from your commits."
             echo "Fix: git rm --cached crates/librefang-api/static/react/ && git commit --amend"
@@ -266,6 +268,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -335,12 +338,13 @@ jobs:
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
       - name: Build + clippy
+        env:
+          CRATES: ${{ needs.changes.outputs.crates }}
         run: |
           if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
             echo "Full build + clippy (workspace)…"
             cargo xtask ci --no-test --no-web
           else
-            CRATES="${{ needs.changes.outputs.crates }}"
             if [ -z "$CRATES" ]; then
               echo "No crates affected — skipping build + clippy."
               exit 0
@@ -374,6 +378,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.skill_sdk == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -408,6 +413,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.sidecar_rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -670,6 +676,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -718,7 +725,7 @@ jobs:
           fetch-depth: 0
       - name: Install trufflehog
         run: |
-          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin v3.88.23
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/690e5c7aff8347c3885096f3962a0633d9129607/scripts/install.sh | sh -s -- -b /usr/local/bin v3.88.23
       - name: Scan for secrets
         run: |
           trufflehog filesystem . \
@@ -874,12 +881,13 @@ jobs:
             patchelf \
             libdbus-1-dev libsecret-1-dev pkg-config
       - name: Run unit tests (lib + bin)
+        env:
+          CRATES: ${{ needs.changes.outputs.crates }}
         run: |
           if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Running workspace unit tests (lib+bin, full run)…"
             cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
           else
-            CRATES="${{ needs.changes.outputs.crates }}"
             if [ -z "$CRATES" ]; then
               echo "No crates affected — nothing to run."
               exit 0
@@ -952,12 +960,13 @@ jobs:
             patchelf
       - name: Build tests
         if: steps.gate.outputs.skip != 'true'
+        env:
+          CRATES: ${{ needs.changes.outputs.crates }}
         run: |
           if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Building workspace tests (full run, shard ${{ matrix.shard }}/4)…"
             cargo test --workspace --no-run -j 2
           else
-            CRATES="${{ needs.changes.outputs.crates }}"
             if [ -z "$CRATES" ]; then
               echo "No crates affected — skipping build."
               exit 0
@@ -970,6 +979,7 @@ jobs:
       - name: Run tests
         if: steps.gate.outputs.skip != 'true'
         env:
+          CRATES: ${{ needs.changes.outputs.crates }}
           RUST_TEST_THREADS: "1"
         run: |
           if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
@@ -981,7 +991,6 @@ jobs:
             cargo nextest run --workspace --no-fail-fast \
               --partition hash:${{ matrix.shard }}/4
           else
-            CRATES="${{ needs.changes.outputs.crates }}"
             if [ -z "$CRATES" ]; then
               echo "No crates affected — nothing to run."
               exit 0

--- a/.github/workflows/discussion-to-issue.yml
+++ b/.github/workflows/discussion-to-issue.yml
@@ -28,6 +28,7 @@ jobs:
   # ── Auto-promote new discussions ─────────────────────────────────
   auto-promote:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.event_name == 'discussion' &&
       (
@@ -51,17 +52,31 @@ jobs:
   # ── Manual /to-issue command from maintainers ────────────────────
   manual-promote:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.event_name == 'discussion_comment' &&
-      contains(github.event.comment.body, '/to-issue') &&
+      startsWith(github.event.comment.body, '/to-issue') &&
       (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'
       )
     steps:
+      - name: Validate command token
+        id: command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          command=${COMMENT_BODY%%[[:space:]]*}
+          if [ "$command" = "/to-issue" ]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: steps.command.outputs.valid == 'true'
       - name: Create issue from discussion
+        if: steps.command.outputs.valid == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -76,7 +91,11 @@ jobs:
   # ── Backfill: scheduled + manual ─────────────────────────────────
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: discussion-backfill
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Backfill existing discussions
@@ -93,6 +112,9 @@ jobs:
           else
             cats=("$INPUT_CATEGORY")
           fi
+
+          failures_file=$(mktemp)
+          trap 'rm -f "$failures_file"' EXIT
 
           for CAT in "${cats[@]}"; do
             echo "=== Scanning category: ${CAT} ==="
@@ -115,8 +137,18 @@ jobs:
                 DISC_NUMBER="$num" DISC_TITLE="$title" DISC_URL="$url" \
                   DISC_AUTHOR="$author" DISC_CATEGORY="$CAT" \
                   bash .github/scripts/discussion-to-issue.sh \
-                  || echo "  (skipped or failed)"
+                  || {
+                    echo "  (FAILED for discussion #${num})"
+                    echo "$num" >> "$failures_file"
+                  }
 
                 sleep 2
               done
           done
+
+          if [ -s "$failures_file" ]; then
+            failure_count=$(wc -l < "$failures_file" | tr -d ' ')
+            echo "Backfill finished with ${failure_count} failure(s):"
+            sed 's/^/  #/' "$failures_file"
+            exit 1
+          fi

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -13,40 +13,39 @@ permissions:
 jobs:
   report:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Generate weekly report
         id: report
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          REPO="librefang/librefang"
+          set -euo pipefail
+
           SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -v-7d +%Y-%m-%dT00:00:00Z)
-          WEEK=$(date -u -d 'last monday' +%Y-%m-%d 2>/dev/null || date -u -v-monday +%Y-%m-%d)
+          WEEK="${SINCE%%T*}"
           TODAY=$(date -u +%Y-%m-%d)
 
           echo "Collecting stats since $SINCE..."
 
           # Merged PRs
-          MERGED_PRS=$(gh pr list --repo $REPO --state merged --search "merged:>=$SINCE" --json number,title,author --limit 50)
+          MERGED_PRS=$(gh pr list --repo "$REPO" --state merged --search "merged:>=$SINCE" --json number,title,author --limit 50)
           MERGED_COUNT=$(echo "$MERGED_PRS" | jq length)
 
           # Opened issues
-          OPENED_ISSUES=$(gh issue list --repo $REPO --state all --search "created:>=$SINCE" --json number,title,labels --limit 50)
+          OPENED_ISSUES=$(gh issue list --repo "$REPO" --state all --search "created:>=$SINCE" --json number,title,labels --limit 50)
           OPENED_COUNT=$(echo "$OPENED_ISSUES" | jq length)
 
           # Closed issues
-          CLOSED_ISSUES=$(gh issue list --repo $REPO --state closed --search "closed:>=$SINCE" --json number,title --limit 50)
+          CLOSED_ISSUES=$(gh issue list --repo "$REPO" --state closed --search "closed:>=$SINCE" --json number,title --limit 50)
           CLOSED_COUNT=$(echo "$CLOSED_ISSUES" | jq length)
 
-          # New contributors (first PR merged this week)
-          NEW_CONTRIBUTORS=$(echo "$MERGED_PRS" | jq -r '.[].author.login' | sort -u)
-
           # Stars
-          STARS=$(gh api repos/$REPO --jq '.stargazers_count')
+          STARS=$(gh api "repos/$REPO" --jq '.stargazers_count')
 
           # Open good-first-issues
-          GFI_COUNT=$(gh issue list --repo $REPO --label "good first issue" --state open --json number --jq 'length')
+          GFI_COUNT=$(gh issue list --repo "$REPO" --label "good first issue" --state open --json number --jq 'length')
 
           # Build markdown report
           cat > /tmp/report.md << REPORT_EOF
@@ -66,52 +65,69 @@ jobs:
 
           # Add merged PRs section
           if [ "$MERGED_COUNT" -gt 0 ]; then
-            echo "## Merged PRs" >> /tmp/report.md
-            echo "" >> /tmp/report.md
-            echo "$MERGED_PRS" | jq -r '.[] | "- \(.title) (#\(.number)) @\(.author.login)"' >> /tmp/report.md
-            echo "" >> /tmp/report.md
+            {
+              echo "## Merged PRs"
+              echo ""
+              echo "$MERGED_PRS" | jq -r '.[] | "- \(.title) (#\(.number)) @\(.author.login)"'
+              echo ""
+            } >> /tmp/report.md
           fi
 
           # Add new issues section
           if [ "$OPENED_COUNT" -gt 0 ]; then
-            echo "## New Issues" >> /tmp/report.md
-            echo "" >> /tmp/report.md
-            echo "$OPENED_ISSUES" | jq -r '.[] | "- \(.title) (#\(.number))"' >> /tmp/report.md
-            echo "" >> /tmp/report.md
+            {
+              echo "## New Issues"
+              echo ""
+              echo "$OPENED_ISSUES" | jq -r '.[] | "- \(.title) (#\(.number))"'
+              echo ""
+            } >> /tmp/report.md
           fi
 
           # Add call to action
-          cat >> /tmp/report.md << 'CTA_EOF'
+          cat >> /tmp/report.md << CTA_EOF
           ## Get Involved
 
-          - 🆕 Check [good first issues](https://github.com/librefang/librefang/labels/good%20first%20issue)
-          - 💬 Join [Discussions](https://github.com/librefang/librefang/discussions)
-          - 📖 Read the [Contributing Guide](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)
+          - 🆕 Check [good first issues](https://github.com/$REPO/labels/good%20first%20issue)
+          - 💬 Join [Discussions](https://github.com/$REPO/discussions)
+          - 📖 Read the [Contributing Guide](https://github.com/$REPO/blob/main/CONTRIBUTING.md)
           CTA_EOF
 
           # Clean up leading whitespace from heredoc indentation
           sed -i 's/^          //' /tmp/report.md
 
-          echo "report_path=/tmp/report.md" >> "$GITHUB_OUTPUT"
-          echo "week=$WEEK" >> "$GITHUB_OUTPUT"
-          echo "today=$TODAY" >> "$GITHUB_OUTPUT"
-          echo "merged_count=$MERGED_COUNT" >> "$GITHUB_OUTPUT"
-          echo "opened_count=$OPENED_COUNT" >> "$GITHUB_OUTPUT"
-          echo "closed_count=$CLOSED_COUNT" >> "$GITHUB_OUTPUT"
-          echo "stars=$STARS" >> "$GITHUB_OUTPUT"
-          echo "gfi_count=$GFI_COUNT" >> "$GITHUB_OUTPUT"
+          {
+            echo "report_path=/tmp/report.md"
+            echo "week=$WEEK"
+            echo "today=$TODAY"
+            echo "merged_count=$MERGED_COUNT"
+            echo "opened_count=$OPENED_COUNT"
+            echo "closed_count=$CLOSED_COUNT"
+            echo "stars=$STARS"
+            echo "gfi_count=$GFI_COUNT"
+          } >> "$GITHUB_OUTPUT"
 
           cat /tmp/report.md
 
       - name: Post to GitHub Discussions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          REPO_ID=$(gh api repos/librefang/librefang --jq '.node_id')
-          CAT_ID=$(gh api graphql -f query='{ repository(owner:"librefang", name:"librefang") { discussionCategories(first:20) { nodes { id, name } } } }' --jq '.data.repository.discussionCategories.nodes[] | select(.name=="Announcements") | .id')
+          set -euo pipefail
+
+          OWNER=${REPO%%/*}
+          NAME=${REPO#*/}
+          REPO_ID=$(gh api "repos/$REPO" --jq '.node_id')
+          # $owner and $name below are GraphQL variables, not shell variables.
+          # shellcheck disable=SC2016
+          CAT_ID=$(gh api graphql \
+            -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { discussionCategories(first: 20) { nodes { id, name } } } }' \
+            -f owner="$OWNER" \
+            -f name="$NAME" \
+            --jq '.data.repository.discussionCategories.nodes[] | select(.name=="Announcements") | .id')
 
           if [ -n "$CAT_ID" ]; then
-            BODY=$(cat /tmp/report.md | jq -Rs .)
+            BODY=$(jq -Rs . < /tmp/report.md)
             gh api graphql -f query="
               mutation {
                 createDiscussion(input: {
@@ -131,7 +147,10 @@ jobs:
       - name: Post to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "No Discord webhook configured, skipping"
             exit 0
@@ -143,11 +162,11 @@ jobs:
           📌 PRs merged: **${{ steps.report.outputs.merged_count }}** | Issues opened: **${{ steps.report.outputs.opened_count }}** | Issues closed: **${{ steps.report.outputs.closed_count }}**
           ⭐ Stars: **${{ steps.report.outputs.stars }}** | Good first issues: **${{ steps.report.outputs.gfi_count }}**
 
-          👉 [Full report](https://github.com/librefang/librefang/discussions) | [Contribute](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md)"
+          👉 [Full report](https://github.com/$REPO/discussions) | [Contribute](https://github.com/$REPO/blob/main/CONTRIBUTING.md)"
 
           # Clean indentation
-          CONTENT=$(echo "$CONTENT" | sed 's/^          //')
+          CONTENT=${CONTENT//$'\n          '/$'\n'}
 
-          curl -s -H "Content-Type: application/json" \
+          curl --fail-with-body --silent --show-error -H "Content-Type: application/json" \
             -d "{\"content\": $(echo "$CONTENT" | jq -Rs .)}" \
             "$DISCORD_WEBHOOK_URL"

--- a/changelog.d/fixed/6904-workflow-report-hardening.md
+++ b/changelog.d/fixed/6904-workflow-report-hardening.md
@@ -1,0 +1,4 @@
+Harden the discussion-to-issue and weekly-report workflows against partial failures and unsafe assumptions.
+The discussion backfill now serializes through a concurrency group, bounds every job with a timeout, and records per-discussion failures instead of continuing past them silently.
+The manual `/to-issue` command now requires an exact token match instead of a substring match, so a comment that merely contains that text can no longer trigger a promotion.
+The weekly report now fails closed on any command error, resolves the repository from `github.repository` instead of a hardcoded name, and surfaces Discord delivery failures instead of swallowing them (#6904) (@houko)

--- a/scripts/tests/test_workflow_report_hardening.py
+++ b/scripts/tests/test_workflow_report_hardening.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Regression checks for discussion backfill and weekly report workflows."""
+"""Regression checks for CI, discussion backfill, and weekly report workflows."""
 
 import os
+import re
 import shutil
 import subprocess
 import unittest
@@ -12,6 +13,18 @@ ROOT = Path(__file__).resolve().parents[2]
 DISCUSSION = ROOT / ".github/workflows/discussion-to-issue.yml"
 WEEKLY = ROOT / ".github/workflows/weekly-report.yml"
 CI = ROOT / ".github/workflows/ci.yml"
+TRUFFLEHOG_INSTALLER_COMMIT = "690e5c7aff8347c3885096f3962a0633d9129607"
+
+
+def workflow_job(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(name)}:\n(?P<body>(?:(?!^  [A-Za-z0-9_-]+:\n).)*)",
+        workflow,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"workflow job not found: {name}")
+    return match.group("body")
 
 
 class WorkflowReportHardeningTests(unittest.TestCase):
@@ -44,13 +57,27 @@ class WorkflowReportHardeningTests(unittest.TestCase):
     def test_workflows_pass_actionlint(self):
         actionlint = os.environ.get("ACTIONLINT") or shutil.which("actionlint")
         self.assertIsNotNone(actionlint, "actionlint is required for this regression test")
-        result = subprocess.run(
+        report_result = subprocess.run(
             [actionlint, str(DISCUSSION), str(WEEKLY)],
             cwd=ROOT,
             text=True,
             capture_output=True,
         )
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            report_result.returncode,
+            0,
+            report_result.stdout + report_result.stderr,
+        )
+        # ci.yml has pre-existing shellcheck findings outside this report's
+        # scope. Keep actionlint's YAML/expression checks as a durable gate
+        # while the two smaller workflows retain full shellcheck coverage.
+        ci_result = subprocess.run(
+            [actionlint, "-shellcheck=", str(CI)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(ci_result.returncode, 0, ci_result.stdout + ci_result.stderr)
 
     def test_ci_runs_this_regression_suite_with_pinned_actionlint(self):
         workflow = CI.read_text(encoding="utf-8")
@@ -61,6 +88,40 @@ class WorkflowReportHardeningTests(unittest.TestCase):
         )
         self.assertIn(
             "python3 scripts/tests/test_workflow_report_hardening.py",
+            workflow,
+        )
+
+    def test_ci_routes_untrusted_values_without_script_interpolation(self):
+        workflow = CI.read_text(encoding="utf-8")
+
+        self.assertIn(r"sed -n 's|^crates/\([A-Za-z0-9_-][A-Za-z0-9_-]*\)/.*|\1|p'", workflow)
+        self.assertNotIn('CRATES="${{ needs.changes.outputs.crates }}"', workflow)
+        self.assertEqual(
+            workflow.count("CRATES: ${{ needs.changes.outputs.crates }}"),
+            4,
+        )
+        self.assertNotIn("origin/${{ github.base_ref }}", workflow)
+        self.assertIn("BASE_REF: ${{ github.base_ref }}", workflow)
+        self.assertIn('"origin/${BASE_REF}...HEAD"', workflow)
+
+    def test_ci_long_running_jobs_have_timeouts(self):
+        workflow = CI.read_text(encoding="utf-8")
+
+        for job, minutes in {
+            "quality": 30,
+            "skills-wasm-sdk": 20,
+            "rust-telegram-sidecar": 30,
+            "security": 15,
+        }.items():
+            with self.subTest(job=job):
+                self.assertIn(f"timeout-minutes: {minutes}", workflow_job(workflow, job))
+
+    def test_ci_pins_trufflehog_installer_to_release_commit(self):
+        workflow = CI.read_text(encoding="utf-8")
+
+        self.assertNotIn("trufflehog/main/scripts/install.sh", workflow)
+        self.assertIn(
+            f"trufflehog/{TRUFFLEHOG_INSTALLER_COMMIT}/scripts/install.sh",
             workflow,
         )
 

--- a/scripts/tests/test_workflow_report_hardening.py
+++ b/scripts/tests/test_workflow_report_hardening.py
@@ -68,9 +68,8 @@ class WorkflowReportHardeningTests(unittest.TestCase):
             0,
             report_result.stdout + report_result.stderr,
         )
-        # ci.yml has pre-existing shellcheck findings outside this report's
-        # scope. Keep actionlint's YAML/expression checks as a durable gate
-        # while the two smaller workflows retain full shellcheck coverage.
+        # ci.yml has pre-existing shellcheck findings outside this report's scope.
+        # Keep actionlint's YAML/expression checks as a durable gate while the two smaller workflows retain full shellcheck coverage.
         ci_result = subprocess.run(
             [actionlint, "-shellcheck=", str(CI)],
             cwd=ROOT,

--- a/scripts/tests/test_workflow_report_hardening.py
+++ b/scripts/tests/test_workflow_report_hardening.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Regression checks for discussion backfill and weekly report workflows."""
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DISCUSSION = ROOT / ".github/workflows/discussion-to-issue.yml"
+WEEKLY = ROOT / ".github/workflows/weekly-report.yml"
+CI = ROOT / ".github/workflows/ci.yml"
+
+
+class WorkflowReportHardeningTests(unittest.TestCase):
+    def test_discussion_backfill_is_bounded_serial_and_reports_failures(self):
+        workflow = DISCUSSION.read_text(encoding="utf-8")
+
+        self.assertIn("group: discussion-backfill", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertGreaterEqual(workflow.count("timeout-minutes:"), 3)
+        self.assertNotIn('|| echo "  (skipped or failed)"', workflow)
+        self.assertIn('echo "$num" >> "$failures_file"', workflow)
+        self.assertIn('if [ -s "$failures_file" ]', workflow)
+        self.assertIn("startsWith(github.event.comment.body, '/to-issue')", workflow)
+        self.assertIn('command=${COMMENT_BODY%%[[:space:]]*}', workflow)
+        self.assertIn('if [ "$command" = "/to-issue" ]', workflow)
+        self.assertIn("if: steps.command.outputs.valid == 'true'", workflow)
+
+    def test_weekly_report_fails_closed_and_uses_repository_context(self):
+        workflow = WEEKLY.read_text(encoding="utf-8")
+
+        self.assertNotIn("uses: actions/checkout", workflow)
+        self.assertEqual(workflow.count("set -euo pipefail"), 3)
+        self.assertIn("REPO: ${{ github.repository }}", workflow)
+        self.assertNotIn('REPO="librefang/librefang"', workflow)
+        self.assertNotIn("github.com/librefang/librefang", workflow)
+        self.assertNotIn("NEW_CONTRIBUTORS=", workflow)
+        self.assertIn("curl --fail-with-body --silent --show-error", workflow)
+        self.assertIn('WEEK="${SINCE%%T*}"', workflow)
+
+    def test_workflows_pass_actionlint(self):
+        actionlint = os.environ.get("ACTIONLINT") or shutil.which("actionlint")
+        self.assertIsNotNone(actionlint, "actionlint is required for this regression test")
+        result = subprocess.run(
+            [actionlint, str(DISCUSSION), str(WEEKLY)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_ci_runs_this_regression_suite_with_pinned_actionlint(self):
+        workflow = CI.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7",
+            workflow,
+        )
+        self.assertIn(
+            "python3 scripts/tests/test_workflow_report_hardening.py",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes
- replace the invalid discussion REST backfill with bounded GraphQL pagination, serialized execution, explicit failure reporting, and exact `/to-issue` command matching
- make the weekly report fail closed, use repository context, remove dead contributor computation, and harden webhook delivery
- restrict affected-crate output to shell-safe crate names and pass all dynamic workflow values through step environments
- add timeouts to quality, WASM SDK, Telegram sidecar, and security jobs
- pin the TruffleHog installer to the commit behind v3.88.23
- run the workflow regression suite from CI with pinned actionlint, including durable CI YAML/expression linting

## Tests
- `python3 scripts/tests/test_workflow_report_hardening.py` (7 passed)
- `python3 -m py_compile scripts/tests/test_workflow_report_hardening.py`
- PyYAML parse of ci.yml (23 jobs)
- actionlint: discussion/weekly with shellcheck; ci.yml YAML/expressions with existing shellcheck noise disabled
- `git diff --check`

## Review
Independent review found no remaining Critical, Important, or Minor issues and marked the branch Ready to merge.