### PR TITLE
perf(kernel): offload workspace metadata scans

### DIFF
--- a/changelog.d/changed/workspace-metadata-off-thread.md
+++ b/changelog.d/changed/workspace-metadata-off-thread.md
@@ -1,0 +1,1 @@
+Workspace metadata cache misses in async non-streaming message paths now scan project and identity files on a blocking worker instead of stalling the runtime worker. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -727,10 +727,14 @@ impl LibreFangKernel {
                 self.agents.registry.peer_agents_summary();
 
             // Use cached workspace metadata (identity files + workspace context)
-            let ws_meta = manifest
-                .workspace
-                .as_ref()
-                .map(|w| self.cached_workspace_metadata(w, manifest.autonomous.is_some()));
+            let ws_meta = if let Some(workspace) = manifest.workspace.as_ref() {
+                Some(
+                    self.cached_workspace_metadata_async(workspace, manifest.autonomous.is_some())
+                        .await,
+                )
+            } else {
+                None
+            };
 
             // Use cached skill metadata (summary + prompt context)
             let skill_meta = if manifest.skills_disabled {

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -535,10 +535,14 @@ impl LibreFangKernel {
             let peer_agents: Vec<(String, String, String)> =
                 self.agents.registry.peer_agents_summary();
 
-            let ws_meta = manifest
-                .workspace
-                .as_ref()
-                .map(|w| self.cached_workspace_metadata(w, manifest.autonomous.is_some()));
+            let ws_meta = if let Some(workspace) = manifest.workspace.as_ref() {
+                Some(
+                    self.cached_workspace_metadata_async(workspace, manifest.autonomous.is_some())
+                        .await,
+                )
+            } else {
+                None
+            };
 
             let agent_id_str = agent_id.0.to_string();
             // One pass over `tools` produces both the name list (for the
@@ -2544,10 +2548,9 @@ impl LibreFangKernel {
                 self.agents.registry.peer_agents_summary();
 
             // Use cached workspace metadata (identity files + workspace context)
-            let ws_meta = manifest
-                .workspace
-                .as_ref()
-                .map(|w| self.cached_workspace_metadata(w, manifest.autonomous.is_some()));
+            let ws_meta = manifest.workspace.as_ref().map(|workspace| {
+                self.cached_workspace_metadata(workspace, manifest.autonomous.is_some())
+            });
 
             // Use cached skill metadata (summary + prompt context)
             let skill_meta = if manifest.skills_disabled {

--- a/crates/librefang-kernel/src/kernel/prompt_context.rs
+++ b/crates/librefang-kernel/src/kernel/prompt_context.rs
@@ -36,30 +36,44 @@ impl LibreFangKernel {
             }
         }
 
-        let metadata = CachedWorkspaceMetadata {
-            workspace_context: {
-                let mut ws_ctx =
-                    librefang_runtime::workspace_context::WorkspaceContext::detect(workspace);
-                Some(ws_ctx.build_context_section())
-            },
-            soul_md: read_identity_file(workspace, "SOUL.md"),
-            user_md: read_identity_file(workspace, "USER.md"),
-            memory_md: read_identity_file(workspace, "MEMORY.md"),
-            agents_md: read_identity_file(workspace, "AGENTS.md"),
-            bootstrap_md: read_identity_file(workspace, "BOOTSTRAP.md"),
-            identity_md: read_identity_file(workspace, "IDENTITY.md"),
-            heartbeat_md: if is_autonomous {
-                read_identity_file(workspace, "HEARTBEAT.md")
-            } else {
-                None
-            },
-            tools_md: read_identity_file(workspace, "TOOLS.md"),
-            created_at: std::time::Instant::now(),
+        let metadata = load_workspace_metadata(workspace, is_autonomous);
+        self.prompt_metadata_cache
+            .workspace
+            .insert(workspace.to_path_buf(), metadata.clone());
+        metadata
+    }
+
+    /// Async-worker-safe counterpart of [`Self::cached_workspace_metadata`].
+    /// Cache misses perform all workspace filesystem inspection on the
+    /// blocking pool; cache hits return without spawning a task.
+    pub(crate) async fn cached_workspace_metadata_async(
+        &self,
+        workspace: &Path,
+        is_autonomous: bool,
+    ) -> CachedWorkspaceMetadata {
+        if let Some(entry) = self.prompt_metadata_cache.workspace.get(workspace) {
+            if !entry.is_expired() {
+                return entry.clone();
+            }
+        }
+
+        let workspace = workspace.to_path_buf();
+        let metadata = match run_workspace_metadata_job({
+            let workspace = workspace.clone();
+            move || load_workspace_metadata(&workspace, is_autonomous)
+        })
+        .await
+        {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::warn!(%error, "workspace metadata task failed");
+                empty_workspace_metadata()
+            }
         };
 
         self.prompt_metadata_cache
             .workspace
-            .insert(workspace.to_path_buf(), metadata.clone());
+            .insert(workspace, metadata.clone());
         metadata
     }
 
@@ -371,5 +385,74 @@ impl LibreFangKernel {
             ));
         }
         context_parts.join("\n\n")
+    }
+}
+
+async fn run_workspace_metadata_job<F, T>(job: F) -> Result<T, tokio::task::JoinError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(job).await
+}
+
+fn load_workspace_metadata(workspace: &Path, is_autonomous: bool) -> CachedWorkspaceMetadata {
+    let workspace_context = {
+        let mut context = librefang_runtime::workspace_context::WorkspaceContext::detect(workspace);
+        Some(context.build_context_section())
+    };
+    CachedWorkspaceMetadata {
+        workspace_context,
+        soul_md: read_identity_file(workspace, "SOUL.md"),
+        user_md: read_identity_file(workspace, "USER.md"),
+        memory_md: read_identity_file(workspace, "MEMORY.md"),
+        agents_md: read_identity_file(workspace, "AGENTS.md"),
+        bootstrap_md: read_identity_file(workspace, "BOOTSTRAP.md"),
+        identity_md: read_identity_file(workspace, "IDENTITY.md"),
+        heartbeat_md: is_autonomous
+            .then(|| read_identity_file(workspace, "HEARTBEAT.md"))
+            .flatten(),
+        tools_md: read_identity_file(workspace, "TOOLS.md"),
+        created_at: std::time::Instant::now(),
+    }
+}
+
+fn empty_workspace_metadata() -> CachedWorkspaceMetadata {
+    CachedWorkspaceMetadata {
+        workspace_context: None,
+        soul_md: None,
+        user_md: None,
+        memory_md: None,
+        agents_md: None,
+        bootstrap_md: None,
+        identity_md: None,
+        heartbeat_md: None,
+        tools_md: None,
+        created_at: std::time::Instant::now(),
+    }
+}
+
+#[cfg(test)]
+mod workspace_metadata_tests {
+    use super::run_workspace_metadata_job;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn workspace_metadata_job_does_not_block_async_worker() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let job = tokio::spawn(run_workspace_metadata_job(move || {
+            let _ = started_tx.send(());
+            release_rx.recv().expect("test releases metadata job");
+        }));
+        started_rx.await.expect("metadata job started");
+
+        tokio::time::timeout(Duration::from_millis(250), tokio::task::yield_now())
+            .await
+            .expect("async worker must remain responsive");
+
+        release_tx.send(()).unwrap();
+        job.await.unwrap().unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- keep workspace metadata cache hits on the existing fast path
- rebuild expired metadata on Tokio's blocking pool for async non-streaming message paths
- log blocking-task join failures and fall back to empty prompt metadata

## Tests

- `cargo test -p librefang-kernel --lib kernel::prompt_context::workspace_metadata_tests::workspace_metadata_job_does_not_block_async_worker -- --exact`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

The public streaming setup API is synchronous and cannot await a blocking task without a broader interface change, so its cache-miss behavior is intentionally unchanged here. Workspace state persistence and other runtime filesystem paths are also left for separate PRs.
