### PR TITLE
perf(api): offload dashboard database probes

### DIFF
--- a/changelog.d/changed/6989-dashboard-db-probes-off-thread.md
+++ b/changelog.d/changed/6989-dashboard-db-probes-off-thread.md
@@ -1,0 +1,3 @@
+`/api/dashboard/snapshot` now runs its database health probe and session-count query together on Tokio's blocking pool instead of inline on the async worker.
+  Both calls go through the synchronous SQLite substrate, so a slow disk could previously stall the worker thread handling the dashboard's 5 s poll.
+  A blocking-task failure now logs at `error` level and falls back to the existing degraded-health / zero-count semantics instead of silently collapsing. (#6989) (@houko)

--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -1043,11 +1043,25 @@ async fn dashboard_snapshot_compute(state: &Arc<AppState>) -> serde_json::Value 
     let shared_id = librefang_types::agent::AgentId(uuid::Uuid::from_bytes([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
     ]));
-    let db_ok = state
-        .kernel
-        .memory_substrate()
-        .structured_get(shared_id, "__health_check__")
-        .is_ok();
+    let substrate = Arc::clone(state.kernel.memory_substrate());
+    // The memory substrate exposes synchronous SQLite operations. Run the
+    // health probe and session count together on the blocking pool so the
+    // dashboard's frequent snapshot poll cannot stall a Tokio worker.
+    let db_result = tokio::task::spawn_blocking(move || {
+        let db_ok = substrate
+            .structured_get(shared_id, "__health_check__")
+            .is_ok();
+        let session_count = substrate.count_sessions().unwrap_or(0);
+        (db_ok, session_count)
+    })
+    .await;
+    let (db_ok, session_count) = match db_result {
+        Ok(result) => result,
+        Err(error) => {
+            tracing::error!(%error, "dashboard database probe task failed");
+            (false, 0)
+        }
+    };
     let health_status = if db_ok { "ok" } else { "degraded" };
     let fts_only = state.kernel.config_ref().memory.fts_only.unwrap_or(false);
     let embedding_ok = fts_only || state.kernel.embedding().is_some();
@@ -1072,11 +1086,6 @@ async fn dashboard_snapshot_compute(state: &Arc<AppState>) -> serde_json::Value 
     // decoding every session blob just to call `.len()`. This is the
     // dashboard snapshot path (`/api/dashboard/snapshot`), hit on
     // every 5 s poll, so the cost compounded.
-    let session_count = state
-        .kernel
-        .memory_substrate()
-        .count_sessions()
-        .unwrap_or(0);
     let cfg = state.kernel.config_snapshot();
     // Runtime stats shared with `/api/status` — the dashboard RuntimePage
     // reads these out of the snapshot for its info panel and KPI tiles.


### PR DESCRIPTION
## Summary
- run the dashboard health query and session count together on Tokio's blocking pool
- preserve the existing degraded-health and zero-count fallback semantics
- log blocking-task failures instead of silently collapsing them

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p librefang-api --test config_status_session_count_test dashboard_snapshot_session_count_matches_substrate_after_seeding`
- `cargo clippy -p librefang-api --lib --tests -- -D warnings`