### PR TITLE
fix(i18n): restore Spanish error-message diacritics

### DIFF
--- a/changelog.d/fixed/6999-spanish-error-diacritics.md
+++ b/changelog.d/fixed/6999-spanish-error-diacritics.md
@@ -1,0 +1,2 @@
+Restored missing diacritics and inverted punctuation across the Spanish error-message locale (`válido`, `sesión`, `configuración`, `¿agente no encontrado?`, and similar), and corrected a few literal, unnatural phrasings alongside unit formatting for size limits.
+Added regression assertions for representative accented translations so a future edit cannot silently strip them again (#6999) (@houko)

--- a/crates/librefang-types/locales/es/errors.ftl
+++ b/crates/librefang-types/locales/es/errors.ftl
@@ -3,64 +3,64 @@
 # Agent errors
 api-error-agent-not-found = Agente no encontrado
 api-error-agent-spawn-failed = Error al crear el agente
-api-error-agent-invalid-id = ID de agente no valido
-api-error-session-invalid-id = ID de sesion no valido
-api-error-context-report-failed = Informe de contexto fallido
+api-error-agent-invalid-id = ID de agente no válido
+api-error-session-invalid-id = ID de sesión no válido
+api-error-context-report-failed = No se pudo generar el informe de contexto
 api-error-agent-already-exists = El agente ya existe
 
 # Message errors
-api-error-message-too-large = Mensaje demasiado grande (max 64KB)
+api-error-message-too-large = Mensaje demasiado grande (máx. 64 KB)
 api-error-message-delivery-failed = Error al enviar el mensaje: { $reason }
 
 # Template errors
-api-error-template-invalid-name = Nombre de plantilla no valido
+api-error-template-invalid-name = Nombre de plantilla no válido
 api-error-template-not-found = Plantilla '{ $name }' no encontrada
 api-error-template-parse-failed = Error al analizar la plantilla: { $error }
 api-error-template-required = Se requiere 'manifest_toml' o 'template'
 
 # Manifest errors
-api-error-manifest-too-large = Manifiesto demasiado grande (max 1MB)
-api-error-manifest-invalid-format = Formato de manifiesto no valido
+api-error-manifest-too-large = Manifiesto demasiado grande (máx. 1 MB)
+api-error-manifest-invalid-format = Formato de manifiesto no válido
 api-error-manifest-signature-mismatch = El contenido del manifiesto firmado no coincide con manifest_toml
-api-error-manifest-signature-failed = Verificacion de firma del manifiesto fallida
+api-error-manifest-signature-failed = Falló la verificación de la firma del manifiesto
 
 # Auth errors
-api-error-auth-invalid-key = Clave API no valida
+api-error-auth-invalid-key = Clave API no válida
 api-error-auth-missing-header = Falta el encabezado Authorization: Bearer <api_key>
-api-error-auth-missing = La clave API de este proveedor no esta configurada
+api-error-auth-missing = La clave API de este proveedor no está configurada
 
 # Session errors
-api-error-session-load-failed = Error al cargar la sesion
-api-error-session-not-found = Sesion no encontrada
+api-error-session-load-failed = Error al cargar la sesión
+api-error-session-not-found = Sesión no encontrada
 
 # Workflow errors
 api-error-workflow-missing-steps = Falta el arreglo 'steps'
 api-error-workflow-step-needs-agent = El paso '{ $step }' necesita 'agent_id' o 'agent_name'
-api-error-workflow-invalid-id = ID de flujo de trabajo no valido
-api-error-workflow-execution-failed = Error en la ejecucion del flujo de trabajo
+api-error-workflow-invalid-id = ID de flujo de trabajo no válido
+api-error-workflow-execution-failed = Error en la ejecución del flujo de trabajo
 
 # Trigger errors
 api-error-trigger-missing-agent-id = Falta 'agent_id'
-api-error-trigger-invalid-agent-id = agent_id no valido
-api-error-trigger-invalid-pattern = Patron de activador no valido
+api-error-trigger-invalid-agent-id = agent_id no válido
+api-error-trigger-invalid-pattern = Patrón de activador no válido
 api-error-trigger-missing-pattern = Falta 'pattern'
-api-error-trigger-registration-failed = Error al registrar el activador (agente no encontrado?)
-api-error-trigger-invalid-id = ID de activador no valido
+api-error-trigger-registration-failed = Error al registrar el activador (¿agente no encontrado?)
+api-error-trigger-invalid-id = ID de activador no válido
 api-error-trigger-not-found = Activador no encontrado
 
 # Budget errors
-api-error-budget-invalid-amount = Monto de presupuesto no valido
+api-error-budget-invalid-amount = Monto de presupuesto no válido
 api-error-budget-update-failed = Error al actualizar el presupuesto
 
 # Config errors
-api-error-config-parse-failed = Error al analizar la configuracion: { $error }
-api-error-config-write-failed = Error al escribir la configuracion: { $error }
+api-error-config-parse-failed = Error al analizar la configuración: { $error }
+api-error-config-write-failed = Error al escribir la configuración: { $error }
 
 # Profile errors
 api-error-profile-not-found = Perfil '{ $name }' no encontrado
 
 # Cron errors
-api-error-cron-invalid-id = ID de tarea programada no valido
+api-error-cron-invalid-id = ID de tarea programada no válido
 api-error-cron-not-found = Tarea programada no encontrada
 api-error-cron-create-failed = Error al crear la tarea programada: { $error }
 
@@ -68,7 +68,7 @@ api-error-cron-create-failed = Error al crear la tarea programada: { $error }
 api-error-not-found = Recurso no encontrado
 api-error-internal = Error interno del servidor
 api-error-bad-request = Solicitud incorrecta: { $reason }
-api-error-rate-limited = Limite de solicitudes excedido. Intente de nuevo mas tarde.
+api-error-rate-limited = Límite de solicitudes excedido. Inténtelo de nuevo más tarde.
 
 # Generic catch-all — interpolates the underlying error string verbatim.
 # Used by 41+ HTTP 500 handlers as a stopgap until each route is moved to a

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -226,6 +226,12 @@ mod tests {
     fn spanish_translation() {
         let t = ErrorTranslator::new("es");
         assert_eq!(t.t("api-error-agent-not-found"), "Agente no encontrado");
+        assert_eq!(t.t("api-error-agent-invalid-id"), "ID de agente no válido");
+        assert_eq!(t.t("api-error-session-not-found"), "Sesión no encontrada");
+        assert_eq!(
+            t.t("api-error-rate-limited"),
+            "Límite de solicitudes excedido. Inténtelo de nuevo más tarde."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- restore missing Spanish accents across the existing error-message translations
- correct punctuation, unit formatting, and a few unnatural literal phrases
- add regression assertions for representative accented messages

This intentionally addresses the scan finding about stripped diacritics without mixing in the much larger missing-key translation project.

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-types i18n --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-types --all-targets -- -D warnings`
- `git diff --check`