### PR TITLE
perf(api): read config exports asynchronously

### DIFF
--- a/changelog.d/fixed/7063-config-export-async-read.md
+++ b/changelog.d/fixed/7063-config-export-async-read.md
@@ -1,0 +1,1 @@
+Read exported configuration asynchronously so downloading `config.toml` cannot block API request workers. (@xiaomo)

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -1047,40 +1047,40 @@ pub async fn export_config(State(state): State<Arc<AppState>>) -> impl IntoRespo
 
     let config_path = state.kernel.home_dir().join("config.toml");
 
-    let toml_content = if config_path.exists() {
-        match std::fs::read_to_string(&config_path) {
-            Ok(content) => content,
-            Err(e) => {
-                // Scrub the io error (audit: rusqlite-errors-leak).
-                tracing::error!(error = %e, "failed to read config for export");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    [(axum::http::header::CONTENT_TYPE, "application/json")],
-                    Body::from(
-                        serde_json::json!({"status": "error", "error": "Internal server error"})
-                            .to_string(),
-                    ),
-                )
-                    .into_response();
+    let toml_content = match tokio::fs::read_to_string(&config_path).await {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Fall back to serializing in-memory config only when there is no
+            // persisted file to export.
+            match toml::to_string_pretty(&**state.kernel.config_ref()) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Scrub the serialize error (audit: rusqlite-errors-leak).
+                    tracing::error!(error = %e, "failed to serialize config for export");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        [(axum::http::header::CONTENT_TYPE, "application/json")],
+                        Body::from(
+                            serde_json::json!({"status": "error", "error": "Internal server error"})
+                                .to_string(),
+                        ),
+                    )
+                        .into_response();
+                }
             }
         }
-    } else {
-        // Fall back to serializing in-memory config
-        match toml::to_string_pretty(&**state.kernel.config_ref()) {
-            Ok(s) => s,
-            Err(e) => {
-                // Scrub the serialize error (audit: rusqlite-errors-leak).
-                tracing::error!(error = %e, "failed to serialize config for export");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    [(axum::http::header::CONTENT_TYPE, "application/json")],
-                    Body::from(
-                        serde_json::json!({"status": "error", "error": "Internal server error"})
-                            .to_string(),
-                    ),
-                )
-                    .into_response();
-            }
+        Err(e) => {
+            // Scrub the io error (audit: rusqlite-errors-leak).
+            tracing::error!(error = %e, "failed to read config for export");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                Body::from(
+                    serde_json::json!({"status": "error", "error": "Internal server error"})
+                        .to_string(),
+                ),
+            )
+                .into_response();
         }
     };
 


### PR DESCRIPTION
## Summary
- read persisted `config.toml` exports through Tokio instead of blocking an async API worker
- remove the separate existence check and keep the in-memory serialization fallback limited to `NotFound`
- preserve existing scrubbed handling for all other read errors

## Testing
- `cargo test -p librefang-api --test config_routes_integration config_export`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
