### PR TITLE
fix(memory): log proactive lock poison recovery

### DIFF
--- a/changelog.d/fixed/7003-proactive-memory-poison-logging.md
+++ b/changelog.d/fixed/7003-proactive-memory-poison-logging.md
@@ -1,0 +1,2 @@
+Proactive-memory lock recovery from a poisoned state is now logged for the runtime config lock and the decay/cleanup/counter-prune maintenance locks, instead of recovering silently.
+Config reads and writes, and background maintenance scheduling, remain usable after recovery (#7003) (@houko)

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -161,14 +161,23 @@ impl ProactiveMemoryStore {
     fn read_config(&self) -> RwLockReadGuard<'_, ProactiveMemoryConfig> {
         self.config.read().unwrap_or_else(|poisoned| {
             tracing::warn!("proactive memory config read lock poisoned; recovering inner state");
-            poisoned.into_inner()
+            let guard = poisoned.into_inner();
+            // `into_inner()` only unwraps the guard; it leaves the lock's
+            // poison flag set. Without this, every later call through this
+            // helper would keep re-entering this branch and re-emitting the
+            // warning above for the rest of the process, even though the
+            // state has already been recovered.
+            self.config.clear_poison();
+            guard
         })
     }
 
     fn write_config(&self) -> RwLockWriteGuard<'_, ProactiveMemoryConfig> {
         self.config.write().unwrap_or_else(|poisoned| {
             tracing::warn!("proactive memory config write lock poisoned; recovering inner state");
-            poisoned.into_inner()
+            let guard = poisoned.into_inner();
+            self.config.clear_poison();
+            guard
         })
     }
 
@@ -178,7 +187,9 @@ impl ProactiveMemoryStore {
                 lock = name,
                 "proactive memory lock poisoned; recovering inner state"
             );
-            poisoned.into_inner()
+            let guard = poisoned.into_inner();
+            lock.clear_poison();
+            guard
         })
     }
 

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -38,7 +38,7 @@ use librefang_types::memory::{
     CHAT_SCOPE_METADATA_KEY,
 };
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::Instrument;
 
 /// Scope names for multi-level memory.
@@ -158,6 +158,30 @@ impl Clone for ProactiveMemoryStore {
 }
 
 impl ProactiveMemoryStore {
+    fn read_config(&self) -> RwLockReadGuard<'_, ProactiveMemoryConfig> {
+        self.config.read().unwrap_or_else(|poisoned| {
+            tracing::warn!("proactive memory config read lock poisoned; recovering inner state");
+            poisoned.into_inner()
+        })
+    }
+
+    fn write_config(&self) -> RwLockWriteGuard<'_, ProactiveMemoryConfig> {
+        self.config.write().unwrap_or_else(|poisoned| {
+            tracing::warn!("proactive memory config write lock poisoned; recovering inner state");
+            poisoned.into_inner()
+        })
+    }
+
+    fn lock_recover<'a, T>(lock: &'a Mutex<T>, name: &'static str) -> MutexGuard<'a, T> {
+        lock.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                lock = name,
+                "proactive memory lock poisoned; recovering inner state"
+            );
+            poisoned.into_inner()
+        })
+    }
+
     /// Create a new proactive memory store with default extractor.
     pub fn new(substrate: Arc<MemorySubstrate>, config: ProactiveMemoryConfig) -> Self {
         let pool = substrate.pool();
@@ -216,15 +240,12 @@ impl ProactiveMemoryStore {
 
     /// Get a snapshot of the current config.
     pub fn config(&self) -> ProactiveMemoryConfig {
-        self.config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.read_config().clone()
     }
 
     /// Hot-swap the runtime config (called on config reload).
     pub fn update_config(&self, new_config: ProactiveMemoryConfig) {
-        let mut guard = self.config.write().unwrap_or_else(|e| e.into_inner());
+        let mut guard = self.write_config();
         *guard = new_config;
     }
 
@@ -247,11 +268,7 @@ impl ProactiveMemoryStore {
     /// maintenance scheduler (see `run_periodic_maintenance`), so a direct
     /// call (e.g. a manual `/decay` endpoint or a test) decays right away.
     pub fn decay_confidence(&self) -> LibreFangResult<()> {
-        let decay_rate = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .confidence_decay_rate;
+        let decay_rate = self.read_config().confidence_decay_rate;
         if decay_rate <= 0.0 {
             return Ok(());
         }
@@ -346,10 +363,7 @@ impl ProactiveMemoryStore {
     fn maybe_decay_confidence(&self) {
         let now = Utc::now();
         // Hold the lock for the entire check-and-update to avoid TOCTOU race
-        let mut guard = self
-            .last_decay_run
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut guard = Self::lock_recover(&self.last_decay_run, "last_decay_run");
 
         let should_run = match *guard {
             Some(last) => (now - last) >= chrono::Duration::hours(1),
@@ -376,11 +390,7 @@ impl ProactiveMemoryStore {
     ///
     /// This is the global variant of `cleanup_expired_sessions` (which is per-agent).
     pub fn cleanup_expired(&self) -> LibreFangResult<u64> {
-        let ttl_hours = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .session_ttl_hours;
+        let ttl_hours = self.read_config().session_ttl_hours;
         if ttl_hours == 0 {
             return Ok(0);
         }
@@ -410,10 +420,7 @@ impl ProactiveMemoryStore {
     fn maybe_cleanup_expired(&self) {
         let now = Utc::now();
         // Hold the lock for the entire check-and-update to avoid TOCTOU race
-        let mut guard = self
-            .last_cleanup_run
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut guard = Self::lock_recover(&self.last_cleanup_run, "last_cleanup_run");
 
         let should_run = match *guard {
             Some(last) => (now - last) >= chrono::Duration::hours(1),
@@ -457,10 +464,7 @@ impl ProactiveMemoryStore {
     /// (review-followup #3).
     fn maybe_prune_counters(&self) {
         let now = Utc::now();
-        let mut guard = self
-            .last_counter_prune
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut guard = Self::lock_recover(&self.last_counter_prune, "last_counter_prune");
 
         let should_run = match *guard {
             Some(last) => (now - last) >= chrono::Duration::hours(1),
@@ -497,7 +501,9 @@ impl ProactiveMemoryStore {
         // an active slot, however slow, is preserved as long as it's
         // been touched within the window; a truly idle slot is
         // reclaimed within ~2 hours of going quiet.
-        if let Ok(mut counters) = self.consolidation_counters.lock() {
+        {
+            let mut counters =
+                Self::lock_recover(&self.consolidation_counters, "consolidation_counters");
             let cutoff = now - chrono::Duration::hours(STALE_COUNTER_IDLE_WINDOW_HOURS);
             let before = counters.len();
             counters.retain(|_, entry| entry.last_touched >= cutoff);
@@ -883,7 +889,7 @@ impl ProactiveMemoryStore {
             "callers must not pre-populate `_update_threshold_cross_cat` — it is private to add_with_decision"
         );
         let (same_cat_thresh, cross_cat_thresh) = {
-            let cfg = self.config.read().unwrap_or_else(|e| e.into_inner());
+            let cfg = self.read_config();
             (
                 cfg.update_threshold_same_category,
                 cfg.update_threshold_cross_category,
@@ -1035,11 +1041,7 @@ impl ProactiveMemoryStore {
     ///
     /// Does nothing when the cap is 0 (disabled) or when there is still room.
     fn evict_if_over_cap(&self, agent_id: AgentId, new_count: usize) -> LibreFangResult<()> {
-        let max = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .max_memories_per_agent;
+        let max = self.read_config().max_memories_per_agent;
         if max == 0 {
             return Ok(()); // cap disabled
         }
@@ -1252,11 +1254,7 @@ impl ProactiveMemoryStore {
     /// names appear in the memory content. Honors the configured
     /// `format_context_max_chars` (H4 review-followup #8).
     pub fn format_context_with_query(&self, memories: &[MemoryItem], query: &str) -> String {
-        let max_chars = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .format_context_max_chars;
+        let max_chars = self.read_config().format_context_max_chars;
         let mut context = librefang_types::memory::format_memories_with_budget(memories, max_chars);
 
         // Append knowledge graph context if relevant
@@ -1270,11 +1268,7 @@ impl ProactiveMemoryStore {
 
     /// Format retrieved memories into a context string for prompt injection.
     pub fn format_context(&self, memories: &[MemoryItem]) -> String {
-        let max_chars = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .format_context_max_chars;
+        let max_chars = self.read_config().format_context_max_chars;
         librefang_types::memory::format_memories_with_budget(memories, max_chars)
     }
 
@@ -1293,7 +1287,7 @@ impl ProactiveMemoryStore {
         // Use SQL GROUP BY to count categories without loading all items into memory
         let categories = self.semantic.count_by_category(Some(agent_id))?;
 
-        let cfg = self.config.read().unwrap_or_else(|e| e.into_inner());
+        let cfg = self.read_config();
         Ok(MemoryStats {
             total,
             user_count,
@@ -1321,7 +1315,7 @@ impl ProactiveMemoryStore {
         // Use SQL GROUP BY to count categories without loading all items into memory
         let categories = self.semantic.count_by_category(None)?;
 
-        let cfg = self.config.read().unwrap_or_else(|e| e.into_inner());
+        let cfg = self.read_config();
         Ok(MemoryStats {
             total,
             user_count,
@@ -1608,11 +1602,7 @@ impl ProactiveMemoryStore {
             );
         }
 
-        let threshold = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .duplicate_threshold;
+        let threshold = self.read_config().duplicate_threshold;
 
         let mut used = vec![false; all_items.len()];
         let mut groups: Vec<Vec<MemoryItem>> = Vec::new();
@@ -1967,12 +1957,7 @@ impl ProactiveMemory for ProactiveMemoryStore {
 
         let agent_id = Self::parse_agent_id(user_id)?;
 
-        let categories = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .extract_categories
-            .clone();
+        let categories = self.read_config().extract_categories.clone();
 
         // Step 1: Extract structured memories
         let extraction = self
@@ -2471,11 +2456,7 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
         peer_id: Option<&str>,
         chat_scope: Option<&str>,
     ) -> LibreFangResult<ExtractionResult> {
-        let cfg = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
+        let cfg = self.read_config().clone();
         if !cfg.enabled || !cfg.auto_memorize || conversation.is_empty() {
             return Ok(ExtractionResult {
                 memories: Vec::new(),
@@ -2586,10 +2567,8 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
         // auto_memorize calls per agent. Detached to a background task
         // by H6 so this branch never blocks the agent's hot path.
         let should_consolidate = {
-            let mut counters = self
-                .consolidation_counters
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let mut counters =
+                Self::lock_recover(&self.consolidation_counters, "consolidation_counters");
             let now = Utc::now();
             let entry = counters.entry(user_id.to_string()).or_insert(CounterEntry {
                 count: 0,
@@ -2670,11 +2649,7 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
         peer_id: Option<&str>,
         chat_scope: Option<&str>,
     ) -> LibreFangResult<Vec<MemoryItem>> {
-        let cfg = self
-            .config
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
+        let cfg = self.read_config().clone();
         if !cfg.enabled || !cfg.auto_retrieve {
             return Ok(Vec::new());
         }
@@ -2757,6 +2732,39 @@ fn memory_chat_scope_allows(memory: &MemoryItem, current: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_recovers_config_and_maintenance_locks_after_poisoning() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let store = ProactiveMemoryStore::with_default_config(Arc::new(substrate));
+
+        let config_poisoner = store.clone();
+        assert!(std::thread::spawn(move || {
+            let mut config = config_poisoner.config.write().unwrap();
+            config.enabled = false;
+            panic!("poison proactive memory config lock");
+        })
+        .join()
+        .is_err());
+        assert!(!store.config().enabled);
+
+        let mut replacement = store.config();
+        replacement.enabled = true;
+        store.update_config(replacement);
+        assert!(store.config().enabled);
+
+        let maintenance_poisoner = store.clone();
+        assert!(std::thread::spawn(move || {
+            let _guard = maintenance_poisoner.last_decay_run.lock().unwrap();
+            panic!("poison proactive memory maintenance lock");
+        })
+        .join()
+        .is_err());
+        let mut recovered =
+            ProactiveMemoryStore::lock_recover(&store.last_decay_run, "last_decay_run");
+        *recovered = Some(Utc::now());
+        assert!(recovered.is_some());
+    }
 
     #[tokio::test]
     async fn test_proactive_memory_search() {

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -162,11 +162,8 @@ impl ProactiveMemoryStore {
         self.config.read().unwrap_or_else(|poisoned| {
             tracing::warn!("proactive memory config read lock poisoned; recovering inner state");
             let guard = poisoned.into_inner();
-            // `into_inner()` only unwraps the guard; it leaves the lock's
-            // poison flag set. Without this, every later call through this
-            // helper would keep re-entering this branch and re-emitting the
-            // warning above for the rest of the process, even though the
-            // state has already been recovered.
+            // `into_inner()` only unwraps the guard; it leaves the lock's poison flag set.
+            // Without this, every later call through this helper would keep re-entering this branch and re-emitting the warning above for the rest of the process, even though the state has already been recovered.
             self.config.clear_poison();
             guard
         })


### PR DESCRIPTION
## Summary
- centralize proactive-memory config and maintenance lock recovery
- warn whenever poisoned state is accepted instead of silently continuing
- recover the consolidation-counter prune lock instead of silently skipping maintenance
- verify config reads, writes, and maintenance state remain available after poisoning

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-memory proactive --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-memory --all-targets -- -D warnings`
- `git diff --check`