### PR TITLE
fix(kernel): report cron shutdown persistence failures

### DIFF
--- a/changelog.d/fixed/6979-cron-shutdown-persist-error.md
+++ b/changelog.d/fixed/6979-cron-shutdown-persist-error.md
@@ -1,0 +1,2 @@
+The cron scheduler's final persistence attempt during kernel shutdown discarded its result with `let _ = …`, so a failed flush of execution state (a full disk, an unwritable data dir) left no trace anywhere.
+`run_cron_scheduler_loop` now logs a structured `warn!` with the underlying I/O error when the shutdown-time persist fails, while still letting shutdown proceed (#6979) (@houko)

--- a/crates/librefang-kernel/src/kernel/cron_tick.rs
+++ b/crates/librefang-kernel/src/kernel/cron_tick.rs
@@ -41,8 +41,11 @@ pub(super) async fn run_cron_scheduler_loop(kernel: Arc<LibreFangKernel>) {
     loop {
         interval.tick().await;
         if kernel.agents.supervisor.is_shutting_down() {
-            // Persist on shutdown
-            let _ = kernel.workflows.cron_scheduler.persist();
+            // This is the scheduler's last chance to flush execution state.
+            // Keep shutdown moving, but never hide the durability failure.
+            if let Err(error) = kernel.workflows.cron_scheduler.persist() {
+                warn!(%error, "failed to persist cron scheduler during shutdown");
+            }
             break;
         }
 


### PR DESCRIPTION
## Summary
- stop silently discarding the cron scheduler's final persistence error during shutdown
- emit a structured warning with the underlying I/O error while allowing shutdown to continue

## Tests
- `cargo clippy -p librefang-kernel --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`