### PR TITLE
fix(i18n): align the generic error locale contract

### DIFF
--- a/crates/librefang-types/locales/en/errors.ftl
+++ b/crates/librefang-types/locales/en/errors.ftl
@@ -310,4 +310,4 @@ api-error-rate-limited = Rate limit exceeded. Try again later.
 # Used by 41+ HTTP 500 handlers as a stopgap until each route is moved to a
 # typed MemoryRouteError-style helper. Without this key, every `t_args("api-error-generic", …)`
 # call returns the literal key as the response body and `$error` interpolation never runs.
-api-error-generic = { $error }
+api-error-generic = An error occurred: { $error }

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -300,6 +300,10 @@ mod tests {
                 result.contains("session DB corrupted"),
                 "lang '{lang}': api-error-generic must interpolate $error; got {result:?}",
             );
+            assert_ne!(
+                result, "session DB corrupted",
+                "lang '{lang}': api-error-generic must retain its localized error label",
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- give the English `api-error-generic` message a localized error label, matching every other supported locale
- preserve verbatim interpolation of the underlying diagnostic
- extend the cross-locale regression test so a locale cannot collapse the generic message to the raw diagnostic again

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-types i18n --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-types --all-targets -- -D warnings`
- `git diff --check`