### PR TITLE
fix(skills): serialize local installs

### DIFF
--- a/changelog.d/fixed/6977-skill-install-race.md
+++ b/changelog.d/fixed/6977-skill-install-race.md
@@ -1,0 +1,3 @@
+Serialized local skill installs (`POST /api/skills/install`) behind the same per-skill file lock already used by evolve and uninstall.
+Previously the handler checked destination existence, then copied the skill directory outside any lock, so two concurrent installs of the same skill could both pass the existence check and race to write into the same directory, and a failed loser's cleanup (`remove_dir_all`) could delete a winner's just-installed files.
+The existence check now happens after the lock is acquired, and cleanup on a failed copy only ever removes the failed copier's own attempt (#6977) (@houko)

--- a/crates/librefang-api/src/routes/skills/mod.rs
+++ b/crates/librefang-api/src/routes/skills/mod.rs
@@ -1258,31 +1258,6 @@ fn status_str_for_catalog(
     }
 }
 
-/// Recursively copy a directory tree.
-fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        // `std::fs::copy` dereferences links, so a symlink planted in the registry checkout would write the target's real contents into the installed skill.
-        // Mirrors `librefang_skills::marketplace::copy_dir_recursive`.
-        if ty.is_symlink() {
-            tracing::warn!(
-                path = %entry.path().display(),
-                "skipping symlink while installing skill"
-            );
-            continue;
-        }
-        let dest_path = dst.join(entry.file_name());
-        if ty.is_dir() {
-            copy_dir_recursive(&entry.path(), &dest_path)?;
-        } else {
-            std::fs::copy(entry.path(), &dest_path)?;
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1308,7 +1283,7 @@ mod tests {
         std::os::unix::fs::symlink(&outside_dir, src.join("link_dir")).unwrap();
 
         let dest = tmp.path().join("dest");
-        copy_dir_recursive(&src, &dest).unwrap();
+        librefang_skills::evolution::install_local_skill(&src, &dest).unwrap();
 
         assert!(dest.join("SKILL.md").exists());
         assert!(dest.join("nested/file.txt").exists());

--- a/crates/librefang-api/src/routes/skills/skill.rs
+++ b/crates/librefang-api/src/routes/skills/skill.rs
@@ -167,18 +167,9 @@ pub async fn install_skill(
     }
 
     let dest = skills_dir.join(&req.name);
-    if dest.exists() {
-        return (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({
-                "error": format!("Skill '{}' is already installed", req.name),
-                "status": "already_installed",
-            })),
-        );
-    }
 
-    // Copy the skill directory from registry to skills
-    match copy_dir_recursive(&registry_src, &dest) {
+    // Copy under the same per-skill lock used by evolve/uninstall operations.
+    match librefang_skills::evolution::install_local_skill(&registry_src, &dest) {
         Ok(()) => {
             let version = "latest".to_string();
 
@@ -194,10 +185,15 @@ pub async fn install_skill(
                 })),
             )
         }
+        Err(librefang_skills::SkillError::AlreadyInstalled(_)) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!("Skill '{}' is already installed", req.name),
+                "status": "already_installed",
+            })),
+        ),
         Err(e) => {
             tracing::warn!("Skill install failed: {e}");
-            // Clean up partial copy
-            let _ = std::fs::remove_dir_all(&dest);
             ApiErrorResponse::internal_scrub(e).into_json_tuple()
         }
     }

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -619,6 +619,44 @@ async fn skills_install_path_traversal_hand_rejected_400() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn skills_install_already_installed_returns_409() {
+    // Regression coverage for #6977: the destination-exists check moved
+    // from before the per-skill lock to inside
+    // `librefang_skills::evolution::install_local_skill`, and a hit now
+    // surfaces through `SkillError::AlreadyInstalled` instead of a
+    // pre-lock `dest.exists()` probe. Assert the HTTP-visible behavior
+    // (first install succeeds, second is a 409) still holds end-to-end.
+    let h = boot().await;
+    install_registry_skill(h.home(), "dup-skill", "A skill installed twice");
+
+    let (first_status, first_body) = json_request(
+        &h,
+        Method::POST,
+        "/api/skills/install",
+        Some(serde_json::json!({"name": "dup-skill"})),
+    )
+    .await;
+    assert_eq!(first_status, StatusCode::OK, "{first_body:?}");
+
+    let (second_status, second_body) = json_request(
+        &h,
+        Method::POST,
+        "/api/skills/install",
+        Some(serde_json::json!({"name": "dup-skill"})),
+    )
+    .await;
+    assert_eq!(second_status, StatusCode::CONFLICT, "{second_body:?}");
+    assert_eq!(second_body["status"], "already_installed", "{second_body:?}");
+    assert!(
+        second_body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("already installed"),
+        "error must mention already-installed: {second_body:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn skillhub_install_path_traversal_hand_rejected_400() {
     // Skillhub has its own install handler. Reject traversal before the
     // hand directory existence probe so an attacker cannot escape the

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -646,7 +646,10 @@ async fn skills_install_already_installed_returns_409() {
     )
     .await;
     assert_eq!(second_status, StatusCode::CONFLICT, "{second_body:?}");
-    assert_eq!(second_body["status"], "already_installed", "{second_body:?}");
+    assert_eq!(
+        second_body["status"], "already_installed",
+        "{second_body:?}"
+    );
     assert!(
         second_body["error"]
             .as_str()

--- a/crates/librefang-skills/src/evolution.rs
+++ b/crates/librefang-skills/src/evolution.rs
@@ -253,6 +253,51 @@ fn acquire_skill_lock(skill_dir: &Path) -> Result<std::fs::File, SkillError> {
     Ok(lock_file)
 }
 
+/// Install a local skill directory while holding the same per-skill lock used
+/// by evolution and uninstall operations.
+///
+/// The destination existence check is deliberately performed after locking so
+/// two concurrent installers cannot both pass the check and copy into the same
+/// partially populated directory.
+pub fn install_local_skill(source: &Path, skill_dir: &Path) -> Result<(), SkillError> {
+    let _lock = acquire_skill_lock(skill_dir)?;
+    if skill_dir.exists() {
+        let name = skill_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown");
+        return Err(SkillError::AlreadyInstalled(name.to_string()));
+    }
+
+    let result = copy_local_skill_recursive(source, skill_dir);
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(skill_dir);
+    }
+    result
+}
+
+fn copy_local_skill_recursive(source: &Path, destination: &Path) -> Result<(), SkillError> {
+    std::fs::create_dir_all(destination)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            tracing::warn!(
+                path = %entry.path().display(),
+                "skipping symlink while installing skill"
+            );
+            continue;
+        }
+        let destination_path = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_local_skill_recursive(&entry.path(), &destination_path)?;
+        } else {
+            std::fs::copy(entry.path(), destination_path)?;
+        }
+    }
+    Ok(())
+}
+
 // ── Atomic file I/O ─────────────────────────────────────────────────
 
 /// Monotonic per-process counter used by `atomic_write` to derive a
@@ -3120,6 +3165,39 @@ mod race_tests {
     use super::*;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[test]
+    fn local_install_rechecks_destination_after_acquiring_lock() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        let destination = dir.path().join("race-skill");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(source.join("SKILL.md"), "---\nname: race-skill\n---\n").unwrap();
+
+        let lock = acquire_skill_lock(&destination).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let source_for_thread = source.clone();
+        let destination_for_thread = destination.clone();
+        let installer = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            install_local_skill(&source_for_thread, &destination_for_thread)
+        });
+        started_rx.recv().unwrap();
+
+        std::fs::create_dir(&destination).unwrap();
+        std::fs::write(destination.join("winner.txt"), "winner").unwrap();
+        drop(lock);
+
+        assert!(matches!(
+            installer.join().unwrap(),
+            Err(SkillError::AlreadyInstalled(name)) if name == "race-skill"
+        ));
+        assert_eq!(
+            std::fs::read_to_string(destination.join("winner.txt")).unwrap(),
+            "winner"
+        );
+        assert!(!destination.join("SKILL.md").exists());
+    }
 
     #[test]
     fn test_concurrent_updates_produce_unique_versions() {

--- a/crates/librefang-skills/src/evolution.rs
+++ b/crates/librefang-skills/src/evolution.rs
@@ -253,12 +253,9 @@ fn acquire_skill_lock(skill_dir: &Path) -> Result<std::fs::File, SkillError> {
     Ok(lock_file)
 }
 
-/// Install a local skill directory while holding the same per-skill lock used
-/// by evolution and uninstall operations.
+/// Install a local skill directory while holding the same per-skill lock used by evolution and uninstall operations.
 ///
-/// The destination existence check is deliberately performed after locking so
-/// two concurrent installers cannot both pass the check and copy into the same
-/// partially populated directory.
+/// The destination existence check is deliberately performed after locking so two concurrent installers cannot both pass the check and copy into the same partially populated directory.
 pub fn install_local_skill(source: &Path, skill_dir: &Path) -> Result<(), SkillError> {
     let _lock = acquire_skill_lock(skill_dir)?;
     if skill_dir.exists() {


### PR DESCRIPTION
## Summary
- move local skill copying behind the existing cross-process per-skill file lock
- re-check destination existence after acquiring the lock so concurrent installers cannot both proceed
- hold the lock through partial-copy cleanup, preventing a failed loser from deleting the winner's installation
- reuse the locked copier for the API route while retaining symlink filtering and 409 responses

## Tests
- `cargo test -p librefang-skills local_install --lib`
- `cargo test -p librefang-skills evolution::race_tests --lib`
- `cargo test -p librefang-api copy_dir_recursive_skips_symlinks --lib`
- `cargo clippy -p librefang-skills -p librefang-api --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`