### PR TITLE
fix(deploy): restrict GCP network exposure

### DIFF
--- a/changelog.d/security/6964-gcp-deploy-network-exposure.md
+++ b/changelog.d/security/6964-gcp-deploy-network-exposure.md
@@ -1,0 +1,2 @@
+The GCP Terraform deploy opened SSH and the LibreFang dashboard/API firewall rules to `0.0.0.0/0`, and cloud-init still set the stale `LIBREFANG_BIND` variable instead of the supported `LIBREFANG_LISTEN`, leaving the public listener with no bearer key configured.
+Both firewall rules now require an operator-supplied `allowed_source_cidr`, with `0.0.0.0/0` and `::/0` rejected at plan time, and a required 32-character-minimum `LIBREFANG_API_KEY` is generated and wired through cloud-init so the API enforces bearer authentication (#6964) (@houko)

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -19,7 +19,10 @@ gcloud auth application-default login
 
 # Configure
 cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars with your project_id and API keys
+# Edit terraform.tfvars with your project_id, a restricted source CIDR,
+# a generated LibreFang API key, and provider keys
+# Current public IPv4: curl -4 https://ifconfig.me
+# API key:            openssl rand -hex 32
 
 # Deploy (~2 minutes)
 terraform init
@@ -34,7 +37,8 @@ Terraform will output:
 
 ```bash
 # Wait ~1 minute for cloud-init to finish, then:
-curl http://<external_ip>:4545/api/health
+curl -H "Authorization: Bearer <librefang_api_key>" \
+  http://<external_ip>:4545/api/health
 ```
 
 ## Teardown
@@ -57,7 +61,8 @@ terraform destroy
 │  │   :4545 ← dashboard/API  │  │
 │  └───────────────────────────┘  │
 │                                 │
-│  Firewall: SSH(22) + HTTP(4545) │
+│  Firewall: SSH(22) + API(4545)  │
+│  restricted to your source CIDR │
 └─────────────────────────────────┘
 ```
 

--- a/deploy/gcp/cloud-init.yml.tpl
+++ b/deploy/gcp/cloud-init.yml.tpl
@@ -25,7 +25,8 @@ write_files:
       Type=simple
       User=librefang
       Environment=LIBREFANG_HOME=/data
-      Environment=LIBREFANG_BIND=0.0.0.0:4545
+      Environment=LIBREFANG_LISTEN=0.0.0.0:4545
+      Environment=LIBREFANG_API_KEY=${librefang_api_key}
       Environment=GROQ_API_KEY=${groq_api_key}
       Environment=OPENAI_API_KEY=${openai_api_key}
       Environment=ANTHROPIC_API_KEY=${anthropic_api_key}

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "allow_ssh" {
     ports    = ["22"]
   }
 
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = [var.allowed_source_cidr]
   target_tags   = ["librefang"]
 }
 
@@ -51,7 +51,7 @@ resource "google_compute_firewall" "allow_http" {
     ports    = ["4545"]
   }
 
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = [var.allowed_source_cidr]
   target_tags   = ["librefang"]
 }
 
@@ -79,6 +79,7 @@ resource "google_compute_instance" "librefang" {
     ssh-keys  = "librefang:${file(pathexpand(var.ssh_pub_key_path))}"
     user-data = templatefile("${path.module}/cloud-init.yml.tpl", {
       librefang_version = var.librefang_version
+      librefang_api_key = var.librefang_api_key
       groq_api_key      = var.groq_api_key
       openai_api_key    = var.openai_api_key
       anthropic_api_key = var.anthropic_api_key

--- a/deploy/gcp/terraform.tfvars.example
+++ b/deploy/gcp/terraform.tfvars.example
@@ -1,6 +1,13 @@
 # Required
 project_id = "my-gcp-project-id"
 
+# Restrict both SSH and the dashboard/API to your current public IPv4 address.
+# Find it with: curl -4 https://ifconfig.me
+allowed_source_cidr = "203.0.113.10/32"
+
+# Generate with: openssl rand -hex 32
+librefang_api_key = "replace-with-a-random-64-character-hex-key"
+
 # Optional (defaults shown)
 # region           = "us-central1"
 # zone             = "us-central1-a"

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -21,6 +21,29 @@ variable "ssh_pub_key_path" {
   default     = "~/.ssh/id_rsa.pub"
 }
 
+variable "allowed_source_cidr" {
+  description = "Trusted IPv4 CIDR allowed to reach SSH and LibreFang (for example, 203.0.113.10/32)"
+  type        = string
+
+  validation {
+    condition = can(cidrhost(var.allowed_source_cidr, 0)) &&
+      var.allowed_source_cidr != "0.0.0.0/0" &&
+      var.allowed_source_cidr != "::/0"
+    error_message = "allowed_source_cidr must be a valid restricted CIDR; public 0.0.0.0/0 and ::/0 are forbidden."
+  }
+}
+
+variable "librefang_api_key" {
+  description = "Bearer key required to access the public LibreFang listener"
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.librefang_api_key) >= 32
+    error_message = "librefang_api_key must contain at least 32 characters."
+  }
+}
+
 variable "librefang_version" {
   description = "LibreFang release tag (e.g. v0.4.2-20260314), or 'latest'"
   type        = string

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -26,7 +26,7 @@ variable "allowed_source_cidr" {
   type        = string
 
   validation {
-    condition = can(cidrhost(var.allowed_source_cidr, 0)) &&
+    condition     = can(cidrhost(var.allowed_source_cidr, 0)) &&
       var.allowed_source_cidr != "0.0.0.0/0" &&
       var.allowed_source_cidr != "::/0"
     error_message = "allowed_source_cidr must be a valid restricted CIDR; public 0.0.0.0/0 and ::/0 are forbidden."

--- a/docs/src/app/getting-started/page.mdx
+++ b/docs/src/app/getting-started/page.mdx
@@ -374,7 +374,8 @@ Deploy on GCP always-free tier (e2-micro). See [deploy/gcp/README.md](https://gi
 ```bash
 cd deploy/gcp
 cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars with your project_id and API keys
+# Edit terraform.tfvars with your project_id, a restricted source CIDR,
+# a generated LibreFang API key, and provider keys
 terraform init && terraform apply
 ```
 

--- a/docs/src/app/zh/getting-started/page.mdx
+++ b/docs/src/app/zh/getting-started/page.mdx
@@ -373,7 +373,8 @@ curl -sL https://raw.githubusercontent.com/librefang/librefang/main/deploy/fly/d
 ```bash
 cd deploy/gcp
 cp terraform.tfvars.example terraform.tfvars
-# 编辑 terraform.tfvars，填入 project_id 和 API keys
+# 编辑 terraform.tfvars，填入 project_id、限制访问的来源 CIDR、
+# 生成的 LibreFang API key，以及各服务商的 API keys
 terraform init && terraform apply
 ```
 


### PR DESCRIPTION
## Summary
- require a restricted source CIDR for both SSH and the LibreFang API firewall rules
- reject universal IPv4 and IPv6 source ranges during Terraform planning
- require a 32-character-or-longer LibreFang bearer key and pass it to cloud-init
- replace the stale `LIBREFANG_BIND` variable with the supported `LIBREFANG_LISTEN` variable
- document authenticated health checks and key/CIDR generation

## Testing
- verified cloud-init template placeholders exactly match the variables passed by `templatefile`
- verified no GCP firewall rule retains `0.0.0.0/0` and no `LIBREFANG_BIND` reference remains
- `git diff --check`

Terraform CLI was not installed locally, so `terraform validate` could not be run.