### PR TITLE
fix(api): surface backup listing errors

### DIFF
--- a/changelog.d/fixed/7053-backup-list-errors.md
+++ b/changelog.d/fixed/7053-backup-list-errors.md
@@ -1,0 +1,1 @@
+- Return an internal error when backup directory entries or metadata cannot be read instead of reporting a misleading empty or zero-sized backup list. (@xiaomo)

--- a/crates/librefang-api/src/routes/backup.rs
+++ b/crates/librefang-api/src/routes/backup.rs
@@ -340,7 +340,11 @@ pub async fn create_backup(
 pub async fn list_backups(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let backups_dir = state.kernel.home_dir().join("backups");
     match tokio::task::spawn_blocking(move || list_backups_blocking(&backups_dir)).await {
-        Ok(body) => Json(body).into_response(),
+        Ok(Ok(body)) => Json(body).into_response(),
+        Ok(Err(error)) => {
+            ApiErrorResponse::internal_scrub(format!("backup listing failed: {error}"))
+                .into_response()
+        }
         Err(error) => {
             ApiErrorResponse::internal_scrub(format!("backup listing task failed: {error}"))
                 .into_response()
@@ -348,41 +352,45 @@ pub async fn list_backups(State(state): State<Arc<AppState>>) -> impl IntoRespon
     }
 }
 
-fn list_backups_blocking(backups_dir: &std::path::Path) -> serde_json::Value {
+fn list_backups_blocking(backups_dir: &std::path::Path) -> std::io::Result<serde_json::Value> {
     let mut backups: Vec<serde_json::Value> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(backups_dir) {
-        for entry in entries.filter_map(|e| e.ok()) {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("zip") {
-                continue;
-            }
-            let filename = path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-            let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-            let modified = std::fs::metadata(&path)
-                .and_then(|m| m.modified())
-                .ok()
-                .map(|t| {
-                    let dt: chrono::DateTime<chrono::Utc> = t.into();
-                    dt.to_rfc3339()
-                });
-
-            // Try to read manifest from the zip
-            let manifest = read_backup_manifest(&path);
-
-            backups.push(serde_json::json!({
-                "filename": filename,
-                "path": path.to_string_lossy(),
-                "size_bytes": size,
-                "modified_at": modified,
-                "components": manifest.as_ref().map(|m| &m.components),
-                "librefang_version": manifest.as_ref().map(|m| &m.librefang_version),
-                "created_at": manifest.as_ref().map(|m| &m.created_at),
-            }));
+    let entries = match std::fs::read_dir(backups_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(serde_json::json!({"backups": [], "total": 0}));
         }
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("zip") {
+            continue;
+        }
+        let filename = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let metadata = entry.metadata()?;
+        let size = metadata.len();
+        let modified = metadata.modified().ok().map(|t| {
+            let dt: chrono::DateTime<chrono::Utc> = t.into();
+            dt.to_rfc3339()
+        });
+
+        // Try to read manifest from the zip
+        let manifest = read_backup_manifest(&path);
+
+        backups.push(serde_json::json!({
+            "filename": filename,
+            "path": path.to_string_lossy(),
+            "size_bytes": size,
+            "modified_at": modified,
+            "components": manifest.as_ref().map(|m| &m.components),
+            "librefang_version": manifest.as_ref().map(|m| &m.librefang_version),
+            "created_at": manifest.as_ref().map(|m| &m.created_at),
+        }));
     }
 
     // Sort by filename descending (newest first since filenames contain timestamps)
@@ -393,7 +401,7 @@ fn list_backups_blocking(backups_dir: &std::path::Path) -> serde_json::Value {
     });
 
     let total = backups.len();
-    serde_json::json!({"backups": backups, "total": total})
+    Ok(serde_json::json!({"backups": backups, "total": total}))
 }
 
 fn is_invalid_backup_filename(filename: &str) -> bool {

--- a/crates/librefang-api/tests/pairing_backup_extra_test.rs
+++ b/crates/librefang-api/tests/pairing_backup_extra_test.rs
@@ -246,6 +246,18 @@ async fn list_backups_returns_empty_when_dir_missing() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn list_backups_reports_unreadable_backup_path() {
+    let h = boot(true).await;
+    let backups_path = h.state.kernel.home_dir().join("backups");
+    std::fs::write(&backups_path, b"not a directory").expect("create invalid backup path");
+
+    let (status, body) = get(&h, "/api/backups").await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(body["message"].as_str(), Some("Internal server error"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn create_backup_writes_archive_and_list_returns_it() {
     let h = boot(true).await;
     let (status, body) = json_post(&h, "/api/backup", serde_json::json!({})).await;


### PR DESCRIPTION
## Summary
- propagate backup directory, entry, and metadata read failures instead of returning a misleading empty or zero-sized list
- preserve the established first-run behavior where a missing backups directory returns an empty list
- reuse each directory entry's metadata rather than issuing duplicate metadata lookups
- add an API regression test for an invalid backups path and retain the missing-directory test

## Testing
- `cargo test -p librefang-api --test pairing_backup_extra_test list_backups -- --nocapture`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
