### PR TITLE
fix(kernel): load WASM modules asynchronously

### DIFF
--- a/changelog.d/fixed/7052-wasm-module-async-read.md
+++ b/changelog.d/fixed/7052-wasm-module-async-read.md
@@ -1,0 +1,1 @@
+- Load WASM agent modules asynchronously so filesystem latency cannot block Tokio worker threads. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -71,7 +71,7 @@ impl LibreFangKernel {
 
         info!(agent = %entry.name, path = %wasm_path.display(), "Executing WASM agent");
 
-        let wasm_bytes = std::fs::read(&wasm_path).map_err(|e| {
+        let wasm_bytes = tokio::fs::read(&wasm_path).await.map_err(|e| {
             KernelError::LibreFang(LibreFangError::Internal(format!(
                 "Failed to read WASM module '{}': {e}",
                 wasm_path.display()


### PR DESCRIPTION
## Summary
- replace the synchronous WASM module file read in the async agent execution path with Tokio filesystem I/O
- preserve the existing typed kernel error and user-visible error text
- leave Wasmtime execution and host callbacks on their existing blocking worker

## Testing
- `cargo test -p librefang-kernel --lib wasm -- --nocapture`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
