### PR TITLE
fix(runtime): preserve unicode while stripping markers

### DIFF
--- a/changelog.d/fixed/6917-session-repair-unicode-markers.md
+++ b/changelog.d/fixed/6917-session-repair-unicode-markers.md
@@ -1,0 +1,1 @@
+Session repair now removes prompt-injection markers after international text without corrupting Unicode byte boundaries. (#6917) (@houko)

--- a/changelog.d/fixed/session-repair-unicode-markers.md
+++ b/changelog.d/fixed/session-repair-unicode-markers.md
@@ -1,1 +1,0 @@
-Session repair now removes prompt-injection markers after international text without corrupting Unicode byte boundaries. (@houko)

--- a/changelog.d/fixed/session-repair-unicode-markers.md
+++ b/changelog.d/fixed/session-repair-unicode-markers.md
@@ -1,0 +1,1 @@
+Session repair now removes prompt-injection markers after international text without corrupting Unicode byte boundaries. (@houko)

--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -15,7 +15,35 @@
 use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
 use librefang_types::tool::ToolExecutionStatus;
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 use tracing::{debug, warn};
+
+const INJECTION_MARKERS: &[&str] = &[
+    "<|system|>",
+    "<|im_start|>",
+    "<|im_end|>",
+    "### SYSTEM:",
+    "### System Prompt:",
+    "[SYSTEM]",
+    "<<SYS>>",
+    "<</SYS>>",
+    "IGNORE PREVIOUS INSTRUCTIONS",
+    "Ignore all previous instructions",
+    "ignore the above",
+    "disregard previous",
+];
+
+static INJECTION_MARKER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    let pattern = INJECTION_MARKERS
+        .iter()
+        .map(|marker| regex::escape(marker))
+        .collect::<Vec<_>>()
+        .join("|");
+    regex::RegexBuilder::new(&pattern)
+        .case_insensitive(true)
+        .build()
+        .expect("injection marker regex must compile")
+});
 
 /// Statistics from a repair operation.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -1059,46 +1087,9 @@ fn is_base64_char(c: char) -> bool {
 
 /// Remove common prompt injection markers from content.
 fn strip_injection_markers(content: &str) -> String {
-    // These patterns are commonly used in prompt injection attempts
-    const INJECTION_MARKERS: &[&str] = &[
-        "<|system|>",
-        "<|im_start|>",
-        "<|im_end|>",
-        "### SYSTEM:",
-        "### System Prompt:",
-        "[SYSTEM]",
-        "<<SYS>>",
-        "<</SYS>>",
-        "IGNORE PREVIOUS INSTRUCTIONS",
-        "Ignore all previous instructions",
-        "ignore the above",
-        "disregard previous",
-    ];
-
-    let mut result = content.to_string();
-    let lower = result.to_lowercase();
-
-    for marker in INJECTION_MARKERS {
-        let marker_lower = marker.to_lowercase();
-        // Case-insensitive replacement
-        if lower.contains(&marker_lower) {
-            // Find and replace case-insensitively
-            let mut new_result = String::with_capacity(result.len());
-            let mut search_pos = 0;
-            let result_lower = result.to_lowercase();
-
-            while let Some(found) = result_lower[search_pos..].find(&marker_lower) {
-                let abs_pos = search_pos + found;
-                new_result.push_str(&result[search_pos..abs_pos]);
-                new_result.push_str("[injection marker removed]");
-                search_pos = abs_pos + marker.len();
-            }
-            new_result.push_str(&result[search_pos..]);
-            result = new_result;
-        }
-    }
-
-    result
+    INJECTION_MARKER_RE
+        .replace_all(content, "[injection marker removed]")
+        .into_owned()
 }
 
 /// Remove NO_REPLY assistant turns and their preceding user-message triggers

--- a/crates/librefang-runtime/src/session_repair/tests.rs
+++ b/crates/librefang-runtime/src/session_repair/tests.rs
@@ -465,6 +465,18 @@ fn test_strip_injection_markers() {
 }
 
 #[test]
+fn test_strip_injection_marker_after_expanding_unicode_lowercase() {
+    let content = "İ prefix IGNORE PREVIOUS INSTRUCTIONS suffix";
+
+    let stripped = strip_tool_result_details(content);
+
+    assert_eq!(
+        stripped, "İ prefix [injection marker removed] suffix",
+        "matching after a lowercase-expanding character must preserve byte boundaries",
+    );
+}
+
+#[test]
 fn test_repair_stats() {
     let messages = vec![
         Message::user("Hello"),


### PR DESCRIPTION
## Summary

- replace lowercase-copy byte indexing with a case-insensitive regex over the original UTF-8 input
- compile the combined injection-marker matcher once with `LazyLock`
- add an end-to-end regression for a marker after a lowercase-expanding Unicode character

## Verification

- `cargo test -p librefang-runtime --lib session_repair::tests` (53 passed)
- `cargo clippy -p librefang-runtime --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

Report: `confirmed/crates/librefang-runtime/src/session_repair.rs.md`