### PR TITLE
fix(dashboard): surface dev proxy errors

### DIFF
--- a/changelog.d/fixed/6965-dashboard-proxy-errors.md
+++ b/changelog.d/fixed/6965-dashboard-proxy-errors.md
@@ -1,0 +1,3 @@
+Restore Vite's default dev-server proxy error logging, which a custom logger and a set of no-op `error` handlers on the `/api` proxy, its outgoing request, and its incoming response were silently swallowing.
+A backend that was down or unreachable during `npm run dev` produced no diagnostic output at all, making the failure look like a hang instead of a connection error.
+The WebSocket (`ws: true`) and five-minute proxy timeout behavior are unchanged (#6965) (@houko)

--- a/crates/librefang-api/dashboard/vite.config.ts
+++ b/crates/librefang-api/dashboard/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, createLogger } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath } from "node:url";
@@ -7,13 +7,6 @@ import { resolve, dirname } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const reactRoot = resolve(__dirname, "node_modules/react");
 const reactDomRoot = resolve(__dirname, "node_modules/react-dom");
-
-const logger = createLogger();
-const origError = logger.error.bind(logger);
-logger.error = (msg, opts) => {
-  if (typeof msg === "string" && msg.includes("proxy error")) return;
-  origError(msg, opts);
-};
 
 // Every React-consuming dep MUST be pre-bundled up-front so Vite doesn't
 // re-optimize mid-session when a lazy route first pulls one. Re-optimization
@@ -44,7 +37,6 @@ const SINGLETON_DEPS = [
 ];
 
 export default defineConfig({
-  customLogger: logger,
   plugins: [react(), tailwindcss()],
   base: "/dashboard/",
   resolve: {
@@ -103,13 +95,6 @@ export default defineConfig({
         ws: true,
         timeout: 300_000,
         proxyTimeout: 300_000,
-        configure: (proxy) => {
-          type Emitter = { on(event: string, fn: (...args: never[]) => void): void };
-          const p = proxy as unknown as Emitter;
-          p.on("error", () => {});
-          p.on("proxyReq", (proxyReq: Emitter) => { proxyReq.on("error", () => {}); });
-          p.on("proxyRes", (proxyRes: Emitter) => { proxyRes.on("error", () => {}); });
-        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- restore Vite’s default proxy error logging
- remove no-op proxy, request, and response error handlers
- preserve the existing WebSocket and five-minute timeout behavior

## Testing
- verified no custom logger or empty proxy error handler remains in `vite.config.ts`
- `git diff --check`

The worktree had no dashboard `node_modules`. Reusing another worktree’s TypeScript binary could not resolve dependencies relative to this worktree, so a clean typecheck was not available; the change only removes custom logger/event-handler code.