### PR TITLE
chore(cargo): inherit workspace package metadata

### DIFF
--- a/crates/librefang-acp/Cargo.toml
+++ b/crates/librefang-acp/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-acp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Agent Client Protocol (ACP) adapter for LibreFang — embeds LibreFang agents in Zed/VSCode/JetBrains via stdio JSON-RPC (#3313)"
 
 [features]

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-api"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "HTTP/WebSocket API server for the LibreFang Agent OS daemon"
 readme = "README.md"
 

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-channels"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Channel Bridge Layer — pluggable messaging integrations for LibreFang"
 readme = "README.md"
 

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "CLI tool for the LibreFang Agent OS"
 readme = "README.md"
 

--- a/crates/librefang-desktop/Cargo.toml
+++ b/crates/librefang-desktop/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-desktop"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Native desktop application for the LibreFang Agent OS (Tauri 2.0)"
 
 [build-dependencies]

--- a/crates/librefang-extensions/Cargo.toml
+++ b/crates/librefang-extensions/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-extensions"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Extension & integration system for LibreFang — one-click MCP server setup, credential vault, OAuth2 PKCE"
 
 [dependencies]

--- a/crates/librefang-hands/Cargo.toml
+++ b/crates/librefang-hands/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-hands"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Hands system for LibreFang — curated autonomous capability packages"
 
 [dependencies]

--- a/crates/librefang-http/Cargo.toml
+++ b/crates/librefang-http/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-http"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Shared HTTP client builder with proxy and TLS fallback for LibreFang"
 
 [dependencies]

--- a/crates/librefang-import/Cargo.toml
+++ b/crates/librefang-import/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-import"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Import engine for migrating from other agent frameworks into LibreFang"
 
 [dependencies]

--- a/crates/librefang-kernel-handle/Cargo.toml
+++ b/crates/librefang-kernel-handle/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-kernel-handle"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "KernelHandle trait for in-process callers into the LibreFang kernel"
 
 [dependencies]

--- a/crates/librefang-kernel-metering/Cargo.toml
+++ b/crates/librefang-kernel-metering/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-kernel-metering"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Cost metering and quota enforcement for the LibreFang kernel"
 
 [dependencies]

--- a/crates/librefang-kernel-router/Cargo.toml
+++ b/crates/librefang-kernel-router/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-kernel-router"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Hand/Template routing engine for the LibreFang kernel"
 
 [dependencies]

--- a/crates/librefang-kernel/Cargo.toml
+++ b/crates/librefang-kernel/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-kernel"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Core kernel for the LibreFang Agent OS"
 readme = "README.md"
 

--- a/crates/librefang-llm-driver/Cargo.toml
+++ b/crates/librefang-llm-driver/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-llm-driver"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "LLM driver trait and shared types for LibreFang"
 
 [dependencies]

--- a/crates/librefang-llm-drivers/Cargo.toml
+++ b/crates/librefang-llm-drivers/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-llm-drivers"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Concrete LLM provider drivers (anthropic, openai, gemini, …) implementing the librefang-llm-driver trait"
 readme = "README.md"
 

--- a/crates/librefang-memory-wiki/Cargo.toml
+++ b/crates/librefang-memory-wiki/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-memory-wiki"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Durable markdown knowledge vault for the LibreFang Agent OS — provenance frontmatter + Obsidian-friendly export. See issue #3329."
 
 [dependencies]

--- a/crates/librefang-memory/Cargo.toml
+++ b/crates/librefang-memory/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-memory"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Memory substrate for the LibreFang Agent OS"
 readme = "README.md"
 

--- a/crates/librefang-rl-export/Cargo.toml
+++ b/crates/librefang-rl-export/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-rl-export"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Long-horizon RL rollout trajectory exporter (W&B / Tinker / Atropos integration surface)"
 
 [dependencies]

--- a/crates/librefang-runtime-audit/Cargo.toml
+++ b/crates/librefang-runtime-audit/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-runtime-audit"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Tamper-evident audit log for LibreFang runtime (refs #3710 Phase 1)"
 readme = "README.md"
 

--- a/crates/librefang-runtime-mcp/Cargo.toml
+++ b/crates/librefang-runtime-mcp/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-runtime-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "MCP (Model Context Protocol) client for LibreFang runtime"
 
 [dependencies]

--- a/crates/librefang-runtime-media/Cargo.toml
+++ b/crates/librefang-runtime-media/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-runtime-media"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Media generation drivers (TTS, image, video, music) for LibreFang (refs #3710 Phase 1)"
 readme = "README.md"
 

--- a/crates/librefang-runtime-sandbox-docker/Cargo.toml
+++ b/crates/librefang-runtime-sandbox-docker/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-runtime-sandbox-docker"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Docker sandbox for tool exec (refs #3710 Phase 1)"
 readme = "README.md"
 

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-runtime"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Agent runtime and execution environment for LibreFang"
 readme = "README.md"
 

--- a/crates/librefang-skills/Cargo.toml
+++ b/crates/librefang-skills/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-skills"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Skill system for LibreFang — registry, loader, marketplace, and OpenClaw compatibility"
 
 [dependencies]

--- a/crates/librefang-subprocess/Cargo.toml
+++ b/crates/librefang-subprocess/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-subprocess"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Persistent JSON-over-stdio subprocess transport shared by LibreFang's sidecar bridges"
 readme = "README.md"
 

--- a/crates/librefang-telemetry/Cargo.toml
+++ b/crates/librefang-telemetry/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-telemetry"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "OpenTelemetry + Prometheus metrics instrumentation for LibreFang"
 
 [dependencies]

--- a/crates/librefang-testing/Cargo.toml
+++ b/crates/librefang-testing/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-testing"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Test infrastructure: mock kernel, mock LLM driver and API route test utilities"
 
 [dependencies]

--- a/crates/librefang-types/Cargo.toml
+++ b/crates/librefang-types/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-types"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Core types and traits for the LibreFang Agent OS"
 readme = "README.md"
 

--- a/crates/librefang-wire/Cargo.toml
+++ b/crates/librefang-wire/Cargo.toml
@@ -3,6 +3,8 @@ name = "librefang-wire"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "LibreFang Protocol (OFP) — agent-to-agent networking"
 
 [dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,6 +3,8 @@ name = "xtask"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Build automation for the LibreFang workspace"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- inherit the workspace repository URL in all 30 workspace packages
- inherit the workspace MSRV in all 30 workspace packages
- keep the values centralized in `[workspace.package]`

## Testing
- `cargo metadata --no-deps --format-version 1`
- verified all 30 metadata records expose repository `https://github.com/librefang/librefang` and rust version `1.94.1`
- `cargo fmt --all -- --check`
- `git diff --check`