### PR TITLE
perf(api): offload hand lifecycle I/O

### DIFF
--- a/changelog.d/changed/7039-hands-lifecycle-io-off-thread.md
+++ b/changelog.d/changed/7039-hands-lifecycle-io-off-thread.md
@@ -1,0 +1,3 @@
+`POST /api/hands/{id}/pause|resume|deactivate` and `POST /api/hands/reload` ran hand-registry persistence, and for activation/deactivation the workspace and SQLite I/O behind it, synchronously on the async worker thread handling the request.
+  All five lifecycle operations now run their kernel call through `tokio::task::spawn_blocking` so the request handler never parks on disk I/O.
+  Successful responses and existing business-error status codes are unchanged; a join failure on the blocking task now returns a scrubbed 500 instead of propagating as an unhandled panic (#7039) (@houko)

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -1,8 +1,7 @@
 use super::*;
 
-/// Hand lifecycle methods perform synchronous registry persistence and, for
-/// activation/deactivation, workspace and SQLite I/O. Keep that work off the
-/// async request worker.
+/// Hand lifecycle methods perform synchronous registry persistence and, for activation/deactivation, workspace and SQLite I/O.
+/// Keep that work off the async request worker.
 pub(super) async fn run_hand_lifecycle_job<F, T>(job: F) -> Result<T, tokio::task::JoinError>
 where
     F: FnOnce() -> T + Send + 'static,

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -1,5 +1,40 @@
 use super::*;
 
+/// Hand lifecycle methods perform synchronous registry persistence and, for
+/// activation/deactivation, workspace and SQLite I/O. Keep that work off the
+/// async request worker.
+pub(super) async fn run_hand_lifecycle_job<F, T>(job: F) -> Result<T, tokio::task::JoinError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(job).await
+}
+
+#[cfg(test)]
+mod lifecycle_job_tests {
+    use super::run_hand_lifecycle_job;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn lifecycle_job_does_not_block_the_async_worker() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let job = tokio::spawn(run_hand_lifecycle_job(move || {
+            started_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        }));
+
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("blocking job did not start")
+            .expect("blocking job dropped its start signal");
+        release_tx.send(()).unwrap();
+        job.await.unwrap().unwrap();
+    }
+}
+
 /// GET /api/hands — List all hand definitions (marketplace).
 #[utoipa::path(
     get,
@@ -974,8 +1009,9 @@ pub async fn pause_hand(
     State(state): State<Arc<AppState>>,
     Path(id): Path<uuid::Uuid>,
 ) -> impl IntoResponse {
-    match state.kernel.pause_hand(id) {
-        Ok(()) => match state.kernel.hands().get_instance(id) {
+    let kernel = Arc::clone(&state.kernel);
+    match run_hand_lifecycle_job(move || kernel.pause_hand(id)).await {
+        Ok(Ok(())) => match state.kernel.hands().get_instance(id) {
             // #3832: return the post-mutation entity instead of an ack envelope
             // so the dashboard can setQueryData without a follow-up GET.
             Some(instance) => (StatusCode::OK, Json(hand_instance_to_json(&instance))),
@@ -984,7 +1020,11 @@ pub async fn pause_hand(
                     .into_json_tuple()
             }
         },
-        Err(e) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
+        Ok(Err(e)) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
+        Err(e) => {
+            tracing::error!(instance = %id, error = %e, "hand pause task failed");
+            ApiErrorResponse::internal("Hand pause task failed").into_json_tuple()
+        }
     }
 }
 
@@ -1004,8 +1044,9 @@ pub async fn resume_hand(
     State(state): State<Arc<AppState>>,
     Path(id): Path<uuid::Uuid>,
 ) -> impl IntoResponse {
-    match state.kernel.resume_hand(id) {
-        Ok(()) => match state.kernel.hands().get_instance(id) {
+    let kernel = Arc::clone(&state.kernel);
+    match run_hand_lifecycle_job(move || kernel.resume_hand(id)).await {
+        Ok(Ok(())) => match state.kernel.hands().get_instance(id) {
             // #3832: return the post-mutation entity instead of an ack envelope
             // so the dashboard can setQueryData without a follow-up GET.
             Some(instance) => (StatusCode::OK, Json(hand_instance_to_json(&instance))),
@@ -1014,7 +1055,11 @@ pub async fn resume_hand(
                     .into_json_tuple()
             }
         },
-        Err(e) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
+        Ok(Err(e)) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
+        Err(e) => {
+            tracing::error!(instance = %id, error = %e, "hand resume task failed");
+            ApiErrorResponse::internal("Hand resume task failed").into_json_tuple()
+        }
     }
 }
 
@@ -1034,12 +1079,17 @@ pub async fn deactivate_hand(
     State(state): State<Arc<AppState>>,
     Path(id): Path<uuid::Uuid>,
 ) -> impl IntoResponse {
-    match state.kernel.deactivate_hand(id) {
-        Ok(()) => (
+    let kernel = Arc::clone(&state.kernel);
+    match run_hand_lifecycle_job(move || kernel.deactivate_hand(id)).await {
+        Ok(Ok(())) => (
             StatusCode::OK,
             Json(serde_json::json!({"status": "deactivated", "instance_id": id})),
         ),
-        Err(e) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
+        Ok(Err(e)) => ApiErrorResponse::bad_request(format!("{e}")).into_json_tuple(),
+        Err(e) => {
+            tracing::error!(instance = %id, error = %e, "hand deactivation task failed");
+            ApiErrorResponse::internal("Hand deactivation task failed").into_json_tuple()
+        }
     }
 }
 
@@ -1252,7 +1302,14 @@ pub async fn update_hand_settings(
     )
 )]
 pub async fn reload_hands(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let (added, updated) = state.kernel.reload_hands();
+    let kernel = Arc::clone(&state.kernel);
+    let (added, updated) = match run_hand_lifecycle_job(move || kernel.reload_hands()).await {
+        Ok(counts) => counts,
+        Err(e) => {
+            tracing::error!(error = %e, "hand reload task failed");
+            return ApiErrorResponse::internal("Hand reload task failed").into_json_tuple();
+        }
+    };
     let total = state.kernel.hands().list_definitions().len();
     (
         StatusCode::OK,

--- a/crates/librefang-api/src/routes/skills/mod.rs
+++ b/crates/librefang-api/src/routes/skills/mod.rs
@@ -565,8 +565,14 @@ async fn activate_hand_inner(
         }
     };
 
-    match state.kernel.activate_hand(&hand_id, config) {
-        Ok(instance) => {
+    let kernel = Arc::clone(&state.kernel);
+    let activation_hand_id = hand_id.clone();
+    let activation =
+        hands::run_hand_lifecycle_job(move || kernel.activate_hand(&activation_hand_id, config))
+            .await;
+
+    match activation {
+        Ok(Ok(instance)) => {
             // If the hand agent has a non-reactive schedule (autonomous hands),
             // start its background loop so it begins running immediately.
             if let Some(agent_id) = instance.agent_id() {
@@ -593,10 +599,22 @@ async fn activate_hand_inner(
                 .unwrap_or_else(|_| b"{}".to_vec());
             (StatusCode::OK, body)
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             let payload = serde_json::json!({"error": format!("{e}"), "code": "activate_hand_failed", "type": "activate_hand_failed"});
             (
                 StatusCode::BAD_REQUEST,
+                serde_json::to_vec(&payload).unwrap_or_default(),
+            )
+        }
+        Err(e) => {
+            tracing::error!(hand = %hand_id, error = %e, "hand activation task failed");
+            let payload = serde_json::json!({
+                "error": "Hand activation task failed",
+                "code": "activate_hand_failed",
+                "type": "activate_hand_failed"
+            });
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
                 serde_json::to_vec(&payload).unwrap_or_default(),
             )
         }


### PR DESCRIPTION
## Summary

- dispatch hand activation, pause, resume, deactivation, and reload through Tokio’s blocking pool
- preserve existing successful responses and business-error status codes
- return scrubbed 500 responses when a blocking lifecycle task itself fails
- add a current-thread Tokio regression test proving lifecycle work does not occupy the async worker

## Tests

- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api lifecycle_job_does_not_block_the_async_worker --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test hands_routes_integration unknown_instance`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test hands_routes_integration activate_unknown_hand_returns_400`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test hands_routes_integration reload_hands_returns_counts_envelope`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- non-lifecycle Hands endpoints remain unchanged