### PR TITLE
fix(api): make atomic renames durable

### DIFF
--- a/changelog.d/fixed/6942-atomic-write-dir-sync.md
+++ b/changelog.d/fixed/6942-atomic-write-dir-sync.md
@@ -1,0 +1,3 @@
+`atomic_write` fsynced the staged temp file before the rename but never synced the containing directory afterward, so the rename itself was not guaranteed durable.
+A crash between the rename syscall and the next unrelated fsync of that directory could still lose the update on some filesystems, even though the write looked atomic from the caller's side.
+On Unix, the parent directory is now fsynced after the rename so the new directory entry survives a crash (#6942) (@houko)

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -74,10 +74,9 @@ fn hex_val(b: u8) -> Option<u8> {
 
 /// Write `content` to `path` atomically via a sibling temp file + rename.
 ///
-/// The temp file receives a unique name derived from the process ID and a
-/// per-process monotonic counter so concurrent writers never share a staging
-/// file. The file is `sync_all`-ed before the rename. On Unix, the parent
-/// directory is synced after the rename so the new directory entry is durable.
+/// The temp file receives a unique name derived from the process ID and a per-process monotonic counter so concurrent writers never share a staging file.
+/// The file is `sync_all`-ed before the rename.
+/// On Unix, the parent directory is synced after the rename so the new directory entry is durable.
 pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -111,9 +111,16 @@ pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::R
 
     #[cfg(unix)]
     {
-        let parent = path.parent().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing parent directory")
-        })?;
+        // `Path::parent()` returns `Some("")` (not `None`) for a bare
+        // relative filename like `config.toml` — `None` only happens for
+        // `/` or an empty path itself. Map that empty-but-present case to
+        // `.` so we still fsync the actual containing directory instead of
+        // failing `File::open("")` with ENOENT after the rename already
+        // succeeded.
+        let parent = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => std::path::Path::new("."),
+        };
         std::fs::File::open(parent)?.sync_all()?;
     }
 

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -76,8 +76,8 @@ fn hex_val(b: u8) -> Option<u8> {
 ///
 /// The temp file receives a unique name derived from the process ID and a
 /// per-process monotonic counter so concurrent writers never share a staging
-/// file.  The file is `sync_all`-ed before the rename so a power loss between
-/// the two syscalls does not leave a zero-byte file in place of the original.
+/// file. The file is `sync_all`-ed before the rename. On Unix, the parent
+/// directory is synced after the rename so the new directory entry is durable.
 pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -109,7 +109,37 @@ pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::R
         let _ = std::fs::remove_file(&tmp);
         return Err(e);
     }
+
+    #[cfg(unix)]
+    {
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing parent directory")
+        })?;
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod atomic_write_tests {
+    use super::atomic_write;
+
+    #[test]
+    fn replaces_existing_content_and_leaves_no_staging_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, b"old").expect("seed file");
+
+        atomic_write(&path, b"new content").expect("atomic write");
+
+        assert_eq!(std::fs::read(&path).expect("read result"), b"new content");
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read parent")
+            .map(|entry| entry.expect("directory entry").file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("config.toml")]);
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

- fsync the parent directory after the shared API atomic writer renames its staging file on Unix
- propagate directory-open and directory-sync failures instead of reporting a durable write prematurely
- retain the existing Windows behavior, where opening a directory as a file is not portable
- add coverage for replacement semantics and staging-file cleanup

This shared helper backs config, provider, webhook, budget, user, and upload-metadata writes.

## Verification

- `cargo test -p librefang-api atomic_write_tests --lib`
- `cargo clippy -p librefang-api --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Out of scope

- independent atomic-write helpers in other modules/crates
- changing API route behavior or response shapes