### PR TITLE
fix(deploy): require auth in Fly template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3047,9 +3047,8 @@ jobs:
           ref: ${{ env.RELEASE_REF }}
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
       - name: Deploy public demo
-        # This job owns the intentionally unauthenticated official demo. Keep
-        # that exception out of fly.toml so user deployments remain secure by
-        # default and must explicitly provision authentication.
+        # This job owns the intentionally unauthenticated official demo.
+        # Keep that exception out of fly.toml so user deployments remain secure by default and must explicitly provision authentication.
         run: >-
           flyctl deploy --remote-only --config deploy/fly/fly.toml
           --env LIBREFANG_ALLOW_NO_AUTH=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3046,8 +3046,13 @@ jobs:
         with:
           ref: ${{ env.RELEASE_REF }}
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
-      - name: Deploy
-        run: flyctl deploy --remote-only --config deploy/fly/fly.toml
+      - name: Deploy public demo
+        # This job owns the intentionally unauthenticated official demo. Keep
+        # that exception out of fly.toml so user deployments remain secure by
+        # default and must explicitly provision authentication.
+        run: >-
+          flyctl deploy --remote-only --config deploy/fly/fly.toml
+          --env LIBREFANG_ALLOW_NO_AUTH=1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/changelog.d/security/6963-fly-auth-default.md
+++ b/changelog.d/security/6963-fly-auth-default.md
@@ -1,0 +1,3 @@
+Require authentication by default in the reusable Fly.io deploy template.
+  `deploy/fly/fly.toml` previously shipped `LIBREFANG_ALLOW_NO_AUTH=1` unconditionally, so every deployment derived from the template inherited the official demo's intentionally open auth posture, not just the demo itself.
+  The one-command deploy script now generates a 256-bit `LIBREFANG_API_KEY` and imports it as a Fly secret before the app's first boot, and the official public demo's unauthenticated exception moved into its own release CI job rather than the shared template (#6963) (@houko)

--- a/deploy/fly/deploy.sh
+++ b/deploy/fly/deploy.sh
@@ -67,7 +67,11 @@ flyctl volumes create librefang_data \
   --size 1 \
   --yes
 
-# --- 6. Set secrets (optional) ---
+# --- 6. Set authentication and provider secrets ---
+LIBREFANG_ACCESS_KEY=$(openssl rand -hex 32)
+printf 'LIBREFANG_API_KEY=%s\n' "$LIBREFANG_ACCESS_KEY" \
+  | flyctl secrets import --app "$APP_NAME"
+
 PROVIDER_NAMES=(
   "OpenAI"
   "Anthropic"
@@ -194,7 +198,10 @@ ok "LibreFang is live!"
 echo ""
 echo "  Dashboard:  $APP_URL"
 echo "  API:        $APP_URL/api/health"
+echo "  API key:    $LIBREFANG_ACCESS_KEY"
 echo "  Manage:     flyctl dashboard --app $APP_NAME"
+echo ""
+warn "Save the API key now; it is stored as a Fly secret and cannot be read back."
 echo ""
 echo "  To add or change API keys later:"
 echo "    flyctl secrets set <PROVIDER>_API_KEY=your-key --app $APP_NAME"

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -7,8 +7,8 @@ image = "ghcr.io/librefang/librefang:latest"
 [env]
   LIBREFANG_HOME = "/data"
   LIBREFANG_LISTEN = "0.0.0.0:4545"
-  # Authentication is required for this public bind. The one-command deploy
-  # script provisions LIBREFANG_API_KEY as a Fly secret before first boot.
+  # Authentication is required for this public bind.
+  # The one-command deploy script provisions LIBREFANG_API_KEY as a Fly secret before first boot.
 
 [http_service]
   internal_port = 4545

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -7,8 +7,8 @@ image = "ghcr.io/librefang/librefang:latest"
 [env]
   LIBREFANG_HOME = "/data"
   LIBREFANG_LISTEN = "0.0.0.0:4545"
-  # Public live demo: intentionally open. Replace with LIBREFANG_API_KEY for private deployments.
-  LIBREFANG_ALLOW_NO_AUTH = "1"
+  # Authentication is required for this public bind. The one-command deploy
+  # script provisions LIBREFANG_API_KEY as a Fly secret before first boot.
 
 [http_service]
   internal_port = 4545


### PR DESCRIPTION
## Summary
- remove the unauthenticated public-bind default from the reusable Fly template
- generate a 256-bit API key and import it as a Fly secret before the one-command deployment’s first boot
- print the generated key once with an explicit save warning
- keep the official public demo exception explicit and scoped to its release CI job

## Testing
- `bash -n deploy/fly/deploy.sh`
- verified `deploy/fly/fly.toml` contains no `LIBREFANG_ALLOW_NO_AUTH` assignment
- verified the deploy script provisions `LIBREFANG_API_KEY` before `flyctl deploy`
- `git diff --check`