### PR TITLE
fix(kernel): fail closed on dream lock read errors

### DIFF
--- a/changelog.d/fixed/7056-auto-dream-lock-read-errors.md
+++ b/changelog.d/fixed/7056-auto-dream-lock-read-errors.md
@@ -1,0 +1,1 @@
+- Abort auto-dream lock acquisition when an existing lock file cannot be read instead of treating it as an unowned stale lock. (@xiaomo)

--- a/crates/librefang-kernel/src/auto_dream/lock.rs
+++ b/crates/librefang-kernel/src/auto_dream/lock.rs
@@ -158,7 +158,11 @@ impl ConsolidationLock {
         let (prior_mtime, holder_pid) = match fs::metadata(&self.path).await {
             Ok(meta) => {
                 let mtime = mtime_ms(&meta)?;
-                let body = fs::read_to_string(&self.path).await.unwrap_or_default();
+                let body = fs::read_to_string(&self.path).await.map_err(|e| {
+                    LibreFangError::Internal(format!(
+                        "auto_dream: read existing lock file failed: {e}"
+                    ))
+                })?;
                 let pid = parse_pid_from_body(&body);
                 (Some(mtime), pid)
             }
@@ -429,6 +433,22 @@ mod tests {
             "body should include uuid suffix, got {body:?}",
         );
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn acquire_propagates_existing_lock_read_error() {
+        let path = tmpfile("unreadable");
+        tokio::fs::create_dir(&path).await.unwrap();
+        let lock = ConsolidationLock::new(path.clone());
+
+        let error = lock.try_acquire().await.unwrap_err();
+
+        assert!(error.to_string().contains("read existing lock file"));
+        assert!(
+            path.is_dir(),
+            "failed acquisition must not replace the lock path"
+        );
+        tokio::fs::remove_dir(&path).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- propagate failures reading an existing auto-dream consolidation lock body
- prevent a read failure from being interpreted as an unowned or stale lock and reclaimed while another consolidation may still be live
- preserve the existing absent-file and stale-PID acquisition behavior
- add regression coverage proving the failed acquisition leaves the lock path untouched

## Testing
- `cargo test -p librefang-kernel --lib auto_dream::lock::tests -- --nocapture`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
