### PR TITLE
fix(runtime): recover checkpoint counter poison

### DIFF
--- a/changelog.d/fixed/7030-checkpoint-counter-poison-recovery.md
+++ b/changelog.d/fixed/7030-checkpoint-counter-poison-recovery.md
@@ -1,0 +1,3 @@
+Recovered the checkpoint snapshot concurrency counter after mutex poisoning instead of panicking at snapshot entry or silently skipping the decrement in the cleanup guard.
+A panic while the counter lock was held used to either abort the current snapshot attempt outright or leave the permit accounting off by one forever, since the old cleanup path only decremented on `Ok`.
+The lock is now recovered via `into_inner()` and the poison flag cleared so the mutex stops re-poisoning every later lock attempt, and a regression test exercises the poison-then-recover-then-release sequence (#7030) (@houko)

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -20,7 +20,7 @@
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -146,7 +146,23 @@ pub struct CheckpointManager {
     /// snapshot that cannot immediately obtain the permit is **skipped**
     /// rather than queued — preventing memory pressure from accumulated
     /// waiting tasks.
-    semaphore: Arc<std::sync::Mutex<usize>>,
+    semaphore: Arc<Mutex<usize>>,
+}
+
+fn lock_snapshot_counter(counter: &Mutex<usize>) -> MutexGuard<'_, usize> {
+    counter.lock().unwrap_or_else(|poisoned| {
+        warn!("checkpoint concurrency counter lock poisoned; recovering counter state");
+        poisoned.into_inner()
+    })
+}
+
+struct ConcurrencyGuard(Arc<Mutex<usize>>);
+
+impl Drop for ConcurrencyGuard {
+    fn drop(&mut self) {
+        let mut count = lock_snapshot_counter(&self.0);
+        *count = count.saturating_sub(1);
+    }
 }
 
 impl CheckpointManager {
@@ -157,7 +173,7 @@ impl CheckpointManager {
     pub fn new(base_dir: PathBuf) -> Self {
         Self {
             base_dir,
-            semaphore: Arc::new(std::sync::Mutex::new(0)),
+            semaphore: Arc::new(Mutex::new(0)),
         }
     }
 
@@ -182,7 +198,7 @@ impl CheckpointManager {
         // use 20–50 MB).  The skipped snapshot is non-fatal — the next
         // file_write/apply_patch will attempt a fresh snapshot.
         {
-            let mut count = self.semaphore.lock().unwrap();
+            let mut count = lock_snapshot_counter(&self.semaphore);
             if *count >= MAX_CONCURRENT_SNAPSHOTS {
                 debug!(
                     reason,
@@ -194,14 +210,6 @@ impl CheckpointManager {
             // MutexGuard drops here — lock released before git runs.
         }
         // Decrement the counter when this function returns (success or error).
-        struct ConcurrencyGuard(Arc<std::sync::Mutex<usize>>);
-        impl Drop for ConcurrencyGuard {
-            fn drop(&mut self) {
-                if let Ok(mut c) = self.0.lock() {
-                    *c = c.saturating_sub(1);
-                }
-            }
-        }
         let _guard = ConcurrencyGuard(Arc::clone(&self.semaphore));
 
         let work_dir = normalize_path(work_dir)?;
@@ -704,6 +712,27 @@ fn normalize_path(path: &Path) -> Result<PathBuf, CheckpointError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn poisoned_snapshot_counter_recovers_and_guard_releases_permit() {
+        let counter = Arc::new(Mutex::new(0usize));
+        let poison_counter = Arc::clone(&counter);
+        let poison = std::thread::spawn(move || {
+            let mut count = poison_counter.lock().unwrap();
+            *count = 1;
+            panic!("poison checkpoint concurrency counter");
+        })
+        .join();
+        assert!(poison.is_err());
+
+        {
+            let mut count = lock_snapshot_counter(&counter);
+            *count += 1;
+        }
+        drop(ConcurrencyGuard(Arc::clone(&counter)));
+
+        assert_eq!(*lock_snapshot_counter(&counter), 1);
+    }
 
     #[test]
     fn valid_commit_hashes_are_accepted() {

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -153,12 +153,8 @@ fn lock_snapshot_counter(counter: &Mutex<usize>) -> MutexGuard<'_, usize> {
     counter.lock().unwrap_or_else(|poisoned| {
         warn!("checkpoint concurrency counter lock poisoned; recovering counter state");
         let guard = poisoned.into_inner();
-        // `into_inner` recovers the guard but leaves the mutex's poison flag
-        // set, so every future `lock()` call would keep taking this
-        // `Err(PoisonError)` branch (and re-logging this warning) even
-        // though the counter itself is now known-good. Clear it once we've
-        // recovered so the mutex behaves normally again for the rest of
-        // the process's life.
+        // `into_inner` recovers the guard but leaves the mutex's poison flag set, so every future `lock()` call would keep taking this `Err(PoisonError)` branch (and re-logging this warning) even though the counter itself is now known-good.
+        // Clear it once we've recovered so the mutex behaves normally again for the rest of the process's life.
         counter.clear_poison();
         guard
     })

--- a/crates/librefang-runtime/src/checkpoint_manager.rs
+++ b/crates/librefang-runtime/src/checkpoint_manager.rs
@@ -152,7 +152,15 @@ pub struct CheckpointManager {
 fn lock_snapshot_counter(counter: &Mutex<usize>) -> MutexGuard<'_, usize> {
     counter.lock().unwrap_or_else(|poisoned| {
         warn!("checkpoint concurrency counter lock poisoned; recovering counter state");
-        poisoned.into_inner()
+        let guard = poisoned.into_inner();
+        // `into_inner` recovers the guard but leaves the mutex's poison flag
+        // set, so every future `lock()` call would keep taking this
+        // `Err(PoisonError)` branch (and re-logging this warning) even
+        // though the counter itself is now known-good. Clear it once we've
+        // recovered so the mutex behaves normally again for the rest of
+        // the process's life.
+        counter.clear_poison();
+        guard
     })
 }
 


### PR DESCRIPTION
## Summary
- recover the checkpoint concurrency counter after mutex poisoning instead of panicking at snapshot entry
- make the RAII cleanup guard recover and release its permit instead of silently skipping the decrement
- verify preserved counter state and balanced permit cleanup after poisoning

## Verification
- `cargo test -p librefang-runtime poisoned_snapshot_counter_recovers_and_guard_releases_permit --lib`
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`