### PR TITLE
perf(api): offload sidecar config deletion

### DIFF
--- a/changelog.d/changed/6991-sidecar-delete-io-off-thread.md
+++ b/changelog.d/changed/6991-sidecar-delete-io-off-thread.md
@@ -1,0 +1,3 @@
+`DELETE /api/channels/sidecar/{name}` rewrote `config.toml` synchronously on the async worker thread handling the request, still holding the existing `config_write_lock` across the call.
+  The sidecar-block removal and durable atomic rewrite now run on Tokio's blocking pool instead, with the config write lock held across the whole operation exactly as before.
+  A join failure on that blocking task (for example a panic inside the removal closure) is now caught and returned as a scrubbed internal error instead of propagating as an unhandled panic in the request future (#6991) (@houko)

--- a/changelog.d/changed/6991-sidecar-delete-off-thread.md
+++ b/changelog.d/changed/6991-sidecar-delete-off-thread.md
@@ -1,2 +1,0 @@
-`DELETE /api/channels/sidecar/{name}` rewrote `config.toml` inline on the axum/tokio worker handling the request, so the read, TOML parse, and durable atomic write all ran on the async executor and could stall other requests scheduled on that worker for the duration of the disk I/O.
-The rewrite now runs on `tokio::task::spawn_blocking`, still performed while holding `config_write_lock` so it continues to serialize against `configure` and `POST /api/config/set`; delete, reload, and error behavior are unchanged (#6991) (@houko)

--- a/changelog.d/changed/6991-sidecar-delete-off-thread.md
+++ b/changelog.d/changed/6991-sidecar-delete-off-thread.md
@@ -1,0 +1,2 @@
+`DELETE /api/channels/sidecar/{name}` rewrote `config.toml` inline on the axum/tokio worker handling the request, so the read, TOML parse, and durable atomic write all ran on the async executor and could stall other requests scheduled on that worker for the duration of the disk I/O.
+The rewrite now runs on `tokio::task::spawn_blocking`, still performed while holding `config_write_lock` so it continues to serialize against `configure` and `POST /api/config/set`; delete, reload, and error behavior are unchanged (#6991) (@houko)

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1158,10 +1158,11 @@ pub async fn delete_sidecar_channel(
     // Rewrite config.toml under the same lock that gates configure and POST /api/config/set.
     let removed = {
         let _config_guard = state.config_write_lock.lock().await;
-        let remove_path = config_path.clone();
+        // `config_path` isn't read again after this block, so move it straight into the
+        // blocking task instead of cloning; `name` is still needed below for the 404 message.
         let remove_name = name.clone();
         tokio::task::spawn_blocking(move || {
-            super::sidecar_toml::remove_sidecar_block(&remove_path, &remove_name)
+            super::sidecar_toml::remove_sidecar_block(&config_path, &remove_name)
         })
         .await
         .map_err(|e| {

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1158,8 +1158,17 @@ pub async fn delete_sidecar_channel(
     // Rewrite config.toml under the same lock that gates configure and POST /api/config/set.
     let removed = {
         let _config_guard = state.config_write_lock.lock().await;
-        super::sidecar_toml::remove_sidecar_block(&config_path, &name)
-            .map_err(|e| ApiErrorResponse::internal_scrub(e).into_json_tuple())?
+        let remove_path = config_path.clone();
+        let remove_name = name.clone();
+        tokio::task::spawn_blocking(move || {
+            super::sidecar_toml::remove_sidecar_block(&remove_path, &remove_name)
+        })
+        .await
+        .map_err(|e| {
+            ApiErrorResponse::internal_scrub(format!("sidecar delete task failed: {e}"))
+                .into_json_tuple()
+        })?
+        .map_err(|e| ApiErrorResponse::internal_scrub(e).into_json_tuple())?
     };
     if !removed {
         return Err(ApiErrorResponse::not_found(format!(


### PR DESCRIPTION
## Summary
- move sidecar config removal and durable atomic rewrite onto Tokio's blocking pool
- keep the existing config write lock held across the mutation
- preserve delete, reload, and error behavior

## Tests
- `cargo fmt --check`
- `cargo test -p librefang-api --test channel_remove_test`
- `cargo test -p librefang-api --test sidecar_toml_test`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`