### PR TITLE
fix(runtime): use vetted SHA-256 for plugin integrity

### DIFF
--- a/changelog.d/security/6940-plugin-checksum-sha2.md
+++ b/changelog.d/security/6940-plugin-checksum-sha2.md
@@ -1,0 +1,3 @@
+Replace the hand-rolled SHA-256 implementation in the plugin integrity path with the workspace's existing vetted `sha2` crate.
+The hand-rolled version was never audited and carried a stale comment suggesting a future swap to `sha2` that never happened, leaving plugin checksum verification resting on unreviewed cryptographic code.
+The public `sha256_hex` API and its lowercase 64-character hex digest format are unchanged, so no caller or stored checksum is affected (#6940) (@houko)

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -11,6 +11,7 @@
 //! - **Git URL**: clone a git repo into the plugins directory
 
 use librefang_types::config::{PluginManifest, PluginSystemRequirement};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
@@ -439,105 +440,14 @@ pub fn list_plugins() -> Vec<PluginInfo> {
 
 /// Compute a hex-encoded SHA-256 digest of `bytes`.
 pub fn sha256_hex(bytes: &[u8]) -> String {
-    // NOTE: Rust's `DefaultHasher` is NOT cryptographic. We use a simple
-    // hand-rolled SHA-256 here so we don't pull in a new crate. If the project
-    // adds `sha2` in future, swap this implementation out.
-    //
-    // This is a pure-Rust SHA-256 implementation (RFC 6234).
-    const K: [u32; 64] = [
-        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
-        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
-        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
-        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
-        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
-        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
-        0xc67178f2,
-    ];
-
-    let mut h: [u32; 8] = [
-        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
-        0x5be0cd19,
-    ];
-
-    // Pre-processing: padding
-    let bit_len = (bytes.len() as u64).wrapping_mul(8);
-    let mut msg = bytes.to_vec();
-    msg.push(0x80);
-    while msg.len() % 64 != 56 {
-        msg.push(0x00);
-    }
-    msg.extend_from_slice(&bit_len.to_be_bytes());
-
-    // Process each 512-bit (64-byte) block
-    for block in msg.chunks(64) {
-        let mut w = [0u32; 64];
-        for i in 0..16 {
-            w[i] = u32::from_be_bytes([
-                block[i * 4],
-                block[i * 4 + 1],
-                block[i * 4 + 2],
-                block[i * 4 + 3],
-            ]);
-        }
-        for i in 16..64 {
-            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
-            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
-            w[i] = w[i - 16]
-                .wrapping_add(s0)
-                .wrapping_add(w[i - 7])
-                .wrapping_add(s1);
-        }
-        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] =
-            [h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]];
-        for i in 0..64 {
-            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
-            let ch = (e & f) ^ ((!e) & g);
-            let temp1 = hh
-                .wrapping_add(s1)
-                .wrapping_add(ch)
-                .wrapping_add(K[i])
-                .wrapping_add(w[i]);
-            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
-            let maj = (a & b) ^ (a & c) ^ (b & c);
-            let temp2 = s0.wrapping_add(maj);
-            hh = g;
-            g = f;
-            f = e;
-            e = d.wrapping_add(temp1);
-            d = c;
-            c = b;
-            b = a;
-            a = temp1.wrapping_add(temp2);
-        }
-        h[0] = h[0].wrapping_add(a);
-        h[1] = h[1].wrapping_add(b);
-        h[2] = h[2].wrapping_add(c);
-        h[3] = h[3].wrapping_add(d);
-        h[4] = h[4].wrapping_add(e);
-        h[5] = h[5].wrapping_add(f);
-        h[6] = h[6].wrapping_add(g);
-        h[7] = h[7].wrapping_add(hh);
-    }
-
-    format!(
-        "{:08x}{:08x}{:08x}{:08x}{:08x}{:08x}{:08x}{:08x}",
-        h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]
-    )
-}
-
-/// Compute the SHA-256 hex digest of a byte slice (delegates to [`sha256_hex`]).
-fn sha256_hex_of_bytes(data: &[u8]) -> String {
-    sha256_hex(data)
+    format!("{:x}", Sha256::digest(bytes))
 }
 
 /// Verify downloaded plugin bytes against an expected SHA-256 checksum.
 ///
 /// Returns `Ok(())` on match, `Err(message)` on mismatch or parse failure.
 fn verify_checksum(data: &[u8], expected: &str) -> Result<(), String> {
-    let actual = sha256_hex_of_bytes(data);
+    let actual = sha256_hex(data);
     if actual.eq_ignore_ascii_case(expected.trim()) {
         Ok(())
     } else {

--- a/crates/librefang-runtime/src/plugin_manager/tests.rs
+++ b/crates/librefang-runtime/src/plugin_manager/tests.rs
@@ -9,6 +9,36 @@ use super::*;
 use crate::test_env::ENV_LOCK;
 
 #[test]
+fn sha256_hex_matches_standard_vectors_across_padding_boundaries() {
+    let vectors: &[(&[u8], &str)] = &[
+        (
+            b"",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ),
+        (
+            b"abc",
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        ),
+        (
+            &[b'a'; 55],
+            "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318",
+        ),
+        (
+            &[b'a'; 56],
+            "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a",
+        ),
+        (
+            &[b'a'; 64],
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb",
+        ),
+    ];
+
+    for (input, expected) in vectors {
+        assert_eq!(sha256_hex(input), *expected);
+    }
+}
+
+#[test]
 fn test_plugins_dir() {
     let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 


### PR DESCRIPTION
## Summary

- replace the hand-rolled SHA-256 implementation in the plugin integrity path with the existing `sha2` dependency
- preserve the public `sha256_hex` API and lowercase 64-character digest format
- remove the redundant digest wrapper
- add standard vectors covering empty input and SHA-256 padding boundaries

## Verification

- `cargo test -p librefang-runtime sha256_hex_matches_standard_vectors_across_padding_boundaries --lib`
- `cargo test -p librefang-runtime 'plugin_manager::tests::' --lib` (33 passed, 2 ignored)
- `cargo clippy -p librefang-runtime --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Out of scope

- other hand-rolled cryptographic code identified by the repository scan
- changes to plugin checksum formats or registry policy