### PR TITLE
fix(ci): harden repository automation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
       "version": "20"
     }
   },
-  "postCreateCommand": "cargo build --workspace 2>&1 | tail -5 && echo '✅ Build complete!'",
+  "postCreateCommand": "bash -o pipefail -c \"cargo build --workspace 2>&1 | tail -5 && echo '✅ Build complete!'\"",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           # `openapi-drift` job still gates direct edits.
           RUST=false;    has '^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)' && RUST=true
           DOCS=false;    has '^(docs/|.*\.md$)'                                       && DOCS=true
-          CI=false;      has '^\.github/workflows/'                                   && CI=true
+          CI=false;      has '^(\.github/workflows/|\.devcontainer/|scripts/tests/test_release_tag_workflow_safety\.py$)' && CI=true
           INSTALL=false; has '^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$' && INSTALL=true
           # The WASM-skill guest SDK and its example are independent
           # workspaces (own `[workspace]` roots), so the main RUST lane —

--- a/.github/workflows/kernel-ignored-tests.yml
+++ b/.github/workflows/kernel-ignored-tests.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}-{2}', github.workflow, github.event_name, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -44,8 +44,8 @@ jobs:
     name: audit script self-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
       - name: Run --self-test (embedded fixtures)
@@ -56,8 +56,8 @@ jobs:
     needs: self-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
       - name: Run supply-chain audit (strict)

--- a/changelog.d/fixed/6916-automation-workflow-hardening.md
+++ b/changelog.d/fixed/6916-automation-workflow-hardening.md
@@ -1,0 +1,1 @@
+Repository automation now preserves devcontainer build failures, cancels only superseded ignored-test PR runs, and pins first-party actions in the supply-chain audit. (#6916) (@houko)

--- a/changelog.d/fixed/automation-workflow-hardening.md
+++ b/changelog.d/fixed/automation-workflow-hardening.md
@@ -1,1 +1,0 @@
-Repository automation now preserves devcontainer build failures, cancels only superseded ignored-test PR runs, and pins first-party actions in the supply-chain audit. (@houko)

--- a/changelog.d/fixed/automation-workflow-hardening.md
+++ b/changelog.d/fixed/automation-workflow-hardening.md
@@ -1,0 +1,1 @@
+Repository automation now preserves devcontainer build failures, cancels only superseded ignored-test PR runs, and pins first-party actions in the supply-chain audit. (@houko)

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Regression checks for untrusted release workflow inputs."""
+"""Regression checks for release and repository automation safety."""
 
+import json
 import os
 import re
 import subprocess
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -15,6 +17,7 @@ WORKFLOWS = (
     ROOT / ".github" / "workflows" / "release-cli.yml",
 )
 INPUTS_TOKEN = re.compile(r"\binputs\b")
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 
 
 def contains_direct_input(script: str) -> bool:
@@ -24,7 +27,116 @@ def contains_direct_input(script: str) -> bool:
     return "${{" in script and INPUTS_TOKEN.search(script) is not None
 
 
+def check_repository_automation() -> None:
+    devcontainer = json.loads(
+        (ROOT / ".devcontainer" / "devcontainer.json").read_text(encoding="utf-8")
+    )
+    post_create = devcontainer.get("postCreateCommand")
+    if not isinstance(post_create, str):
+        raise SystemExit("devcontainer has no string postCreateCommand")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fake_cargo = Path(temp_dir) / "cargo"
+        fake_cargo.write_text(
+            "#!/bin/sh\n"
+            "if [ \"${FAKE_CARGO_FAIL:-}\" = 1 ]; then\n"
+            "  echo simulated build failure >&2\n"
+            "  exit 7\n"
+            "fi\n"
+            "echo simulated build success\n"
+        )
+        fake_cargo.chmod(0o755)
+        environment = os.environ.copy()
+        environment["PATH"] = f"{temp_dir}{os.pathsep}{environment['PATH']}"
+        environment["FAKE_CARGO_FAIL"] = "1"
+        failed = subprocess.run(
+            ["sh", "-c", post_create],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        environment.pop("FAKE_CARGO_FAIL")
+        succeeded = subprocess.run(
+            ["sh", "-c", post_create],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    if failed.returncode == 0 or "Build complete" in failed.stdout:
+        raise SystemExit("devcontainer postCreateCommand masks cargo build failures")
+    if succeeded.returncode != 0 or "Build complete" not in succeeded.stdout:
+        raise SystemExit("devcontainer postCreateCommand does not report successful builds")
+
+    ci_workflow = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    )
+    route_step = next(
+        (
+            step
+            for step in ci_workflow.get("jobs", {}).get("changes", {}).get("steps", [])
+            if step.get("name") == "Compute diff and route"
+        ),
+        None,
+    )
+    route_script = route_step.get("run", "") if isinstance(route_step, dict) else ""
+    for routed_path in (
+        r"\.devcontainer/",
+        r"scripts/tests/test_release_tag_workflow_safety\.py",
+    ):
+        if routed_path not in route_script:
+            raise SystemExit(f"CI routing does not cover {routed_path}")
+
+    ignored_tests = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "kernel-ignored-tests.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    concurrency = ignored_tests.get("concurrency", {})
+    group = concurrency.get("group") if isinstance(concurrency, dict) else None
+    cancel = concurrency.get("cancel-in-progress") if isinstance(concurrency, dict) else None
+    if not isinstance(group, str) or not all(
+        token in group for token in ("github.event_name", "github.ref", "github.run_id")
+    ):
+        raise SystemExit("kernel ignored-tests runs do not isolate PR and non-PR concurrency")
+    if cancel != "${{ github.event_name == 'pull_request' }}":
+        raise SystemExit("kernel ignored-tests workflow does not cancel superseded PR runs")
+
+    supply_chain = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "supply-chain-audit.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected_actions = {
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97",
+    }
+    jobs = supply_chain.get("jobs", {})
+    for job_name in ("self-test", "audit"):
+        job = jobs.get(job_name, {})
+        actual_actions = {
+            step.get("uses", "")
+            for step in job.get("steps", [])
+            if step.get("uses", "").startswith(
+                ("actions/checkout@", "actions/setup-python@")
+            )
+        }
+        if actual_actions != expected_actions:
+            raise SystemExit(
+                f"supply-chain-audit {job_name} actions are not pinned as expected: "
+                f"{sorted(actual_actions)}"
+            )
+        if any(
+            FULL_SHA.fullmatch(uses.rsplit("@", 1)[1]) is None
+            for uses in actual_actions
+        ):
+            raise SystemExit(f"supply-chain-audit {job_name} has a non-SHA action pin")
+
+
 def main() -> None:
+    check_repository_automation()
     unsafe_forms = (
         "${{ inputs.version }}",
         "${{inputs['version']}}",
@@ -119,7 +231,7 @@ def main() -> None:
     ):
         raise SystemExit("release-cli workflow does not verify the exact release tag")
 
-    print("release workflows keep the inputs context out of shell source")
+    print("release and repository automation safety checks passed")
 
 
 if __name__ == "__main__":

--- a/xtask/src/check_changed.rs
+++ b/xtask/src/check_changed.rs
@@ -109,7 +109,10 @@ fn lane_regexes() -> &'static LaneRegexes {
         rust: regex::Regex::new(r"^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)")
             .expect("static regex"),
         docs: regex::Regex::new(r"^(docs/|.*\.md$)").expect("static regex"),
-        ci: regex::Regex::new(r"^\.github/workflows/").expect("static regex"),
+        ci: regex::Regex::new(
+            r"^(\.github/workflows/|\.devcontainer/|scripts/tests/test_release_tag_workflow_safety\.py$)",
+        )
+        .expect("static regex"),
         install: regex::Regex::new(
             r"^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$",
         )
@@ -448,6 +451,17 @@ mod tests {
         assert!(l.ci);
         assert!(!l.rust);
         assert!(!l.workspace_cargo);
+    }
+
+    #[test]
+    fn repository_automation_paths_flag_ci_lane() {
+        for path in [
+            ".devcontainer/devcontainer.json",
+            "scripts/tests/test_release_tag_workflow_safety.py",
+        ] {
+            let lanes = lanes_from(&[path]);
+            assert!(lanes.ci, "expected CI lane for {path}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve devcontainer Cargo build failures through the output-trimming pipeline
- cancel only superseded pull-request runs of the ignored kernel test workflow
- pin first-party actions in the supply-chain audit to verified commit SHAs
- route devcontainer and regression-test changes through the existing quality gate

## Verification

- `cargo test -p xtask` (119 passed)
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `python3 scripts/tests/test_release_tag_workflow_safety.py`
- `actionlint .github/workflows/kernel-ignored-tests.yml .github/workflows/supply-chain-audit.yml`
- `actionlint -shellcheck= .github/workflows/ci.yml`
- JSON parse, py_compile, fmt, and diff-check

Reports:
- `confirmed/.devcontainer/devcontainer.json.md`
- `confirmed/.github/workflows/kernel-ignored-tests.yml.md`
- `confirmed/.github/workflows/supply-chain-audit.yml.md`