### PR TITLE
fix(api): surface extension reload failures

### DIFF
--- a/changelog.d/fixed/7057-extension-reload-errors.md
+++ b/changelog.d/fixed/7057-extension-reload-errors.md
@@ -1,0 +1,1 @@
+- Return a scrubbed server error when an extension install or uninstall cannot apply its on-disk MCP configuration, instead of reporting success against stale runtime state. (@xiaomo)

--- a/crates/librefang-api/src/routes/skills/extensions.rs
+++ b/crates/librefang-api/src/routes/skills/extensions.rs
@@ -188,11 +188,14 @@ pub async fn install_extension(
     // [[mcp_servers]] entry is invisible and the endpoint reports "installed"
     // without actually connecting anything.
     if let Err(e) = state.kernel.reload_config().await {
-        tracing::warn!("Failed to reload config after extension install: {e}");
+        return extension_reload_error("install", "config", e);
     }
 
     state.kernel.mcp_health().register(&result.server.name);
-    let connected = state.kernel.clone().reload_mcp_servers().await.unwrap_or(0);
+    let connected = match state.kernel.clone().reload_mcp_servers().await {
+        Ok(connected) => connected,
+        Err(e) => return extension_reload_error("install", "MCP servers", e),
+    };
 
     (
         StatusCode::OK,
@@ -250,13 +253,13 @@ pub async fn uninstall_extension(
     // removed entry and `reload_mcp_servers` happily reconnects the server
     // we just deleted.
     if let Err(e) = state.kernel.reload_config().await {
-        tracing::warn!("Failed to reload config after extension uninstall: {e}");
+        return extension_reload_error("uninstall", "config", e);
     }
 
     state.kernel.mcp_health().unregister(&server_name);
     state.kernel.disconnect_mcp_server(&server_name).await;
     if let Err(e) = state.kernel.clone().reload_mcp_servers().await {
-        tracing::warn!("Failed to reload MCP servers after uninstall: {e}");
+        return extension_reload_error("uninstall", "MCP servers", e);
     }
 
     (
@@ -266,4 +269,33 @@ pub async fn uninstall_extension(
             "name": name,
         })),
     )
+}
+
+fn extension_reload_error(
+    action: &str,
+    target: &str,
+    error: impl std::fmt::Display,
+) -> (StatusCode, Json<serde_json::Value>) {
+    ApiErrorResponse::internal_scrub(format!(
+        "failed to reload {target} after extension {action}: {error}"
+    ))
+    .into_json_tuple()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_reload_errors_return_scrubbed_server_error() {
+        let (status, Json(body)) = extension_reload_error(
+            "install",
+            "config",
+            "invalid TOML at /srv/private/config.toml",
+        );
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["error"]["message"], "Internal server error");
+        assert!(!body.to_string().contains("/srv/private"));
+    }
 }


### PR DESCRIPTION
## Summary
- return a scrubbed 500 when an extension install or uninstall cannot reload the updated config
- propagate MCP reload failures instead of reporting an installed or uninstalled success state
- add a regression test for the scrubbed error response

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --lib extension_reload_errors_return_scrubbed_server_error -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-api --all-targets -- -D warnings`

## Out of scope
- MCP server CRUD endpoints retain their existing `saved_reload_failed` response contract.