### PR TITLE
fix(api): harden session history responses

### DIFF
--- a/changelog.d/fixed/6921-session-history-response-hardening.md
+++ b/changelog.d/fixed/6921-session-history-response-hardening.md
@@ -1,0 +1,1 @@
+Reuse stable session-scoped files when loading inline history images, move their filesystem work off Tokio worker threads, keep empty-session response fields consistent, localize malformed session IDs, and enforce the documented 100 KiB tool-result cap in UTF-8 bytes (#6921) (@houko)

--- a/changelog.d/fixed/session-history-response-hardening.md
+++ b/changelog.d/fixed/session-history-response-hardening.md
@@ -1,2 +1,0 @@
-Reuse stable session-scoped files when loading inline history images, move their filesystem work off Tokio worker threads, keep empty-session response fields consistent, localize malformed session IDs, and enforce the documented 100 KiB tool-result cap in UTF-8 bytes.
-(@houko)

--- a/changelog.d/fixed/session-history-response-hardening.md
+++ b/changelog.d/fixed/session-history-response-hardening.md
@@ -1,0 +1,2 @@
+Reuse stable session-scoped files when loading inline history images, move their filesystem work off Tokio worker threads, keep empty-session response fields consistent, localize malformed session IDs, and enforce the documented 100 KiB tool-result cap in UTF-8 bytes.
+(@houko)

--- a/crates/librefang-api/src/routes/agents/sessions.rs
+++ b/crates/librefang-api/src/routes/agents/sessions.rs
@@ -46,8 +46,7 @@ async fn materialize_history_image(
     let digest = hasher.finalize();
     let mut file_id_bytes = [0_u8; 16];
     file_id_bytes.copy_from_slice(&digest[..16]);
-    // RFC 9562 UUIDv8 keeps the content-derived 128-bit identifier compatible
-    // with the upload route while reserving the standard version/variant bits.
+    // RFC 9562 UUIDv8 keeps the content-derived 128-bit identifier compatible with the upload route while reserving the standard version/variant bits.
     file_id_bytes[6] = (file_id_bytes[6] & 0x0f) | 0x80;
     file_id_bytes[8] = (file_id_bytes[8] & 0x3f) | 0x80;
     let file_id = uuid::Uuid::from_bytes(file_id_bytes).to_string();

--- a/crates/librefang-api/src/routes/agents/sessions.rs
+++ b/crates/librefang-api/src/routes/agents/sessions.rs
@@ -1,5 +1,101 @@
 use super::*;
 
+const TOOL_RESULT_MAX_BYTES: usize = 100 * 1024;
+
+fn cap_tool_result(result: &str) -> String {
+    if result.len() <= TOOL_RESULT_MAX_BYTES {
+        return result.to_string();
+    }
+    let mut end = TOOL_RESULT_MAX_BYTES;
+    while !result.is_char_boundary(end) {
+        end -= 1;
+    }
+    result[..end].to_string()
+}
+
+async fn remove_history_image_temp(path: &std::path::Path) {
+    if let Err(error) = tokio::fs::remove_file(path).await {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(%error, "failed to clean up session history image");
+        }
+    }
+}
+
+async fn materialize_history_image(
+    upload_dir: &std::path::Path,
+    session_scope: &[u8],
+    media_type: &str,
+    data: &str,
+) -> Option<serde_json::Value> {
+    use base64::Engine as _;
+    use sha2::{Digest, Sha256};
+
+    let bytes = match base64::engine::general_purpose::STANDARD.decode(data) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!(%error, "failed to decode session history image");
+            return None;
+        }
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(session_scope);
+    hasher.update([0]);
+    hasher.update(media_type.as_bytes());
+    hasher.update([0]);
+    hasher.update(&bytes);
+    let digest = hasher.finalize();
+    let mut file_id_bytes = [0_u8; 16];
+    file_id_bytes.copy_from_slice(&digest[..16]);
+    // RFC 9562 UUIDv8 keeps the content-derived 128-bit identifier compatible
+    // with the upload route while reserving the standard version/variant bits.
+    file_id_bytes[6] = (file_id_bytes[6] & 0x0f) | 0x80;
+    file_id_bytes[8] = (file_id_bytes[8] & 0x3f) | 0x80;
+    let file_id = uuid::Uuid::from_bytes(file_id_bytes).to_string();
+    let on_disk = librefang_types::media::on_disk_name(&file_id, media_type, "");
+
+    if let Err(error) = tokio::fs::create_dir_all(upload_dir).await {
+        tracing::warn!(%error, "failed to create session image directory");
+        return None;
+    }
+    let path = upload_dir.join(on_disk);
+    let exists = match tokio::fs::try_exists(&path).await {
+        Ok(exists) => exists,
+        Err(error) => {
+            tracing::warn!(%error, "failed to inspect session history image");
+            return None;
+        }
+    };
+    if !exists {
+        let temporary = upload_dir.join(format!(".{file_id}.{}.tmp", uuid::Uuid::new_v4()));
+        if let Err(error) = tokio::fs::write(&temporary, &bytes).await {
+            tracing::warn!(%error, "failed to write temporary session history image");
+            remove_history_image_temp(&temporary).await;
+            return None;
+        }
+        if let Err(error) = tokio::fs::rename(&temporary, &path).await {
+            if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
+                tracing::warn!(%error, "failed to publish session history image");
+                remove_history_image_temp(&temporary).await;
+                return None;
+            }
+            remove_history_image_temp(&temporary).await;
+        }
+    }
+
+    let filename = format!("image.{}", media_type.rsplit('/').next().unwrap_or("png"));
+    UPLOAD_REGISTRY
+        .entry(file_id.clone())
+        .or_insert_with(|| UploadMeta {
+            filename: filename.clone(),
+            content_type: media_type.to_string(),
+            uploaded_by: None,
+        });
+    Some(serde_json::json!({
+        "file_id": file_id,
+        "filename": filename,
+    }))
+}
+
 /// Query params for `GET /api/agents/{id}/session`.
 ///
 /// Using a typed struct (rather than `HashMap<String,String>`) gives us
@@ -29,11 +125,19 @@ pub async fn get_agent_session(
     query: Result<Query<GetAgentSessionQuery>, axum::extract::rejection::QueryRejection>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let (err_session_invalid, err_agent_invalid, err_agent_not_found, err_session_load_failed) = {
+        let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+        (
+            t.t("api-error-session-invalid-id"),
+            t.t("api-error-agent-invalid-id"),
+            t.t("api-error-agent-not-found"),
+            t.t("api-error-session-load-failed"),
+        )
+    };
     let Query(params) = match query {
         Ok(q) => q,
         Err(_) => {
-            return ApiErrorResponse::bad_request("invalid session_id")
+            return ApiErrorResponse::bad_request(err_session_invalid)
                 .with_code("invalid_session_id")
                 .into_response();
         }
@@ -41,7 +145,7 @@ pub async fn get_agent_session(
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+            return ApiErrorResponse::bad_request(err_agent_invalid)
                 .with_code("invalid_agent_id")
                 .into_response();
         }
@@ -50,7 +154,7 @@ pub async fn get_agent_session(
     let entry = match state.kernel.agent_registry().get(agent_id) {
         Some(e) => e,
         None => {
-            return ApiErrorResponse::not_found(t.t("api-error-agent-not-found"))
+            return ApiErrorResponse::not_found(err_agent_not_found)
                 .with_code("agent_not_found")
                 .into_response();
         }
@@ -84,7 +188,6 @@ pub async fn get_agent_session(
             // collects all tool_use entries keyed by id; pass 2 attaches results.
 
             // Pass 1: build messages and a lookup from tool_use_id → (msg_idx, tool_idx)
-            use base64::Engine as _;
             let mut built_messages: Vec<serde_json::Value> = Vec::new();
             let mut tool_use_index: std::collections::HashMap<String, (usize, usize)> =
                 std::collections::HashMap::new();
@@ -122,48 +225,20 @@ pub async fn get_agent_session(
                                     data,
                                 } => {
                                     texts.push("[Image]".to_string());
-                                    // Persist image to upload dir so it can be
-                                    // served back when loading session history.
-                                    let file_id = uuid::Uuid::new_v4().to_string();
                                     let upload_dir = state
                                         .kernel
                                         .config_ref()
                                         .channels
                                         .effective_file_download_dir();
-                                    if let Err(e) = std::fs::create_dir_all(&upload_dir) {
-                                        tracing::warn!("Failed to create upload directory: {e}");
-                                    }
-                                    if let Ok(bytes) =
-                                        base64::engine::general_purpose::STANDARD.decode(data)
+                                    if let Some(image) = materialize_history_image(
+                                        &upload_dir,
+                                        target_session_id.0.as_bytes(),
+                                        media_type,
+                                        data,
+                                    )
+                                    .await
                                     {
-                                        // Persist as `<uuid>.<ext>` (#6530); the
-                                        // registry stores content_type so the
-                                        // history-load serve reconstructs it.
-                                        let on_disk = librefang_types::media::on_disk_name(
-                                            &file_id, media_type, "",
-                                        );
-                                        if let Err(e) =
-                                            std::fs::write(upload_dir.join(&on_disk), &bytes)
-                                        {
-                                            tracing::warn!("Failed to write upload file: {e}");
-                                        }
-                                        UPLOAD_REGISTRY.insert(
-                                            file_id.clone(),
-                                            UploadMeta {
-                                                filename: format!(
-                                                    "image.{}",
-                                                    media_type.rsplit('/').next().unwrap_or("png")
-                                                ),
-                                                content_type: media_type.clone(),
-                                                // Generated content has no
-                                                // operator owner — leave None.
-                                                uploaded_by: None,
-                                            },
-                                        );
-                                        msg_images.push(serde_json::json!({
-                                            "file_id": file_id,
-                                            "filename": format!("image.{}", media_type.rsplit('/').next().unwrap_or("png")),
-                                        }));
+                                        msg_images.push(image);
                                     }
                                 }
                                 librefang_types::message::ContentBlock::ToolUse {
@@ -250,9 +325,8 @@ pub async fn get_agent_session(
                                         msg.get_mut("tools").and_then(|v| v.as_array_mut())
                                     {
                                         if let Some(tool_obj) = tools_arr.get_mut(tool_idx) {
-                                            // Cap at 100 KB to keep session responses manageable
-                                            let capped: String =
-                                                result.chars().take(102_400).collect();
+                                            // Cap at 100 KiB of UTF-8 without splitting a code point.
+                                            let capped = cap_tool_result(result);
                                             tool_obj["result"] = serde_json::Value::String(capped);
                                             tool_obj["is_error"] =
                                                 serde_json::Value::Bool(*is_error);
@@ -344,6 +418,7 @@ pub async fn get_agent_session(
                             "agent_id": agent_id.to_string(),
                             "message_count": 0,
                             "context_window_tokens": 0,
+                            "label": null,
                             "messages": [],
                             "compacted_summary": compacted_summary,
                         })),
@@ -353,7 +428,7 @@ pub async fn get_agent_session(
         }
         Err(e) => {
             tracing::warn!("Session load failed for agent {id}: {e}");
-            ApiErrorResponse::internal(t.t("api-error-session-load-failed"))
+            ApiErrorResponse::internal(err_session_load_failed)
                 .with_code("session_load_failed")
                 .into_response()
         }
@@ -1337,5 +1412,61 @@ pub async fn stop_session(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": scrub_500(&e, &t)})),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+
+    #[tokio::test]
+    async fn history_image_materialization_is_stable_and_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"same image bytes");
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(16));
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let path = temp.path().to_path_buf();
+            let encoded = encoded.clone();
+            let barrier = barrier.clone();
+            tasks.spawn(async move {
+                barrier.wait().await;
+                materialize_history_image(&path, b"session-a", "image/png", &encoded).await
+            });
+        }
+        let mut materialized = Vec::new();
+        while let Some(result) = tasks.join_next().await {
+            materialized.push(result.unwrap().expect("concurrent materialization"));
+        }
+
+        let first = &materialized[0];
+        assert!(materialized
+            .iter()
+            .all(|image| image["file_id"] == first["file_id"]));
+        assert_eq!(std::fs::read_dir(temp.path()).unwrap().count(), 1);
+        let file_id = first["file_id"].as_str().unwrap();
+        assert!(uuid::Uuid::parse_str(file_id).is_ok());
+        assert!(UPLOAD_REGISTRY.contains_key(file_id));
+
+        let other_session =
+            materialize_history_image(temp.path(), b"session-b", "image/png", &encoded)
+                .await
+                .expect("other-session materialization");
+        let other_file_id = other_session["file_id"].as_str().unwrap();
+        assert_ne!(file_id, other_file_id);
+        assert_eq!(std::fs::read_dir(temp.path()).unwrap().count(), 2);
+
+        UPLOAD_REGISTRY.remove(file_id);
+        UPLOAD_REGISTRY.remove(other_file_id);
+    }
+
+    #[test]
+    fn tool_result_cap_is_a_utf8_byte_limit() {
+        let input = "界".repeat(40_000);
+        let capped = cap_tool_result(&input);
+        assert!(capped.len() <= 102_400);
+        assert!(capped.is_char_boundary(capped.len()));
+        assert!(input.starts_with(&capped));
     }
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -104,6 +104,10 @@ async fn start_test_server_with_provider(
             axum::routing::get(routes::get_agent_session),
         )
         .route(
+            "/api/uploads/{file_id}",
+            axum::routing::get(routes::serve_upload),
+        )
+        .route(
             "/api/agents/{id}/sessions/{session_id}/trajectory",
             axum::routing::get(routes::export_session_trajectory),
         )
@@ -1037,6 +1041,11 @@ async fn test_agent_session_empty() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["message_count"], 0);
     assert_eq!(body["messages"].as_array().unwrap().len(), 0);
+    assert!(
+        body.get("label").is_some(),
+        "empty session must include label"
+    );
+    assert!(body["label"].is_null());
 }
 
 /// Regression test for the cross-agent session-read guard added in PR #3071.
@@ -1129,6 +1138,8 @@ memory_write = ["self.*"]
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let error: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(error["error"]["message"], "Invalid session ID");
 
     // Same-agent round-trip: A's id with A's own session_id → 200.
     let resp = client
@@ -1152,6 +1163,73 @@ memory_write = ["self.*"]
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["session_id"].as_str().unwrap(), a_session_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_agent_session_reuses_materialized_history_images() {
+    use base64::Engine as _;
+    use librefang_types::agent::AgentId;
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    let spawned: serde_json::Value = resp.json().await.unwrap();
+    let agent_id: AgentId = spawned["agent_id"].as_str().unwrap().parse().unwrap();
+
+    let substrate = server.state.kernel.memory_substrate();
+    let mut session = substrate.create_session(agent_id).unwrap();
+    session.messages.push(Message {
+        role: Role::User,
+        content: MessageContent::Blocks(vec![ContentBlock::Image {
+            media_type: "image/png".to_string(),
+            data: base64::engine::general_purpose::STANDARD.encode(b"history image"),
+        }]),
+        pinned: false,
+        timestamp: None,
+    });
+    substrate.save_session(&session).unwrap();
+
+    let url = format!(
+        "{}/api/agents/{}/session?session_id={}",
+        server.base_url, agent_id, session.id.0
+    );
+    let first: serde_json::Value = client.get(&url).send().await.unwrap().json().await.unwrap();
+    let second: serde_json::Value = client.get(&url).send().await.unwrap().json().await.unwrap();
+    let first_id = first["messages"][0]["images"][0]["file_id"]
+        .as_str()
+        .unwrap();
+    let second_id = second["messages"][0]["images"][0]["file_id"]
+        .as_str()
+        .unwrap();
+    assert_eq!(first_id, second_id);
+
+    let download = client
+        .get(format!("{}/api/uploads/{first_id}", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(download.status(), StatusCode::OK);
+    assert_eq!(download.bytes().await.unwrap().as_ref(), b"history image");
+
+    let upload_dir = server
+        .state
+        .kernel
+        .config_ref()
+        .channels
+        .effective_file_download_dir();
+    let image_path = upload_dir.join(librefang_types::media::on_disk_name(
+        first_id,
+        "image/png",
+        "",
+    ));
+    assert_eq!(std::fs::read(&image_path).unwrap(), b"history image");
+    std::fs::remove_file(image_path).unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- reuse stable, session-scoped UUID file IDs for inline history images and publish them asynchronously through atomic renames
- keep empty-session response fields consistent, localize malformed session IDs, and enforce the 100 KiB tool-result cap in UTF-8 bytes
- add concurrent materialization and real HTTP download regression coverage

## Verification

- `LIBREFANG_HOME=<empty> cargo test -p librefang-api --lib -- --test-threads=1` (928 passed)
- `cargo test -p librefang-api --lib routes::agents::sessions::tests`
- `cargo test -p librefang-api --test api_integration_test test_agent_session_empty`
- `cargo test -p librefang-api --test api_integration_test test_get_agent_session`
- `cargo clippy -p librefang-api --lib -- -A clippy::nonminimal-bool -D warnings`
- `cargo check --workspace --lib`
- `cargo fmt --all -- --check`
- `git diff --check`