### PR TITLE
perf: move session summary persistence off thread

### DIFF
--- a/changelog.d/changed/7038-session-summary-persist-off-thread.md
+++ b/changelog.d/changed/7038-session-summary-persist-off-thread.md
@@ -1,0 +1,3 @@
+Session-summary persistence (the SQLite `kv_store` write and the workspace `memory/session-*.md` mirror written when a session resets) ran synchronously inside the fire-and-forget background task that generates the summary, still occupying a Tokio worker thread for the duration of the disk I/O.
+  That write now runs on Tokio's blocking pool via `tokio::task::spawn_blocking`, keeping the existing generate-then-persist ordering and the no-runtime synchronous fallback unchanged.
+  A join failure on the blocking task is now logged as a WARN instead of propagating as an unhandled panic (#7038) (@houko)

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -1115,13 +1115,10 @@ impl LibreFangKernel {
                         &messages,
                     )
                     .await;
-                    persist_session_summary(
-                        memory.as_ref(),
-                        agent_id,
-                        session_id,
-                        workspace.as_deref(),
-                        &summary,
-                    );
+                    persist_session_summary_off_thread(
+                        memory, agent_id, session_id, workspace, summary,
+                    )
+                    .await;
                 });
             }
             Err(_) => {
@@ -1141,6 +1138,35 @@ impl LibreFangKernel {
                 );
             }
         }
+    }
+}
+
+/// Move the synchronous SQLite and filesystem summary writes off the Tokio
+/// worker that generated the summary.
+async fn persist_session_summary_off_thread(
+    memory: Arc<librefang_memory::MemorySubstrate>,
+    agent_id: AgentId,
+    session_id: SessionId,
+    workspace: Option<std::path::PathBuf>,
+    summary: String,
+) {
+    if let Err(error) = tokio::task::spawn_blocking(move || {
+        persist_session_summary(
+            memory.as_ref(),
+            agent_id,
+            session_id,
+            workspace.as_deref(),
+            &summary,
+        );
+    })
+    .await
+    {
+        warn!(
+            agent_id = %agent_id,
+            session_id = %session_id.0,
+            %error,
+            "Session summary persistence task failed"
+        );
     }
 }
 
@@ -1518,7 +1544,11 @@ fn persist_session_summary(
 
 #[cfg(test)]
 mod session_summary_tests {
-    use super::{build_trivial_session_summary, render_session_transcript};
+    use super::{
+        build_trivial_session_summary, persist_session_summary_off_thread,
+        render_session_transcript,
+    };
+    use librefang_types::agent::{AgentId, SessionId};
     use librefang_types::message::{ContentBlock, Message, Role};
 
     fn tool_use(name: &str, input_text: &str) -> Message {
@@ -1546,6 +1576,43 @@ mod session_summary_tests {
             status: librefang_types::tool::ToolExecutionStatus::default(),
             approval_request_id: None,
         }])
+    }
+
+    #[tokio::test]
+    async fn off_thread_persistence_writes_kv_and_workspace_mirror() {
+        let memory =
+            std::sync::Arc::new(librefang_memory::MemorySubstrate::open_in_memory(0.1).unwrap());
+        let agent_id = AgentId::new();
+        let session_id = SessionId::new();
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::create_dir(workspace.path().join("memory")).unwrap();
+        let summary = "summary persisted off thread".to_string();
+
+        persist_session_summary_off_thread(
+            std::sync::Arc::clone(&memory),
+            agent_id,
+            session_id,
+            Some(workspace.path().to_path_buf()),
+            summary.clone(),
+        )
+        .await;
+
+        assert_eq!(
+            memory
+                .structured_get(agent_id, &format!("session_{}", session_id.0))
+                .unwrap(),
+            Some(serde_json::Value::String(summary.clone()))
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                workspace
+                    .path()
+                    .join("memory")
+                    .join(format!("session-{}.md", session_id.0))
+            )
+            .unwrap(),
+            summary
+        );
     }
 
     #[test]
@@ -1679,7 +1746,6 @@ mod session_summary_tests {
         CompletionRequest, CompletionResponse, LlmDriver, LlmError, StreamEvent,
     };
     use librefang_testing::{FailingLlmDriver, MockLlmDriver};
-    use librefang_types::agent::{AgentId, SessionId};
     use librefang_types::message::{StopReason, TokenUsage};
     use std::time::Duration;
 

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -1141,8 +1141,7 @@ impl LibreFangKernel {
     }
 }
 
-/// Move the synchronous SQLite and filesystem summary writes off the Tokio
-/// worker that generated the summary.
+/// Move the synchronous SQLite and filesystem summary writes off the Tokio worker that generated the summary.
 async fn persist_session_summary_off_thread(
     memory: Arc<librefang_memory::MemorySubstrate>,
     agent_id: AgentId,


### PR DESCRIPTION
## Summary

- move synchronous SQLite and workspace-file session summary writes onto the Tokio blocking pool
- keep summary generation and persistence ordering unchanged
- add a regression test covering both structured memory and the workspace mirror

## Tests

- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-kernel off_thread_persistence_writes_kv_and_workspace_mirror --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- the no-runtime compatibility fallback remains synchronous because no Tokio blocking pool is available there