### PR TITLE
fix(ci): paginate issue automation queries

### DIFF
--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -20,8 +20,9 @@ jobs:
           CUTOFF=$(date -u -d '14 days ago' +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -v-14d +%Y-%m-%dT00:00:00Z)
 
           # Find assigned issues with no activity for 14 days
-          gh api "repos/$REPO/issues?state=open&per_page=100&since=2000-01-01T00:00:00Z" --jq '
-            [.[] | select(.assignees | length > 0) | select(.pull_request == null) |
+          gh api --paginate --slurp \
+            "repos/$REPO/issues?state=open&per_page=100&since=2000-01-01T00:00:00Z" --jq '
+            [flatten[] | select(.assignees | length > 0) | select(.pull_request == null) |
             {number, title, updated_at, assignee: .assignees[0].login}]
           ' 2>/dev/null | jq -c '.[]' | while read -r line; do
             NUMBER=$(echo "$line" | jq -r '.number')

--- a/.github/workflows/issue-pr-link.yml
+++ b/.github/workflows/issue-pr-link.yml
@@ -58,7 +58,7 @@ jobs:
                   core.info(`Issue #${num}: added "${LABEL}"`);
                 } else if (pr.state === 'closed' && !pr.merged && hasLabel) {
                   // PR closed without merge — check if any other open PR links this issue
-                  const { data: prs } = await github.rest.pulls.list({
+                  const prs = await github.paginate(github.rest.pulls.list, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     state: 'open',

--- a/changelog.d/fixed/6959-issue-workflow-pagination.md
+++ b/changelog.d/fixed/6959-issue-workflow-pagination.md
@@ -1,0 +1,2 @@
+Paginate the GitHub API queries in the issue-inactive and issue-pr-link workflows, which previously only read the first page of results.
+A repository with more than 100 open assigned issues could skip inactive-issue reminders for issues past the first page, and a repository with more than 100 open pull requests could have `has-pr` incorrectly stripped from an issue that a later-page PR still linked (#6959) (@houko)


### PR DESCRIPTION
## Summary
- paginate and combine every open-issue page before selecting inactive assignments
- paginate every open PR before deciding a closed PR was the issue’s last link
- preserve the existing 100-item page size while removing the first-page correctness limit

## Testing
- exercised the slurped multi-page jq filter with representative page arrays
- verified the PR query uses `github.paginate`
- `git diff --check`

`actionlint` was not available locally.