### PR TITLE
fix(api): unbreak main — dropped-translator session guard, the test premise it hid, and the clippy debt behind it

### DIFF
--- a/crates/librefang-api/src/routes/agents/sessions.rs
+++ b/crates/librefang-api/src/routes/agents/sessions.rs
@@ -160,7 +160,12 @@ pub async fn get_agent_session(
         }
     };
     if !super::super::can_access_agent(&state, agent_id, api_user.as_ref()) {
-        return ApiErrorResponse::not_found(t.t("api-error-agent-not-found"))
+        // `err_agent_not_found` rather than a fresh `ErrorTranslator`: the
+        // translator is `!Send` and this handler awaits below, so #6921 moved
+        // it into a block that pre-resolves every message and drops it before
+        // the first await. The move in the registry-miss arm above sits on a
+        // diverging branch, so the binding is still live on this path.
+        return ApiErrorResponse::not_found(err_agent_not_found)
             .with_code("agent_not_found")
             .into_response();
     }

--- a/crates/librefang-api/src/routes/config/system.rs
+++ b/crates/librefang-api/src/routes/config/system.rs
@@ -335,7 +335,11 @@ pub async fn ready(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         (false, false) => "skipped",
     };
 
-    let is_ready = db_ok && !(embedding_required && !embedding_present);
+    // Written as "database ok, and the embedding requirement is satisfied"
+    // rather than negating the failure case: `clippy::nonminimal_bool` rejects
+    // the `!(a && !b)` form, and the positive reading matches the two `checks`
+    // entries reported below.
+    let is_ready = db_ok && (!embedding_required || embedding_present);
     let code = if is_ready {
         StatusCode::OK
     } else {

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -5029,6 +5029,31 @@ async fn test_upload_owner_metadata_survives_registry_miss() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn message_routes_reject_foreign_upload_attachments() {
+    // The agent is authored by Eve on purpose. The owner-scoping guard added in
+    // #6753 runs ahead of attachment resolution in `send_message`, so a caller
+    // who cannot reach the agent at all is turned away with 404
+    // `agent_not_found` (covered by `non_owner_cannot_message_another_users_agent`
+    // in `owner_scoped_routes_integration.rs`) and never reaches the check this
+    // test is about. Eve owning the agent while Alice owns the upload is what
+    // isolates the attachment-ownership boundary.
+    const EVE_MANIFEST: &str = r#"
+name = "eve-agent"
+version = "0.1.0"
+description = "Integration test agent owned by Eve"
+author = "Eve"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent. Reply concisely."
+
+[capabilities]
+tools = ["file_read"]
+memory_read = ["*"]
+memory_write = ["self.*"]
+"#;
+
     let server = start_test_server_with_rbac_users(
         "any-key",
         vec![
@@ -5041,7 +5066,7 @@ async fn message_routes_reject_foreign_upload_attachments() {
     let spawn = client
         .post(format!("{}/api/agents", server.base_url))
         .header("authorization", "Bearer any-key")
-        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .json(&serde_json::json!({"manifest_toml": EVE_MANIFEST}))
         .send()
         .await
         .unwrap();


### PR DESCRIPTION
`main` does not build, and every CI lane on it is red for the same reason. At `120945ae8`:

```
error[E0425]: cannot find value `t` in this scope
   --> crates/librefang-api/src/routes/agents/sessions.rs:163:44
    |
163 |         return ApiErrorResponse::not_found(t.t("api-error-agent-not-found"))
    |                                            ^ not found in this scope
```

All eleven failing jobs on the last push to `main` (`Quality`, `OpenAPI Drift`, `Build / Linux aarch64`, `Test / Unit (lib+bin)`, the four Ubuntu shards, macOS, both Windows shards, and therefore `CI Gate`) trace to that single error, as does the scheduled `Kernel Ignored Tests` run.

## Why it happened

#6753 and #6921 were each green against their own base and merged four seconds apart, #6753 first. Neither result said anything about the combination.

- #6921 owns the scope in `get_agent_session`: `ErrorTranslator` is `!Send` and the handler now awaits `materialize_history_image`, so the translator moved into a block that pre-resolves the four messages and drops it before the first await.
- #6753 adds an owner-scoping guard into that same function, and the guard still called `t.t(...)`.

The two edits land on different lines, so git merges them without a conflict and the result does not compile. This is the exact failure mode described under "Two green PRs can still break `main` together" in `CLAUDE.md`.

## Changes

- `crates/librefang-api/src/routes/agents/sessions.rs` — the guard now uses the pre-resolved `err_agent_not_found`. The binding is still live at that point: the only other use sits in the registry-miss arm above, which diverges, so the move never reaches this path. The four other `t.t(...)` sites in this file (`get_agent_session_context`, `attach_session_stream`, `export_session`, `export_session_trajectory`) each hold their own live translator and were checked one by one rather than assumed.
- `crates/librefang-api/tests/api_integration_test.rs` — repairs the premise of `message_routes_reject_foreign_upload_attachments`, the second failure the compile error was hiding. The test (added by #6922) asserts 403 `upload_access_denied` when a caller attaches an upload owned by someone else, but it drove the request as Eve against a `test`-authored agent. #6753's guard runs ahead of attachment resolution in `send_message`, so Eve is now turned away with 404 `agent_not_found` and the attachment check is never reached — the `left: 404 / right: 403` failure on `Test / Ubuntu (shard 1/4)`. The guard ordering is the authoritative contract: a caller who cannot reach the agent must not learn anything about an upload attached to it. So the stale side is the test's setup. The agent is now authored by Eve while the upload stays owned by Alice, which isolates the attachment-ownership boundary the test is named after; the 404 path it used to hit by accident is already covered deliberately by `non_owner_cannot_message_another_users_agent` in `owner_scoped_routes_integration.rs`.

- `crates/librefang-api/src/routes/config/system.rs` — the third thing the build failure was hiding. `GET /api/ready` computed `db_ok && !(embedding_required && !embedding_present)`, which current stable clippy rejects under `nonminimal_bool` (twice: the whole expression, and the negated inner conjunction). The lint fires on code #6638 landed unchanged, so it is toolchain-bump debt, not a new defect — it stayed invisible because both clippy shapes CI runs sit behind the `cargo build` that has been failing on the E0425. Repairing only the compile error would have turned `Quality` red on the next push to `main` for a different reason. `db_ok && (!embedding_required || embedding_present)` is the same predicate (`!(a && !b)` is `!a || b`) and reads in the same direction as the two `checks` entries in the response body.

Rebased onto `120945ae8` so CI validates the combination that will actually land, rather than the eight-commit-old base the branch was cut from.

No CHANGELOG fragment: the break never reached a release, and the repaired behaviour is what the two merged PRs already describe.

## Verification

```
$ cargo test -p librefang-api --test api_integration_test message_routes_reject_foreign_upload_attachments
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 49s
     Running tests/api_integration_test.rs (target/debug/deps/api_integration_test-0ca63e452d886f2e)

running 1 test
test message_routes_reject_foreign_upload_attachments ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 5.70s
```

Both clippy shapes CI uses, run locally against this branch:

```
$ cargo clippy -p librefang-api --all-targets --all-features -- -D warnings   # PR lane
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.23s
exit 0

$ cargo clippy --workspace --all-targets -- -D warnings                       # main-push lane
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 22s
exit 0
```

The workspace run is what establishes that `config/system.rs` was the *only* accumulated lint in the tree, rather than the first of a series that would keep `main` red one push at a time.

`cargo fmt --check` clean on the touched files; the compile of `librefang-api` that the test run implies is the direct check on the `sessions.rs` line.

On this branch's earlier head, before the clippy commit: `Security`, `OpenAPI Drift`, `Conflict Check` and `Test / Ubuntu` shards 2/4, 3/4 and 4/4 all passed — so nothing outside the three fixes above was broken on `main`.

## Out of scope, raised for a maintainer decision

`crates/librefang-api/src/ws.rs` authenticates the WebSocket upgrade but never calls `can_access_agent`, so a `User`-role caller can open `/api/agents/{someone-elses-agent}/ws` and drive a full LLM turn — the same gap #6753 closed on the HTTP side. It is why the WebSocket sibling of the test above still passes with Eve against a `test`-authored agent. Adding the guard there is a behaviour change with its own blast radius (dashboard clients connecting to agents they do not author), so it is not bundled into a build-repair PR.
