### PR TITLE
perf(api): offload CLI model config detection

### DIFF
--- a/changelog.d/changed/6983-offload-cli-model-config-detection.md
+++ b/changelog.d/changed/6983-offload-cli-model-config-detection.md
@@ -1,0 +1,2 @@
+CLI passthrough model-config detection (Codex, Claude Code, Gemini CLI, Qwen Code) now runs on the blocking thread pool instead of the async request handler, since it reads files and environment variables from disk synchronously.
+All four probes are grouped into a single blocking task per request, and the reads are skipped entirely when an explicit `?tier=` filter excludes the synthesized `custom` rows they would produce (#6983) (@houko)

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -183,7 +183,7 @@ fn claude_code_profile_config_dir(
 }
 
 /// Detect, for every CLI passthrough provider, the model it is configured to run (read live from the tool's own config), as `(provider_id, label, model)`. `claude_profile_dir` is the resolved first profile dir from active claude-code rotation so detection reads the same `settings.json` the spawned CLI uses.
-fn detect_cli_configured_models(
+fn detect_cli_configured_models_blocking(
     claude_profile_dir: Option<&std::path::Path>,
 ) -> Vec<(&'static str, &'static str, String)> {
     let mut out = Vec::new();
@@ -200,6 +200,22 @@ fn detect_cli_configured_models(
         out.push(("qwen-code", "Qwen Code", m));
     }
     out
+}
+
+async fn detect_cli_configured_models(
+    claude_profile_dir: Option<std::path::PathBuf>,
+) -> Vec<(&'static str, &'static str, String)> {
+    match tokio::task::spawn_blocking(move || {
+        detect_cli_configured_models_blocking(claude_profile_dir.as_deref())
+    })
+    .await
+    {
+        Ok(models) => models,
+        Err(error) => {
+            tracing::warn!(%error, "CLI model config detection task failed");
+            Vec::new()
+        }
+    }
 }
 
 /// Synthesized catalog row for a CLI provider's live-detected model, or `None` when the id is already a catalog model (`id_already_known`) or filtered out by `available_only`. Dedup is against the *whole* catalog, not the (possibly tier-filtered) response slice, so a `?tier=custom` query can't re-surface a catalog default as a sentinel-0 row. Pure (no FS/env) so dedup/filter/shape stay unit-testable.
@@ -287,6 +303,17 @@ pub async fn list_models(
             tracing::warn!(%error, "EveryAPI live catalog unavailable; using registered snapshot");
         }
     }
+    let cli_tier_ok = tier_filter
+        .as_deref()
+        .map(|t| t == "custom")
+        .unwrap_or(true);
+    let cli_configured_models = if cli_tier_ok {
+        let claude_profile_dir =
+            claude_code_profile_config_dir(&state.kernel.config_ref().default_model);
+        detect_cli_configured_models(claude_profile_dir).await
+    } else {
+        Vec::new()
+    };
     let catalog = state.kernel.model_catalog_ref().load();
 
     // Pre-compute the live-discovered model ID set per local provider so we
@@ -402,16 +429,8 @@ pub async fn list_models(
         .collect();
 
     // Surface the model each CLI passthrough provider is configured to run, read live from its own config (DeepSeek via Codex's config.toml, a Kimi id via Claude Code's ANTHROPIC_MODEL / settings.json, a Gemini preview via GEMINI_MODEL, an OpenAI-compatible id via Qwen Code) since the static catalog only ships the tool's defaults. Synthesized rows are `custom` tier, so honour an explicit tier filter.
-    let cli_tier_ok = tier_filter
-        .as_deref()
-        .map(|t| t == "custom")
-        .unwrap_or(true);
     if cli_tier_ok {
-        let claude_profile_dir =
-            claude_code_profile_config_dir(&state.kernel.config_ref().default_model);
-        for (provider, label, configured) in
-            detect_cli_configured_models(claude_profile_dir.as_deref())
-        {
+        for (provider, label, configured) in cli_configured_models {
             let in_scope = provider_filter
                 .as_deref()
                 .map(|p| p == provider)
@@ -646,11 +665,12 @@ pub async fn get_model(
             // codex-cli/deepseek-chat) is not in the catalog, so find_model
             // misses it. Resolve it the same way list_models does so the list
             // and detail endpoints agree on the ids the API advertises.
+            drop(catalog);
             let claude_dir =
                 claude_code_profile_config_dir(&state.kernel.config_ref().default_model);
-            for (provider, label, configured) in detect_cli_configured_models(claude_dir.as_deref())
-            {
+            for (provider, label, configured) in detect_cli_configured_models(claude_dir).await {
                 if format!("{provider}/{configured}").eq_ignore_ascii_case(&id) {
+                    let catalog = state.kernel.model_catalog_ref().load();
                     let available = catalog
                         .get_provider(provider)
                         .map(|p| p.auth_status.is_available())


### PR DESCRIPTION
## Summary\n- run Codex, Claude Code, Gemini CLI, and Qwen Code model-config detection on the blocking pool\n- group all four probes into one blocking task per request\n- avoid CLI config reads entirely when a non-custom tier excludes synthesized rows\n- release the catalog snapshot before awaiting fallback detection in model detail lookup\n- preserve environment precedence, profile-directory selection, deduplication, and response shape\n\n## Tests\n- 
running 13 tests
test routes::providers::tests::cli_row_dedups_against_known_catalog_id ... ok
test routes::providers::tests::claude_code_settings_rejects_empty_and_invalid ... ok
test routes::providers::tests::gemini_style_settings_reads_nested_model_name ... ok
test routes::providers::tests::claude_code_settings_prefers_top_level_model_then_env ... ok
test routes::providers::tests::cli_row_respects_available_only_filter ... ok
test routes::providers::tests::cli_row_synthesizes_with_expected_shape ... ok
test routes::providers::tests::codex_config_extracts_top_level_model_past_provider_blocks ... ok
test routes::providers::tests::codex_config_trims_and_handles_provider_only ... ok
test routes::providers::tests::codex_config_rejects_empty_and_invalid ... ok
test routes::providers::tests::test_provider_json_includes_media_capabilities ... ok
test routes::providers::tests::test_list_profiles_returns_all ... ok
test routes::providers::tests::test_get_profile_not_found ... ok
test routes::providers::tests::test_get_profile_found ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 933 filtered out; finished in 0.41s\n- \n- \n- \n- \n