### PR TITLE
perf(runtime): cache link extraction regex

### DIFF
--- a/changelog.d/fixed/6912-link-understanding-regex-cache.md
+++ b/changelog.d/fixed/6912-link-understanding-regex-cache.md
@@ -1,0 +1,1 @@
+Link understanding now compiles its URL extraction pattern once and shares it across messages, avoiding repeated regex parsing and allocation on the message processing path. (#6912) (@houko)

--- a/changelog.d/fixed/link-understanding-regex-cache.md
+++ b/changelog.d/fixed/link-understanding-regex-cache.md
@@ -1,0 +1,3 @@
+Link understanding now compiles its URL extraction pattern once and shares it
+across messages, avoiding repeated regex parsing and allocation on the message
+processing path. (@houko)

--- a/changelog.d/fixed/link-understanding-regex-cache.md
+++ b/changelog.d/fixed/link-understanding-regex-cache.md
@@ -1,3 +1,0 @@
-Link understanding now compiles its URL extraction pattern once and shares it
-across messages, avoiding repeated regex parsing and allocation on the message
-processing path. (@houko)

--- a/crates/librefang-runtime/src/link_understanding.rs
+++ b/crates/librefang-runtime/src/link_understanding.rs
@@ -2,6 +2,15 @@
 
 use tracing::warn;
 
+static URL_PATTERN: std::sync::LazyLock<regex_lite::Regex> = std::sync::LazyLock::new(|| {
+    regex_lite::Regex::new(r#"https?://[^\s<>\[\](){}|\\^`"']+[^\s<>\[\](){}|\\^`"'.,;:!?\-)]"#)
+        .expect("URL regex is valid")
+});
+
+fn url_pattern() -> &'static regex_lite::Regex {
+    &URL_PATTERN
+}
+
 /// Configuration for link understanding (re-exported from types).
 pub use librefang_types::media::LinkConfig;
 
@@ -20,16 +29,10 @@ pub struct LinkSummary {
 /// Returns up to `max` valid, unique URLs that do not contain private literal targets or restricted hostnames.
 /// Any later fetch must still use the shared WebFetch SSRF resolver and pinned transport to validate DNS at connect time.
 pub fn extract_urls(text: &str, max: usize) -> Vec<String> {
-    // Simple but effective URL regex
-    let url_pattern = regex_lite::Regex::new(
-        r#"https?://[^\s<>\[\](){}|\\^`"']+[^\s<>\[\](){}|\\^`"'.,;:!?\-)]"#,
-    )
-    .expect("URL regex is valid");
-
     let mut seen = std::collections::HashSet::new();
     let mut urls = Vec::new();
 
-    for m in url_pattern.find_iter(text) {
+    for m in url_pattern().find_iter(text) {
         let url = m.as_str().to_string();
 
         // Deduplicate
@@ -155,6 +158,11 @@ pub fn build_link_context(text: &str, config: &LinkConfig) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn url_pattern_is_shared_across_extractions() {
+        assert!(std::ptr::eq(url_pattern(), url_pattern()));
+    }
 
     #[test]
     fn test_extract_urls_basic() {


### PR DESCRIPTION
## Changes
- compile the invariant link-extraction URL pattern once with `std::sync::LazyLock`
- reuse the same thread-safe `regex_lite::Regex` for every message
- add a regression test that pins the shared-instance contract

## Tests
- RED: the new shared-pattern test failed before the accessor existed
- `cargo test -p librefang-runtime link_understanding::tests --lib` (19 passed)
- `cargo clippy -p librefang-runtime --lib --no-deps -- -D warnings`
- `cargo check --workspace --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- The SSRF literal parsing, userinfo handling, and alternate-IP findings were already fixed by #6763.
- DNS resolution is intentionally not performed by this synchronous extraction-only layer; actual network retrieval remains protected by the shared WebFetch resolver and pinned transport.