### PR TITLE
fix(kernel): reap finished agent watchers

### DIFF
--- a/changelog.d/fixed/7069-agent-watcher-gc.md
+++ b/changelog.d/fixed/7069-agent-watcher-gc.md
@@ -1,1 +1,1 @@
-Reclaim completed per-agent background watcher handles during periodic garbage collection while retaining running tasks for agent shutdown. (@xiaomo)
+Reclaim completed per-agent background watcher handles during periodic garbage collection while retaining running tasks for agent shutdown. (#7069) (@xiaomo)

--- a/changelog.d/fixed/7069-agent-watcher-gc.md
+++ b/changelog.d/fixed/7069-agent-watcher-gc.md
@@ -1,0 +1,1 @@
+Reclaim completed per-agent background watcher handles during periodic garbage collection while retaining running tasks for agent shutdown. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/accessors.rs
+++ b/crates/librefang-kernel/src/kernel/accessors.rs
@@ -1305,6 +1305,25 @@ impl LibreFangKernel {
             }
         }
 
+        // 2. agent_watchers — completed background tasks no longer need to be
+        // retained just so a future kill_agent can abort them. Registration
+        // also performs this cleanup opportunistically, but an agent that
+        // starts only one watcher would otherwise retain its finished
+        // JoinHandle for the rest of the daemon lifetime.
+        for slot in self.agents.agent_watchers.iter() {
+            match slot.value().lock() {
+                Ok(mut handles) => {
+                    let before = handles.len();
+                    handles.retain(|handle| !handle.is_finished());
+                    total_removed += before - handles.len();
+                }
+                Err(_) => warn!(
+                    agent_id = %slot.key(),
+                    "Agent watcher lock poisoned during GC; leaving handles for a later sweep"
+                ),
+            }
+        }
+
         // 3. agent_msg_locks — remove locks for dead agents, but only when the
         // map slot is the sole remaining holder of the Arc (`Arc::strong_count
         // == 1`). This mirrors the session_msg_locks pass below. The dead-agent

--- a/crates/librefang-kernel/src/kernel/accessors.rs
+++ b/crates/librefang-kernel/src/kernel/accessors.rs
@@ -1305,11 +1305,8 @@ impl LibreFangKernel {
             }
         }
 
-        // 2. agent_watchers — completed background tasks no longer need to be
-        // retained just so a future kill_agent can abort them. Registration
-        // also performs this cleanup opportunistically, but an agent that
-        // starts only one watcher would otherwise retain its finished
-        // JoinHandle for the rest of the daemon lifetime.
+        // 2. agent_watchers — completed background tasks no longer need to be retained just so a future kill_agent can abort them.
+        // Registration also performs this cleanup opportunistically, but an agent that starts only one watcher would otherwise retain its finished JoinHandle for the rest of the daemon lifetime.
         for slot in self.agents.agent_watchers.iter() {
             match slot.value().lock() {
                 Ok(mut handles) => {

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5788,6 +5788,77 @@ async fn gc_sweep_aborts_orphaned_running_task_5142() {
     kernel.shutdown();
 }
 
+/// A live agent that starts one short-lived background watcher may never call
+/// `register_agent_watcher` again, so registration-time cleanup alone cannot
+/// reclaim the completed JoinHandle. The periodic sweep must drop completed
+/// handles while retaining tasks that are still running for `kill_agent` to
+/// abort later.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_sweep_reaps_finished_agent_watchers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-kernel-gc-agent-watchers");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let kernel = LibreFangKernel::boot_with_config(KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    })
+    .expect("kernel should boot");
+
+    let manifest = AgentManifest {
+        name: "gc-agent-watcher".to_string(),
+        description: "agent for watcher GC".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+
+    let finished = tokio::spawn(async {});
+    while !finished.is_finished() {
+        tokio::task::yield_now().await;
+    }
+    let running = tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+    });
+    let running_abort = running.abort_handle();
+
+    kernel.agents.agent_watchers.insert(
+        agent_id,
+        Arc::new(std::sync::Mutex::new(vec![finished, running])),
+    );
+
+    kernel.gc_sweep();
+
+    {
+        let slot = kernel
+            .agents
+            .agent_watchers
+            .get(&agent_id)
+            .expect("live agent watcher slot must remain");
+        let handles = slot.lock().expect("watcher lock");
+        assert_eq!(handles.len(), 1, "finished watcher must be reclaimed");
+        assert!(
+            !handles[0].is_finished(),
+            "running watcher must remain tracked for kill_agent"
+        );
+    }
+
+    kernel.kill_agent(agent_id).expect("kill should succeed");
+    for _ in 0..50 {
+        if running_abort.is_finished() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(
+        running_abort.is_finished(),
+        "retained watcher must still be aborted when the agent is killed"
+    );
+
+    kernel.shutdown();
+}
+
 /// TOCTOU regression: the periodic GC sweep must NOT abort a *successor* turn that swapped into `running_tasks` after the sweep snapshotted a finished predecessor under the same `(agent, session)` key.
 /// Pre-fix the sweep collected the keys, then did a bare `running_tasks.remove(&key)`; a faster successor inserted between the collect and the remove was dropped and its in-flight `AbortHandle` fired, killing a live turn.
 /// The fix snapshots the observed `task_id` and removes via `remove_if(... v.task_id == observed)`, so a swapped-in successor (different task_id) is never touched.

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5788,11 +5788,8 @@ async fn gc_sweep_aborts_orphaned_running_task_5142() {
     kernel.shutdown();
 }
 
-/// A live agent that starts one short-lived background watcher may never call
-/// `register_agent_watcher` again, so registration-time cleanup alone cannot
-/// reclaim the completed JoinHandle. The periodic sweep must drop completed
-/// handles while retaining tasks that are still running for `kill_agent` to
-/// abort later.
+/// A live agent that starts one short-lived background watcher may never call `register_agent_watcher` again, so registration-time cleanup alone cannot reclaim the completed JoinHandle.
+/// The periodic sweep must drop completed handles while retaining tasks that are still running for `kill_agent` to abort later.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gc_sweep_reaps_finished_agent_watchers() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- sweep completed per-agent background watcher handles during periodic kernel garbage collection
- retain running watcher tasks so `kill_agent` can still abort them and release their resources
- log poisoned watcher locks and leave their contents for a later sweep
- add regression coverage for both completed-handle reclamation and running-task shutdown

## Verification
- `cargo test -p librefang-kernel --lib gc_sweep_reaps_finished_agent_watchers -- --nocapture`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- session blind-write conflict detection and unrelated collection cleanup remain separate scan findings and are not changed here.