### PR TITLE
fix(api): fail closed on config read errors

### DIFF
--- a/changelog.d/fixed/7055-config-read-before-write-errors.md
+++ b/changelog.d/fixed/7055-config-read-before-write-errors.md
@@ -1,0 +1,1 @@
+- Abort sidecar config and secrets.env read-modify-write operations when an existing file cannot be read instead of treating the failure as an empty file. (@xiaomo)

--- a/crates/librefang-api/src/routes/secrets_env.rs
+++ b/crates/librefang-api/src/routes/secrets_env.rs
@@ -56,7 +56,11 @@ pub fn upsert_secret(path: &Path, key: &str, value: &str) -> Result<(), String> 
         return Err(format!("invalid secret key `{key}`"));
     }
 
-    let original = fs::read_to_string(path).unwrap_or_default();
+    let original = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(format!("read {path:?}: {error}")),
+    };
     let mut out = String::with_capacity(original.len() + key.len() + value.len() + 2);
     let mut replaced = false;
     for line in original.lines() {
@@ -176,25 +180,21 @@ mod tests {
     }
 
     #[test]
-    fn rename_failure_cleans_up_staging_file() {
+    fn existing_secret_read_error_does_not_replace_target() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("secrets.env");
-        // Make the destination an existing directory so the final
-        // `fs::rename(tmp, path)` fails (ENOTDIR/EISDIR) without touching
-        // the write/fsync stage at all — this exercises the rename-failure
-        // cleanup path specifically, distinct from the write-failure path.
+        // A directory at the target path reliably produces a non-NotFound
+        // read error on every supported platform.
         fs::create_dir(&path).unwrap();
 
         let err = upsert_secret(&path, "OPENAI_API_KEY", "sk-123").unwrap_err();
-        assert!(err.contains("rename"), "got: {err}");
+        assert!(err.contains("read"), "got: {err}");
+        assert!(path.is_dir(), "the unreadable target must remain untouched");
 
-        // Only the pre-existing `secrets.env/` directory should remain;
-        // the `.secrets.env.tmp.*` staging file must not survive a failed
-        // rename.
         assert_eq!(
             fs::read_dir(dir.path()).unwrap().count(),
             1,
-            "leftover staging file after failed rename"
+            "a read failure must not create a secret-bearing staging file"
         );
     }
 }

--- a/crates/librefang-api/src/routes/sidecar_toml.rs
+++ b/crates/librefang-api/src/routes/sidecar_toml.rs
@@ -9,6 +9,14 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use toml_edit::{value, Array, ArrayOfTables, DocumentMut, Item, Table};
 
+fn read_existing_or_empty(path: &Path) -> Result<String, String> {
+    match fs::read_to_string(path) {
+        Ok(contents) => Ok(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(format!("read {path:?}: {error}")),
+    }
+}
+
 pub fn upsert_sidecar_block(
     path: &Path,
     name: &str,
@@ -18,7 +26,7 @@ pub fn upsert_sidecar_block(
     env: &BTreeMap<String, String>,
     managed_env_keys: &[&str],
 ) -> Result<(), String> {
-    let original = fs::read_to_string(path).unwrap_or_default();
+    let original = read_existing_or_empty(path)?;
     let mut doc: DocumentMut = original
         .parse()
         .map_err(|e| format!("parse {path:?}: {e}"))?;
@@ -190,7 +198,7 @@ fn next_tmp_name() -> String {
 
 /// Remove the `[[sidecar_channels]]` block identified by `name`; returns whether one was removed.
 pub fn remove_sidecar_block(path: &Path, name: &str) -> Result<bool, String> {
-    let original = fs::read_to_string(path).unwrap_or_default();
+    let original = read_existing_or_empty(path)?;
     let mut doc: DocumentMut = original
         .parse()
         .map_err(|e| format!("parse {path:?}: {e}"))?;
@@ -245,6 +253,22 @@ mod tests {
             fs::read_dir(dir.path()).unwrap().count(),
             1,
             "successful writes must not leave staging files"
+        );
+    }
+
+    #[test]
+    fn remove_propagates_existing_config_read_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::create_dir(&path).unwrap();
+
+        let error = remove_sidecar_block(&path, "telegram").unwrap_err();
+
+        assert!(error.contains("read"), "got: {error}");
+        assert_eq!(
+            fs::read_dir(dir.path()).unwrap().count(),
+            1,
+            "a read failure must not create a staging file"
         );
     }
 


### PR DESCRIPTION
## Summary
- distinguish a missing sidecar config or secrets.env file from other read failures before read-modify-write operations
- preserve first-time creation for `NotFound`
- abort before creating a staging file when an existing target cannot be read, preventing replacement with a partial document
- add regression coverage for both config.toml and secrets.env read failures

## Testing
- `cargo test -p librefang-api --test sidecar_toml_test -- --nocapture`
- `cargo test -p librefang-api --lib routes::secrets_env::tests -- --nocapture`
- `cargo test -p librefang-api --lib routes::sidecar_toml::tests -- --nocapture`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
