### PR TITLE
fix(hands): log activation lock recovery

### DIFF
--- a/changelog.d/fixed/7028-hand-activation-lock-logging.md
+++ b/changelog.d/fixed/7028-hand-activation-lock-logging.md
@@ -1,3 +1,4 @@
 Hand activation now logs when the activation mutex recovers from a poisoned lock, instead of recovering silently.
 The mutex only serializes the check-and-insert critical section and guards no data of its own, so recovering via `into_inner()` was already safe — the gap was visibility into a prior panic, not correctness.
+The recovery path also clears the mutex's poison flag once the inner state has been read out, so a single panic produces one diagnostic log line rather than a permanent per-call warning for the rest of the process, matching the fix already applied to `CommandQueue`'s locks (#7013).
 This brings `activate_with_id` in line with the existing `persist_lock` poison-recovery logging (#7028) (@houko)

--- a/changelog.d/fixed/7028-hand-activation-lock-logging.md
+++ b/changelog.d/fixed/7028-hand-activation-lock-logging.md
@@ -1,0 +1,3 @@
+Hand activation now logs when the activation mutex recovers from a poisoned lock, instead of recovering silently.
+The mutex only serializes the check-and-insert critical section and guards no data of its own, so recovering via `into_inner()` was already safe — the gap was visibility into a prior panic, not correctness.
+This brings `activate_with_id` in line with the existing `persist_lock` poison-recovery logging (#7028) (@houko)

--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -1184,7 +1184,10 @@ impl HandRegistry {
         }
 
         // Hold the lock for the duration of check + insert to prevent races.
-        let _guard = self.activate_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = self.activate_lock.lock().unwrap_or_else(|e| {
+            warn!("activate_with_id: activate_lock poisoned, recovering: {e}");
+            e.into_inner()
+        });
 
         // Check if already active — only block when instance_id is None
         // (single-instance mode). When Some(uuid) is passed, it's an explicit
@@ -1828,6 +1831,29 @@ fn check_option_available(provider_env: Option<&str>, binary: Option<&str>) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn poisoned_activation_lock_recovers_and_activation_remains_usable() {
+        let reg = HandRegistry::new();
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let _guard = reg.activate_lock.lock().unwrap();
+                    panic!("poison hand activation lock");
+                })
+                .join()
+        });
+        assert!(poison.is_err());
+
+        reg.reload_from_disk(&ensure_test_home());
+        let instance = reg.activate("clip", HashMap::new()).unwrap();
+        assert_eq!(instance.hand_id, "clip");
+        assert!(matches!(
+            reg.activate("clip", HashMap::new()),
+            Err(HandError::AlreadyActive(_))
+        ));
+        reg.deactivate(instance.instance_id).unwrap();
+    }
 
     /// Ensure the test home dir has synced registry content.
     /// resolve_home_dir_for_tests() handles sync internally via OnceLock.

--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -1186,6 +1186,11 @@ impl HandRegistry {
         // Hold the lock for the duration of check + insert to prevent races.
         let _guard = self.activate_lock.lock().unwrap_or_else(|e| {
             warn!("activate_with_id: activate_lock poisoned, recovering: {e}");
+            // `into_inner()` only unwraps this guard; it does not reset the lock's
+            // poison flag, so without `clear_poison()` every future call would
+            // re-enter this branch and re-log forever (see #7013 for the same
+            // fix applied to `CommandQueue`'s locks).
+            self.activate_lock.clear_poison();
             e.into_inner()
         });
 
@@ -1844,9 +1849,14 @@ mod tests {
                 .join()
         });
         assert!(poison.is_err());
+        assert!(reg.activate_lock.is_poisoned());
 
         reg.reload_from_disk(&ensure_test_home());
         let instance = reg.activate("clip", HashMap::new()).unwrap();
+        // The first post-panic access must clear the poison flag, not just
+        // unwrap around it — otherwise every subsequent call re-enters the
+        // recovery branch (and its `warn!`) for the rest of the process.
+        assert!(!reg.activate_lock.is_poisoned());
         assert_eq!(instance.hand_id, "clip");
         assert!(matches!(
             reg.activate("clip", HashMap::new()),


### PR DESCRIPTION
## Summary
- make hand activation mutex poison recovery observable, matching the existing persistence-lock behavior
- preserve atomic check-and-insert activation after recovery
- verify activation, duplicate rejection, and deactivation remain usable after poisoning

## Verification
- `cargo test -p librefang-hands poisoned_activation_lock_recovers_and_activation_remains_usable --lib`
- `cargo clippy -p librefang-hands --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`