### PR TITLE
fix(kernel,skills): resolve an empty parent to the current directory in atomic writers

### DIFF
--- a/changelog.d/fixed/7036-atomic-writer-empty-parent.md
+++ b/changelog.d/fixed/7036-atomic-writer-empty-parent.md
@@ -1,0 +1,4 @@
+`Path::parent()` yields `Some("")` rather than `None` for a bare relative filename, and three recently added atomic writers treated that empty-but-present case as an error.
+In the cron script writer the parent is opened for the post-rename directory fsync, so an empty parent would fail with ENOENT after the rename had already succeeded — reporting failure for a write that landed on disk.
+In the Skillhub and skill-evolution writers it only anchors the staging file beside the target, where an empty parent happened to work because the join and the rename both resolved against the process directory, making the same-directory invariant that keeps the rename atomic hold by accident.
+All three now resolve an empty parent to `.`, matching the API crate's atomic writer, which already handled it (#7036) (@houko)

--- a/crates/librefang-kernel/src/kernel/cron_script.rs
+++ b/crates/librefang-kernel/src/kernel/cron_script.rs
@@ -196,14 +196,28 @@ pub(super) fn atomic_write_toml(path: &Path, content: &str) -> std::io::Result<(
     }
 
     #[cfg(unix)]
-    path.parent()
-        .ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing parent directory")
-        })
-        .and_then(std::fs::File::open)?
-        .sync_all()?;
+    std::fs::File::open(parent_dir_for_fsync(path))?.sync_all()?;
 
     Ok(())
+}
+
+/// Resolve the directory whose entry must be fsynced after replacing `path`.
+///
+/// `Path::parent()` returns `Some("")` — not `None` — for a bare relative
+/// filename like `agent.toml`; `None` only happens for `/` or an empty path
+/// itself. Treating the empty-but-present case as an error would fail
+/// `File::open("")` with ENOENT *after* the rename already succeeded,
+/// reporting failure for a write that actually landed on disk. Mapping it to
+/// `.` fsyncs the real containing directory instead.
+///
+/// This mirrors the same resolution in `librefang_api::atomic_write`; keep the
+/// two in step if either changes.
+#[cfg(unix)]
+pub(super) fn parent_dir_for_fsync(path: &Path) -> &Path {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    }
 }
 
 /// Parse the wake gate from script stdout.

--- a/crates/librefang-kernel/src/kernel/cron_script.rs
+++ b/crates/librefang-kernel/src/kernel/cron_script.rs
@@ -203,15 +203,11 @@ pub(super) fn atomic_write_toml(path: &Path, content: &str) -> std::io::Result<(
 
 /// Resolve the directory whose entry must be fsynced after replacing `path`.
 ///
-/// `Path::parent()` returns `Some("")` — not `None` — for a bare relative
-/// filename like `agent.toml`; `None` only happens for `/` or an empty path
-/// itself. Treating the empty-but-present case as an error would fail
-/// `File::open("")` with ENOENT *after* the rename already succeeded,
-/// reporting failure for a write that actually landed on disk. Mapping it to
-/// `.` fsyncs the real containing directory instead.
+/// `Path::parent()` returns `Some("")` — not `None` — for a bare relative filename like `agent.toml`; `None` only happens for `/` or an empty path itself.
+/// Treating the empty-but-present case as an error would fail `File::open("")` with ENOENT *after* the rename already succeeded, reporting failure for a write that actually landed on disk.
+/// Mapping it to `.` fsyncs the real containing directory instead.
 ///
-/// This mirrors the same resolution in `librefang_api::atomic_write`; keep the
-/// two in step if either changes.
+/// This mirrors the same resolution in `librefang_api::atomic_write`; keep the two in step if either changes.
 #[cfg(unix)]
 pub(super) fn parent_dir_for_fsync(path: &Path) -> &Path {
     match path.parent() {

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4160,10 +4160,7 @@ fn atomic_write_leaves_no_tmp_file_on_success() {
 fn parent_dir_for_fsync_maps_bare_filename_to_current_dir() {
     use std::path::Path;
 
-    // The premise this resolution exists for: a bare filename has an
-    // empty-but-present parent, so `ok_or_else`-style handling would let
-    // `""` through to `File::open` and fail with ENOENT after the rename
-    // already succeeded.
+    // The premise this resolution exists for: a bare filename has an empty-but-present parent, so `ok_or_else`-style handling would let `""` through to `File::open` and fail with ENOENT after the rename already succeeded.
     assert_eq!(Path::new("agent.toml").parent(), Some(Path::new("")));
 
     assert_eq!(

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4155,6 +4155,39 @@ fn atomic_write_leaves_no_tmp_file_on_success() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn parent_dir_for_fsync_maps_bare_filename_to_current_dir() {
+    use std::path::Path;
+
+    // The premise this resolution exists for: a bare filename has an
+    // empty-but-present parent, so `ok_or_else`-style handling would let
+    // `""` through to `File::open` and fail with ENOENT after the rename
+    // already succeeded.
+    assert_eq!(Path::new("agent.toml").parent(), Some(Path::new("")));
+
+    assert_eq!(
+        super::cron_script::parent_dir_for_fsync(Path::new("agent.toml")),
+        Path::new("."),
+        "a bare filename must fsync the current directory, not \"\""
+    );
+    assert_eq!(
+        super::cron_script::parent_dir_for_fsync(Path::new("/")),
+        Path::new("."),
+        "a rootless path (parent() == None) must also fall back to \".\""
+    );
+    assert_eq!(
+        super::cron_script::parent_dir_for_fsync(Path::new("/srv/librefang/agent.toml")),
+        Path::new("/srv/librefang"),
+        "an absolute path must fsync its real containing directory"
+    );
+    assert_eq!(
+        super::cron_script::parent_dir_for_fsync(Path::new("nested/agent.toml")),
+        Path::new("nested"),
+        "a relative path with a directory component must keep that directory"
+    );
+}
+
 #[test]
 fn atomic_write_no_partial_state_under_concurrency() {
     // Spawn two threads racing to write the same path with very

--- a/crates/librefang-skills/src/evolution.rs
+++ b/crates/librefang-skills/src/evolution.rs
@@ -270,14 +270,7 @@ static ATOMIC_WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::A
 /// a nanosecond timestamp so collisions are extremely unlikely even
 /// under concurrent callers targeting the same final path.
 fn atomic_write(path: &Path, content: &str) -> Result<(), SkillError> {
-    // `Path::parent()` yields `Some("")` for a bare filename, so the staging
-    // file has to be anchored at `.` rather than joined onto an empty path —
-    // otherwise the "same directory as the target" invariant that keeps the
-    // rename atomic holds only by accident.
-    let parent = match path.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => parent,
-        _ => Path::new("."),
-    };
+    let parent = crate::resolve_parent_or_cwd(path);
     std::fs::create_dir_all(parent)?;
 
     // Keep the thread-id string to ASCII-safe chars — `ThreadId`'s

--- a/crates/librefang-skills/src/evolution.rs
+++ b/crates/librefang-skills/src/evolution.rs
@@ -270,9 +270,14 @@ static ATOMIC_WRITE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::A
 /// a nanosecond timestamp so collisions are extremely unlikely even
 /// under concurrent callers targeting the same final path.
 fn atomic_write(path: &Path, content: &str) -> Result<(), SkillError> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| SkillError::Io(std::io::Error::other("no parent directory")))?;
+    // `Path::parent()` yields `Some("")` for a bare filename, so the staging
+    // file has to be anchored at `.` rather than joined onto an empty path —
+    // otherwise the "same directory as the target" invariant that keeps the
+    // rename atomic holds only by accident.
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
     std::fs::create_dir_all(parent)?;
 
     // Keep the thread-id string to ASCII-safe chars — `ThreadId`'s

--- a/crates/librefang-skills/src/lib.rs
+++ b/crates/librefang-skills/src/lib.rs
@@ -23,7 +23,22 @@ pub mod verify;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Resolve the directory that a same-directory atomic-write staging file should be anchored in for a write targeting `path`.
+///
+/// `Path::parent()` returns `Some("")` — not `None` — for a bare relative filename like `skill.toml`; `None` only happens for `/` or an empty path itself.
+/// Joining a staging-file name onto `""` happens to resolve against the process's current directory, which is the same directory the final `rename` targets — but only by accident.
+/// Mapping the empty-but-present case to `.` makes that same-directory invariant hold explicitly instead of by coincidence.
+///
+/// Shared by `skillhub::atomic_write_manifest` and `evolution::atomic_write`, the two same-crate call sites that stage a temp file beside their target.
+/// Mirrors the equivalent resolution in `librefang_kernel::kernel::cron_script::parent_dir_for_fsync` (which fsyncs the parent after rename rather than staging inside it) and in `librefang_api`'s atomic writer; keep all three in step if any changes.
+pub(crate) fn resolve_parent_or_cwd(path: &Path) -> &Path {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    }
+}
 
 /// Errors from the skill system.
 #[derive(Debug, thiserror::Error)]
@@ -274,6 +289,33 @@ pub struct SkillToolResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_parent_or_cwd_maps_bare_filename_to_current_dir() {
+        // The premise this resolution exists for: a bare filename has an empty-but-present parent, so naively joining a staging name onto it (or `ok_or_else`-style rejection) either loses the same-directory guarantee or errors out unnecessarily.
+        assert_eq!(Path::new("skill.toml").parent(), Some(Path::new("")));
+
+        assert_eq!(
+            resolve_parent_or_cwd(Path::new("skill.toml")),
+            Path::new("."),
+            "a bare filename must resolve to the current directory, not \"\""
+        );
+        assert_eq!(
+            resolve_parent_or_cwd(Path::new("/")),
+            Path::new("."),
+            "a rootless path (parent() == None) must also fall back to \".\""
+        );
+        assert_eq!(
+            resolve_parent_or_cwd(Path::new("/srv/librefang/skill.toml")),
+            Path::new("/srv/librefang"),
+            "an absolute path must keep its real containing directory"
+        );
+        assert_eq!(
+            resolve_parent_or_cwd(Path::new("nested/skill.toml")),
+            Path::new("nested"),
+            "a relative path with a directory component must keep that directory"
+        );
+    }
 
     #[test]
     fn test_skill_manifest_parse() {

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -33,14 +33,7 @@ fn atomic_write_manifest(path: &Path, contents: &[u8]) -> Result<(), SkillError>
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static SEQ: AtomicU64 = AtomicU64::new(0);
-    // `Path::parent()` yields `Some("")` for a bare filename, so the staging
-    // file has to be anchored at `.` rather than joined onto an empty path —
-    // otherwise the "same directory as the target" invariant that keeps the
-    // rename atomic holds only by accident.
-    let parent = match path.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => parent,
-        _ => Path::new("."),
-    };
+    let parent = crate::resolve_parent_or_cwd(path);
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let tmp = parent.join(format!(".skill.toml.tmp.{}.{}", std::process::id(), seq));
 

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -33,9 +33,14 @@ fn atomic_write_manifest(path: &Path, contents: &[u8]) -> Result<(), SkillError>
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static SEQ: AtomicU64 = AtomicU64::new(0);
-    let parent = path.parent().ok_or_else(|| {
-        SkillError::InvalidManifest("Skillhub: skill.toml has no parent directory".to_string())
-    })?;
+    // `Path::parent()` yields `Some("")` for a bare filename, so the staging
+    // file has to be anchored at `.` rather than joined onto an empty path —
+    // otherwise the "same directory as the target" invariant that keeps the
+    // rename atomic holds only by accident.
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let tmp = parent.join(format!(".skill.toml.tmp.{}.{}", std::process::id(), seq));
 


### PR DESCRIPTION
## Summary

`Path::parent()` returns `Some("")` for a bare relative filename like `agent.toml` — `None` only happens for `/` or an empty path itself.
Three atomic writers added over the last day treat that empty-but-present case as an error via `ok_or_else`, and the consequence differs by what each one does with the parent.

**`cron_script::atomic_write_toml` (#6948) — a real error path.**
The parent is opened for the post-rename directory fsync, so an empty parent reaches `File::open("")` and fails with ENOENT *after* the rename already succeeded — reporting failure for a write that actually landed on disk.
Every current caller (`agent_runtime.rs:276`, `agent_state.rs:72`, `workspace_setup.rs:518`) passes an absolute path built with `join`, so this is latent rather than live today.

**`skillhub::atomic_write_manifest` (#6995) and `evolution::atomic_write` — silently accidental.**
Here the parent only anchors the staging file next to the target.
An empty parent still "works", because joining onto it resolves relative to the process directory and the rename then happens inside that same directory.
The same-directory invariant that makes the rename atomic therefore holds by accident, and only for as long as the target path is also relative.

All three now resolve an empty parent to `.`, which is what `librefang_api::atomic_write` (#6942) already did — it hit this case first and documented it. This PR brings the other three in line rather than inventing a new convention.

## Changes

- `cron_script.rs`: extract `parent_dir_for_fsync` and use it for the post-rename fsync
- `skillhub.rs`, `evolution.rs`: resolve an empty parent to `.` before joining the staging filename
- `tests.rs`: unit-test the resolution across bare filename / rootless / absolute / nested-relative inputs

The kernel resolution is extracted into a function specifically so it can be unit-tested **without** `set_current_dir`, which is process-global and would race the rest of the suite under the default multi-threaded test runner.

## Verification

Run in the repo's `Dockerfile.rust-dev` image against a per-worktree target volume:

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p librefang-kernel -p librefang-skills --all-targets -- -D warnings` — silent
- `cargo test -p librefang-kernel --lib parent_dir_for_fsync` — 1 passed
- `cargo test -p librefang-kernel --lib atomic_write` — 3 passed (pre-existing atomicity/concurrency tests unaffected)
- `cargo test -p librefang-skills --lib` — 240 passed

Mutation-checked: reverting the fallback to `Path::new("")` — i.e. the pre-fix behaviour — turns the new test red, so it genuinely exercises the resolution rather than passing incidentally.

## Out of scope

`librefang_api::atomic_write` is unchanged; it already resolves this correctly. Its inline resolution is left inline rather than shared, since the two crates have no natural common dependency for a helper this small — the kernel copy carries a comment pointing at it.
