### PR TITLE
fix(dashboard): surface mutation failures

### DIFF
--- a/changelog.d/fixed/6978-dashboard-mutation-error-toasts.md
+++ b/changelog.d/fixed/6978-dashboard-mutation-error-toasts.md
@@ -1,0 +1,2 @@
+Add a global React Query `MutationCache` error fallback so a rejected mutation without its own `onError` handler now surfaces a localized toast instead of failing silently.
+Mutations that already register a mutation-specific `onError` are left untouched to avoid duplicate feedback (#6978) (@houko)

--- a/crates/librefang-api/dashboard/src/lib/queryClient.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queryClient.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDashboardQueryClient } from "./queryClient";
+import { useUIStore } from "./store";
+
+afterEach(() => {
+  useUIStore.setState({ toasts: [] });
+});
+
+describe("dashboard mutation errors", () => {
+  it("shows an error toast when a mutation has no local handler", async () => {
+    const client = createDashboardQueryClient();
+    const mutation = client.getMutationCache().build(client, {
+      mutationFn: async () => {
+        throw new Error("save failed");
+      },
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toThrow("save failed");
+
+    expect(useUIStore.getState().toasts).toMatchObject([
+      { message: "save failed", type: "error" },
+    ]);
+  });
+
+  it("defers to a mutation-specific error handler", async () => {
+    const client = createDashboardQueryClient();
+    const onError = vi.fn();
+    const mutation = client.getMutationCache().build(client, {
+      mutationFn: async () => {
+        throw new Error("save failed");
+      },
+      onError,
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toThrow("save failed");
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(useUIStore.getState().toasts).toEqual([]);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queryClient.ts
+++ b/crates/librefang-api/dashboard/src/lib/queryClient.ts
@@ -1,0 +1,28 @@
+import { MutationCache, QueryClient } from "@tanstack/react-query";
+import i18n from "./i18n";
+import { toastErr } from "./errors";
+import { useUIStore } from "./store";
+
+export function createDashboardQueryClient(): QueryClient {
+  return new QueryClient({
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        // A mutation-specific handler can provide more actionable context and
+        // already owns its UI. This callback is the fallback for bare mutate()
+        // calls that would otherwise fail without any visible feedback.
+        if (mutation.options.onError) return;
+
+        const fallback = i18n.t("common.error", { defaultValue: "Error" });
+        useUIStore.getState().addToast(toastErr(error, fallback), "error");
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        retry: 1,
+        refetchOnWindowFocus: false,
+        staleTime: 30_000,
+        refetchIntervalInBackground: false,
+      },
+    },
+  });
+}

--- a/crates/librefang-api/dashboard/src/main.tsx
+++ b/crates/librefang-api/dashboard/src/main.tsx
@@ -8,13 +8,14 @@ setupBundleMode();
 
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import { router } from "./router";
 import { ToastContainer } from "./components/ui/Toast";
 import "./index.css";
 import i18n from "./lib/i18n";
 import { channelKeys, handKeys, mcpKeys, pluginKeys } from "./lib/queries/keys";
+import { createDashboardQueryClient } from "./lib/queryClient";
 
 interface RootErrorBoundaryState {
   hasError: boolean;
@@ -67,16 +68,7 @@ class RootErrorBoundary extends React.Component<
   }
 }
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      refetchOnWindowFocus: false,
-      staleTime: 30_000,
-      refetchIntervalInBackground: false,
-    }
-  }
-});
+const queryClient = createDashboardQueryClient();
 
 // Backend resolves Accept-Language against `[i18n.<lang>]` blocks in
 // plugin / MCP catalog / hand / channel manifests, so the response body


### PR DESCRIPTION
## Summary
- configure a global React Query `MutationCache` error fallback
- display rejected mutations through the existing localized toast system
- defer to mutation-specific `onError` handlers to avoid duplicate feedback
- extract query client creation for focused regression coverage

## Tests
- `pnpm test -- src/lib/queryClient.test.ts` (95 files, 994 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`