### PR TITLE
fix(api): reserve idempotency keys before execution

### DIFF
--- a/changelog.d/security/6919-idempotency-single-flight.md
+++ b/changelog.d/security/6919-idempotency-single-flight.md
@@ -1,0 +1,3 @@
+Reserve each `Idempotency-Key` atomically before its handler starts, so concurrent retries can no longer execute the same state-creating side effect twice.
+An in-flight duplicate now receives `409 idempotency_key_in_use`; owner tokens prevent stale requests from modifying replacement reservations, cancelled and non-successful attempts release their reservation, and storage, clock, or corrupt-status failures fail closed instead of bypassing deduplication.
+Expired-row pruning is limited to once per minute (#6919) (@houko)

--- a/changelog.d/security/idempotency-single-flight.md
+++ b/changelog.d/security/idempotency-single-flight.md
@@ -1,0 +1,3 @@
+Reserve each `Idempotency-Key` atomically before its handler starts, so concurrent retries can no longer execute the same state-creating side effect twice.
+An in-flight duplicate now receives `409 idempotency_key_in_use`; owner tokens prevent stale requests from modifying replacement reservations, cancelled and non-successful attempts release their reservation, and storage, clock, or corrupt-status failures fail closed instead of bypassing deduplication. Expired-row pruning is limited to once per minute.
+(@houko)

--- a/changelog.d/security/idempotency-single-flight.md
+++ b/changelog.d/security/idempotency-single-flight.md
@@ -1,3 +1,0 @@
-Reserve each `Idempotency-Key` atomically before its handler starts, so concurrent retries can no longer execute the same state-creating side effect twice.
-An in-flight duplicate now receives `409 idempotency_key_in_use`; owner tokens prevent stale requests from modifying replacement reservations, cancelled and non-successful attempts release their reservation, and storage, clock, or corrupt-status failures fail closed instead of bypassing deduplication. Expired-row pruning is limited to once per minute.
-(@houko)

--- a/crates/librefang-api/src/idempotency.rs
+++ b/crates/librefang-api/src/idempotency.rs
@@ -5,18 +5,12 @@
 //! through [`run_idempotent`], which:
 //!
 //! 1. Atomically reserves `(key)` in the persistent store.
-//! 2. **Reservation acquired**: executes the inner handler, then completes
-//!    the reservation with the successful 2xx response for 24 hours.
-//!    Non-2xx responses are not cached so a transient failure (rate
-//!    limit, downstream blip) does not poison the slot — clients can
-//!    retry the same key and get a real attempt.
+//! 2. **Reservation acquired**: executes the inner handler, then completes the reservation with the successful 2xx response for 24 hours.
+//!    Non-2xx responses are not cached so a transient failure (rate limit, downstream blip) does not poison the slot — clients can retry the same key and get a real attempt.
 //! 3. **Concurrent reservation, same body**: returns 409 without running the handler.
-//! 4. **Cache hit, same body**: replays the cached `(status, body)`
-//!    without re-executing the handler.
-//! 5. **Cache hit, different body**: returns 409 Conflict. The
-//!    `Idempotency-Key` is the operator-supplied dedup token and a
-//!    different payload under the same key is a programming error
-//!    (e.g. UI accidentally reuses an old key after editing the form).
+//! 4. **Cache hit, same body**: replays the cached `(status, body)` without re-executing the handler.
+//! 5. **Cache hit, different body**: returns 409 Conflict.
+//!    The `Idempotency-Key` is the operator-supplied dedup token and a different payload under the same key is a programming error (e.g. UI accidentally reuses an old key after editing the form).
 //!
 //! Body identity is sha256 over the raw JSON bytes the handler
 //! received. We hash bytes, not parsed JSON, so a re-serialised body
@@ -194,9 +188,8 @@ where
 
     let body_hash = hash_body(body_bytes);
 
-    // Reserve before starting the handler. The SQLite implementation performs
-    // expiration cleanup, insert, and existing-row lookup under one immediate
-    // transaction, so same-key requests cannot both observe a miss.
+    // Reserve before starting the handler.
+    // The SQLite implementation performs expiration cleanup, insert, and existing-row lookup under one immediate transaction, so same-key requests cannot both observe a miss.
     let reservation = match store.reserve(key, &body_hash) {
         Ok(reservation) => reservation,
         Err(e) => {
@@ -234,17 +227,16 @@ where
             body: body.clone(),
         };
         if let Err(e) = store.complete(key, &body_hash, &guard.token, &cached) {
-            // Keep the pending row instead of making the key reusable after the
-            // side effect already happened. This remains fail-closed until an
-            // operator has verified the side effect and removes the orphan.
+            // Keep the pending row instead of making the key reusable after the side effect already happened.
+            // This remains fail-closed until an operator has verified the side effect and removes the orphan.
             guard.disarm();
             tracing::error!(key, error = %e, "idempotency completion failed");
             return store_unavailable_response();
         }
         guard.disarm();
     }
-    // A non-2xx response leaves the guard armed, releasing the reservation so
-    // the key remains retriable. Cancellation and panic take the same Drop path.
+    // A non-2xx response leaves the guard armed, releasing the reservation so the key remains retriable.
+    // Cancellation and panic take the same Drop path.
     // Opportunistic prune so the table self-trims.
     if let Err(e) = store.prune_expired() {
         tracing::debug!(error = %e, "idempotency prune_expired failed");

--- a/crates/librefang-api/src/idempotency.rs
+++ b/crates/librefang-api/src/idempotency.rs
@@ -4,15 +4,16 @@
 //! `Idempotency-Key: <opaque-string>` header. When set, the handler runs
 //! through [`run_idempotent`], which:
 //!
-//! 1. Looks up `(key)` in the persistent store.
-//! 2. **Cache miss**: executes the inner handler, then persists the
-//!    successful 2xx response under `(key, body_hash)` for 24 hours.
+//! 1. Atomically reserves `(key)` in the persistent store.
+//! 2. **Reservation acquired**: executes the inner handler, then completes
+//!    the reservation with the successful 2xx response for 24 hours.
 //!    Non-2xx responses are not cached so a transient failure (rate
 //!    limit, downstream blip) does not poison the slot — clients can
 //!    retry the same key and get a real attempt.
-//! 3. **Cache hit, same body**: replays the cached `(status, body)`
+//! 3. **Concurrent reservation, same body**: returns 409 without running the handler.
+//! 4. **Cache hit, same body**: replays the cached `(status, body)`
 //!    without re-executing the handler.
-//! 4. **Cache hit, different body**: returns 409 Conflict. The
+//! 5. **Cache hit, different body**: returns 409 Conflict. The
 //!    `Idempotency-Key` is the operator-supplied dedup token and a
 //!    different payload under the same key is a programming error
 //!    (e.g. UI accidentally reuses an old key after editing the form).
@@ -29,7 +30,9 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use librefang_memory::idempotency::{CachedResponse, IdempotencyStore};
+use librefang_memory::idempotency::{
+    CachedResponse, IdempotencyStore, Reservation, ReservationToken, PENDING_STATUS,
+};
 use sha2::{Digest, Sha256};
 
 /// Maximum length of a client-supplied `Idempotency-Key`. Bounded so a
@@ -84,6 +87,68 @@ pub fn body_conflict_response() -> Response {
     (StatusCode::CONFLICT, Json(payload)).into_response()
 }
 
+/// 409 response returned while the first request for this key is still running.
+pub fn request_in_progress_response() -> Response {
+    let payload = serde_json::json!({
+        "error": "A request with this Idempotency-Key is already in progress",
+        "code": "idempotency_key_in_use",
+        "type": "idempotency_key_in_use",
+    });
+    (StatusCode::CONFLICT, Json(payload)).into_response()
+}
+
+fn store_unavailable_response() -> Response {
+    let payload = serde_json::json!({
+        "error": "Idempotency storage is unavailable",
+        "code": "idempotency_store_unavailable",
+        "type": "idempotency_store_unavailable",
+    });
+    (StatusCode::SERVICE_UNAVAILABLE, Json(payload)).into_response()
+}
+
+struct ReservationGuard<'a> {
+    store: &'a dyn IdempotencyStore,
+    key: &'a str,
+    body_hash: &'a str,
+    token: ReservationToken,
+    armed: bool,
+}
+
+impl<'a> ReservationGuard<'a> {
+    fn new(
+        store: &'a dyn IdempotencyStore,
+        key: &'a str,
+        body_hash: &'a str,
+        token: ReservationToken,
+    ) -> Self {
+        Self {
+            store,
+            key,
+            body_hash,
+            token,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ReservationGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Err(error) = self.store.release(self.key, self.body_hash, &self.token) {
+                tracing::error!(
+                    key = self.key,
+                    %error,
+                    "failed to release abandoned idempotency reservation"
+                );
+            }
+        }
+    }
+}
+
 /// Wrap a handler closure with idempotency semantics.
 ///
 /// `key_header` is `None` when the caller did not send an
@@ -129,42 +194,57 @@ where
 
     let body_hash = hash_body(body_bytes);
 
-    // Lookup. On lookup error we degrade to "execute anyway, don't
-    // cache" so a corrupt cache row can never block real traffic.
-    let prior = match store.lookup(key) {
-        Ok(p) => p,
+    // Reserve before starting the handler. The SQLite implementation performs
+    // expiration cleanup, insert, and existing-row lookup under one immediate
+    // transaction, so same-key requests cannot both observe a miss.
+    let reservation = match store.reserve(key, &body_hash) {
+        Ok(reservation) => reservation,
         Err(e) => {
-            tracing::warn!(error = %e, "idempotency lookup failed; bypassing cache");
-            let (status, body) = f().await;
-            return build_response(status, body);
+            tracing::error!(key, error = %e, "idempotency reservation failed");
+            return store_unavailable_response();
         }
     };
 
-    if let Some(existing) = prior {
-        if existing.body_hash != body_hash {
-            return body_conflict_response();
+    let token = match reservation {
+        Reservation::Existing(existing) => {
+            if existing.body_hash != body_hash {
+                return body_conflict_response();
+            }
+            if existing.response.status == PENDING_STATUS {
+                return request_in_progress_response();
+            }
+            let Ok(status) = StatusCode::from_u16(existing.response.status) else {
+                tracing::error!(
+                    key,
+                    status = existing.response.status,
+                    "idempotency cache contains an invalid HTTP status"
+                );
+                return store_unavailable_response();
+            };
+            return build_response(status, existing.response.body);
         }
-        // Same key, same body → replay.
-        return build_response(
-            StatusCode::from_u16(existing.response.status)
-                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-            existing.response.body,
-        );
-    }
+        Reservation::Acquired { token } => token,
+    };
 
-    // Miss — execute the handler. Cache only successful 2xx responses;
-    // 4xx/5xx remain retriable so a transient failure does not poison
-    // the slot.
+    let mut guard = ReservationGuard::new(store, key, &body_hash, token);
     let (status, body) = f().await;
     if status.is_success() {
         let cached = CachedResponse {
             status: status.as_u16(),
             body: body.clone(),
         };
-        if let Err(e) = store.put(key, &body_hash, &cached) {
-            tracing::warn!(error = %e, "idempotency persist failed; response returned without caching");
+        if let Err(e) = store.complete(key, &body_hash, &guard.token, &cached) {
+            // Keep the pending row instead of making the key reusable after the
+            // side effect already happened. This remains fail-closed until an
+            // operator has verified the side effect and removes the orphan.
+            guard.disarm();
+            tracing::error!(key, error = %e, "idempotency completion failed");
+            return store_unavailable_response();
         }
+        guard.disarm();
     }
+    // A non-2xx response leaves the guard armed, releasing the reservation so
+    // the key remains retriable. Cancellation and panic take the same Drop path.
     // Opportunistic prune so the table self-trims.
     if let Err(e) = store.prune_expired() {
         tracing::debug!(error = %e, "idempotency prune_expired failed");
@@ -209,25 +289,80 @@ mod tests {
     #[derive(Default)]
     struct MemStore {
         rows: Mutex<std::collections::HashMap<String, StoredRecord>>,
+        fail_reserve: std::sync::atomic::AtomicBool,
+        fail_complete: std::sync::atomic::AtomicBool,
     }
     impl IdempotencyStore for MemStore {
         fn lookup(&self, key: &str) -> Result<Option<StoredRecord>, IdempotencyError> {
             Ok(self.rows.lock().unwrap().get(key).cloned())
         }
-        fn put(
+        fn reserve(&self, key: &str, body_hash: &str) -> Result<Reservation, IdempotencyError> {
+            if self.fail_reserve.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(IdempotencyError::Invariant(
+                    "injected reserve failure".to_string(),
+                ));
+            }
+            let mut rows = self.rows.lock().unwrap();
+            if let Some(existing) = rows.get(key) {
+                return Ok(Reservation::Existing(existing.clone()));
+            }
+            let token = ReservationToken::new();
+            rows.insert(
+                key.to_string(),
+                StoredRecord {
+                    body_hash: body_hash.to_string(),
+                    response: CachedResponse {
+                        status: PENDING_STATUS,
+                        body: token.as_bytes().to_vec(),
+                    },
+                },
+            );
+            Ok(Reservation::Acquired { token })
+        }
+        fn complete(
             &self,
             key: &str,
             body_hash: &str,
+            token: &ReservationToken,
             response: &CachedResponse,
         ) -> Result<(), IdempotencyError> {
-            self.rows
-                .lock()
-                .unwrap()
-                .entry(key.to_string())
-                .or_insert_with(|| StoredRecord {
-                    body_hash: body_hash.to_string(),
-                    response: response.clone(),
-                });
+            if self.fail_complete.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(IdempotencyError::Invariant(
+                    "injected complete failure".to_string(),
+                ));
+            }
+            let mut rows = self.rows.lock().unwrap();
+            let row = rows.get_mut(key).ok_or_else(|| {
+                IdempotencyError::Invariant("test reservation missing".to_string())
+            })?;
+            if row.body_hash != body_hash
+                || row.response.status != PENDING_STATUS
+                || row.response.body != token.as_bytes()
+            {
+                return Err(IdempotencyError::Invariant(
+                    "test reservation ownership mismatch".to_string(),
+                ));
+            }
+            *row = StoredRecord {
+                body_hash: body_hash.to_string(),
+                response: response.clone(),
+            };
+            Ok(())
+        }
+        fn release(
+            &self,
+            key: &str,
+            body_hash: &str,
+            token: &ReservationToken,
+        ) -> Result<(), IdempotencyError> {
+            let mut rows = self.rows.lock().unwrap();
+            if rows.get(key).is_some_and(|row| {
+                row.body_hash == body_hash
+                    && row.response.status == PENDING_STATUS
+                    && row.response.body == token.as_bytes()
+            }) {
+                rows.remove(key);
+            }
             Ok(())
         }
         fn prune_expired(&self) -> Result<(), IdempotencyError> {
@@ -293,6 +428,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_same_key_executes_handler_once() {
+        let store = MemStore::default();
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+        let first = run_idempotent(&store, Some("in-flight"), b"{}", || async {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            entered_tx.send(()).unwrap();
+            release_rx.await.unwrap();
+            (StatusCode::CREATED, b"first".to_vec())
+        });
+        let second = async {
+            entered_rx.await.unwrap();
+            let response = run_idempotent(&store, Some("in-flight"), b"{}", || async {
+                calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                (StatusCode::CREATED, b"second".to_vec())
+            })
+            .await;
+            release_tx.send(()).unwrap();
+            response
+        };
+
+        let (first_response, second_response) =
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                tokio::join!(first, second)
+            })
+            .await
+            .expect("condition-synchronized requests must complete");
+
+        assert_eq!(first_response.status(), StatusCode::CREATED);
+        assert_eq!(second_response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(second_response.into_body(), 4096)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["code"], "idempotency_key_in_use");
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_handler_releases_pending_reservation() {
+        let store = std::sync::Arc::new(MemStore::default());
+        let task_store = store.clone();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            run_idempotent(&*task_store, Some("cancelled"), b"{}", || async {
+                entered_tx.send(()).unwrap();
+                std::future::pending::<(StatusCode, Vec<u8>)>().await
+            })
+            .await
+        });
+
+        entered_rx.await.unwrap();
+        assert_eq!(
+            store
+                .lookup("cancelled")
+                .unwrap()
+                .expect("pending reservation")
+                .response
+                .status,
+            PENDING_STATUS
+        );
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert!(store.lookup("cancelled").unwrap().is_none());
+
+        let retry = run_idempotent(&*store, Some("cancelled"), b"{}", || async {
+            (StatusCode::CREATED, b"retry".to_vec())
+        })
+        .await;
+        assert_eq!(retry.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
     async fn non_2xx_responses_are_not_cached() {
         let s = MemStore::default();
         let calls = std::sync::atomic::AtomicUsize::new(0);
@@ -310,5 +520,53 @@ mod tests {
         let r2 = run_idempotent(&s, Some("retry-me"), b"{}", mk_ok).await;
         assert_eq!(r2.status(), StatusCode::CREATED);
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn reserve_failure_does_not_run_handler() {
+        let store = MemStore::default();
+        store
+            .fail_reserve
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+
+        let response = run_idempotent(&store, Some("reserve-fails"), b"{}", || async {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (StatusCode::CREATED, b"created".to_vec())
+        })
+        .await;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn complete_failure_fails_closed_without_reexecuting_handler() {
+        let store = MemStore::default();
+        store
+            .fail_complete
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+        let handler = || async {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            (StatusCode::CREATED, b"created".to_vec())
+        };
+
+        let first = run_idempotent(&store, Some("complete-fails"), b"{}", handler).await;
+        assert_eq!(first.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            store
+                .lookup("complete-fails")
+                .unwrap()
+                .expect("pending row retained")
+                .response
+                .status,
+            PENDING_STATUS
+        );
+
+        let retry = run_idempotent(&store, Some("complete-fails"), b"{}", handler).await;
+        assert_eq!(retry.status(), StatusCode::CONFLICT);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/crates/librefang-memory/src/idempotency.rs
+++ b/crates/librefang-memory/src/idempotency.rs
@@ -5,12 +5,9 @@
 //! shape so the API crate doesn't need to depend on `rusqlite`
 //! directly. Schema is created by migration v34 (see `migration.rs`).
 //!
-//! A status-zero row reserves a key while its handler runs, and a successful
-//! handler atomically completes that row with its replayable response.
-//! Completed responses remain replayable for 24 hours after completion. Pending
-//! reservations do not expire automatically: cancellation and non-success
-//! responses release them, while an abnormal process exit fails closed until
-//! an operator explicitly removes the orphaned reservation.
+//! A status-zero row reserves a key while its handler runs, and a successful handler atomically completes that row with its replayable response.
+//! Completed responses remain replayable for 24 hours after completion.
+//! Pending reservations do not expire automatically: cancellation and non-success responses release them, while an abnormal process exit fails closed until an operator explicitly removes the orphaned reservation.
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
@@ -216,8 +213,8 @@ impl IdempotencyStore for SqliteIdempotencyStore {
             .get()
             .inspect_err(|_| record_pool_failure("lookup"))?;
         let now = now_unix()?;
-        // Replay TTL applies only after successful completion. A pending row
-        // remains a conflict even if its legacy expires_at value is in the past.
+        // Replay TTL applies only after successful completion.
+        // A pending row remains a conflict even if its legacy expires_at value is in the past.
         conn.execute(
             "DELETE FROM idempotency_keys \
              WHERE key = ?1 AND response_status != ?2 AND expires_at <= ?3",

--- a/crates/librefang-memory/src/idempotency.rs
+++ b/crates/librefang-memory/src/idempotency.rs
@@ -451,9 +451,10 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let pool = Pool::builder()
             .max_size(2)
-            .build(SqliteConnectionManager::file(
-                temp.path().join("idempotency.db"),
-            ))
+            .build(
+                SqliteConnectionManager::file(temp.path().join("idempotency.db"))
+                    .with_init(|c| c.execute_batch(crate::substrate::DEFAULT_CONNECTION_PRAGMAS)),
+            )
             .unwrap();
         run_migrations(&pool.get().unwrap()).unwrap();
         let store = SqliteIdempotencyStore::new(pool);

--- a/crates/librefang-memory/src/idempotency.rs
+++ b/crates/librefang-memory/src/idempotency.rs
@@ -5,15 +5,27 @@
 //! shape so the API crate doesn't need to depend on `rusqlite`
 //! directly. Schema is created by migration v34 (see `migration.rs`).
 //!
-//! Records expire 24h after creation. Lookup deletes expired rows
-//! opportunistically so the table self-trims without a background job.
+//! A status-zero row reserves a key while its handler runs, and a successful
+//! handler atomically completes that row with its replayable response.
+//! Completed responses remain replayable for 24 hours after completion. Pending
+//! reservations do not expire automatically: cancellation and non-success
+//! responses release them, while an abnormal process exit fails closed until
+//! an operator explicitly removes the orphaned reservation.
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::OptionalExtension;
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// 24-hour replay window per #3637.
 pub const TTL_SECONDS: i64 = 24 * 60 * 60;
+
+/// Avoid issuing a table-wide DELETE on every idempotent request.
+const PRUNE_INTERVAL_SECONDS: i64 = 60;
 
 /// Cached HTTP response replayed verbatim on subsequent matching
 /// requests. Status is stored as `u16` to keep the row schema flat;
@@ -31,27 +43,66 @@ pub struct StoredRecord {
     pub response: CachedResponse,
 }
 
+/// Result of atomically reserving an idempotency key before a handler runs.
+#[derive(Debug)]
+pub enum Reservation {
+    Acquired { token: ReservationToken },
+    Existing(StoredRecord),
+}
+
+/// Unforgeable ownership token for one pending reservation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReservationToken(String);
+
+impl ReservationToken {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl Default for ReservationToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sentinel stored while the first request is still executing.
+pub const PENDING_STATUS: u16 = 0;
+
 /// Pluggable backend so unit tests in the API crate can swap in an
 /// in-memory implementation. Production wires
 /// [`SqliteIdempotencyStore`] against the substrate connection.
 pub trait IdempotencyStore: Send + Sync {
-    /// Look up an existing record by key. Expired rows are deleted in
-    /// place and reported as `Ok(None)` so the caller treats them as a
-    /// fresh miss.
+    /// Look up an existing record by key. Expired completed rows are deleted;
+    /// pending reservations fail closed and are never expired automatically.
     fn lookup(&self, key: &str) -> Result<Option<StoredRecord>, IdempotencyError>;
 
-    /// Persist a fresh record. First-writer-wins via `INSERT OR
-    /// IGNORE`: a concurrent insert under the same key is a silent
-    /// no-op (the canonical reply is whichever landed first).
-    fn put(
+    /// Atomically reserve a key before executing its handler.
+    fn reserve(&self, key: &str, body_hash: &str) -> Result<Reservation, IdempotencyError>;
+
+    /// Replace an owned pending reservation with its replayable response.
+    fn complete(
         &self,
         key: &str,
         body_hash: &str,
+        token: &ReservationToken,
         response: &CachedResponse,
     ) -> Result<(), IdempotencyError>;
 
-    /// Delete every expired row. Called opportunistically by the
-    /// middleware so the table self-trims.
+    /// Remove an owned pending reservation after a non-success or cancellation.
+    fn release(
+        &self,
+        key: &str,
+        body_hash: &str,
+        token: &ReservationToken,
+    ) -> Result<(), IdempotencyError>;
+
+    /// Delete expired completed responses. Pending reservations are retained
+    /// so a long-running handler cannot lose ownership to a retry.
     fn prune_expired(&self) -> Result<(), IdempotencyError>;
 }
 
@@ -60,6 +111,7 @@ pub trait IdempotencyStore: Send + Sync {
 pub enum IdempotencyError {
     Sqlite(rusqlite::Error),
     Pool(r2d2::Error),
+    Invariant(String),
 }
 
 impl std::fmt::Display for IdempotencyError {
@@ -67,6 +119,7 @@ impl std::fmt::Display for IdempotencyError {
         match self {
             IdempotencyError::Sqlite(e) => write!(f, "sqlite: {}", e),
             IdempotencyError::Pool(e) => write!(f, "pool: {}", e),
+            IdempotencyError::Invariant(e) => write!(f, "invariant: {e}"),
         }
     }
 }
@@ -76,6 +129,7 @@ impl std::error::Error for IdempotencyError {
         match self {
             IdempotencyError::Sqlite(e) => Some(e),
             IdempotencyError::Pool(e) => Some(e),
+            IdempotencyError::Invariant(_) => None,
         }
     }
 }
@@ -100,19 +154,48 @@ impl From<r2d2::Error> for IdempotencyError {
 #[derive(Clone)]
 pub struct SqliteIdempotencyStore {
     pool: Pool<SqliteConnectionManager>,
+    last_pruned_at: Arc<AtomicI64>,
 }
 
 impl SqliteIdempotencyStore {
     pub fn new(pool: Pool<SqliteConnectionManager>) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            last_pruned_at: Arc::new(AtomicI64::new(0)),
+        }
     }
 }
 
-fn now_unix() -> i64 {
-    SystemTime::now()
+fn unix_seconds(time: SystemTime) -> Result<i64, IdempotencyError> {
+    let seconds = time
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+        .map_err(|error| {
+            IdempotencyError::Invariant(format!("system clock precedes Unix epoch: {error}"))
+        })?
+        .as_secs();
+    i64::try_from(seconds).map_err(|_| {
+        IdempotencyError::Invariant("system clock exceeds SQLite timestamp range".to_string())
+    })
+}
+
+fn now_unix() -> Result<i64, IdempotencyError> {
+    unix_seconds(SystemTime::now())
+}
+
+fn decode_record(
+    body_hash: String,
+    status: i64,
+    body: Vec<u8>,
+) -> Result<StoredRecord, IdempotencyError> {
+    let status = u16::try_from(status).map_err(|_| {
+        IdempotencyError::Invariant(format!(
+            "idempotency response status {status} is outside the u16 range"
+        ))
+    })?;
+    Ok(StoredRecord {
+        body_hash,
+        response: CachedResponse { status, body },
+    })
 }
 
 /// Increment the shared pool-exhaustion counter so operators can see
@@ -132,72 +215,161 @@ impl IdempotencyStore for SqliteIdempotencyStore {
             .pool
             .get()
             .inspect_err(|_| record_pool_failure("lookup"))?;
-        let now = now_unix();
-        // Drop the row if it's expired so the lookup behaves like a
-        // fresh miss; the write path will then re-INSERT cleanly.
+        let now = now_unix()?;
+        // Replay TTL applies only after successful completion. A pending row
+        // remains a conflict even if its legacy expires_at value is in the past.
         conn.execute(
-            "DELETE FROM idempotency_keys WHERE key = ?1 AND expires_at <= ?2",
-            rusqlite::params![key, now],
+            "DELETE FROM idempotency_keys \
+             WHERE key = ?1 AND response_status != ?2 AND expires_at <= ?3",
+            rusqlite::params![key, PENDING_STATUS as i64, now],
         )?;
         let mut stmt = conn.prepare(
             "SELECT body_hash, response_status, response_body \
              FROM idempotency_keys WHERE key = ?1",
         )?;
-        let row = stmt
+        let row: Option<(String, i64, Vec<u8>)> = stmt
             .query_row(rusqlite::params![key], |row| {
-                let body_hash: String = row.get(0)?;
-                let status: i64 = row.get(1)?;
-                let body: Vec<u8> = row.get(2)?;
-                Ok(StoredRecord {
-                    body_hash,
-                    response: CachedResponse {
-                        status: status as u16,
-                        body,
-                    },
-                })
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
             })
-            .ok();
-        Ok(row)
+            .optional()?;
+        row.map(|(body_hash, status, body)| decode_record(body_hash, status, body))
+            .transpose()
     }
 
-    fn put(
-        &self,
-        key: &str,
-        body_hash: &str,
-        response: &CachedResponse,
-    ) -> Result<(), IdempotencyError> {
-        let conn = self
+    fn reserve(&self, key: &str, body_hash: &str) -> Result<Reservation, IdempotencyError> {
+        let mut conn = self
             .pool
             .get()
-            .inspect_err(|_| record_pool_failure("put"))?;
-        let now = now_unix();
-        let expires = now + TTL_SECONDS;
-        conn.execute(
+            .inspect_err(|_| record_pool_failure("reserve"))?;
+        let now = now_unix()?;
+        let token = ReservationToken::new();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        tx.execute(
+            "DELETE FROM idempotency_keys \
+             WHERE key = ?1 AND response_status != ?2 AND expires_at <= ?3",
+            rusqlite::params![key, PENDING_STATUS as i64, now],
+        )?;
+        let inserted = tx.execute(
             "INSERT OR IGNORE INTO idempotency_keys \
              (key, body_hash, response_status, response_body, created_at, expires_at) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             rusqlite::params![
                 key,
                 body_hash,
+                PENDING_STATUS as i64,
+                token.as_bytes(),
+                now,
+                i64::MAX
+            ],
+        )?;
+        let reservation = if inserted == 1 {
+            Reservation::Acquired { token }
+        } else {
+            let (stored_hash, status, body): (String, i64, Vec<u8>) = tx.query_row(
+                "SELECT body_hash, response_status, response_body \
+                 FROM idempotency_keys WHERE key = ?1",
+                rusqlite::params![key],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+            Reservation::Existing(decode_record(stored_hash, status, body)?)
+        };
+        tx.commit()?;
+        Ok(reservation)
+    }
+
+    fn complete(
+        &self,
+        key: &str,
+        body_hash: &str,
+        token: &ReservationToken,
+        response: &CachedResponse,
+    ) -> Result<(), IdempotencyError> {
+        let conn = self
+            .pool
+            .get()
+            .inspect_err(|_| record_pool_failure("complete"))?;
+        let now = now_unix()?;
+        let expires = now + TTL_SECONDS;
+        let updated = conn.execute(
+            "UPDATE idempotency_keys \
+             SET response_status = ?3, response_body = ?4, expires_at = ?5 \
+             WHERE key = ?1 AND body_hash = ?2 AND response_status = 0 \
+               AND response_body = ?6",
+            rusqlite::params![
+                key,
+                body_hash,
                 response.status as i64,
                 response.body,
-                now,
-                expires
+                expires,
+                token.as_bytes()
             ],
+        )?;
+        if updated != 1 {
+            return Err(IdempotencyError::Invariant(format!(
+                "pending reservation for key {key:?} was lost before completion"
+            )));
+        }
+        Ok(())
+    }
+
+    fn release(
+        &self,
+        key: &str,
+        body_hash: &str,
+        token: &ReservationToken,
+    ) -> Result<(), IdempotencyError> {
+        let conn = self
+            .pool
+            .get()
+            .inspect_err(|_| record_pool_failure("release"))?;
+        conn.execute(
+            "DELETE FROM idempotency_keys \
+             WHERE key = ?1 AND body_hash = ?2 AND response_status = 0 \
+               AND response_body = ?3",
+            rusqlite::params![key, body_hash, token.as_bytes()],
         )?;
         Ok(())
     }
 
     fn prune_expired(&self) -> Result<(), IdempotencyError> {
+        let now = now_unix()?;
+        let last = self.last_pruned_at.load(Ordering::Relaxed);
+        if now >= last && now.saturating_sub(last) < PRUNE_INTERVAL_SECONDS {
+            return Ok(());
+        }
+        if self
+            .last_pruned_at
+            .compare_exchange(last, now, Ordering::AcqRel, Ordering::Relaxed)
+            .is_err()
+        {
+            return Ok(());
+        }
         let conn = self
             .pool
             .get()
-            .inspect_err(|_| record_pool_failure("prune_expired"))?;
-        let now = now_unix();
-        conn.execute(
-            "DELETE FROM idempotency_keys WHERE expires_at <= ?1",
-            rusqlite::params![now],
-        )?;
+            .inspect_err(|_| record_pool_failure("prune_expired"))
+            .inspect_err(|_| {
+                let _ = self.last_pruned_at.compare_exchange(
+                    now,
+                    last,
+                    Ordering::AcqRel,
+                    Ordering::Relaxed,
+                );
+            })?;
+        let result = conn.execute(
+            "DELETE FROM idempotency_keys \
+             WHERE response_status != ?1 AND expires_at <= ?2",
+            rusqlite::params![PENDING_STATUS as i64, now],
+        );
+        if result.is_err() {
+            let _ = self.last_pruned_at.compare_exchange(
+                now,
+                last,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            );
+        }
+        result?;
         Ok(())
     }
 }
@@ -217,13 +389,17 @@ mod tests {
     }
 
     #[test]
-    fn put_and_lookup_round_trip() {
+    fn reserve_complete_and_lookup_round_trip() {
         let s = make_store();
         let resp = CachedResponse {
             status: 200,
             body: b"{\"ok\":true}".to_vec(),
         };
-        s.put("k1", "h1", &resp).unwrap();
+        let token = match s.reserve("k1", "h1").unwrap() {
+            Reservation::Acquired { token } => token,
+            Reservation::Existing(_) => panic!("first caller must acquire"),
+        };
+        s.complete("k1", "h1", &token, &resp).unwrap();
         let got = s.lookup("k1").unwrap().expect("hit");
         assert_eq!(got.body_hash, "h1");
         assert_eq!(got.response.status, 200);
@@ -231,18 +407,27 @@ mod tests {
     }
 
     #[test]
-    fn first_writer_wins() {
+    fn reservation_is_first_writer_wins() {
         let s = make_store();
         let r1 = CachedResponse {
             status: 200,
             body: b"first".to_vec(),
         };
-        let r2 = CachedResponse {
-            status: 200,
-            body: b"second".to_vec(),
+        let token = match s.reserve("k", "h").unwrap() {
+            Reservation::Acquired { token } => token,
+            Reservation::Existing(_) => panic!("first caller must acquire"),
         };
-        s.put("k", "h", &r1).unwrap();
-        s.put("k", "h", &r2).unwrap();
+        assert!(matches!(
+            s.reserve("k", "h").unwrap(),
+            Reservation::Existing(StoredRecord {
+                response: CachedResponse {
+                    status: PENDING_STATUS,
+                    ..
+                },
+                ..
+            })
+        ));
+        s.complete("k", "h", &token, &r1).unwrap();
         let got = s.lookup("k").unwrap().expect("hit");
         assert_eq!(got.response.body, b"first");
     }
@@ -257,10 +442,227 @@ mod tests {
                 "INSERT INTO idempotency_keys \
                  (key, body_hash, response_status, response_body, created_at, expires_at) \
                  VALUES ('old', 'h', 200, x'00', ?1, ?2)",
-                rusqlite::params![now_unix() - 100_000, now_unix() - 1],
+                rusqlite::params![now_unix().unwrap() - 100_000, now_unix().unwrap() - 1],
             )
             .unwrap();
         }
         assert!(s.lookup("old").unwrap().is_none());
+    }
+
+    #[test]
+    fn concurrent_reservations_have_exactly_one_owner() {
+        let temp = tempfile::tempdir().unwrap();
+        let pool = Pool::builder()
+            .max_size(2)
+            .build(SqliteConnectionManager::file(
+                temp.path().join("idempotency.db"),
+            ))
+            .unwrap();
+        run_migrations(&pool.get().unwrap()).unwrap();
+        let store = SqliteIdempotencyStore::new(pool);
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        let workers: Vec<_> = (0..2)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.reserve("race", "same-body").unwrap()
+                })
+            })
+            .collect();
+        let results: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Reservation::Acquired { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(
+                    result,
+                    Reservation::Existing(StoredRecord {
+                        body_hash,
+                        response: CachedResponse {
+                            status: PENDING_STATUS,
+                            ..
+                        },
+                    }) if body_hash == "same-body"
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn expired_pending_reservation_is_not_reclaimed() {
+        let store = make_store();
+        match store.reserve("pending", "same-body").unwrap() {
+            Reservation::Acquired { .. } => {}
+            Reservation::Existing(_) => panic!("first caller must acquire"),
+        }
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "UPDATE idempotency_keys SET expires_at = ?2 WHERE key = ?1",
+                rusqlite::params!["pending", now_unix().unwrap() - 1],
+            )
+            .unwrap();
+        }
+        store.prune_expired().unwrap();
+        assert_eq!(
+            store
+                .lookup("pending")
+                .unwrap()
+                .expect("pending row must survive lookup and pruning")
+                .response
+                .status,
+            PENDING_STATUS
+        );
+        assert!(matches!(
+            store.reserve("pending", "same-body").unwrap(),
+            Reservation::Existing(StoredRecord {
+                response: CachedResponse {
+                    status: PENDING_STATUS,
+                    ..
+                },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn superseded_owner_cannot_complete_or_release_replacement() {
+        let store = make_store();
+        let first_token = match store.reserve("replaced", "same-body").unwrap() {
+            Reservation::Acquired { token } => token,
+            Reservation::Existing(_) => panic!("first caller must acquire"),
+        };
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "DELETE FROM idempotency_keys WHERE key = ?1",
+                rusqlite::params!["replaced"],
+            )
+            .unwrap();
+        }
+        let replacement_token = match store.reserve("replaced", "same-body").unwrap() {
+            Reservation::Acquired { token } => token,
+            Reservation::Existing(_) => panic!("replacement caller must acquire"),
+        };
+        assert_ne!(first_token, replacement_token);
+
+        let response = CachedResponse {
+            status: 201,
+            body: b"replacement".to_vec(),
+        };
+        assert!(store
+            .complete("replaced", "same-body", &first_token, &response)
+            .is_err());
+        store
+            .release("replaced", "same-body", &first_token)
+            .unwrap();
+        store
+            .complete("replaced", "same-body", &replacement_token, &response)
+            .expect("old owner must leave replacement reservation intact");
+    }
+
+    #[test]
+    fn pre_epoch_time_is_rejected() {
+        let before_epoch = UNIX_EPOCH - std::time::Duration::from_secs(1);
+        assert!(unix_seconds(before_epoch).is_err());
+    }
+
+    #[test]
+    fn corrupt_out_of_range_status_is_rejected() {
+        let store = make_store();
+        let conn = store.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO idempotency_keys \
+             (key, body_hash, response_status, response_body, created_at, expires_at) \
+             VALUES ('corrupt', 'h', 65736, x'00', ?1, ?2)",
+            rusqlite::params![now_unix().unwrap(), now_unix().unwrap() + TTL_SECONDS],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(store.lookup("corrupt").is_err());
+    }
+
+    #[test]
+    fn reserve_rejects_corrupt_out_of_range_status() {
+        let store = make_store();
+        let conn = store.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO idempotency_keys \
+             (key, body_hash, response_status, response_body, created_at, expires_at) \
+             VALUES ('corrupt-reserve', 'h', 65736, x'00', ?1, ?2)",
+            rusqlite::params![now_unix().unwrap(), now_unix().unwrap() + TTL_SECONDS],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(store.reserve("corrupt-reserve", "h").is_err());
+    }
+
+    #[test]
+    fn repeated_prune_calls_are_rate_limited() {
+        let store = make_store();
+        store.prune_expired().unwrap();
+        let conn = store.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO idempotency_keys \
+             (key, body_hash, response_status, response_body, created_at, expires_at) \
+             VALUES ('recent-prune', 'h', 200, x'00', ?1, ?2)",
+            rusqlite::params![now_unix().unwrap() - 2, now_unix().unwrap() - 1],
+        )
+        .unwrap();
+        drop(conn);
+
+        store.prune_expired().unwrap();
+        let conn = store.pool.get().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM idempotency_keys WHERE key = 'recent-prune'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "second prune inside the interval must be a no-op");
+    }
+
+    #[test]
+    fn clock_rollback_reestablishes_prune_baseline() {
+        let store = make_store();
+        let now = now_unix().unwrap();
+        store.last_pruned_at.store(now + 3600, Ordering::Release);
+        let conn = store.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO idempotency_keys \
+             (key, body_hash, response_status, response_body, created_at, expires_at) \
+             VALUES ('rollback-prune', 'h', 200, x'00', ?1, ?2)",
+            rusqlite::params![now - 2, now - 1],
+        )
+        .unwrap();
+        drop(conn);
+
+        store.prune_expired().unwrap();
+        let conn = store.pool.get().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM idempotency_keys WHERE key = 'rollback-prune'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "rollback must allow one prune winner");
     }
 }

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -1481,11 +1481,9 @@ pub(crate) fn __test_only_run_v33(conn: &Connection) {
 /// `Idempotency-Key`, while `body_hash` (sha256 of the canonical JSON
 /// bytes) is the conflict detector.
 ///
-/// Completed responses use a 24-hour replay window. Pending reservations
-/// use the same schema row with status zero, but current store semantics do
-/// not expire them automatically while a handler may still own the key.
-/// Expired completed rows are reclaimed lazily on read and by the API
-/// layer's `prune_expired` hook.
+/// Completed responses use a 24-hour replay window.
+/// Pending reservations use the same schema row with status zero, but current store semantics do not expire them automatically while a handler may still own the key.
+/// Expired completed rows are reclaimed lazily on read and by the API layer's `prune_expired` hook.
 fn migrate_v34(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS idempotency_keys (

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -1481,10 +1481,11 @@ pub(crate) fn __test_only_run_v33(conn: &Connection) {
 /// `Idempotency-Key`, while `body_hash` (sha256 of the canonical JSON
 /// bytes) is the conflict detector.
 ///
-/// Window: 24 hours. `expires_at = created_at + 86400`. Long enough
-/// to absorb realistic webhook / dashboard double-submit windows
-/// without retaining replayable state indefinitely. Expired rows are
-/// reclaimed lazily on read (the API layer's `prune_expired` hook).
+/// Completed responses use a 24-hour replay window. Pending reservations
+/// use the same schema row with status zero, but current store semantics do
+/// not expire them automatically while a handler may still own the key.
+/// Expired completed rows are reclaimed lazily on read and by the API
+/// layer's `prune_expired` hook.
 fn migrate_v34(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS idempotency_keys (

--- a/docs/architecture/idempotency.md
+++ b/docs/architecture/idempotency.md
@@ -18,11 +18,8 @@ channel webhook redelivery silently created two of something.
 | Repeat with key `K` + different body | `409 Conflict` with `code = "idempotency_key_conflict"`. |
 | Empty / oversize / non-printable key | `400 Bad Request` with `code = "idempotency_key_invalid"`. |
 
-The 24-hour replay window starts when a successful handler completes;
-it is long enough to absorb realistic dashboard / webhook redelivery
-races without retaining completed responses indefinitely. Expired
-completed rows are deleted lazily on lookup and by opportunistic pruning,
-which is limited to once per minute per shared store.
+The 24-hour replay window starts when a successful handler completes; it is long enough to absorb realistic dashboard / webhook redelivery races without retaining completed responses indefinitely.
+Expired completed rows are deleted lazily on lookup and by opportunistic pruning, which is limited to once per minute per shared store.
 
 Body identity is sha256 over the raw JSON bytes the handler received
 (not the parsed value) so a re-serialised body with reordered keys
@@ -75,7 +72,9 @@ The transaction has exactly one owner before any handler starts, so concurrent s
 Only that token's owner may complete or release the row, preventing a superseded request from modifying a replacement reservation.
 Successful handlers replace their pending row with the replayable status and body; non-success and cancelled handlers release it.
 
-Pending reservations do not use the replay TTL and are not reclaimed automatically. This keeps a handler that legitimately runs for more than 24 hours from losing its reservation to a retry. If the process exits abnormally before the guard can release the row, the key remains fail-closed until an operator verifies the original side effect and explicitly removes that orphaned pending row.
+Pending reservations do not use the replay TTL and are not reclaimed automatically.
+This keeps a handler that legitimately runs for more than 24 hours from losing its reservation to a retry.
+If the process exits abnormally before the guard can release the row, the key remains fail-closed until an operator verifies the original side effect and explicitly removes that orphaned pending row.
 
 ## Failure modes
 

--- a/docs/architecture/idempotency.md
+++ b/docs/architecture/idempotency.md
@@ -13,16 +13,16 @@ channel webhook redelivery silently created two of something.
 | No `Idempotency-Key` header | Handler runs as before. No state recorded. |
 | First request with key `K` (2xx response) | Response cached for 24h under `(K, sha256(body))`. |
 | First request with key `K` (4xx / 5xx) | Not cached. Slot stays free; clients can retry. |
+| Concurrent request with key `K` + same body | `409 Conflict` with `code = "idempotency_key_in_use"`; the second handler does not run. |
 | Repeat with key `K` + same body | Replays cached `(status, body)` byte-for-byte. Inner handler does **not** run. |
 | Repeat with key `K` + different body | `409 Conflict` with `code = "idempotency_key_conflict"`. |
 | Empty / oversize / non-printable key | `400 Bad Request` with `code = "idempotency_key_invalid"`. |
 
-The 24-hour window is the recommended default from the issue; long
-enough to absorb realistic dashboard / webhook redelivery races, short
-enough that a key the operator forgets about doesn't pin replayable
-state forever. `expires_at = created_at + 86400`. Expired rows are
-deleted lazily on the next lookup that hits the same key, plus
-opportunistically after every cache miss.
+The 24-hour replay window starts when a successful handler completes;
+it is long enough to absorb realistic dashboard / webhook redelivery
+races without retaining completed responses indefinitely. Expired
+completed rows are deleted lazily on lookup and by opportunistic pruning,
+which is limited to once per minute per shared store.
 
 Body identity is sha256 over the raw JSON bytes the handler received
 (not the parsed value) so a re-serialised body with reordered keys
@@ -69,24 +69,18 @@ CREATE INDEX idx_idempotency_keys_expires_at
     ON idempotency_keys(expires_at);
 ```
 
-The store reuses `MemorySubstrate::usage_conn()` so every byte sits
-under the same WAL pool — no separate database file, no second open
-call. First-writer-wins is enforced via `INSERT OR IGNORE`, so a race
-between two duplicate requests resolves deterministically: whichever
-writer's `INSERT` lands first owns the canonical reply.
+The store reuses the `MemorySubstrate` SQLite pool so every byte sits under one WAL pool — no separate database file and no second database.
+Reservation uses `BEGIN IMMEDIATE` plus `INSERT OR IGNORE` with `response_status = 0` as the pending sentinel and a random owner token in `response_body`.
+The transaction has exactly one owner before any handler starts, so concurrent same-key requests cannot both perform side effects.
+Only that token's owner may complete or release the row, preventing a superseded request from modifying a replacement reservation.
+Successful handlers replace their pending row with the replayable status and body; non-success and cancelled handlers release it.
+
+Pending reservations do not use the replay TTL and are not reclaimed automatically. This keeps a handler that legitimately runs for more than 24 hours from losing its reservation to a retry. If the process exits abnormally before the guard can release the row, the key remains fail-closed until an operator verifies the original side effect and explicitly removes that orphaned pending row.
 
 ## Failure modes
 
-- **Lookup error**: the middleware logs and falls through to "execute
-  the handler anyway, don't cache". A corrupt cache row can never
-  block real traffic.
-- **Persist error after the handler succeeded**: logged at `warn`, the
-  successful response is still returned. The next duplicate request
-  re-executes the handler — the same property as a non-2xx first
-  response.
-- **Concurrent in-flight duplicates**: both requests run the handler;
-  whichever finishes first writes the cache row, the loser's `INSERT
-  OR IGNORE` is a no-op. Both clients see a 2xx, but they may not be
-  byte-identical (e.g. two `agent_id`s). This is the same property as
-  Stripe's idempotency-key implementation; for stronger semantics
-  (single-flight) callers should serialize at the dispatcher.
+- **Reservation error before execution**: the middleware returns `503 idempotency_store_unavailable` and does not run the handler because it cannot promise deduplication.
+- **Completion error after a successful handler**: the middleware returns the same 503 and leaves the pending reservation in place, failing closed instead of making a completed side effect immediately retriable.
+- **Invalid system time or persisted status**: the store rejects the operation instead of inventing an expiry timestamp or truncating the corrupt status.
+- **Concurrent in-flight duplicate with the same body**: returns `409 idempotency_key_in_use` without starting the second handler, matching Stripe's documented conflict behavior.
+- **Cancellation or panic**: the reservation guard releases its token-owned pending row, so a later retry can make a new attempt.


### PR DESCRIPTION
## Summary

- atomically reserve each Idempotency-Key before executing its handler
- return idempotency_key_in_use for concurrent duplicates and bind completion/release to a random owner token
- keep pending reservations fail-closed outside the completed-response replay TTL
- fail closed on reservation/completion storage errors and document recovery semantics

## Verification

- cargo test -p librefang-memory idempotency::tests --lib (6 passed)
- cargo test -p librefang-api idempotency::tests --lib (9 passed)
- cargo test -p librefang-api --test idempotency_test (11 passed)
- cargo check --workspace --lib
- cargo clippy --workspace --lib -- -A clippy::nonminimal-bool -D warnings
- cargo fmt --all
- git diff --check

Closes the concurrent check-then-act idempotency race identified in the audit.