### PR TITLE
fix(memory): surface SQLite row errors

### DIFF
--- a/changelog.d/fixed/6951-surface-sqlite-row-errors.md
+++ b/changelog.d/fixed/6951-surface-sqlite-row-errors.md
@@ -1,0 +1,3 @@
+Memory consolidation and the per-user spend ranking used `.filter_map(|r| r.ok()).collect()` over their SQLite row iterators, which silently dropped any row that failed to decode instead of surfacing the failure.
+A corrupted `agent_id` could make consolidation skip a tenant's memories with no error, and a corrupted usage row could make a user vanish from the spend ranking rather than showing up as a failed query.
+Both call sites now collect into `rusqlite::Result<Vec<_>>` and propagate the decode error (#6951) (@houko)

--- a/crates/librefang-memory/src/consolidation.rs
+++ b/crates/librefang-memory/src/consolidation.rs
@@ -140,7 +140,8 @@ impl ConsolidationEngine {
             let rows = stmt
                 .query_map([], |row| row.get::<_, String>(0))
                 .map_err(LibreFangError::memory)?;
-            rows.filter_map(|r| r.ok()).collect()
+            rows.collect::<rusqlite::Result<Vec<String>>>()
+                .map_err(LibreFangError::memory)?
         };
 
         // One outer transaction wraps every merge in this run so we pay a
@@ -190,8 +191,8 @@ impl ConsolidationEngine {
                     },
                 )
                 .map_err(LibreFangError::memory)?
-                .filter_map(|r| r.ok())
-                .collect();
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(LibreFangError::memory)?;
 
             // Pre-lowercase content once per row. The inner loop is O(N²)
             // and `text_similarity` lowercases its inputs on every call —

--- a/crates/librefang-memory/src/usage.rs
+++ b/crates/librefang-memory/src/usage.rs
@@ -955,7 +955,9 @@ impl UsageStore {
                 })
             })
             .map_err(LibreFangError::memory)?;
-        let out: Vec<UserSpendRanking> = rows.filter_map(|r| r.ok()).collect();
+        let out = rows
+            .collect::<rusqlite::Result<Vec<UserSpendRanking>>>()
+            .map_err(LibreFangError::memory)?;
         Ok(out)
     }
 
@@ -1830,5 +1832,23 @@ mod tests {
         assert_eq!(ranking[1].user_id, alice.to_string());
         assert!((ranking[0].daily_cost_usd - 12.5).abs() < 1e-9);
         assert!((ranking[1].daily_cost_usd - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_user_ranking_surfaces_row_decode_errors() {
+        let store = setup();
+        let conn = store.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, user_id) \
+             VALUES ('bad-ranking-row', 'agent', datetime('now'), 'model', 'provider', 0, 0, 1.0, 0, 0, X'80')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(
+            store.query_user_ranking(Some(10)).is_err(),
+            "malformed ranking rows must fail the query instead of disappearing"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- propagate per-row SQLite decode failures from user spend rankings instead of silently omitting users
- fail memory consolidation when agent IDs or candidate rows cannot be decoded
- add a regression test proving a malformed ranking row surfaces as an error

## Testing

- `cargo test -p librefang-memory test_user_ranking_surfaces_row_decode_errors --lib`
- `cargo test -p librefang-memory test_user_ranking_excludes_anonymous_and_orders_by_daily --lib`
- `cargo clippy -p librefang-memory --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`