### PR TITLE
ci: pin cargo-deny action to a commit

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
         run: cargo xtask compare-build-timings
       - name: Upload timing snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build-timings-${{ github.sha }}
           path: bench-results/build-timings/

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -46,8 +46,7 @@ jobs:
           - bans licenses sources
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      # Pin third-party actions to immutable commits; keep the release tag in
-      # the comment so dependency tooling can still identify the version.
+      # Pin third-party actions to immutable commits; keep the release tag in the comment so dependency tooling can still identify the version.
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -46,9 +46,8 @@ jobs:
           - bans licenses sources
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      # Pin to a SHA after the first green run on main — see follow-up note
-      # in the umbrella issue (#3305). Tag-pinning is acceptable for the
-      # initial roll-out so the action's own auto-update path keeps working.
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      # Pin third-party actions to immutable commits; keep the release tag in
+      # the comment so dependency tooling can still identify the version.
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           command: check ${{ matrix.checks }}

--- a/changelog.d/security/6958-pin-build-timings-upload-artifact.md
+++ b/changelog.d/security/6958-pin-build-timings-upload-artifact.md
@@ -1,0 +1,2 @@
+The `build-timings` workflow still referenced `actions/upload-artifact` by the mutable `v4` tag, which is exactly the supply-chain gap this PR's sibling change to `cargo-deny.yml` was closing.
+It now pins to the same immutable commit already used for `v4` elsewhere in the workflow set (`coverage.yml`), keeping the tag in a trailing comment for readability (#6958) (@houko)

--- a/changelog.d/security/6958-pin-cargo-deny-action.md
+++ b/changelog.d/security/6958-pin-cargo-deny-action.md
@@ -1,0 +1,2 @@
+The `cargo-deny` CI job pinned `EmbarkStudios/cargo-deny-action` to the mutable `v2` tag, so a compromised or repointed tag on that action would run inside CI with no additional review.
+The workflow now pins to an immutable commit SHA, keeping the `v2` release tag in a trailing comment for readability (#6958) (@houko)


### PR DESCRIPTION
## Summary
- pin `EmbarkStudios/cargo-deny-action` to the immutable commit behind its `v2` tag
- retain the release tag as a comment for dependency update tooling
- remove the stale initial-rollout comment that explicitly deferred SHA pinning

## Testing
- verified every `.github/workflows` `uses:` reference is now a 40-character commit SHA
- `git diff --check`