### PR TITLE
fix(kernel): bound MCP summary cache growth

### DIFF
--- a/changelog.d/fixed/6939-bound-mcp-summary-cache.md
+++ b/changelog.d/fixed/6939-bound-mcp-summary-cache.md
@@ -1,0 +1,3 @@
+Bound the rendered MCP summary cache, which grew one entry per distinct allowlist combination for the lifetime of the daemon.
+Agent manifests control the allowlist, so a caller cycling through one-off combinations (or stale generations left behind by config reloads) could grow the cache without limit.
+The cache now caps at 256 distinct entries and clears wholesale before admitting a new key past that cap, while preserving current-generation cache hits and rendered summary content (#6939) (@houko)

--- a/crates/librefang-kernel/src/kernel/prompt_context.rs
+++ b/crates/librefang-kernel/src/kernel/prompt_context.rs
@@ -243,7 +243,7 @@ impl LibreFangKernel {
         summary
     }
 
-    /// Build a compact MCP server/tool summary for the system prompt; caches per allowlist + mcp_generation to skip Mutex and re-render on hit.
+    /// Build a compact MCP server/tool summary for the system prompt; caches per allowlist + mcp_generation to skip tool-lock acquisition and re-rendering on hit.
     pub(crate) fn build_mcp_summary(&self, mcp_allowlist: &[String]) -> String {
         let mcp_gen = self
             .mcp
@@ -252,8 +252,7 @@ impl LibreFangKernel {
         let cache_key = mcp_summary_cache_key(mcp_allowlist);
 
         // Cache hit on the current generation: clone the cached String.
-        if let Some(entry) = self.mcp.mcp_summary_cache.get(&cache_key) {
-            let (cached_gen, cached_str) = entry.value();
+        if let Some((cached_gen, cached_str)) = self.mcp.mcp_summary_cache.lock().get(&cache_key) {
             if *cached_gen == mcp_gen {
                 return cached_str.clone();
             }
@@ -279,9 +278,17 @@ impl LibreFangKernel {
             .unwrap_or_default();
 
         let rendered = render_mcp_summary(&tool_names, &configured_servers, mcp_allowlist);
-        self.mcp
-            .mcp_summary_cache
-            .insert(cache_key, (mcp_gen, rendered.clone()));
+        let mut cache = self.mcp.mcp_summary_cache.lock();
+        if cache.len() >= super::subsystems::mcp::MAX_MCP_SUMMARY_CACHE_ENTRIES
+            && !cache.contains_key(&cache_key)
+        {
+            // Allowlist combinations are caller-controlled through agent
+            // manifests. Drop the derived cache wholesale at its hard cap so
+            // stale generations and one-off combinations cannot grow for the
+            // lifetime of the daemon.
+            cache.clear();
+        }
+        cache.insert(cache_key, (mcp_gen, rendered.clone()));
         rendered
     }
 

--- a/crates/librefang-kernel/src/kernel/subsystems/mcp.rs
+++ b/crates/librefang-kernel/src/kernel/subsystems/mcp.rs
@@ -9,7 +9,6 @@
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use dashmap::DashMap;
 use librefang_extensions::catalog::McpCatalog;
 use librefang_extensions::health::HealthMonitor;
 use librefang_runtime::mcp::McpConnection;
@@ -17,6 +16,8 @@ use librefang_runtime::mcp_oauth::{McpAuthStates, McpOAuthProvider};
 use librefang_types::config::McpServerConfigEntry;
 use librefang_types::tool::ToolDefinition;
 use std::sync::atomic::AtomicU64;
+
+pub(crate) const MAX_MCP_SUMMARY_CACHE_ENTRIES: usize = 256;
 
 /// Focused MCP API.
 pub trait McpSubsystemApi: Send + Sync {
@@ -49,9 +50,9 @@ pub struct McpSubsystem {
     /// MCP tool definitions cache (populated after connections are
     /// established).
     pub(crate) mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
-    /// Rendered MCP summary cache keyed by allowlist + mcp_generation;
-    /// skips Mutex + re-render on hit.
-    pub(crate) mcp_summary_cache: DashMap<String, (u64, String)>,
+    /// Bounded rendered MCP summary cache keyed by allowlist + mcp_generation.
+    pub(crate) mcp_summary_cache:
+        parking_lot::Mutex<std::collections::HashMap<String, (u64, String)>>,
     /// MCP catalog — read-only set of server templates shipped by the
     /// registry. Lock-free reads via `ArcSwap`; writes use `rcu()`.
     pub(crate) mcp_catalog: ArcSwap<McpCatalog>,
@@ -79,7 +80,7 @@ impl McpSubsystem {
             mcp_auth_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             mcp_oauth_provider,
             mcp_tools: std::sync::Mutex::new(Vec::new()),
-            mcp_summary_cache: DashMap::new(),
+            mcp_summary_cache: parking_lot::Mutex::new(std::collections::HashMap::new()),
             mcp_catalog: ArcSwap::from_pointee(mcp_catalog),
             mcp_health,
             effective_mcp_servers: std::sync::RwLock::new(effective_mcp_servers),

--- a/crates/librefang-kernel/src/kernel/subsystems/mcp.rs
+++ b/crates/librefang-kernel/src/kernel/subsystems/mcp.rs
@@ -51,8 +51,16 @@ pub struct McpSubsystem {
     /// established).
     pub(crate) mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
     /// Bounded rendered MCP summary cache keyed by allowlist + mcp_generation.
+    ///
+    /// `BTreeMap`, not `HashMap` (#3298): cached values are the rendered
+    /// strings this crate hands straight to the LLM system prompt, and
+    /// this crate's taboo list bans `HashMap` in any field that ends up
+    /// there. Iteration order is moot here (the cache is only ever
+    /// point-looked-up by key, never iterated to build output), but the
+    /// rule is enforced at the type level so a future caller that *does*
+    /// iterate it can't reintroduce nondeterminism silently.
     pub(crate) mcp_summary_cache:
-        parking_lot::Mutex<std::collections::HashMap<String, (u64, String)>>,
+        parking_lot::Mutex<std::collections::BTreeMap<String, (u64, String)>>,
     /// MCP catalog — read-only set of server templates shipped by the
     /// registry. Lock-free reads via `ArcSwap`; writes use `rcu()`.
     pub(crate) mcp_catalog: ArcSwap<McpCatalog>,
@@ -80,7 +88,7 @@ impl McpSubsystem {
             mcp_auth_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             mcp_oauth_provider,
             mcp_tools: std::sync::Mutex::new(Vec::new()),
-            mcp_summary_cache: parking_lot::Mutex::new(std::collections::HashMap::new()),
+            mcp_summary_cache: parking_lot::Mutex::new(std::collections::BTreeMap::new()),
             mcp_catalog: ArcSwap::from_pointee(mcp_catalog),
             mcp_health,
             effective_mcp_servers: std::sync::RwLock::new(effective_mcp_servers),

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8021,6 +8021,41 @@ fn mcp_summary_cache_key_is_order_independent() {
 }
 
 #[test]
+fn mcp_summary_cache_is_bounded_across_distinct_allowlists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("librefang-mcp-cache-bound-test");
+    std::fs::create_dir_all(home.join("data")).unwrap();
+    let kernel = LibreFangKernel::boot_with_config(KernelConfig {
+        home_dir: home.clone(),
+        data_dir: home.join("data"),
+        ..KernelConfig::default()
+    })
+    .expect("kernel should boot");
+
+    kernel
+        .tools_ref()
+        .lock()
+        .unwrap()
+        .push(librefang_types::tool::ToolDefinition {
+            name: "mcp_server_tool".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+
+    let cap = super::subsystems::mcp::MAX_MCP_SUMMARY_CACHE_ENTRIES;
+    for index in 0..=cap {
+        let _ = kernel.build_mcp_summary(&[format!("server-{index}")]);
+    }
+
+    let cache = kernel.mcp.mcp_summary_cache.lock();
+    assert!(
+        cache.len() <= cap,
+        "caller-controlled allowlists must not grow the cache past {cap} entries"
+    );
+    assert!(cache.contains_key(&format!("server-{cap}")));
+}
+
+#[test]
 fn available_tools_mcp_section_is_sorted_across_connect_orders() {
     // Regression for #3765: connect / hot-reload order of MCP servers must
     // not mutate the LLM tool definition list, otherwise provider prompt


### PR DESCRIPTION
## Summary

- cap the rendered MCP summary cache at 256 distinct allowlist combinations
- clear the derived cache at the cap before admitting a new key, preventing stale generations and one-off agent manifests from growing memory for the daemon lifetime
- preserve current-generation cache hits and MCP summary rendering semantics
- add a regression test that exercises more distinct allowlists than the cap

## Verification

- `cargo test -p librefang-kernel mcp_summary_cache --lib`
- `cargo clippy -p librefang-kernel --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Out of scope

- other cache-growth findings from the repository scan
- changing MCP allowlist semantics or rendered prompt content