### PR TITLE
fix(i18n): restore French error-message diacritics

### DIFF
--- a/changelog.d/fixed/7000-french-error-diacritics.md
+++ b/changelog.d/fixed/7000-french-error-diacritics.md
@@ -1,0 +1,2 @@
+Restored missing diacritics across the French error-message locale (`déjà`, `échec`, `créée`, `déclencheur`, and similar), and corrected unit-abbreviation typography for size limits.
+Added regression assertions for representative accented translations so a future edit cannot silently strip them again (#7000) (@houko)

--- a/changelog.d/fixed/7000-french-error-diacritics.md
+++ b/changelog.d/fixed/7000-french-error-diacritics.md
@@ -1,2 +1,2 @@
-Restored missing diacritics across the French error-message locale (`déjà`, `échec`, `créée`, `déclencheur`, and similar), and corrected unit-abbreviation typography for size limits.
+Restored missing diacritics across the French error-message locale (`déjà`, `échec`, `création`, `déclencheur`, and similar), and corrected unit-abbreviation typography for size limits.
 Added regression assertions for representative accented translations so a future edit cannot silently strip them again (#7000) (@houko)

--- a/crates/librefang-types/locales/fr/errors.ftl
+++ b/crates/librefang-types/locales/fr/errors.ftl
@@ -1,74 +1,74 @@
 # --- API error messages (French) ---
 
 # Agent errors
-api-error-agent-not-found = Agent non trouve
-api-error-agent-spawn-failed = Echec de la creation de l'agent
+api-error-agent-not-found = Agent non trouvé
+api-error-agent-spawn-failed = Échec de la création de l'agent
 api-error-agent-invalid-id = ID d'agent non valide
 api-error-session-invalid-id = ID de session non valide
-api-error-context-report-failed = Echec du rapport de contexte
-api-error-agent-already-exists = L'agent existe deja
+api-error-context-report-failed = Échec du rapport de contexte
+api-error-agent-already-exists = L'agent existe déjà
 
 # Message errors
-api-error-message-too-large = Message trop volumineux (max 64 Ko)
-api-error-message-delivery-failed = Echec de la livraison du message : { $reason }
+api-error-message-too-large = Message trop volumineux (max. 64 Ko)
+api-error-message-delivery-failed = Échec de la livraison du message : { $reason }
 
 # Template errors
-api-error-template-invalid-name = Nom de modele non valide
-api-error-template-not-found = Modele '{ $name }' non trouve
-api-error-template-parse-failed = Echec de l'analyse du modele : { $error }
+api-error-template-invalid-name = Nom de modèle non valide
+api-error-template-not-found = Modèle '{ $name }' non trouvé
+api-error-template-parse-failed = Échec de l'analyse du modèle : { $error }
 api-error-template-required = 'manifest_toml' ou 'template' est requis
 
 # Manifest errors
-api-error-manifest-too-large = Manifeste trop volumineux (max 1 Mo)
+api-error-manifest-too-large = Manifeste trop volumineux (max. 1 Mo)
 api-error-manifest-invalid-format = Format de manifeste non valide
-api-error-manifest-signature-mismatch = Le contenu du manifeste signe ne correspond pas a manifest_toml
-api-error-manifest-signature-failed = Echec de la verification de la signature du manifeste
+api-error-manifest-signature-mismatch = Le contenu du manifeste signé ne correspond pas à manifest_toml
+api-error-manifest-signature-failed = Échec de la vérification de la signature du manifeste
 
 # Auth errors
-api-error-auth-invalid-key = Cle API non valide
-api-error-auth-missing-header = En-tete Authorization: Bearer <api_key> manquant
-api-error-auth-missing = La cle API de ce fournisseur n'est pas configuree
+api-error-auth-invalid-key = Clé API non valide
+api-error-auth-missing-header = En-tête Authorization: Bearer <api_key> manquant
+api-error-auth-missing = La clé API de ce fournisseur n'est pas configurée
 
 # Session errors
-api-error-session-load-failed = Echec du chargement de la session
-api-error-session-not-found = Session non trouvee
+api-error-session-load-failed = Échec du chargement de la session
+api-error-session-not-found = Session non trouvée
 
 # Workflow errors
 api-error-workflow-missing-steps = Tableau 'steps' manquant
-api-error-workflow-step-needs-agent = L'etape '{ $step }' necessite 'agent_id' ou 'agent_name'
+api-error-workflow-step-needs-agent = L'étape '{ $step }' nécessite 'agent_id' ou 'agent_name'
 api-error-workflow-invalid-id = ID de workflow non valide
-api-error-workflow-execution-failed = Echec de l'execution du workflow
+api-error-workflow-execution-failed = Échec de l'exécution du workflow
 
 # Trigger errors
 api-error-trigger-missing-agent-id = 'agent_id' manquant
 api-error-trigger-invalid-agent-id = agent_id non valide
-api-error-trigger-invalid-pattern = Modele de declencheur non valide
+api-error-trigger-invalid-pattern = Modèle de déclencheur non valide
 api-error-trigger-missing-pattern = 'pattern' manquant
-api-error-trigger-registration-failed = Echec de l'enregistrement du declencheur (agent non trouve ?)
-api-error-trigger-invalid-id = ID de declencheur non valide
-api-error-trigger-not-found = Declencheur non trouve
+api-error-trigger-registration-failed = Échec de l'enregistrement du déclencheur (agent non trouvé ?)
+api-error-trigger-invalid-id = ID de déclencheur non valide
+api-error-trigger-not-found = Déclencheur non trouvé
 
 # Budget errors
 api-error-budget-invalid-amount = Montant du budget non valide
-api-error-budget-update-failed = Echec de la mise a jour du budget
+api-error-budget-update-failed = Échec de la mise à jour du budget
 
 # Config errors
-api-error-config-parse-failed = Echec de l'analyse de la configuration : { $error }
-api-error-config-write-failed = Echec de l'ecriture de la configuration : { $error }
+api-error-config-parse-failed = Échec de l'analyse de la configuration : { $error }
+api-error-config-write-failed = Échec de l'écriture de la configuration : { $error }
 
 # Profile errors
-api-error-profile-not-found = Profil '{ $name }' non trouve
+api-error-profile-not-found = Profil '{ $name }' non trouvé
 
 # Cron errors
-api-error-cron-invalid-id = ID de tache planifiee non valide
-api-error-cron-not-found = Tache planifiee non trouvee
-api-error-cron-create-failed = Echec de la creation de la tache planifiee : { $error }
+api-error-cron-invalid-id = ID de tâche planifiée non valide
+api-error-cron-not-found = Tâche planifiée non trouvée
+api-error-cron-create-failed = Échec de la création de la tâche planifiée : { $error }
 
 # General errors
-api-error-not-found = Ressource non trouvee
+api-error-not-found = Ressource non trouvée
 api-error-internal = Erreur interne du serveur
-api-error-bad-request = Requete invalide : { $reason }
-api-error-rate-limited = Limite de requetes depassee. Veuillez reessayer plus tard.
+api-error-bad-request = Requête invalide : { $reason }
+api-error-rate-limited = Limite de requêtes dépassée. Veuillez réessayer plus tard.
 
 # Generic catch-all — interpolates the underlying error string verbatim.
 # Used by 41+ HTTP 500 handlers as a stopgap until each route is moved to a

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -237,7 +237,13 @@ mod tests {
     #[test]
     fn french_translation() {
         let t = ErrorTranslator::new("fr");
-        assert_eq!(t.t("api-error-agent-not-found"), "Agent non trouve");
+        assert_eq!(t.t("api-error-agent-not-found"), "Agent non trouvé");
+        assert_eq!(t.t("api-error-auth-invalid-key"), "Clé API non valide");
+        assert_eq!(t.t("api-error-session-not-found"), "Session non trouvée");
+        assert_eq!(
+            t.t("api-error-rate-limited"),
+            "Limite de requêtes dépassée. Veuillez réessayer plus tard."
+        );
     }
 
     #[test]

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -238,11 +238,82 @@ mod tests {
     fn french_translation() {
         let t = ErrorTranslator::new("fr");
         assert_eq!(t.t("api-error-agent-not-found"), "Agent non trouvé");
+        assert_eq!(
+            t.t("api-error-agent-spawn-failed"),
+            "Échec de la création de l'agent"
+        );
+        assert_eq!(
+            t.t("api-error-context-report-failed"),
+            "Échec du rapport de contexte"
+        );
+        assert_eq!(t.t("api-error-agent-already-exists"), "L'agent existe déjà");
+        assert_eq!(
+            t.t("api-error-template-invalid-name"),
+            "Nom de modèle non valide"
+        );
+        assert_eq!(
+            t.t("api-error-manifest-signature-mismatch"),
+            "Le contenu du manifeste signé ne correspond pas à manifest_toml"
+        );
+        assert_eq!(
+            t.t("api-error-manifest-signature-failed"),
+            "Échec de la vérification de la signature du manifeste"
+        );
         assert_eq!(t.t("api-error-auth-invalid-key"), "Clé API non valide");
+        assert_eq!(
+            t.t("api-error-auth-missing-header"),
+            "En-tête Authorization: Bearer <api_key> manquant"
+        );
+        assert_eq!(
+            t.t("api-error-auth-missing"),
+            "La clé API de ce fournisseur n'est pas configurée"
+        );
+        assert_eq!(
+            t.t("api-error-session-load-failed"),
+            "Échec du chargement de la session"
+        );
         assert_eq!(t.t("api-error-session-not-found"), "Session non trouvée");
+        assert_eq!(
+            t.t("api-error-workflow-execution-failed"),
+            "Échec de l'exécution du workflow"
+        );
+        assert_eq!(
+            t.t("api-error-trigger-invalid-pattern"),
+            "Modèle de déclencheur non valide"
+        );
+        assert_eq!(
+            t.t("api-error-trigger-registration-failed"),
+            "Échec de l'enregistrement du déclencheur (agent non trouvé ?)"
+        );
+        assert_eq!(
+            t.t("api-error-trigger-invalid-id"),
+            "ID de déclencheur non valide"
+        );
+        assert_eq!(t.t("api-error-trigger-not-found"), "Déclencheur non trouvé");
+        assert_eq!(
+            t.t("api-error-budget-update-failed"),
+            "Échec de la mise à jour du budget"
+        );
+        assert_eq!(
+            t.t("api-error-cron-invalid-id"),
+            "ID de tâche planifiée non valide"
+        );
+        assert_eq!(
+            t.t("api-error-cron-not-found"),
+            "Tâche planifiée non trouvée"
+        );
+        assert_eq!(t.t("api-error-not-found"), "Ressource non trouvée");
         assert_eq!(
             t.t("api-error-rate-limited"),
             "Limite de requêtes dépassée. Veuillez réessayer plus tard."
+        );
+        assert_eq!(
+            t.t_args("api-error-workflow-step-needs-agent", &[("step", "run")]),
+            "L'étape 'run' nécessite 'agent_id' ou 'agent_name'"
+        );
+        assert_eq!(
+            t.t_args("api-error-config-parse-failed", &[("error", "boom")]),
+            "Échec de l'analyse de la configuration : boom"
         );
     }
 


### PR DESCRIPTION
## Summary
- restore missing French accents across the existing error-message translations
- correct unit typography while preserving Fluent keys and variables
- update regression assertions for representative accented messages

This intentionally addresses the scan finding about stripped diacritics without mixing in the much larger missing-key translation project.

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-types i18n --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-types --all-targets -- -D warnings`
- `git diff --check`