### PR TITLE
fix(api): durably persist registry content

### DIFF
--- a/changelog.d/fixed/6984-registry-content-durable-write.md
+++ b/changelog.d/fixed/6984-registry-content-durable-write.md
@@ -1,0 +1,3 @@
+Registry content creation raced on the no-overwrite check: two concurrent `POST /api/registry/content/{type}` calls for the same identifier could both observe an absent file and each write, silently discarding whichever write lost.
+The existence check and the write are now serialized under the same `config_write_lock` used by the other config-mutating endpoints, and the write itself goes through the fsync-based atomic writer instead of a plain `fs::write`.
+A rejected provider definition is now rolled back to its prior contents (rather than merely deleted), so a failed overwrite of an existing provider no longer leaves it missing (#6984) (@houko)

--- a/crates/librefang-api/src/routes/registry.rs
+++ b/crates/librefang-api/src/routes/registry.rs
@@ -87,6 +87,42 @@ async fn registry_schema_by_type(
 /// identifier cannot overflow a path-component limit on any target filesystem.
 const MAX_REGISTRY_IDENTIFIER_LEN: usize = 128;
 
+#[derive(Debug)]
+enum RegistryContentWriteError {
+    AlreadyExists,
+    Io(std::io::Error),
+}
+
+fn persist_registry_content(
+    target: &std::path::Path,
+    content: &[u8],
+    allow_overwrite: bool,
+) -> Result<Option<Vec<u8>>, RegistryContentWriteError> {
+    if !allow_overwrite && target.exists() {
+        return Err(RegistryContentWriteError::AlreadyExists);
+    }
+    let previous = if target.exists() {
+        Some(std::fs::read(target).map_err(RegistryContentWriteError::Io)?)
+    } else {
+        None
+    };
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(RegistryContentWriteError::Io)?;
+    }
+    crate::atomic_write(target, content).map_err(RegistryContentWriteError::Io)?;
+    Ok(previous)
+}
+
+fn rollback_registry_content(
+    target: &std::path::Path,
+    previous: Option<&[u8]>,
+) -> std::io::Result<()> {
+    match previous {
+        Some(content) => crate::atomic_write(target, content),
+        None => std::fs::remove_file(target),
+    }
+}
+
 /// Validate a registry content identifier against `^[a-zA-Z0-9._-]+$` with a
 /// length cap of [`MAX_REGISTRY_IDENTIFIER_LEN`].
 ///
@@ -207,31 +243,6 @@ async fn create_registry_content(
         }
     };
 
-    // Don't overwrite existing content unless explicitly allowed.
-    //
-    // The message names the actions a caller can actually take. It used to
-    // point only at `?allow_overwrite=true`, which the dashboard never sends —
-    // so a user who hit this on a built-in provider (trying to give the keyless
-    // `vllm` entry an API key) was told to do something no UI surface offers
-    // (#6703). For providers the answer is almost never "replace the file":
-    // the per-provider key / URL / discovery endpoints edit the live entry
-    // without touching the registry-managed TOML, which the boot-time registry
-    // sync would revert anyway.
-    if target.exists() && !allow_overwrite {
-        let remedy = if content_type == "provider" {
-            format!(
-                " — set its API key with POST /api/providers/{identifier}/key, its endpoint with PUT /api/providers/{identifier}/url, or replace the whole definition with PUT /api/registry/content/provider"
-            )
-        } else {
-            format!(" — replace the whole definition with PUT /api/registry/content/{content_type}")
-        };
-        return ApiErrorResponse::conflict(format!(
-            "{content_type} '{identifier}' already exists{remedy}"
-        ))
-        .into_json_tuple()
-        .into_response();
-    }
-
     // For providers: extract the `api_key` value (if present) before writing TOML.
     // The actual key is stored in secrets.env, NOT in the provider TOML file.
     let api_key_to_save: Option<(String, String)> = if content_type == "provider" {
@@ -282,19 +293,52 @@ async fn create_registry_content(
         }
     };
 
-    // Create parent directories and write file
-    if let Some(parent) = target.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            return ApiErrorResponse::internal(e.to_string())
+    // Serialize the no-overwrite check with the durable replacement. Without
+    // the shared guard, two concurrent POSTs can both observe an absent target
+    // and silently overwrite one another. The fsync-based writer is blocking,
+    // so perform the filesystem transaction off the async runtime worker.
+    let _write_guard = state.config_write_lock.lock().await;
+    let write_target = target.clone();
+    let write_content = toml_string.into_bytes();
+    let write_result = tokio::task::spawn_blocking(move || {
+        persist_registry_content(&write_target, &write_content, allow_overwrite)
+    })
+    .await;
+    let previous_content = match write_result {
+        Ok(Ok(previous)) => previous,
+        Ok(Err(RegistryContentWriteError::AlreadyExists)) => {
+            // The message names the actions a caller can actually take. For
+            // providers the answer is usually to edit the live key or URL,
+            // not replace a registry-managed definition (#6703).
+            let remedy = if content_type == "provider" {
+                format!(
+                    " — set its API key with POST /api/providers/{identifier}/key, its endpoint with PUT /api/providers/{identifier}/url, or replace the whole definition with PUT /api/registry/content/provider"
+                )
+            } else {
+                format!(
+                    " — replace the whole definition with PUT /api/registry/content/{content_type}"
+                )
+            };
+            return ApiErrorResponse::conflict(format!(
+                "{content_type} '{identifier}' already exists{remedy}"
+            ))
+            .into_json_tuple()
+            .into_response();
+        }
+        Ok(Err(RegistryContentWriteError::Io(error))) => {
+            tracing::error!(%error, "failed to persist registry content");
+            return ApiErrorResponse::internal("failed to persist registry content")
                 .into_json_tuple()
                 .into_response();
         }
-    }
-    if let Err(e) = std::fs::write(&target, &toml_string) {
-        return ApiErrorResponse::internal(e.to_string())
+        Err(error) => {
+            return ApiErrorResponse::internal_scrub(format!(
+                "registry content write task failed: {error}"
+            ))
             .into_json_tuple()
             .into_response();
-    }
+        }
+    };
 
     // For provider files, refresh the in-memory model catalog so new models
     // and provider config changes are available immediately.
@@ -303,7 +347,17 @@ async fn create_registry_content(
         // is immediately recognized as configured.
         if let Some((env_var, key_value)) = &api_key_to_save {
             let secrets_path = state.kernel.home_dir().join("secrets.env");
-            if let Err(e) = write_secret_env(&secrets_path, env_var, key_value) {
+            let env_var_for_write = env_var.clone();
+            let key_value_for_write = key_value.clone();
+            let secret_result = tokio::task::spawn_blocking(move || {
+                write_secret_env(&secrets_path, &env_var_for_write, &key_value_for_write)
+            })
+            .await;
+            if let Err(e) = secret_result.unwrap_or_else(|e| {
+                Err(std::io::Error::other(format!(
+                    "secret write task failed: {e}"
+                )))
+            }) {
                 tracing::warn!("Failed to write API key to secrets.env: {e}");
             }
             // Serialized through the process-global env write guard (#5142):
@@ -312,14 +366,20 @@ async fn create_registry_content(
         }
 
         let target_for_closure = target.clone();
+        let kernel = state.kernel.clone();
         // The trait method returns `()`; capture the load result via a
         // surrounding `&mut Option<_>` (per the `model_catalog_update` contract).
-        let mut merge_result: Option<Result<usize, String>> = None;
-        let sink = &mut merge_result;
-        state.kernel.model_catalog_update(&mut move |catalog| {
-            *sink = Some(catalog.load_catalog_file(&target_for_closure));
-            catalog.detect_auth();
-        });
+        let merge_result = tokio::task::spawn_blocking(move || {
+            let mut merge_result: Option<Result<usize, String>> = None;
+            let sink = &mut merge_result;
+            kernel.model_catalog_update(&mut move |catalog| {
+                *sink = Some(catalog.load_catalog_file(&target_for_closure));
+                catalog.detect_auth();
+            });
+            merge_result
+        })
+        .await
+        .unwrap_or_else(|error| Some(Err(format!("catalog load task failed: {error}"))));
         // Invalidate cached LLM drivers — URLs/keys may have changed.
         state.kernel.clear_driver_cache();
 
@@ -330,7 +390,18 @@ async fn create_registry_content(
         // parse warning on every daemon boot — and surface the error so the
         // operator can correct the definition.
         if let Some(Err(e)) = merge_result {
-            let _ = std::fs::remove_file(&target);
+            let rollback_target = target.clone();
+            let rollback_result = tokio::task::spawn_blocking(move || {
+                rollback_registry_content(&rollback_target, previous_content.as_deref())
+            })
+            .await;
+            if let Err(error) = rollback_result.unwrap_or_else(|error| {
+                Err(std::io::Error::other(format!(
+                    "registry rollback task failed: {error}"
+                )))
+            }) {
+                tracing::error!(%error, "failed to roll back rejected provider definition");
+            }
             return ApiErrorResponse::bad_request(format!(
                 "Provider definition was rejected and not saved: {e}"
             ))
@@ -614,6 +685,42 @@ mod identifier_validation_tests {
         assert!(
             !is_valid_registry_identifier(&over),
             "129 chars must be rejected"
+        );
+    }
+}
+
+#[cfg(test)]
+mod registry_content_write_tests {
+    use super::*;
+
+    #[test]
+    fn creates_and_atomically_replaces_without_staging_residue() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("providers/example.toml");
+
+        assert_eq!(
+            persist_registry_content(&target, b"first", false).unwrap(),
+            None
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"first");
+
+        let error = persist_registry_content(&target, b"rejected", false).unwrap_err();
+        assert!(matches!(error, RegistryContentWriteError::AlreadyExists));
+        assert_eq!(std::fs::read(&target).unwrap(), b"first");
+
+        assert_eq!(
+            persist_registry_content(&target, b"second", true).unwrap(),
+            Some(b"first".to_vec())
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"second");
+
+        rollback_registry_content(&target, Some(b"first")).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"first");
+        rollback_registry_content(&target, None).unwrap();
+        assert!(!target.exists());
+        assert_eq!(
+            std::fs::read_dir(target.parent().unwrap()).unwrap().count(),
+            0
         );
     }
 }

--- a/crates/librefang-api/tests/registry_content_path_test.rs
+++ b/crates/librefang-api/tests/registry_content_path_test.rs
@@ -96,6 +96,27 @@ async fn post_json(
     (status, value)
 }
 
+async fn put_json(
+    app: &Router,
+    path: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri(path)
+        .header(header::AUTHORIZATION, format!("Bearer {TEST_API_KEY}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, value)
+}
+
 /// The response `path` must be **relative** — must not start with the
 /// host's home_dir, and must not contain the OS-username-bearing
 /// `/Users/` or `/home/` prefixes from the canonical Unix layouts.
@@ -286,4 +307,29 @@ async fn provider_rejected_by_catalog_returns_400_and_leaves_no_file() {
         !file.exists(),
         "the rejected provider file must be rolled back, not left at {file:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejected_provider_overwrite_restores_previous_file() {
+    let h = boot().await;
+    let path = h.home_dir.join("providers/existing-provider.toml");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let previous = "[provider]\nid = \"existing-provider\"\ndisplay_name = \"Existing\"\nbase_url = \"https://example.invalid/v1\"\nkey_required = false\n";
+    std::fs::write(&path, previous).unwrap();
+
+    let body = serde_json::json!({
+        "id": "existing-provider",
+        "display_name": "Broken replacement",
+        "base_url": "https://example.invalid/v2",
+        "key_required": false,
+        "models": [{
+            "id": "broken-model",
+            "display_name": "Broken Model",
+            "context_window": "not-a-number"
+        }]
+    });
+    let (status, response) = put_json(&h.app, "/api/registry/content/provider", body).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    assert_eq!(std::fs::read_to_string(path).unwrap(), previous);
 }


### PR DESCRIPTION
## Summary\n- serialize registry content creation/overwrite through the shared write lock\n- move directory creation, durable atomic replacement, secret persistence, catalog loading, and rollback off async runtime workers\n- make the no-overwrite check part of the locked filesystem transaction\n- restore the prior provider file when an invalid overwrite is rejected\n- scrub filesystem errors from API responses while retaining detailed server logs\n- add durable write, conflict, cleanup, and overwrite-rollback regressions\n\n## Tests\n- 
running 1 test
test routes::registry::registry_content_write_tests::creates_and_atomically_replaces_without_staging_residue ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 946 filtered out; finished in 0.09s\n- 
running 6 tests
test registry_content_rejects_malformed_identifiers ... ok
test registry_content_path_is_relative_not_absolute ... ok
test provider_rejected_by_catalog_returns_400_and_leaves_no_file ... ok
test registry_content_accepts_dotted_and_dashed_identifiers ... ok
test rejected_provider_overwrite_restores_previous_file ... ok
test provider_with_reasoning_tier_model_loads_into_catalog ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.63s\n- 
running 1 test
test rejected_provider_overwrite_restores_previous_file ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 8.55s\n- \n- \n- \n- \n