### PR TITLE
fix(channels): stop dispatch when journal write fails

### DIFF
--- a/changelog.d/fixed/7040-message-journal-record-errors.md
+++ b/changelog.d/fixed/7040-message-journal-record-errors.md
@@ -1,0 +1,2 @@
+Stop channel message dispatch when the recovery journal fails to persist an entry, instead of logging the failure and continuing as if the write-ahead record existed.
+`MessageJournal::record` now returns `true` only once the entry is durable and indexed, and both `dispatch_message` and `dispatch_with_blocks` abort with a user-facing retry notice on `false` rather than proceeding without crash-recovery coverage (#7040) (@houko)

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -4786,7 +4786,22 @@ async fn dispatch_message(
             metadata: std::collections::HashMap::new(),
             next_retry_after: None,
         };
-        j.record(entry).await;
+        if !j.record(entry).await {
+            error!(
+                id = %message.platform_message_id,
+                channel = ct_str,
+                "Message dispatch aborted because the recovery journal could not persist it"
+            );
+            send_response(
+                adapter,
+                &message.sender,
+                "Message could not be queued safely. Please try again.".to_string(),
+                thread_id,
+                output_format,
+            )
+            .await;
+            return;
+        }
     }
 
     // Send typing indicator (best-effort)
@@ -6672,7 +6687,22 @@ async fn dispatch_with_blocks(
             metadata: std::collections::HashMap::new(),
             next_retry_after: None,
         };
-        j.record(entry).await;
+        if !j.record(entry).await {
+            error!(
+                id = %message.platform_message_id,
+                channel = ct_str,
+                "Multimodal dispatch aborted because the recovery journal could not persist it"
+            );
+            send_response(
+                adapter,
+                &message.sender,
+                "Message could not be queued safely. Please try again.".to_string(),
+                thread_id,
+                output_format,
+            )
+            .await;
+            return;
+        }
     }
 
     if !typing_indicator_suppressed(overrides.and_then(|o| o.typing_mode)) {

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -175,12 +175,15 @@ impl MessageJournal {
     /// async reactor; the lock is `tokio::sync::Mutex`, so we can hold it
     /// across the `.await` without blocking other tokio tasks (only other
     /// journal mutators queue, which is what we want).
-    pub async fn record(&self, entry: JournalEntry) {
+    /// Returns `true` only after the entry is durable and present in the
+    /// in-memory recovery index. Callers must not dispatch when this returns
+    /// `false`, otherwise the write-ahead guarantee has been lost.
+    pub async fn record(&self, entry: JournalEntry) -> bool {
         let line = match serde_json::to_string(&entry) {
             Ok(l) => l,
             Err(e) => {
                 error!(error = %e, id = %entry.message_id, "Failed to serialize journal entry");
-                return;
+                return false;
             }
         };
         let mut inner = self.inner.lock().await;
@@ -191,14 +194,15 @@ impl MessageJournal {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
                 error!(error = %e, id = %entry.message_id, "Failed to write journal entry");
-                return;
+                return false;
             }
             Err(e) => {
                 error!(error = %e, id = %entry.message_id, "spawn_blocking panicked writing journal");
-                return;
+                return false;
             }
         }
         inner.pending.insert(entry.message_id.clone(), entry);
+        true
     }
 
     /// Record a terminal dispatch outcome.
@@ -728,6 +732,16 @@ mod tests {
 
         let pending = journal.pending_entries().await;
         assert_eq!(pending.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn record_reports_failure_and_does_not_index_unpersisted_entry() {
+        let dir = TempDir::new().unwrap();
+        let journal = MessageJournal::open(dir.path()).unwrap();
+        std::fs::create_dir(dir.path().join("message_journal.jsonl")).unwrap();
+
+        assert!(!journal.record(test_entry("msg-1")).await);
+        assert!(journal.pending_entries().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -175,9 +175,8 @@ impl MessageJournal {
     /// async reactor; the lock is `tokio::sync::Mutex`, so we can hold it
     /// across the `.await` without blocking other tokio tasks (only other
     /// journal mutators queue, which is what we want).
-    /// Returns `true` only after the entry is durable and present in the
-    /// in-memory recovery index. Callers must not dispatch when this returns
-    /// `false`, otherwise the write-ahead guarantee has been lost.
+    /// Returns `true` only after the entry is durable and present in the in-memory recovery index.
+    /// Callers must not dispatch when this returns `false`, otherwise the write-ahead guarantee has been lost.
     pub async fn record(&self, entry: JournalEntry) -> bool {
         let line = match serde_json::to_string(&entry) {
             Ok(l) => l,


### PR DESCRIPTION
## Summary

- make initial message-journal recording report whether the WAL entry became durable
- abort text and multimodal dispatch when the write-ahead record cannot be persisted
- send a retryable user-facing response instead of processing an unrecoverable message
- add a regression test proving failed writes do not enter the in-memory recovery index

## Tests

- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-channels record_reports_failure_and_does_not_index_unpersisted_entry --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-channels message_journal::tests --lib`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-channels --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- terminal outcome updates and periodic compaction retain their existing best-effort logging behavior