### PR TITLE
fix(memory): surface session search row errors

### DIFF
--- a/changelog.d/fixed/7032-session-search-row-errors.md
+++ b/changelog.d/fixed/7032-session-search-row-errors.md
@@ -1,0 +1,2 @@
+Session search (`SessionStore::search_sessions` / `search_sessions_paginated`) now propagates a row-decode failure from `sessions_fts` as an error instead of silently dropping the corrupt row and returning a partial result set.
+A single malformed row previously vanished from search results without a trace; the same failure is now surfaced to the caller so the underlying corruption gets noticed and investigated (#7032) (@houko)

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -1595,7 +1595,8 @@ impl SessionStore {
                 )
                 .map_err(LibreFangError::memory)?;
 
-            rows.filter_map(|r| r.ok()).collect()
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(LibreFangError::memory)?
         } else {
             let mut stmt = conn
                 .prepare(
@@ -1621,7 +1622,8 @@ impl SessionStore {
                 )
                 .map_err(LibreFangError::memory)?;
 
-            rows.filter_map(|r| r.ok()).collect()
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(LibreFangError::memory)?
         };
 
         Ok(results)
@@ -2849,6 +2851,25 @@ mod tests {
         // Empty query should return nothing
         let results = store.search_sessions("", None).unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn fts_search_surfaces_corrupt_result_rows() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO sessions_fts (session_id, agent_id, content) VALUES (?1, ?2, ?3)",
+                rusqlite::params![vec![0xff_u8], agent_id.0.to_string(), "corruptneedle"],
+            )
+            .unwrap();
+        }
+
+        assert!(store.search_sessions("corruptneedle", None).is_err());
+        assert!(store
+            .search_sessions("corruptneedle", Some(&agent_id))
+            .is_err());
     }
 
     /// search_sessions_paginated must:

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -1595,8 +1595,10 @@ impl SessionStore {
                 )
                 .map_err(LibreFangError::memory)?;
 
-            rows.collect::<rusqlite::Result<Vec<_>>>()
-                .map_err(LibreFangError::memory)?
+            rows.collect::<rusqlite::Result<Vec<_>>>().map_err(|e| {
+                warn!(error = %e, "session FTS search: row decode failed");
+                LibreFangError::memory(e)
+            })?
         } else {
             let mut stmt = conn
                 .prepare(
@@ -1622,8 +1624,10 @@ impl SessionStore {
                 )
                 .map_err(LibreFangError::memory)?;
 
-            rows.collect::<rusqlite::Result<Vec<_>>>()
-                .map_err(LibreFangError::memory)?
+            rows.collect::<rusqlite::Result<Vec<_>>>().map_err(|e| {
+                warn!(error = %e, "session FTS search: row decode failed");
+                LibreFangError::memory(e)
+            })?
         };
 
         Ok(results)


### PR DESCRIPTION
## Summary
- propagate FTS session-search row decoding failures instead of silently omitting corrupt matches
- apply the same fail-closed behavior to filtered and unfiltered searches
- verify a malformed FTS row is reported by both query paths

## Verification
- `cargo test -p librefang-memory fts_search_surfaces_corrupt_result_rows --lib`
- `cargo clippy -p librefang-memory --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`