### PR TITLE
fix(audit): log audit-chain lock poison recovery

### DIFF
--- a/changelog.d/fixed/7007-audit-lock-poison-logging.md
+++ b/changelog.d/fixed/7007-audit-lock-poison-logging.md
@@ -1,0 +1,2 @@
+Audit-log lock recovery from a poisoned state is now logged with the specific state involved — entries, tip, chain anchor, or load-error — instead of recovering silently across every accessor.
+Recording, verification, and retention all continue to operate correctly after recovery, with the hash chain's integrity preserved (#7007) (@houko)

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -16,7 +16,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
+
+fn lock_audit_recover<'a, T>(mutex: &'a Mutex<T>, state: &'static str) -> MutexGuard<'a, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!(state, "audit log lock poisoned; recovering inner state");
+        poisoned.into_inner()
+    })
+}
 
 /// Default hard cap on the number of audit entries kept in memory when no
 /// operator-supplied `max_in_memory_entries` is configured.
@@ -527,9 +534,8 @@ impl AuditLog {
         // return `Err` in that case so `/api/audit/verify` surfaces it.
         match Self::read_anchor(&anchor_path) {
             Ok(Some(record)) => {
-                let current_tip = log.tip.lock().unwrap_or_else(|e| e.into_inner()).clone();
-                let current_seq =
-                    log.entries.lock().unwrap_or_else(|e| e.into_inner()).len() as u64;
+                let current_tip = lock_audit_recover(&log.tip, "tip").clone();
+                let current_seq = lock_audit_recover(&log.entries, "entries").len() as u64;
                 if record.hash != current_tip {
                     tracing::error!(
                         anchor_seq = record.seq,
@@ -550,8 +556,8 @@ impl AuditLog {
             Ok(None) => {
                 // First run with an anchor configured: seed it from the
                 // current tip so subsequent boots can detect tampering.
-                let tip = log.tip.lock().unwrap_or_else(|e| e.into_inner()).clone();
-                let seq = log.entries.lock().unwrap_or_else(|e| e.into_inner()).len() as u64;
+                let tip = lock_audit_recover(&log.tip, "tip").clone();
+                let seq = lock_audit_recover(&log.entries, "entries").len() as u64;
                 if let Err(e) = Self::write_anchor(&anchor_path, seq, &tip) {
                     tracing::warn!("Failed to initialise audit anchor {anchor_path:?}: {e}");
                 } else {
@@ -793,8 +799,8 @@ impl AuditLog {
         let outcome = outcome.into();
         let timestamp = Utc::now().to_rfc3339();
 
-        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        let mut tip = self.tip.lock().unwrap_or_else(|e| e.into_inner());
+        let mut entries = lock_audit_recover(&self.entries, "entries");
+        let mut tip = lock_audit_recover(&self.tip, "tip");
 
         // Derive the next seq from the last entry, not `entries.len()`,
         // because a retention trim may have dropped a prefix — using
@@ -972,7 +978,7 @@ impl AuditLog {
             let overflow = entries.len() - soft_cap;
             let new_anchor = entries[overflow - 1].hash.clone();
             {
-                let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
+                let mut anchor = lock_audit_recover(&self.chain_anchor, "chain_anchor");
                 *anchor = Some(new_anchor);
             }
             entries.drain(..overflow);
@@ -1008,25 +1014,16 @@ impl AuditLog {
     /// Returns `Ok(())` if the chain is intact, or `Err(msg)` describing
     /// the first inconsistency found.
     pub fn verify_integrity(&self) -> Result<(), String> {
-        if let Some(error) = self
-            .load_error
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .as_ref()
-        {
+        if let Some(error) = lock_audit_recover(&self.load_error, "load_error").as_ref() {
             return Err(format!("audit trail was only partially loaded: {error}"));
         }
 
-        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entries = lock_audit_recover(&self.entries, "entries");
         // When the retention trim job has dropped a prefix, the first
         // surviving entry's `prev_hash` points at the last dropped
         // entry rather than the genesis sentinel. Seed the walk from
         // the chain anchor so the trim boundary verifies cleanly.
-        let anchor = self
-            .chain_anchor
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
+        let anchor = lock_audit_recover(&self.chain_anchor, "chain_anchor").clone();
         let mut expected_prev = anchor.unwrap_or_else(|| "0".repeat(64));
 
         for entry in entries.iter() {
@@ -1127,12 +1124,12 @@ impl AuditLog {
     /// Returns the current tip hash (the hash of the most recent entry,
     /// or the genesis sentinel if the log is empty).
     pub fn tip_hash(&self) -> String {
-        self.tip.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        lock_audit_recover(&self.tip, "tip").clone()
     }
 
     /// Returns the number of entries in the log.
     pub fn len(&self) -> usize {
-        self.entries.lock().unwrap_or_else(|e| e.into_inner()).len()
+        lock_audit_recover(&self.entries, "entries").len()
     }
 
     /// Returns the configured external tip-anchor path, if any.
@@ -1147,15 +1144,12 @@ impl AuditLog {
 
     /// Returns whether the log is empty.
     pub fn is_empty(&self) -> bool {
-        self.entries
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_empty()
+        lock_audit_recover(&self.entries, "entries").is_empty()
     }
 
     /// Returns up to the most recent `n` entries (cloned).
     pub fn recent(&self, n: usize) -> Vec<AuditEntry> {
-        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entries = lock_audit_recover(&self.entries, "entries");
         let start = entries.len().saturating_sub(n);
         entries[start..].to_vec()
     }
@@ -1179,7 +1173,7 @@ impl AuditLog {
     /// strictly increasing `seq` order; `record_with_context` is the
     /// only mutator and it monotonically allocates `seq` before push.
     pub fn since_seq(&self, cursor: u64) -> Vec<AuditEntry> {
-        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entries = lock_audit_recover(&self.entries, "entries");
         let idx = entries.partition_point(|e| e.seq <= cursor);
         entries[idx..].to_vec()
     }
@@ -1210,7 +1204,7 @@ impl AuditLog {
         policy: &AuditRetentionConfig,
         now: chrono::DateTime<chrono::Utc>,
     ) -> TrimReport {
-        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let mut entries = lock_audit_recover(&self.entries, "entries");
 
         // Decide the prefix length to drop. We compute `drop_count`
         // first without mutating, then apply both the DB delete and the
@@ -1335,7 +1329,7 @@ impl AuditLog {
         // lock) sees a consistent (anchor, first_survivor) pair when
         // it acquires.
         {
-            let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
+            let mut anchor = lock_audit_recover(&self.chain_anchor, "chain_anchor");
             *anchor = report.new_chain_anchor.clone();
         }
         entries.drain(..drop_count);
@@ -1348,7 +1342,7 @@ impl AuditLog {
         // "audit anchor mismatch" on the very next verification.
         if let Some(ref anchor_path) = self.anchor_path {
             let new_count = self.persisted_rows.load(Ordering::Relaxed) as u64;
-            let tip = self.tip.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            let tip = lock_audit_recover(&self.tip, "tip").clone();
             if let Err(e) = Self::write_anchor(anchor_path, new_count, &tip) {
                 tracing::warn!(
                     path = ?anchor_path,
@@ -1382,7 +1376,7 @@ impl AuditLog {
         let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
         let cutoff_str = cutoff.to_rfc3339();
 
-        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let mut entries = lock_audit_recover(&self.entries, "entries");
         let total = entries.len();
         if total == 0 {
             return 0;
@@ -1459,7 +1453,7 @@ impl AuditLog {
         // `entries[0].prev_hash` no longer matches the anchor —
         // verify_integrity would then raise a spurious "chain break".
         {
-            let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
+            let mut anchor = lock_audit_recover(&self.chain_anchor, "chain_anchor");
             *anchor = Some(new_anchor);
         }
         entries.drain(..drop_count);
@@ -1471,7 +1465,7 @@ impl AuditLog {
         // itself does not move (we only drop a prefix).
         if let Some(ref anchor_path) = self.anchor_path {
             let new_count = self.persisted_rows.load(Ordering::Relaxed) as u64;
-            let tip = self.tip.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            let tip = lock_audit_recover(&self.tip, "tip").clone();
             if let Err(e) = Self::write_anchor(anchor_path, new_count, &tip) {
                 tracing::warn!(
                     path = ?anchor_path,

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -21,6 +21,9 @@ use std::sync::{Mutex, MutexGuard};
 fn lock_audit_recover<'a, T>(mutex: &'a Mutex<T>, state: &'static str) -> MutexGuard<'a, T> {
     mutex.lock().unwrap_or_else(|poisoned| {
         tracing::warn!(state, "audit log lock poisoned; recovering inner state");
+        // `into_inner()` only unwraps this guard; it does not reset the mutex's poison flag.
+        // Without `clear_poison()`, every future access through this helper would re-enter this branch and re-log forever for that same lock.
+        mutex.clear_poison();
         poisoned.into_inner()
     })
 }

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -24,11 +24,18 @@ fn test_audit_log_recovers_poisoned_chain_locks_with_integrity_intact() {
             .join()
     });
     assert!(tip_poison.is_err());
+    assert!(log.entries.is_poisoned());
+    assert!(log.tip.is_poisoned());
 
     log.record("agent-1", AuditAction::ShellExec, "after poison", "ok");
     assert_eq!(log.len(), 2);
     assert!(log.verify_integrity().is_ok());
     assert_eq!(log.tip_hash(), log.recent(1)[0].hash);
+
+    // The first post-panic access must clear the poison flag via `clear_poison()`, not just unwrap around it with `into_inner()`.
+    // Otherwise every later call through `lock_audit_recover` for that same lock re-enters the poisoned branch and re-emits the `warn!` for the rest of the process instead of recovering once.
+    assert!(!log.entries.is_poisoned());
+    assert!(!log.tip.is_poisoned());
 }
 
 #[test]

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -1,6 +1,37 @@
 use super::*;
 
 #[test]
+fn test_audit_log_recovers_poisoned_chain_locks_with_integrity_intact() {
+    let log = AuditLog::new();
+    log.record("agent-1", AuditAction::ToolInvoke, "before poison", "ok");
+
+    let entries_poison = std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let _guard = log.entries.lock().unwrap();
+                panic!("poison audit entries lock");
+            })
+            .join()
+    });
+    assert!(entries_poison.is_err());
+
+    let tip_poison = std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let _guard = log.tip.lock().unwrap();
+                panic!("poison audit tip lock");
+            })
+            .join()
+    });
+    assert!(tip_poison.is_err());
+
+    log.record("agent-1", AuditAction::ShellExec, "after poison", "ok");
+    assert_eq!(log.len(), 2);
+    assert!(log.verify_integrity().is_ok());
+    assert_eq!(log.tip_hash(), log.recent(1)[0].hash);
+}
+
+#[test]
 fn test_audit_chain_integrity() {
     let log = AuditLog::new();
     log.record(


### PR DESCRIPTION
## Summary
- centralize audit-log mutex recovery with warnings identifying entries, tip, chain anchor, or load-error state
- replace every silent poison recovery across recording, verification, retention, and accessors
- verify recording can continue after entries/tip poisoning while the complete hash chain still passes integrity validation

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-runtime-audit --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-runtime-audit --all-targets -- -D warnings`
- `git diff --check`