### PR TITLE
fix(api): preserve budget serialization errors

### DIFF
--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -336,7 +336,7 @@ pub async fn budget_status(State(state): State<Arc<AppState>>) -> impl IntoRespo
         .kernel
         .metering_ref()
         .budget_status(&state.kernel.budget_config());
-    Json(serde_json::to_value(&status).unwrap_or_default())
+    Json(status)
 }
 
 /// PUT /api/budget — Update global budget limits and persist to `config.toml`.
@@ -541,7 +541,7 @@ pub async fn update_budget(
     );
 
     let status = state.kernel.metering_ref().budget_status(&new_budget);
-    Json(serde_json::to_value(&status).unwrap_or_default()).into_response()
+    Json(status).into_response()
 }
 
 /// Failure modes for [`persist_budget`].


### PR DESCRIPTION
## Summary

- return typed `Json<BudgetStatus>` responses from budget GET and successful PUT handlers
- stop converting serialization failures into successful `null` responses through `unwrap_or_default()`
- preserve the existing budget response schema

## Testing

- `cargo test -p librefang-api --test budget_routes_test budget_status_returns_configured_limits_with_zero_spend`
- `cargo test -p librefang-api --test budget_routes_test budget_put_then_get_reflects_update`
- `cargo clippy -p librefang-api --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`