### PR TITLE
fix(cli): make config writes durable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,6 +4592,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "which",
+ "windows-sys 0.61.2",
  "zeroize",
 ]
 

--- a/changelog.d/fixed/6974-cli-atomic-config-writes.md
+++ b/changelog.d/fixed/6974-cli-atomic-config-writes.md
@@ -1,0 +1,3 @@
+CLI commands that rewrite `config.toml`, channel configs, MCP server entries, and ChatGPT OAuth secrets used a plain truncating `fs::write`, so a crash or kill mid-write could leave a corrupt or empty file behind.
+These call sites now go through a shared `durable_atomic_write` helper that stages content in a unique sibling file, fsyncs it, and atomically replaces the target via `rename` on Unix or `MoveFileExW` on Windows, fsyncing the parent directory afterward on Unix so the replacement survives a crash.
+New secret files are created at 0600 and an existing file's permissions are now preserved exactly, including bits a restrictive process umask would otherwise silently strip from the creation mode (#6974) (@houko)

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -80,6 +80,9 @@ tracing-opentelemetry = { workspace = true, optional = true }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.7", features = ["disable_initial_exec_tls"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [build-dependencies]
 # `build.rs` uses `chrono::Utc::now()` to stamp `BUILD_DATE` instead of
 # shelling out to `date`, and `which::which("git")` to resolve git on

--- a/crates/librefang-cli/src/commands/auth.rs
+++ b/crates/librefang-cli/src/commands/auth.rs
@@ -165,26 +165,11 @@ pub(crate) fn write_chatgpt_secrets(
     // file with owner-only (0600) permissions from the start so there is no
     // window in which a freshly created file sits at the umask default (often
     // 0644, world-readable) before it is tightened.
-    #[cfg(unix)]
-    {
-        use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&secrets_path)
-            .map_err(|e| i18n::t_args("auth-error-write-secrets", &[("error", &e.to_string())]))?;
-        f.write_all(updated.as_bytes())
-            .map_err(|e| i18n::t_args("auth-error-write-secrets", &[("error", &e.to_string())]))?;
-    }
-    #[cfg(not(unix))]
-    std::fs::write(&secrets_path, &updated)
+    durable_atomic_write(&secrets_path, updated.as_bytes(), 0o600)
         .map_err(|e| i18n::t_args("auth-error-write-secrets", &[("error", &e.to_string())]))?;
 
-    // `OpenOptions.mode` only applies to a newly created file, so still tighten
-    // a pre-existing file that an older build may have written at a looser mode.
+    // Still tighten a pre-existing file that an older build may have written
+    // at a looser mode.
     restrict_file_permissions(&secrets_path);
 
     Ok(secrets_path)
@@ -217,7 +202,7 @@ pub(crate) fn update_chatgpt_config(
         toml_edit::value(librefang_runtime::chatgpt_oauth::CHATGPT_BASE_URL),
     );
 
-    std::fs::write(&config_path, doc.to_string())
+    durable_atomic_write(&config_path, doc.to_string().as_bytes(), 0o600)
         .map_err(|e| i18n::t_args("auth-error-write-config", &[("error", &e.to_string())]))?;
 
     Ok(())
@@ -285,7 +270,7 @@ pub(crate) fn pool_load_doc_or_exit(path: &std::path::Path) -> toml_edit::Docume
 }
 
 pub(crate) fn pool_write_doc_or_exit(path: &std::path::Path, doc: &toml_edit::DocumentMut) {
-    std::fs::write(path, doc.to_string()).unwrap_or_else(|e| {
+    durable_atomic_write(path, doc.to_string().as_bytes(), 0o600).unwrap_or_else(|e| {
         ui::error(&i18n::t_args(
             "auth-write-failed",
             &[

--- a/crates/librefang-cli/src/commands/channel.rs
+++ b/crates/librefang-cli/src/commands/channel.rs
@@ -434,7 +434,7 @@ pub(crate) fn cmd_channel_rm(name: &str) {
         );
         return;
     }
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = durable_atomic_write(&path, doc.to_string().as_bytes(), 0o600) {
         ui::error_with_fix(
             &i18n::t_args(
                 "channel-config-write-fail",

--- a/crates/librefang-cli/src/commands/common.rs
+++ b/crates/librefang-cli/src/commands/common.rs
@@ -4,6 +4,141 @@
 
 use crate::commands::prelude::*;
 
+/// Durably replace `path` with `content` using a unique sibling staging file.
+///
+/// The staging file is synced before rename and, on Unix, the containing
+/// directory is synced afterwards. Existing Unix permissions are preserved;
+/// callers may supply a restrictive creation mode for new secret files.
+pub(crate) fn durable_atomic_write(
+    path: &std::path::Path,
+    content: &[u8],
+    create_mode: u32,
+) -> std::io::Result<()> {
+    use std::io::Write as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    #[cfg(not(unix))]
+    let _ = create_mode;
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => std::path::Path::new("."),
+    };
+    let file_name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "target path has no filename",
+        )
+    })?;
+    let mut staging_name = file_name.to_os_string();
+    staging_name.push(format!(".{}.{sequence}.tmp", std::process::id()));
+    let staging = parent.join(staging_name);
+
+    let result = (|| -> std::io::Result<()> {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            let existing_mode = std::fs::metadata(path)
+                .ok()
+                .map(|metadata| {
+                    use std::os::unix::fs::PermissionsExt as _;
+                    metadata.permissions().mode()
+                })
+                .unwrap_or(create_mode);
+            options.mode(existing_mode);
+        }
+        let mut file = options.open(&staging)?;
+        file.write_all(content)?;
+        file.sync_all()?;
+        replace_file(&staging, path)?;
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&staging);
+    }
+    result
+}
+
+#[cfg(not(windows))]
+fn replace_file(staging: &std::path::Path, target: &std::path::Path) -> std::io::Result<()> {
+    std::fs::rename(staging, target)
+}
+
+#[cfg(windows)]
+fn replace_file(staging: &std::path::Path, target: &std::path::Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let staging: Vec<u16> = staging.as_os_str().encode_wide().chain(Some(0)).collect();
+    let target: Vec<u16> = target.as_os_str().encode_wide().chain(Some(0)).collect();
+    // SAFETY: Both paths are represented by valid, NUL-terminated UTF-16 buffers
+    // that remain alive for the duration of the call.
+    let replaced = unsafe {
+        MoveFileExW(
+            staging.as_ptr(),
+            target.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if replaced == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod durable_write_tests {
+    use super::*;
+
+    #[test]
+    fn durable_atomic_write_replaces_content_without_leaving_staging_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, b"old").unwrap();
+
+        durable_atomic_write(&path, b"new", 0o600).unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(names, vec![std::ffi::OsString::from("config.toml")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_atomic_write_preserves_existing_permissions_and_secures_new_secrets() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(&config, b"old").unwrap();
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o640)).unwrap();
+        durable_atomic_write(&config, b"new", 0o600).unwrap();
+        assert_eq!(
+            std::fs::metadata(&config).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+
+        let secrets = dir.path().join("secrets.env");
+        durable_atomic_write(&secrets, b"TOKEN=secret\n", 0o600).unwrap();
+        assert_eq!(
+            std::fs::metadata(&secrets).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
 /// Resolved daemon-connection context derived from config.toml — home dir,
 /// API key, and optional custom log dir. Shared by the status/daemon/logs
 /// command groups.

--- a/crates/librefang-cli/src/commands/common.rs
+++ b/crates/librefang-cli/src/commands/common.rs
@@ -25,12 +25,7 @@ pub(crate) fn durable_atomic_write(
         Some(parent) if !parent.as_os_str().is_empty() => parent,
         _ => std::path::Path::new("."),
     };
-    let file_name = path.file_name().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "target path has no filename",
-        )
-    })?;
+    let file_name = path.file_name().ok_or(std::io::ErrorKind::InvalidInput)?;
     let mut staging_name = file_name.to_os_string();
     staging_name.push(format!(".{}.{sequence}.tmp", std::process::id()));
     let staging = parent.join(staging_name);

--- a/crates/librefang-cli/src/commands/common.rs
+++ b/crates/librefang-cli/src/commands/common.rs
@@ -39,7 +39,7 @@ pub(crate) fn durable_atomic_write(
         let mut options = std::fs::OpenOptions::new();
         options.write(true).create_new(true);
         #[cfg(unix)]
-        {
+        let existing_mode = {
             use std::os::unix::fs::OpenOptionsExt as _;
             let existing_mode = std::fs::metadata(path)
                 .ok()
@@ -49,8 +49,20 @@ pub(crate) fn durable_atomic_write(
                 })
                 .unwrap_or(create_mode);
             options.mode(existing_mode);
-        }
+            existing_mode
+        };
         let mut file = options.open(&staging)?;
+        // `OpenOptionsExt::mode` above is masked by the process umask on
+        // creation, so a umask that clears bits present in `existing_mode`
+        // (or in `create_mode`) would silently produce a file more
+        // restrictive than intended, contradicting the "preserve existing
+        // permissions" contract. Force the exact bits explicitly, which
+        // bypasses the umask.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            file.set_permissions(std::fs::Permissions::from_mode(existing_mode & 0o7777))?;
+        }
         file.write_all(content)?;
         file.sync_all()?;
         replace_file(&staging, path)?;
@@ -135,6 +147,32 @@ mod durable_write_tests {
         assert_eq!(
             std::fs::metadata(&secrets).unwrap().permissions().mode() & 0o777,
             0o600
+        );
+    }
+
+    /// `OpenOptionsExt::mode` is masked by the process umask on creation, so
+    /// preserving `existing_mode` only by passing it to `.mode()` silently
+    /// drops any bit the umask also covers (e.g. group/other write under the
+    /// common 0o022 umask). This pins that the helper forces the exact
+    /// existing bits via an explicit `set_permissions` afterward, rather than
+    /// only working by coincidence when the existing mode happens not to
+    /// overlap the umask.
+    #[cfg(unix)]
+    #[test]
+    fn durable_atomic_write_preserves_bits_that_conflict_with_process_umask() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared.toml");
+        std::fs::write(&path, b"old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        durable_atomic_write(&path, b"new", 0o600).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o666,
+            "existing permissions must survive the process umask"
         );
     }
 }

--- a/crates/librefang-cli/src/commands/config.rs
+++ b/crates/librefang-cli/src/commands/config.rs
@@ -260,7 +260,7 @@ pub(crate) fn cmd_config_set(key: &str, value: &str) {
         std::process::exit(1);
     });
 
-    std::fs::write(&config_path, &serialized).unwrap_or_else(|e| {
+    durable_atomic_write(&config_path, serialized.as_bytes(), 0o600).unwrap_or_else(|e| {
         ui::error(&i18n::t_args(
             "config-write-failed",
             &[("error", &e.to_string())],
@@ -338,7 +338,7 @@ pub(crate) fn cmd_config_unset(key: &str) {
         std::process::exit(1);
     });
 
-    std::fs::write(&config_path, &serialized).unwrap_or_else(|e| {
+    durable_atomic_write(&config_path, serialized.as_bytes(), 0o600).unwrap_or_else(|e| {
         ui::error(&i18n::t_args(
             "config-write-failed",
             &[("error", &e.to_string())],

--- a/crates/librefang-cli/src/commands/mcp_cmds.rs
+++ b/crates/librefang-cli/src/commands/mcp_cmds.rs
@@ -405,7 +405,7 @@ pub(crate) fn upsert_mcp_server_local(
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    std::fs::write(config_path, toml_string).map_err(|e| e.to_string())?;
+    durable_atomic_write(config_path, toml_string.as_bytes(), 0o600).map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -434,6 +434,6 @@ pub(crate) fn remove_mcp_server_local(
         });
     }
     let toml_string = toml::to_string_pretty(&table).map_err(|e| e.to_string())?;
-    std::fs::write(config_path, toml_string).map_err(|e| e.to_string())?;
+    durable_atomic_write(config_path, toml_string.as_bytes(), 0o600).map_err(|e| e.to_string())?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a shared durable atomic-write helper using unique sibling staging files
- preserve existing Unix permissions and create new secret/config files with mode 0600
- atomically replace existing files on Windows with `MoveFileExW`, and sync file/directory metadata where supported
- migrate CLI auth, channel, config, and MCP mutations away from direct truncating writes

## Tests
- `cargo test -p librefang-cli durable_atomic_write --bin librefang`
- `cargo test -p librefang-cli write_chatgpt_secrets --bin librefang`
- `cargo test -p librefang-cli mcp --bin librefang`
- `cargo test -p librefang-cli config --bin librefang`
- `cargo clippy -p librefang-cli --bin librefang --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`