### PR TITLE
fix: propagate roster storage errors

### DIFF
--- a/changelog.d/fixed/7033-roster-store-error-contract.md
+++ b/changelog.d/fixed/7033-roster-store-error-contract.md
@@ -1,0 +1,3 @@
+Group roster storage (`RosterStore::upsert`, `members`, `remove_member`, `member_count`) swallowed every SQLite pool-exhaustion and row-decode error, returning empty results or fixed defaults instead of failing.
+A corrupted `group_roster` row was silently dropped from `members()` rather than surfacing as a query failure, and a pool outage during `upsert` or `remove_member` looked identical to success to every caller.
+All four methods now return `LibreFangResult`, and the channel bridge and kernel handle boundaries propagate the error instead of discarding it (#7033) (@houko)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1025,14 +1025,11 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         display_name: &str,
         username: Option<&str>,
     ) -> Result<(), String> {
-        self.kernel.memory_substrate().roster().upsert(
-            channel,
-            chat_id,
-            user_id,
-            display_name,
-            username,
-        );
-        Ok(())
+        self.kernel
+            .memory_substrate()
+            .roster()
+            .upsert(channel, chat_id, user_id, display_name, username)
+            .map_err(|error| error.to_string())
     }
 
     async fn uptime_info(&self) -> String {

--- a/crates/librefang-kernel/src/kernel/handles/channel_sender.rs
+++ b/crates/librefang-kernel/src/kernel/handles/channel_sender.rs
@@ -339,8 +339,7 @@ impl kernel_handle::ChannelSender for LibreFangKernel {
         self.memory
             .substrate
             .roster()
-            .upsert(channel, chat_id, user_id, display_name, username);
-        Ok(())
+            .upsert(channel, chat_id, user_id, display_name, username)
     }
 
     fn roster_members(
@@ -348,7 +347,7 @@ impl kernel_handle::ChannelSender for LibreFangKernel {
         channel: &str,
         chat_id: &str,
     ) -> Result<Vec<serde_json::Value>, kernel_handle::KernelOpError> {
-        let members = self.memory.substrate.roster().members(channel, chat_id);
+        let members = self.memory.substrate.roster().members(channel, chat_id)?;
         Ok(members
             .into_iter()
             .map(|(user_id, display_name, username)| {
@@ -370,8 +369,7 @@ impl kernel_handle::ChannelSender for LibreFangKernel {
         self.memory
             .substrate
             .roster()
-            .remove_member(channel, chat_id, user_id);
-        Ok(())
+            .remove_member(channel, chat_id, user_id)
     }
 
     fn resolve_channel_owner(

--- a/crates/librefang-memory/src/roster_store.rs
+++ b/crates/librefang-memory/src/roster_store.rs
@@ -6,7 +6,8 @@
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
-use tracing;
+
+use librefang_types::error::{LibreFangError, LibreFangResult};
 
 /// Persistent roster of group chat members, backed by SQLite.
 pub struct RosterStore {
@@ -35,25 +36,20 @@ impl RosterStore {
         user_id: &str,
         display_name: &str,
         username: Option<&str>,
-    ) {
+    ) -> LibreFangResult<()> {
         if chat_id.is_empty() || user_id.is_empty() {
-            return;
+            return Ok(());
         }
-        let Ok(c) = self.pool.get() else {
+        let c = self.pool.get().map_err(|error| {
             metrics::counter!(
                 "librefang_memory_pool_get_failed_total",
                 "store" => "roster",
                 "op" => "upsert",
             )
             .increment(1);
-            tracing::warn!(
-                "roster pool exhausted; skipping upsert for {}/{}",
-                channel,
-                chat_id
-            );
-            return;
-        };
-        let _ = c.execute(
+            LibreFangError::memory(error)
+        })?;
+        c.execute(
             "INSERT INTO group_roster (channel_type, chat_id, user_id, display_name, username, first_seen, last_seen)
              VALUES (?1, ?2, ?3, ?4, ?5, strftime('%s','now'), strftime('%s','now'))
              ON CONFLICT(channel_type, chat_id, user_id) DO UPDATE SET
@@ -61,88 +57,91 @@ impl RosterStore {
                username = COALESCE(excluded.username, group_roster.username),
                last_seen = strftime('%s','now')",
             rusqlite::params![channel, chat_id, user_id, display_name, username],
-        );
+        )
+        .map_err(LibreFangError::memory)?;
+        Ok(())
     }
 
     /// List all members of a group chat, ordered by display name.
-    pub fn members(&self, channel: &str, chat_id: &str) -> Vec<(String, String, Option<String>)> {
-        let Ok(c) = self.pool.get() else {
+    pub fn members(
+        &self,
+        channel: &str,
+        chat_id: &str,
+    ) -> LibreFangResult<Vec<(String, String, Option<String>)>> {
+        let c = self.pool.get().map_err(|error| {
             metrics::counter!(
                 "librefang_memory_pool_get_failed_total",
                 "store" => "roster",
                 "op" => "members",
             )
             .increment(1);
-            tracing::warn!(
-                "roster pool exhausted; returning empty members for {}/{}",
-                channel,
-                chat_id
-            );
-            return Vec::new();
-        };
+            LibreFangError::memory(error)
+        })?;
         let mut stmt = c
             .prepare(
                 "SELECT user_id, display_name, username FROM group_roster
                  WHERE channel_type = ?1 AND chat_id = ?2
                  ORDER BY display_name",
             )
-            .unwrap();
-        stmt.query_map(rusqlite::params![channel, chat_id], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, Option<String>>(2)?,
-            ))
-        })
-        .unwrap()
-        .filter_map(|r| r.ok())
-        .collect()
+            .map_err(LibreFangError::memory)?;
+        let rows = stmt
+            .query_map(rusqlite::params![channel, chat_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })
+            .map_err(LibreFangError::memory)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(LibreFangError::memory)
     }
 
     /// Remove a single member from the roster.
-    pub fn remove_member(&self, channel: &str, chat_id: &str, user_id: &str) {
-        let Ok(c) = self.pool.get() else {
+    pub fn remove_member(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+    ) -> LibreFangResult<()> {
+        let c = self.pool.get().map_err(|error| {
             metrics::counter!(
                 "librefang_memory_pool_get_failed_total",
                 "store" => "roster",
                 "op" => "remove_member",
             )
             .increment(1);
-            tracing::warn!(
-                "roster pool exhausted; skipping remove_member for {}/{}",
-                channel,
-                chat_id
-            );
-            return;
-        };
-        let _ = c.execute(
+            LibreFangError::memory(error)
+        })?;
+        c.execute(
             "DELETE FROM group_roster WHERE channel_type = ?1 AND chat_id = ?2 AND user_id = ?3",
             rusqlite::params![channel, chat_id, user_id],
-        );
+        )
+        .map_err(LibreFangError::memory)?;
+        Ok(())
     }
 
     /// Count the members in a group chat.
-    pub fn member_count(&self, channel: &str, chat_id: &str) -> usize {
-        let Ok(c) = self.pool.get() else {
+    pub fn member_count(&self, channel: &str, chat_id: &str) -> LibreFangResult<usize> {
+        let c = self.pool.get().map_err(|error| {
             metrics::counter!(
                 "librefang_memory_pool_get_failed_total",
                 "store" => "roster",
                 "op" => "member_count",
             )
             .increment(1);
-            tracing::warn!(
-                "roster pool exhausted; returning 0 for member_count {}/{}",
-                channel,
-                chat_id
-            );
-            return 0;
-        };
-        c.query_row(
-            "SELECT COUNT(*) FROM group_roster WHERE channel_type = ?1 AND chat_id = ?2",
-            rusqlite::params![channel, chat_id],
-            |row| row.get::<_, i64>(0),
-        )
-        .unwrap_or(0) as usize
+            LibreFangError::memory(error)
+        })?;
+        let count = c
+            .query_row(
+                "SELECT COUNT(*) FROM group_roster WHERE channel_type = ?1 AND chat_id = ?2",
+                rusqlite::params![channel, chat_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(LibreFangError::memory)?;
+        usize::try_from(count).map_err(|_| {
+            LibreFangError::memory_msg(format!("invalid roster member count: {count}"))
+        })
     }
 }
 
@@ -162,10 +161,12 @@ mod tests {
     #[test]
     fn upsert_and_list() {
         let store = in_memory_store();
-        store.upsert("telegram", "-100", "1", "Alice", Some("alice"));
-        store.upsert("telegram", "-100", "2", "Bob", None);
+        store
+            .upsert("telegram", "-100", "1", "Alice", Some("alice"))
+            .unwrap();
+        store.upsert("telegram", "-100", "2", "Bob", None).unwrap();
 
-        let members = store.members("telegram", "-100");
+        let members = store.members("telegram", "-100").unwrap();
         assert_eq!(members.len(), 2);
         assert_eq!(members[0].1, "Alice");
         assert_eq!(members[1].1, "Bob");
@@ -176,10 +177,14 @@ mod tests {
     #[test]
     fn idempotent_upsert_updates_display_name() {
         let store = in_memory_store();
-        store.upsert("telegram", "-100", "1", "Alice", Some("alice"));
-        store.upsert("telegram", "-100", "1", "Alice Updated", Some("alice"));
+        store
+            .upsert("telegram", "-100", "1", "Alice", Some("alice"))
+            .unwrap();
+        store
+            .upsert("telegram", "-100", "1", "Alice Updated", Some("alice"))
+            .unwrap();
 
-        let members = store.members("telegram", "-100");
+        let members = store.members("telegram", "-100").unwrap();
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].1, "Alice Updated");
     }
@@ -187,40 +192,79 @@ mod tests {
     #[test]
     fn remove_member() {
         let store = in_memory_store();
-        store.upsert("telegram", "-100", "1", "Alice", None);
-        store.upsert("telegram", "-100", "2", "Bob", None);
-        assert_eq!(store.member_count("telegram", "-100"), 2);
+        store
+            .upsert("telegram", "-100", "1", "Alice", None)
+            .unwrap();
+        store.upsert("telegram", "-100", "2", "Bob", None).unwrap();
+        assert_eq!(store.member_count("telegram", "-100").unwrap(), 2);
 
-        store.remove_member("telegram", "-100", "1");
-        assert_eq!(store.member_count("telegram", "-100"), 1);
-        let members = store.members("telegram", "-100");
+        store.remove_member("telegram", "-100", "1").unwrap();
+        assert_eq!(store.member_count("telegram", "-100").unwrap(), 1);
+        let members = store.members("telegram", "-100").unwrap();
         assert_eq!(members[0].1, "Bob");
     }
 
     #[test]
     fn empty_chat_returns_nothing() {
         let store = in_memory_store();
-        let members = store.members("telegram", "-999");
+        let members = store.members("telegram", "-999").unwrap();
         assert!(members.is_empty());
-        assert_eq!(store.member_count("telegram", "-999"), 0);
+        assert_eq!(store.member_count("telegram", "-999").unwrap(), 0);
     }
 
     #[test]
     fn different_chats_are_isolated() {
         let store = in_memory_store();
-        store.upsert("telegram", "-100", "1", "Alice", None);
-        store.upsert("telegram", "-200", "2", "Bob", None);
+        store
+            .upsert("telegram", "-100", "1", "Alice", None)
+            .unwrap();
+        store.upsert("telegram", "-200", "2", "Bob", None).unwrap();
 
-        assert_eq!(store.member_count("telegram", "-100"), 1);
-        assert_eq!(store.member_count("telegram", "-200"), 1);
+        assert_eq!(store.member_count("telegram", "-100").unwrap(), 1);
+        assert_eq!(store.member_count("telegram", "-200").unwrap(), 1);
     }
 
     #[test]
     fn empty_ids_are_ignored() {
         let store = in_memory_store();
-        store.upsert("telegram", "", "1", "Alice", None);
-        store.upsert("telegram", "-100", "", "Bob", None);
-        assert_eq!(store.member_count("telegram", "-100"), 0);
-        assert_eq!(store.member_count("telegram", ""), 0);
+        store.upsert("telegram", "", "1", "Alice", None).unwrap();
+        store.upsert("telegram", "-100", "", "Bob", None).unwrap();
+        assert_eq!(store.member_count("telegram", "-100").unwrap(), 0);
+        assert_eq!(store.member_count("telegram", "").unwrap(), 0);
+    }
+
+    #[test]
+    fn storage_errors_are_returned_to_callers() {
+        let store = in_memory_store();
+        store
+            .pool
+            .get()
+            .unwrap()
+            .execute("DROP TABLE group_roster", [])
+            .unwrap();
+
+        assert!(store
+            .upsert("telegram", "-100", "1", "Alice", None)
+            .is_err());
+        assert!(store.members("telegram", "-100").is_err());
+        assert!(store.remove_member("telegram", "-100", "1").is_err());
+        assert!(store.member_count("telegram", "-100").is_err());
+    }
+
+    #[test]
+    fn corrupt_member_rows_are_not_silently_dropped() {
+        let store = in_memory_store();
+        store
+            .pool
+            .get()
+            .unwrap()
+            .execute(
+                "INSERT INTO group_roster (channel_type, chat_id, user_id, display_name) \
+                 VALUES ('telegram', '-100', '1', X'00')",
+                [],
+            )
+            .unwrap();
+
+        assert!(store.members("telegram", "-100").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- return typed memory errors from every SQLite-backed roster operation
- propagate roster failures through the existing channel bridge and kernel handle Result boundaries
- reject corrupt member rows instead of silently omitting them from group membership

## Verification
- `cargo test -p librefang-memory roster_store --lib`
- `cargo test -p librefang-kernel --test kernel_handle_contract_broader test_roster_roundtrip`
- `cargo clippy -p librefang-memory -p librefang-kernel -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- the separate in-memory `GroupRosterStore` in librefang-channels; it does not use SQLite or share this failure mode