### PR TITLE
fix(i18n): complete Japanese error translations

### DIFF
--- a/changelog.d/fixed/6998-japanese-error-locale-completeness.md
+++ b/changelog.d/fixed/6998-japanese-error-locale-completeness.md
@@ -1,0 +1,2 @@
+Added the five error-message translations missing from the Japanese Fluent locale (an agent invalid-sort key and four webhook error keys), preserving every Fluent interpolation variable used by the English source.
+Added a regression test asserting the Japanese locale covers every English error key so a newly introduced key can no longer ship without a translation (#6998) (@houko)

--- a/crates/librefang-types/locales/ja/errors.ftl
+++ b/crates/librefang-types/locales/ja/errors.ftl
@@ -16,6 +16,7 @@ api-error-agent-execution-failed = エージェントの実行に失敗しまし
 api-error-agent-clone-spawn-failed = クローンの作成に失敗しました: { $error }
 api-error-agent-error = エージェントエラー: { $error }
 api-error-agent-not-found-with-id = エージェントが見つかりません: { $id }
+api-error-agent-invalid-sort = 無効なソートフィールド '{ $field }' です。有効なフィールド: { $valid }
 
 # メッセージエラー
 api-error-message-too-large = メッセージが大きすぎます（最大 64KB）
@@ -219,6 +220,10 @@ api-error-webhook-invalid-events = イベントタイプは文字列である必
 api-error-webhook-event-types-required = 少なくとも 1 つのイベントタイプが必要です
 api-error-webhook-url-unreachable = Webhook URL に到達できません: { $error }
 api-error-webhook-event-publish-failed = イベントの発行に失敗しました: { $error }
+api-error-webhook-invalid-url = Webhook URL の形式が無効です
+api-error-webhook-agent-exec-failed = Webhook エージェントの実行に失敗しました: { $error }
+api-error-webhook-reach-failed = Webhook URL への接続に失敗しました: { $error }
+api-error-webhook-unknown-event = 不明なイベントタイプ '{ $event }' です。有効なタイプ: { $valid }
 
 # バックアップエラー
 api-error-backup-not-found = バックアップが見つかりません

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -405,4 +405,28 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn japanese_locale_covers_every_english_error_key() {
+        fn message_keys(source: &str) -> std::collections::BTreeSet<&str> {
+            source
+                .lines()
+                .filter_map(|line| {
+                    let (key, _) = line.split_once('=')?;
+                    let key = key.trim();
+                    (!key.is_empty() && !key.starts_with('.') && !key.starts_with('#'))
+                        .then_some(key)
+                })
+                .collect()
+        }
+
+        let english = message_keys(EN_FTL);
+        let japanese = message_keys(JA_FTL);
+        let missing: Vec<_> = english.difference(&japanese).copied().collect();
+
+        assert!(
+            missing.is_empty(),
+            "Japanese error locale is missing keys: {missing:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add the five error-message translations missing from the Japanese Fluent locale
- preserve all Fluent interpolation variables used by the English source
- add a regression test requiring Japanese to cover every English error key

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-types i18n --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-types --all-targets -- -D warnings`
- `git diff --check`