### PR TITLE
fix(audit): fail integrity checks on row load errors

### DIFF
--- a/changelog.d/fixed/6968-audit-row-load-errors.md
+++ b/changelog.d/fixed/6968-audit-row-load-errors.md
@@ -1,0 +1,2 @@
+The audit trail's boot-time integrity check verified as intact even when a row failed to decode from SQLite, because the loader silently skipped the malformed row instead of treating the load as incomplete.
+`AuditLog::with_db` now records the first load error it hits — a bad connection, a failed query, or a row that fails to decode — and `verify_integrity` fails closed whenever one is present, so a partially loaded chain never reports as verified (#6968) (@houko)

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -397,6 +397,10 @@ pub struct AuditLog {
     /// repopulates the full window. Every mutation and read happens under
     /// the `entries` mutex, so `Relaxed` ordering is sufficient.
     persisted_rows: AtomicUsize,
+    /// Any failure encountered while reloading persisted rows. A partially
+    /// decoded audit trail must never verify as intact merely because the
+    /// malformed row was skipped by the SQLite iterator.
+    load_error: Mutex<Option<String>>,
 }
 
 /// Per-trim summary returned by [`AuditLog::trim`].
@@ -445,6 +449,7 @@ impl AuditLog {
             chain_anchor: Mutex::new(None),
             max_in_memory_entries: AtomicUsize::new(0),
             persisted_rows: AtomicUsize::new(0),
+            load_error: Mutex::new(None),
         }
     }
 
@@ -613,60 +618,92 @@ impl AuditLog {
     pub fn with_db(pool: Pool<SqliteConnectionManager>) -> Self {
         let mut entries = Vec::new();
         let mut tip = "0".repeat(64);
+        let mut load_error = None;
+        let mut persisted_count = 0;
 
         // Load existing entries from database. Schema v22 added the
         // `user_id` / `channel` columns; rows persisted before that
         // migration return NULL for both, which deserialises to `None`
         // and keeps the original hash intact (the hash function omits
         // absent fields, see `compute_entry_hash`).
-        if let Ok(db) = pool.get() {
-            let result = db.prepare(
+        match pool.get() {
+            Ok(db) => {
+                let result = db.prepare(
                 "SELECT seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash FROM audit_entries ORDER BY seq ASC",
             );
-            if let Ok(mut stmt) = result {
-                let rows = stmt.query_map([], |row| {
-                    let action_str: String = row.get(3)?;
-                    // Decode via `FromStr` (exhaustive over every variant).
-                    // A genuinely unknown string means the row was written by
-                    // a newer daemon whose enum this binary does not know; we
-                    // log it by name rather than silently coercing, because
-                    // any coercion recomputes a different `action.to_string()`
-                    // than the persisted one and would trip `verify_integrity`
-                    // with a false hash mismatch on every subsequent boot.
-                    let action = action_str.parse::<AuditAction>().unwrap_or_else(|e| {
-                        tracing::warn!(
-                            seq = row.get::<_, i64>(0).unwrap_or_default(),
-                            "Audit reload hit {e}; retaining the row but its hash \
+                match result {
+                    Ok(mut stmt) => {
+                        let rows = stmt.query_map([], |row| {
+                            let action_str: String = row.get(3)?;
+                            // Decode via `FromStr` (exhaustive over every variant).
+                            // A genuinely unknown string means the row was written by
+                            // a newer daemon whose enum this binary does not know; we
+                            // log it by name rather than silently coercing, because
+                            // any coercion recomputes a different `action.to_string()`
+                            // than the persisted one and would trip `verify_integrity`
+                            // with a false hash mismatch on every subsequent boot.
+                            let action = action_str.parse::<AuditAction>().unwrap_or_else(|e| {
+                                tracing::warn!(
+                                    seq = row.get::<_, i64>(0).unwrap_or_default(),
+                                    "Audit reload hit {e}; retaining the row but its hash \
                              will not recompute until this binary is upgraded to a \
                              version that knows the action"
-                        );
-                        AuditAction::ToolInvoke
-                    });
-                    let seq_raw: i64 = row.get(0)?;
-                    let seq = u64::try_from(seq_raw)
-                        .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, seq_raw))?;
-                    let user_id_str: Option<String> = row.get(6)?;
-                    let user_id = user_id_str.as_deref().and_then(|s| s.parse().ok());
-                    let channel: Option<String> = row.get(7)?;
-                    Ok(AuditEntry {
-                        seq,
-                        timestamp: row.get(1)?,
-                        agent_id: row.get(2)?,
-                        action,
-                        detail: row.get(4)?,
-                        outcome: row.get(5)?,
-                        user_id,
-                        channel,
-                        prev_hash: row.get(8)?,
-                        hash: row.get(9)?,
-                    })
-                });
-                if let Ok(rows) = rows {
-                    for entry in rows.flatten() {
-                        tip = entry.hash.clone();
-                        entries.push(entry);
+                                );
+                                AuditAction::ToolInvoke
+                            });
+                            let seq_raw: i64 = row.get(0)?;
+                            let seq = u64::try_from(seq_raw).map_err(|_| {
+                                rusqlite::Error::IntegralValueOutOfRange(0, seq_raw)
+                            })?;
+                            let user_id_str: Option<String> = row.get(6)?;
+                            let user_id = user_id_str.as_deref().and_then(|s| s.parse().ok());
+                            let channel: Option<String> = row.get(7)?;
+                            Ok(AuditEntry {
+                                seq,
+                                timestamp: row.get(1)?,
+                                agent_id: row.get(2)?,
+                                action,
+                                detail: row.get(4)?,
+                                outcome: row.get(5)?,
+                                user_id,
+                                channel,
+                                prev_hash: row.get(8)?,
+                                hash: row.get(9)?,
+                            })
+                        });
+                        match rows {
+                            Ok(rows) => {
+                                for (row_index, result) in rows.enumerate() {
+                                    persisted_count += 1;
+                                    match result {
+                                        Ok(entry) => {
+                                            tip = entry.hash.clone();
+                                            entries.push(entry);
+                                        }
+                                        Err(error) => {
+                                            let message = format!(
+                                                "failed to decode audit row at ordered index {row_index}: {error}"
+                                            );
+                                            tracing::error!(%error, row_index, "Audit reload skipped a malformed row");
+                                            load_error.get_or_insert(message);
+                                        }
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                load_error = Some(format!("failed to query audit rows: {error}"));
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        load_error = Some(format!("failed to prepare audit reload query: {error}"));
                     }
                 }
+            }
+            Err(error) => {
+                load_error = Some(format!(
+                    "failed to acquire audit database connection: {error}"
+                ));
             }
         }
 
@@ -691,9 +728,10 @@ impl AuditLog {
             anchor_path: None,
             chain_anchor: Mutex::new(recovered_anchor),
             max_in_memory_entries: AtomicUsize::new(0),
-            // Every loaded row is a persisted row; at boot the in-memory
-            // window and the DB population are identical.
-            persisted_rows: AtomicUsize::new(count),
+            // Count every row yielded by SQLite, including malformed rows
+            // that could not be admitted to the in-memory chain.
+            persisted_rows: AtomicUsize::new(persisted_count),
+            load_error: Mutex::new(load_error.clone()),
         };
 
         // Verify chain integrity on load. Logged at WARN: the message itself
@@ -704,7 +742,7 @@ impl AuditLog {
         // path fires routinely after every untracked restart. Keeping it
         // at ERROR (the original level) made `grep ERROR daemon.log`
         // useless on dev hosts (#5478).
-        if count > 0 {
+        if count > 0 || load_error.is_some() {
             if let Err(e) = log.verify_integrity() {
                 tracing::warn!(
                     "Audit trail integrity check failed on boot: {e}. \
@@ -972,6 +1010,15 @@ impl AuditLog {
     /// Returns `Ok(())` if the chain is intact, or `Err(msg)` describing
     /// the first inconsistency found.
     pub fn verify_integrity(&self) -> Result<(), String> {
+        if let Some(error) = self
+            .load_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+        {
+            return Err(format!("audit trail was only partially loaded: {error}"));
+        }
+
         let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
         // When the retention trim job has dropped a prefix, the first
         // surviving entry's `prev_hash` points at the last dropped

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -397,9 +397,8 @@ pub struct AuditLog {
     /// repopulates the full window. Every mutation and read happens under
     /// the `entries` mutex, so `Relaxed` ordering is sufficient.
     persisted_rows: AtomicUsize,
-    /// Any failure encountered while reloading persisted rows. A partially
-    /// decoded audit trail must never verify as intact merely because the
-    /// malformed row was skipped by the SQLite iterator.
+    /// Any failure encountered while reloading persisted rows.
+    /// A partially decoded audit trail must never verify as intact merely because the malformed row was skipped by the SQLite iterator.
     load_error: Mutex<Option<String>>,
 }
 
@@ -728,8 +727,7 @@ impl AuditLog {
             anchor_path: None,
             chain_anchor: Mutex::new(recovered_anchor),
             max_in_memory_entries: AtomicUsize::new(0),
-            // Count every row yielded by SQLite, including malformed rows
-            // that could not be admitted to the in-memory chain.
+            // Count every row yielded by SQLite, including malformed rows that could not be admitted to the in-memory chain.
             persisted_rows: AtomicUsize::new(persisted_count),
             load_error: Mutex::new(load_error.clone()),
         };

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -154,6 +154,44 @@ fn test_record_with_context_persists_user_and_channel() {
 }
 
 #[test]
+fn malformed_persisted_row_fails_integrity_verification() {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(SqliteConnectionManager::memory())
+        .unwrap();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            );
+            INSERT INTO audit_entries VALUES (
+                0, X'00', 'agent-1', 'ToolInvoke', 'detail', 'ok', NULL, NULL,
+                '0000000000000000000000000000000000000000000000000000000000000000',
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            );",
+        )
+        .unwrap();
+    }
+
+    let log = AuditLog::with_db(pool);
+
+    assert_eq!(log.len(), 0, "malformed rows must not enter the chain");
+    let error = log.verify_integrity().unwrap_err();
+    assert!(error.contains("only partially loaded"), "{error}");
+    assert!(error.contains("ordered index 0"), "{error}");
+}
+
+#[test]
 fn test_new_rbac_variants_preserve_chain() {
     // RBAC M5: UserLogin / RoleChange / PermissionDenied / BudgetExceeded
     // must hash like every other variant — adding them MUST NOT shift the


### PR DESCRIPTION
## Summary
- stop silently discarding malformed SQLite audit rows during startup
- retain row-load failures on the audit log so integrity verification fails closed
- count all persisted rows, including malformed rows excluded from the in-memory chain
- add a regression test with an invalid SQLite column type

## Testing
- `cargo test -p librefang-runtime-audit --lib`
- `cargo clippy -p librefang-runtime-audit --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`