### PR TITLE
perf(api): move config set I/O off async workers

### DIFF
--- a/changelog.d/changed/6990-config-set-io-off-thread.md
+++ b/changelog.d/changed/6990-config-set-io-off-thread.md
@@ -1,0 +1,3 @@
+`POST /api/config/set` read the existing `config.toml`, created the backup directory, copied the backup, and wrote the new file synchronously on the async worker thread handling the request.
+  The existing-config read and the backup copy now go through Tokio's async filesystem APIs, and the durable atomic write of the new config runs on Tokio's blocking pool instead of inline.
+  The missing-file case (no config to read or back up yet) is now handled via `ErrorKind::NotFound` instead of a synchronous `exists()` pre-check, preserving the same allowlist, TOML round-trip, validation, reload, and scrubbed-error behavior (#6990) (@houko)

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -1366,24 +1366,21 @@ pub async fn config_set(
     // …) MUST abort — falling back to "" would silently drop every other
     // section in `config.toml` (agents, providers, taint rules, …) on the
     // next write. Same protection as `users::persist_users` (#3368).
-    let raw_content = if config_path.exists() {
-        match std::fs::read_to_string(&config_path) {
-            Ok(s) => s,
-            Err(e) => {
-                // Scrub the io error (audit: rusqlite-errors-leak) —
-                // path / permission detail stays in the log.
-                tracing::error!(error = %e, "could not read existing config.toml");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "status": "error",
-                        "error": "Internal server error"
-                    })),
-                );
-            }
+    let raw_content = match tokio::fs::read_to_string(&config_path).await {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            // Scrub the io error (audit: rusqlite-errors-leak) —
+            // path / permission detail stays in the log.
+            tracing::error!(%error, "could not read existing config.toml");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "status": "error",
+                    "error": "Internal server error"
+                })),
+            );
         }
-    } else {
-        String::new()
     };
     // Parse failure means the on-disk file is already corrupt — refuse to
     // write rather than overwriting with an empty document, which would
@@ -1499,23 +1496,39 @@ pub async fn config_set(
     }
 
     // Backup under backups/ before write (single rolling copy).
-    if config_path.exists() {
-        if let Some(home_dir) = config_path.parent() {
-            let backups_dir = home_dir.join("backups");
-            if std::fs::create_dir_all(&backups_dir).is_ok() {
-                let _ = std::fs::copy(&config_path, backups_dir.join("config.toml.prev"));
+    if let Some(home_dir) = config_path.parent() {
+        let backups_dir = home_dir.join("backups");
+        if tokio::fs::create_dir_all(&backups_dir).await.is_ok() {
+            match tokio::fs::copy(&config_path, backups_dir.join("config.toml.prev")).await {
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => tracing::warn!(%error, "failed to back up config.toml"),
             }
         }
     }
 
     // Write back — preserves comments, whitespace, and key ordering
-    if let Err(e) = crate::atomic_write(&config_path, new_toml_str.as_bytes()) {
-        // Scrub the io error (audit: rusqlite-errors-leak).
-        tracing::error!(error = %e, "failed to write config.toml");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"status": "error", "error": "Internal server error"})),
-        );
+    let write_path = config_path.clone();
+    let write_bytes = new_toml_str.into_bytes();
+    let write_result =
+        tokio::task::spawn_blocking(move || crate::atomic_write(&write_path, &write_bytes)).await;
+    match write_result {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            // Scrub the io error (audit: rusqlite-errors-leak).
+            tracing::error!(%error, "failed to write config.toml");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"status": "error", "error": "Internal server error"})),
+            );
+        }
+        Err(error) => {
+            tracing::error!(%error, "config write task failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"status": "error", "error": "Internal server error"})),
+            );
+        }
     }
 
     // Trigger reload


### PR DESCRIPTION
## Summary
- read and back up `config.toml` through Tokio filesystem APIs inside the existing config write lock
- run the durable atomic write on Tokio's blocking pool
- preserve allowlist, TOML round-trip, validation, reload, and scrubbed-error behavior

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p librefang-api --test config_routes_integration config_set_writes_allowlisted_path_to_tempdir_toml`
- `cargo test -p librefang-api --test config_routes_integration config_set_then_get_round_trips_a_previously_write_only_field`
- `cargo clippy -p librefang-api --lib --tests -- -D warnings`