### PR TITLE
perf(api): offload agent file mutations

### DIFF
--- a/changelog.d/fixed/7060-agent-file-io-off-thread.md
+++ b/changelog.d/fixed/7060-agent-file-io-off-thread.md
@@ -1,0 +1,1 @@
+- Move agent identity-file writes, renames, canonicalization, and deletes off Tokio worker threads while preserving containment checks and atomic replacement. (@xiaomo)

--- a/crates/librefang-api/src/routes/agents/files.rs
+++ b/crates/librefang-api/src/routes/agents/files.rs
@@ -248,6 +248,66 @@ pub(crate) struct SetAgentFileRequest {
     pub content: String,
 }
 
+#[derive(Debug)]
+enum IdentityFileMutationError {
+    Workspace,
+    NotFound,
+    Forbidden,
+    Io(std::io::Error),
+}
+
+fn write_identity_file(
+    workspace: &std::path::Path,
+    filename: &str,
+    content: &str,
+) -> Result<(), IdentityFileMutationError> {
+    let ws_canonical = workspace
+        .canonicalize()
+        .map_err(|_| IdentityFileMutationError::Workspace)?;
+    let identity_dir = workspace.join(".identity");
+    std::fs::create_dir_all(&identity_dir).map_err(IdentityFileMutationError::Io)?;
+    let file_path = identity_dir.join(filename);
+
+    let canonical_identity = identity_dir
+        .canonicalize()
+        .map_err(IdentityFileMutationError::Io)?;
+    if !canonical_identity.starts_with(&ws_canonical) {
+        return Err(IdentityFileMutationError::Forbidden);
+    }
+
+    let tmp_path = identity_dir.join(format!(".{filename}.tmp"));
+    std::fs::write(&tmp_path, content).map_err(IdentityFileMutationError::Io)?;
+    if let Err(error) = std::fs::rename(&tmp_path, &file_path) {
+        if let Err(cleanup_error) = std::fs::remove_file(&tmp_path) {
+            tracing::warn!(error = %cleanup_error, "Failed to remove temporary identity file");
+        }
+        return Err(IdentityFileMutationError::Io(error));
+    }
+    Ok(())
+}
+
+fn delete_identity_file(
+    workspace: &std::path::Path,
+    filename: &str,
+) -> Result<(), IdentityFileMutationError> {
+    let ws_canonical = workspace
+        .canonicalize()
+        .map_err(|_| IdentityFileMutationError::Workspace)?;
+    let identity_candidate = workspace.join(".identity").join(filename);
+    let file_path = if identity_candidate.exists() {
+        identity_candidate
+    } else {
+        workspace.join(filename)
+    };
+    let canonical = file_path
+        .canonicalize()
+        .map_err(|_| IdentityFileMutationError::NotFound)?;
+    if !canonical.starts_with(&ws_canonical) {
+        return Err(IdentityFileMutationError::Forbidden);
+    }
+    std::fs::remove_file(canonical).map_err(IdentityFileMutationError::Io)
+}
+
 /// PUT /api/agents/{id}/files/{filename} — Write a workspace identity file.
 #[utoipa::path(
     put,
@@ -269,7 +329,8 @@ pub async fn set_agent_file(
     lang: Option<axum::Extension<RequestLanguage>>,
     Json(req): Json<SetAgentFileRequest>,
 ) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let resolved_lang = super::resolve_lang(lang.as_ref());
+    let t = ErrorTranslator::new(resolved_lang);
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
@@ -317,58 +378,45 @@ pub async fn set_agent_file(
         }
     };
 
-    // Security: verify workspace path and target stays inside it
-    let ws_canonical = match workspace.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
+    let size_bytes = req.content.len();
+    let filename_for_write = filename.clone();
+    drop(t);
+    let result = tokio::task::spawn_blocking(move || {
+        write_identity_file(&workspace, &filename_for_write, &req.content)
+    })
+    .await;
+    let t = ErrorTranslator::new(resolved_lang);
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(IdentityFileMutationError::Workspace)) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": t.t("api-error-file-workspace-error")})),
             );
         }
-    };
-
-    // Always write to .identity/ (current layout)
-    let identity_dir = workspace.join(".identity");
-    if let Err(e) = std::fs::create_dir_all(&identity_dir) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": scrub_500(&e, &t)})),
-        );
-    }
-    let file_path = identity_dir.join(&filename);
-
-    // Security: ensure .identity/ is inside the workspace
-    let check_path = identity_dir
-        .canonicalize()
-        .map(|p| p.join(&filename))
-        .unwrap_or_else(|_| file_path.clone());
-    if !check_path.starts_with(&ws_canonical) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": t.t("api-error-file-path-traversal")})),
-        );
-    }
-
-    // Atomic write: write to .tmp, then rename
-    let tmp_path = identity_dir.join(format!(".{filename}.tmp"));
-    if let Err(e) = std::fs::write(&tmp_path, &req.content) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": scrub_500(&e, &t)})),
-        );
-    }
-    if let Err(e) = std::fs::rename(&tmp_path, &file_path) {
-        if let Err(e) = std::fs::remove_file(&tmp_path) {
-            tracing::warn!("Failed to remove temporary file: {e}");
+        Ok(Err(IdentityFileMutationError::Forbidden)) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": t.t("api-error-file-path-traversal")})),
+            );
         }
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": scrub_500(&e, &t)})),
-        );
+        Ok(Err(IdentityFileMutationError::Io(error))) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": scrub_500(&error, &t)})),
+            );
+        }
+        Ok(Err(IdentityFileMutationError::NotFound)) => {
+            unreachable!("write never returns NotFound")
+        }
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": scrub_500(&error, &t)})),
+            );
+        }
     }
 
-    let size_bytes = req.content.len();
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -398,7 +446,8 @@ pub async fn delete_agent_file(
     Path((id, filename)): Path<(String, String)>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let resolved_lang = super::resolve_lang(lang.as_ref());
+    let t = ErrorTranslator::new(resolved_lang);
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
@@ -435,45 +484,44 @@ pub async fn delete_agent_file(
         }
     };
 
-    let ws_canonical = match workspace.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
+    let filename_for_delete = filename.clone();
+    drop(t);
+    let result =
+        tokio::task::spawn_blocking(move || delete_identity_file(&workspace, &filename_for_delete))
+            .await;
+    let t = ErrorTranslator::new(resolved_lang);
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(IdentityFileMutationError::Workspace)) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": t.t("api-error-file-workspace-error")})),
             );
         }
-    };
-
-    // Resolve path: prefer .identity/ (current layout), fall back to workspace root
-    let identity_candidate = workspace.join(".identity").join(&filename);
-    let file_path = if identity_candidate.exists() {
-        identity_candidate
-    } else {
-        workspace.join(&filename)
-    };
-
-    let canonical = match file_path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
+        Ok(Err(IdentityFileMutationError::NotFound)) => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({"error": t.t("api-error-file-not-found")})),
             );
         }
-    };
-    if !canonical.starts_with(&ws_canonical) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": t.t("api-error-file-path-traversal")})),
-        );
-    }
-
-    if let Err(e) = std::fs::remove_file(&canonical) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": scrub_500(&e, &t)})),
-        );
+        Ok(Err(IdentityFileMutationError::Forbidden)) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": t.t("api-error-file-path-traversal")})),
+            );
+        }
+        Ok(Err(IdentityFileMutationError::Io(error))) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": scrub_500(&error, &t)})),
+            );
+        }
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": scrub_500(&error, &t)})),
+            );
+        }
     }
 
     (


### PR DESCRIPTION
## Summary
- move identity-file canonicalization, directory creation, writes, renames, and deletes into blocking workers
- keep containment validation and the filesystem mutation in one synchronous operation
- preserve current API status and localized error behavior
- keep temporary-file cleanup and atomic replacement semantics

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo test -p librefang-api --test agents_capabilities_files_integration -- --nocapture` (21 passed)
- `CARGO_TARGET_DIR=/tmp/librefang-sidecar-delete/target cargo clippy -p librefang-api --all-targets -- -D warnings`

## Out of scope
- The already-offloaded identity-file listing path and asynchronous read path are unchanged.
- Other route-domain filesystem mutations remain separate follow-ups.