### PR TITLE
ci: pin remaining workflow tooling

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
         run: cargo xtask compare-build-timings
       - name: Upload timing snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build-timings-${{ github.sha }}
           path: bench-results/build-timings/

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -65,4 +65,4 @@ jobs:
           # the run-block via shell expansion.  See deploy-web.yml for
           # the same fix; #3938 missed both deploy workflows.
           HEAD_REF: ${{ github.head_ref || github.ref_name }}
-        run: npx -y wrangler@4 pages deploy docs/out --project-name=librefang-docs --branch="$HEAD_REF"
+        run: npx -y wrangler@4.121.0 pages deploy docs/out --project-name=librefang-docs --branch="$HEAD_REF"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -69,4 +69,4 @@ jobs:
           # injection vector — #3938 hardened release.yml and
           # discussion-to-issue.yml the same way but missed this site.
           HEAD_REF: ${{ github.head_ref || github.ref_name }}
-        run: npx -y wrangler@4 pages deploy web/dist --project-name=librefang --branch="$HEAD_REF"
+        run: npx -y wrangler@4.121.0 pages deploy web/dist --project-name=librefang --branch="$HEAD_REF"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx -y wrangler@4 deploy
+        run: npx -y wrangler@4.121.0 deploy
 
   deploy-github-stats:
     name: Deploy GitHub Stats Worker
@@ -46,4 +46,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx -y wrangler@4 deploy
+        run: npx -y wrangler@4.121.0 deploy

--- a/changelog.d/security/6972-pin-remaining-workflow-tooling.md
+++ b/changelog.d/security/6972-pin-remaining-workflow-tooling.md
@@ -1,0 +1,2 @@
+The build-timings workflow's `upload-artifact` step and every Cloudflare Wrangler deployment invocation still referenced a mutable major-version tag (`actions/upload-artifact@v4`, `wrangler@4`), so a new release published under that same tag would run in CI without any additional review.
+`upload-artifact` now pins to the same audited v4 commit already used by `coverage.yml`, and each `wrangler` invocation is pinned to the exact `4.121.0` release (#6972) (@houko)


### PR DESCRIPTION
## Summary
- pin the build-timings upload-artifact action to the same audited v4 commit used elsewhere in the repository
- pin all Cloudflare deployment invocations to exact Wrangler 4.121.0 instead of the mutable major tag
- leave the cargo-deny mutable action to the already-open dedicated #6958

## Verification
- parsed all four edited workflows with Ruby YAML
- verified no bare `wrangler@4` invocation remains
- verified no mutable `uses:` reference remains except `cargo-deny-action@v2`, covered by #6958
- `git diff --check`