### PR TITLE
fix(kernel): make TOML renames durable

### DIFF
--- a/changelog.d/fixed/6948-cron-toml-durable-write.md
+++ b/changelog.d/fixed/6948-cron-toml-durable-write.md
@@ -1,0 +1,2 @@
+Cron script TOML writes opened their staging file with `File::create`, which truncates and silently reuses an existing file of the same name instead of failing loudly on a staging-name collision.
+The staging file is now opened with `create_new` so a collision surfaces as an error rather than being silently overwritten, and the parent directory is fsynced after the atomic rename on Unix so a completed write survives a crash immediately afterward (#6948) (@houko)

--- a/crates/librefang-kernel/src/kernel/cron_script.rs
+++ b/crates/librefang-kernel/src/kernel/cron_script.rs
@@ -169,7 +169,10 @@ pub(super) fn atomic_write_toml(path: &Path, content: &str) -> std::io::Result<(
     tmp.set_file_name(tmp_name);
 
     let write_result = (|| -> std::io::Result<()> {
-        let mut f = std::fs::File::create(&tmp)?;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)?;
         f.write_all(content.as_bytes())?;
         // fsync so the bytes hit disk before we publish via rename;
         // without this a power loss between rename and flush would
@@ -191,6 +194,15 @@ pub(super) fn atomic_write_toml(path: &Path, content: &str) -> std::io::Result<(
         let _ = std::fs::remove_file(&tmp);
         return Err(e);
     }
+
+    #[cfg(unix)]
+    path.parent()
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing parent directory")
+        })
+        .and_then(std::fs::File::open)?
+        .sync_all()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- create kernel TOML staging files exclusively instead of truncating an unexpected existing path
- fsync the parent directory on Unix after publishing a staged TOML file by rename
- preserve the existing unique-name, file-sync, failure-cleanup, and atomic-replace behavior

## Testing

- `cargo test -p librefang-kernel atomic_write_ --lib`
- `cargo clippy -p librefang-kernel --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`