### PR TITLE
fix(auth): gate guest network and tool discovery

### DIFF
--- a/changelog.d/fixed/6908-auth-guest-tool-gate.md
+++ b/changelog.d/fixed/6908-auth-guest-tool-gate.md
@@ -1,0 +1,1 @@
+Require approval before unrecognized channel senders can use network or tool-discovery capabilities. (#6908) (@houko)

--- a/changelog.d/fixed/auth-guest-tool-gate.md
+++ b/changelog.d/fixed/auth-guest-tool-gate.md
@@ -1,1 +1,0 @@
-- Require approval before unrecognized channel senders can use network or tool-discovery capabilities. (@houko)

--- a/changelog.d/fixed/auth-guest-tool-gate.md
+++ b/changelog.d/fixed/auth-guest-tool-gate.md
@@ -1,0 +1,1 @@
+- Require approval before unrecognized channel senders can use network or tool-discovery capabilities. (@houko)

--- a/crates/librefang-kernel/src/auth.rs
+++ b/crates/librefang-kernel/src/auth.rs
@@ -1060,9 +1060,8 @@ fn default_memory_acl(role: UserRole) -> UserMemoryAccess {
     }
 }
 
-/// Gate decision for an unrecognised sender. Mirrors design decision #2
-/// (default-allow with minimal perms): allow only passive local inspection,
-/// and require approval for network access or capability discovery.
+/// Gate decision for an unrecognised sender.
+/// Mirrors design decision #2 (default-allow with minimal perms): allow only passive local inspection, and require approval for network access or capability discovery.
 fn guest_gate(tool_name: &str) -> UserToolGate {
     const READ_ONLY_TOOLS: &[&str] = &[
         "file_read",

--- a/crates/librefang-kernel/src/auth.rs
+++ b/crates/librefang-kernel/src/auth.rs
@@ -1061,8 +1061,8 @@ fn default_memory_acl(role: UserRole) -> UserMemoryAccess {
 }
 
 /// Gate decision for an unrecognised sender. Mirrors design decision #2
-/// (default-allow with minimal perms): allow well-known read-only tools,
-/// require approval for anything else.
+/// (default-allow with minimal perms): allow only passive local inspection,
+/// and require approval for network access or capability discovery.
 fn guest_gate(tool_name: &str) -> UserToolGate {
     const READ_ONLY_TOOLS: &[&str] = &[
         "file_read",
@@ -1070,12 +1070,8 @@ fn guest_gate(tool_name: &str) -> UserToolGate {
         "code_search",
         "glob",
         "grep",
-        "web_search",
-        "web_fetch",
         "list_agents",
         "list_skills",
-        "tool_load",
-        "tool_search",
     ];
     if READ_ONLY_TOOLS.contains(&tool_name) {
         UserToolGate::Allow
@@ -1486,6 +1482,31 @@ mod tests {
         let unsafe_ =
             mgr.resolve_user_tool_decision("shell_exec", Some("guest42"), Some("telegram"), false);
         assert!(matches!(unsafe_, UserToolGate::NeedsApproval { .. }));
+    }
+
+    #[test]
+    fn rbac_unknown_sender_requires_approval_for_network_and_tool_discovery() {
+        let mgr = AuthManager::with_tool_groups(
+            &[user_with_policy(
+                "Alice",
+                "owner",
+                "1",
+                None,
+                None,
+                None,
+                HashMap::new(),
+            )],
+            &[],
+        );
+
+        for tool in ["web_search", "web_fetch", "tool_load", "tool_search"] {
+            let gate =
+                mgr.resolve_user_tool_decision(tool, Some("unrecognized"), Some("telegram"), false);
+            assert!(
+                matches!(gate, UserToolGate::NeedsApproval { .. }),
+                "unrecognized sender must not invoke {tool} without approval: {gate:?}"
+            );
+        }
     }
 
     /// H6 regression: two users sharing the same platform-id on

--- a/docs/src/app/security/approvals/page.mdx
+++ b/docs/src/app/security/approvals/page.mdx
@@ -66,7 +66,7 @@ When an approval times out, the action falls through to `timeout_fallback`:
 
 Because RBAC runs first, a "needs approval" verdict from it wins before the `trusted_senders` bypass is ever consulted.
 So when `[[users]]` is configured and a sender is **not** a registered user on the `api` channel — the channel REST `POST /api/agents/{id}/message` requests arrive on — that sender falls to the built-in guest gate (`guest_gate`).
-The guest gate allows only a small read-only set (file reads, search, `web_fetch`, …) and returns "needs approval" for everything else — including `memory_store` / `memory_recall`, which are otherwise low-risk.
+The guest gate allows only a small read-only set (file reads, search, `list_agents` / `list_skills`, …) and returns "needs approval" for everything else — including `memory_store` / `memory_recall`, which are otherwise low-risk, and including `web_search` / `web_fetch` / `tool_load` / `tool_search`, which are gated as network access and capability discovery (#6908).
 The surprising consequence: an ID listed in `trusted_senders` that is not *also* a registered `[[users]]` on the `api` channel still has its `memory_*` calls gated, because the guest gate forced approval before `trusted_senders` could waive it.
 
 **Fix — register the operator as a user bound to the `api` channel**, with a tool policy covering the tools it drives:

--- a/docs/src/app/zh/security/approvals/page.mdx
+++ b/docs/src/app/zh/security/approvals/page.mdx
@@ -65,7 +65,7 @@ totp_tools = []                        # 留空表示审批列表内所有工具
 
 由于 RBAC 先运行，它给出的「需要审批」结论会在 `trusted_senders` 免审批被查阅之前就先生效。
 因此，当配置了 `[[users]]` 而某个发送者**不是** `api` 通道上已注册的用户时（REST `POST /api/agents/{id}/message` 请求正是走 `api` 通道），该发送者会落入内置的 guest gate（`guest_gate`）。
-guest gate 只放行一小组只读工具（文件读取、搜索、`web_fetch` 等），对其余一切都返回「需要审批」——包括本属低风险的 `memory_store` / `memory_recall`。
+guest gate 只放行一小组只读工具（文件读取、搜索、`list_agents` / `list_skills` 等），对其余一切都返回「需要审批」——包括本属低风险的 `memory_store` / `memory_recall`，也包括作为网络访问与能力发现而被拦截的 `web_search` / `web_fetch` / `tool_load` / `tool_search`（#6908）。
 由此得出一个反直觉的结果：一个列入 `trusted_senders`、但**未**同时注册为 `api` 通道上 `[[users]]` 的 ID，其 `memory_*` 调用仍会被拦截，因为 guest gate 在 `trusted_senders` 免审批生效之前就已强制审批。
 
 **解决办法——把该操作者注册为绑定到 `api` 通道的用户**，并授予覆盖其所用工具的策略：


### PR DESCRIPTION
## Summary

- require approval before an unrecognized channel sender can call `web_search` or `web_fetch`
- require approval before the same sender can discover or load tool capabilities
- retain passive local inspection for the deliberately small guest allowlist

This resolves the remaining confirmed authorization finding in the `auth.rs` report from the full OCR inventory. The reload race in that report was already resolved by #6754; the role-typo claim does not produce the reported privilege escalation and remains an inventory classification item.

## Verification

- regression test demonstrated RED on current behavior, then GREEN after the allowlist change
- `cargo test -p librefang-kernel` (1401 lib tests passed, 1 ignored; all integration tests passed)
- `cargo check --workspace --lib`
- `cargo clippy -p librefang-kernel --lib --no-deps -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- independent review: no Critical, Important, or Minor findings

## Out of scope

- existing workspace-wide clippy warning in `crates/librefang-api/src/routes/config/system.rs`