### PR TITLE
fix(api): surface session query failures

### DIFF
--- a/changelog.d/fixed/7041-session-query-error-surfacing.md
+++ b/changelog.d/fixed/7041-session-query-error-surfacing.md
@@ -1,0 +1,3 @@
+`GET /api/sessions` swallowed a failed `count_sessions` call with `.unwrap_or(0)` and both it and `GET /api/sessions/search` fell back to an empty `200 OK` page on a database error, so a broken sessions table looked identical to "no sessions yet" from the client's side.
+`search_sessions` also leaked the raw SQLite error string (e.g. table names) straight into the response body via `ApiErrorResponse::internal(error.to_string())`.
+Both handlers now propagate the failure as a scrubbed `500` with a generic message, logging the real error server-side with `tracing::error!`, consistent with the rest of the file (#7041) (@houko)

--- a/crates/librefang-api/src/routes/tools_sessions.rs
+++ b/crates/librefang-api/src/routes/tools_sessions.rs
@@ -414,7 +414,7 @@ pub async fn list_sessions(
     let query_result = tokio::task::spawn_blocking(move || {
         // Push pagination into SQLite so we don't deserialize every session
         // blob (#3485).
-        let total = substrate.count_sessions().unwrap_or(0);
+        let total = substrate.count_sessions()?;
         substrate
             .list_sessions_paginated(Some(limit), offset)
             .map(|items| (items, total, offset, limit))
@@ -424,12 +424,12 @@ pub async fn list_sessions(
     let (mut items, total, offset_out, limit_out) = match query_result {
         Ok(Ok(result)) => result,
         Ok(Err(error)) => {
-            tracing::warn!(%error, "failed to list sessions");
-            (Vec::new(), 0, 0, PaginationParams::DEFAULT_LIMIT)
+            tracing::error!(%error, "failed to list sessions");
+            return ApiErrorResponse::internal("Failed to list sessions").into_response();
         }
         Err(error) => {
             tracing::error!(%error, "session list query task failed");
-            (Vec::new(), 0, 0, PaginationParams::DEFAULT_LIMIT)
+            return ApiErrorResponse::internal("Session list query task failed").into_response();
         }
     };
     annotate_sessions_active(&mut items, &running);
@@ -439,6 +439,7 @@ pub async fn list_sessions(
         offset: offset_out,
         limit: Some(limit_out),
     })
+    .into_response()
 }
 
 /// Inject an `"active": bool` field into each session JSON row by looking
@@ -910,9 +911,12 @@ pub async fn search_sessions(
     match search_result {
         Err(error) => {
             tracing::error!(%error, "session search query task failed");
-            ApiErrorResponse::internal(error.to_string()).into_json_tuple()
+            ApiErrorResponse::internal("Session search query task failed").into_json_tuple()
         }
-        Ok(Err(e)) => ApiErrorResponse::internal(e.to_string()).into_json_tuple(),
+        Ok(Err(error)) => {
+            tracing::error!(%error, "failed to search sessions");
+            ApiErrorResponse::internal("Failed to search sessions").into_json_tuple()
+        }
         Ok(Ok(results)) => {
             // Canonical paginated envelope (#3842): {items,total,offset,limit}.
             // The substrate has no count() for FTS5 search, so `total` is a

--- a/crates/librefang-api/tests/system_tools_sessions_test.rs
+++ b/crates/librefang-api/tests/system_tools_sessions_test.rs
@@ -314,6 +314,24 @@ async fn list_sessions_honours_pagination_query() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn list_sessions_returns_scrubbed_500_on_database_failure() {
+    let h = boot().await;
+    h.state
+        .kernel
+        .memory_substrate()
+        .pool()
+        .get()
+        .unwrap()
+        .execute_batch("DROP TABLE sessions;")
+        .unwrap();
+
+    let (status, body) = get_json(&h, "/api/sessions").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body:?}");
+    assert_eq!(body["error"]["message"], "Failed to list sessions");
+    assert!(!body.to_string().contains("no such table"), "{body:?}");
+}
+
 // ---------------------------------------------------------------------------
 // /api/sessions/search
 // ---------------------------------------------------------------------------
@@ -361,6 +379,24 @@ async fn search_sessions_returns_envelope_on_no_match() {
     // Legacy fields must be gone.
     assert!(body.get("results").is_none(), "{body:?}");
     assert!(body.get("next_offset").is_none(), "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_sessions_returns_scrubbed_500_on_database_failure() {
+    let h = boot().await;
+    h.state
+        .kernel
+        .memory_substrate()
+        .pool()
+        .get()
+        .unwrap()
+        .execute_batch("DROP TABLE sessions_fts;")
+        .unwrap();
+
+    let (status, body) = get_json(&h, "/api/sessions/search?q=anything").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body:?}");
+    assert_eq!(body["error"]["message"], "Failed to search sessions");
+    assert!(!body.to_string().contains("no such table"), "{body:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- propagate session count and list failures instead of returning an empty successful page
- return scrubbed 500 responses for session list and FTS search database failures
- keep detailed database and blocking-task errors in server logs only
- add integration coverage using deliberately removed SQLite tables

## Tests

- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test system_tools_sessions_test database_failure`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test system_tools_sessions_test list_sessions_honours_pagination_query`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test system_tools_sessions_test search_sessions_returns_envelope_on_no_match`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- session mutation endpoints remain unchanged