### PR TITLE
fix(metering): log reservation ledger recovery

### DIFF
--- a/crates/librefang-kernel-metering/src/lib.rs
+++ b/crates/librefang-kernel-metering/src/lib.rs
@@ -14,8 +14,9 @@ use librefang_memory::usage::{ModelUsage, UsageRecord, UsageStore, UsageSummary}
 use librefang_types::agent::{AgentId, ResourceQuota, UserId};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::model_catalog::ModelCatalogEntry;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
+use tracing::warn;
 
 const DEFAULT_INPUT_COST_PER_M: f64 = 1.0;
 const DEFAULT_OUTPUT_COST_PER_M: f64 = 3.0;
@@ -38,8 +39,15 @@ struct CostReservationLedger {
 }
 
 impl CostReservationLedger {
+    fn lock_reserved(&self) -> MutexGuard<'_, f64> {
+        self.reserved_usd.lock().unwrap_or_else(|poisoned| {
+            warn!("cost reservation ledger lock poisoned; recovering pending budget state");
+            poisoned.into_inner()
+        })
+    }
+
     fn current(&self) -> f64 {
-        *self.reserved_usd.lock().unwrap_or_else(|e| e.into_inner())
+        *self.lock_reserved()
     }
 
     /// Atomically check that adding `usd` to the current pending total
@@ -56,7 +64,7 @@ impl CostReservationLedger {
     /// second waits on the mutex until the first has either added or
     /// returned.
     fn check_and_add(&self, usd: f64, caps: &[(f64, f64)]) -> Result<(f64, f64), CapBreach> {
-        let mut g = self.reserved_usd.lock().unwrap_or_else(|e| e.into_inner());
+        let mut g = self.lock_reserved();
         let add = usd.max(0.0);
         for (idx, (limit, already_spent)) in caps.iter().enumerate() {
             if *limit <= 0.0 {
@@ -81,7 +89,7 @@ impl CostReservationLedger {
         if usd <= 0.0 {
             return;
         }
-        let mut g = self.reserved_usd.lock().unwrap_or_else(|e| e.into_inner());
+        let mut g = self.lock_reserved();
         *g = (*g - usd).max(0.0);
     }
 }
@@ -805,6 +813,30 @@ mod tests {
     fn test_catalog() -> librefang_runtime::model_catalog::ModelCatalog {
         let home = librefang_runtime::registry_sync::resolve_home_dir_for_tests();
         librefang_runtime::model_catalog::ModelCatalog::new(&home)
+    }
+
+    #[test]
+    fn poisoned_cost_ledger_lock_recovers_and_preserves_budget_accounting() {
+        let ledger = CostReservationLedger::default();
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let mut reserved = ledger.reserved_usd.lock().unwrap();
+                    *reserved = 0.4;
+                    panic!("poison cost reservation ledger");
+                })
+                .join()
+        });
+
+        assert!(poison.is_err());
+        assert_eq!(ledger.current(), 0.4);
+        let (pending_before, added) = ledger.check_and_add(0.5, &[(1.0, 0.0)]).unwrap();
+        assert_eq!(pending_before, 0.4);
+        assert_eq!(added, 0.5);
+        assert_eq!(ledger.current(), 0.9);
+        assert!(ledger.check_and_add(0.2, &[(1.0, 0.0)]).is_err());
+        ledger.release(0.5);
+        assert!((ledger.current() - 0.4).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- centralize poisoned cost-reservation ledger recovery with an explicit warning
- use the observable recovery path for budget reads, atomic reservations, and releases
- verify pending spend and cap enforcement remain correct after poisoning

## Verification
- `cargo test -p librefang-kernel-metering --lib` (39 passed)
- `cargo clippy -p librefang-kernel-metering --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`