### PR TITLE
fix(kernel): serialize session compaction writes

### DIFF
--- a/changelog.d/fixed/7070-session-compaction-lock.md
+++ b/changelog.d/fixed/7070-session-compaction-lock.md
@@ -1,1 +1,1 @@
-Serialize session compaction with concurrent message writers so an LLM compaction cannot overwrite messages saved after its initial snapshot. (@xiaomo)
+Serialize session compaction with concurrent message writers so an LLM compaction cannot overwrite messages saved after its initial snapshot (#7070) (@houko)

--- a/changelog.d/fixed/7070-session-compaction-lock.md
+++ b/changelog.d/fixed/7070-session-compaction-lock.md
@@ -1,0 +1,1 @@
+Serialize session compaction with concurrent message writers so an LLM compaction cannot overwrite messages saved after its initial snapshot. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/agent_runtime.rs
+++ b/crates/librefang-kernel/src/kernel/agent_runtime.rs
@@ -290,7 +290,7 @@ impl LibreFangKernel {
         agent_id: AgentId,
         force: bool,
     ) -> KernelResult<String> {
-        self.compact_agent_session_with_id(agent_id, None, force)
+        self.compact_agent_session_in_lock_scope(agent_id, None, force, true)
             .await
     }
 
@@ -310,10 +310,75 @@ impl LibreFangKernel {
         session_id_override: Option<SessionId>,
         force: bool,
     ) -> KernelResult<String> {
+        self.compact_agent_session_in_lock_scope(agent_id, session_id_override, force, false)
+            .await
+    }
+
+    /// Compact a session using the same lock domain selected by the caller's
+    /// message turn. An explicit session id does not by itself identify the
+    /// lock domain: agent-scoped turns also pass their resolved session id so
+    /// compaction operates on the exact in-turn session.
+    pub(crate) async fn compact_agent_session_in_lock_scope(
+        &self,
+        agent_id: AgentId,
+        session_id_override: Option<SessionId>,
+        force: bool,
+        agent_scoped: bool,
+    ) -> KernelResult<String> {
         let cfg = self.config.load_full();
         use librefang_runtime::compactor::{
             compact_session, estimate_token_count, needs_compaction, needs_compaction_by_tokens,
             CompactionConfig,
+        };
+
+        // Hold the same serialization lock that a message turn writing this
+        // session uses. Compaction awaits an LLM response between loading the
+        // session and replacing its messages; without this lock, a concurrent
+        // turn can save new messages during that window and the final
+        // compaction UPSERT silently overwrites them with its stale snapshot.
+        //
+        // Automatic compaction runs inside an already-locked agent turn. The
+        // task-local held-lock registry lets that path avoid re-acquiring the
+        // same non-reentrant mutex while external API/channel callers wait for
+        // the active writer before taking their snapshot.
+        let _compaction_guard: Option<tokio::sync::OwnedMutexGuard<()>> = if agent_scoped {
+            if librefang_runtime::held_agent_locks::is_held(agent_id) {
+                None
+            } else {
+                let lock = self
+                    .agents
+                    .agent_msg_locks
+                    .entry(agent_id)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone();
+                Some(lock.lock_owned().await)
+            }
+        } else if let Some(session_id) = session_id_override {
+            if librefang_runtime::held_agent_locks::is_session_held(session_id) {
+                None
+            } else {
+                let lock = self
+                    .agents
+                    .session_msg_locks
+                    .entry(session_id)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone();
+                Some(lock.lock_owned().await)
+            }
+        } else {
+            // The public default-session entry point always sets
+            // `agent_scoped = true`; keep this defensive fallback aligned.
+            if librefang_runtime::held_agent_locks::is_held(agent_id) {
+                None
+            } else {
+                let lock = self
+                    .agents
+                    .agent_msg_locks
+                    .entry(agent_id)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone();
+                Some(lock.lock_owned().await)
+            }
         };
 
         let entry = self.agents.registry.get(agent_id).ok_or_else(|| {

--- a/crates/librefang-kernel/src/kernel/agent_runtime.rs
+++ b/crates/librefang-kernel/src/kernel/agent_runtime.rs
@@ -314,10 +314,8 @@ impl LibreFangKernel {
             .await
     }
 
-    /// Compact a session using the same lock domain selected by the caller's
-    /// message turn. An explicit session id does not by itself identify the
-    /// lock domain: agent-scoped turns also pass their resolved session id so
-    /// compaction operates on the exact in-turn session.
+    /// Compact a session using the same lock domain selected by the caller's message turn.
+    /// An explicit session id does not by itself identify the lock domain: agent-scoped turns also pass their resolved session id so compaction operates on the exact in-turn session.
     pub(crate) async fn compact_agent_session_in_lock_scope(
         &self,
         agent_id: AgentId,
@@ -331,16 +329,11 @@ impl LibreFangKernel {
             CompactionConfig,
         };
 
-        // Hold the same serialization lock that a message turn writing this
-        // session uses. Compaction awaits an LLM response between loading the
-        // session and replacing its messages; without this lock, a concurrent
-        // turn can save new messages during that window and the final
-        // compaction UPSERT silently overwrites them with its stale snapshot.
+        // Hold the same serialization lock that a message turn writing this session uses.
+        // Compaction awaits an LLM response between loading the session and replacing its messages; without this lock, a concurrent turn can save new messages during that window and the final compaction UPSERT silently overwrites them with its stale snapshot.
         //
-        // Automatic compaction runs inside an already-locked agent turn. The
-        // task-local held-lock registry lets that path avoid re-acquiring the
-        // same non-reentrant mutex while external API/channel callers wait for
-        // the active writer before taking their snapshot.
+        // Automatic compaction runs inside an already-locked agent turn.
+        // The task-local held-lock registry lets that path avoid re-acquiring the same non-reentrant mutex while external API/channel callers wait for the active writer before taking their snapshot.
         let _compaction_guard: Option<tokio::sync::OwnedMutexGuard<()>> = if agent_scoped {
             if librefang_runtime::held_agent_locks::is_held(agent_id) {
                 None
@@ -366,8 +359,7 @@ impl LibreFangKernel {
                 Some(lock.lock_owned().await)
             }
         } else {
-            // The public default-session entry point always sets
-            // `agent_scoped = true`; keep this defensive fallback aligned.
+            // The public default-session entry point always sets `agent_scoped = true`; keep this defensive fallback aligned.
             if librefang_runtime::held_agent_locks::is_held(agent_id) {
                 None
             } else {

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -2971,7 +2971,12 @@ impl LibreFangKernel {
             if needs_compact && !loop_opts.is_fork {
                 info!(agent_id = %agent_id, messages = session.messages.len(), "Auto-compacting session");
                 match kernel_clone
-                    .compact_agent_session_with_id(agent_id, Some(session.id), false)
+                    .compact_agent_session_in_lock_scope(
+                        agent_id,
+                        Some(session.id),
+                        false,
+                        agent_scoped,
+                    )
                     .await
                 {
                     Ok(msg) => {
@@ -3322,7 +3327,12 @@ impl LibreFangKernel {
                                 // Pass the session id explicitly (same
                                 // reason as the pre-loop path above).
                                 if let Err(e) = kc
-                                    .compact_agent_session_with_id(agent_id, Some(sid), false)
+                                    .compact_agent_session_in_lock_scope(
+                                        agent_id,
+                                        Some(sid),
+                                        false,
+                                        agent_scoped,
+                                    )
                                     .await
                                 {
                                     warn!(agent_id = %agent_id, "Post-loop compaction failed: {e}");

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -12540,8 +12540,7 @@ async fn compact_session_serializes_with_message_writers_without_self_deadlock()
         .expect("empty-session compaction should succeed");
     assert!(default_result.starts_with("No compaction needed"));
 
-    // An explicit channel/session entry point must wait behind that session's
-    // override-scoped writer rather than the unrelated agent lock.
+    // An explicit channel/session entry point must wait behind that session's override-scoped writer rather than the unrelated agent lock.
     let session_lock = kernel
         .agents
         .session_msg_locks
@@ -12569,9 +12568,8 @@ async fn compact_session_serializes_with_message_writers_without_self_deadlock()
         .expect("compaction task should not panic")
         .expect("empty-session compaction should succeed");
 
-    // Automatic compaction is called inside the turn that already owns the
-    // lock. Its task-local registration must make the compactor skip a second
-    // acquisition of the same non-reentrant mutex.
+    // Automatic compaction is called inside the turn that already owns the lock.
+    // Its task-local registration must make the compactor skip a second acquisition of the same non-reentrant mutex.
     let kernel_for_scope = Arc::clone(&kernel);
     librefang_runtime::held_agent_locks::scope(async move {
         let lock = kernel_for_scope

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -12486,6 +12486,115 @@ fn boot_canonical_recovery_advances_pointer_to_most_recently_active_session_5198
 // Regression test for #5201: when a session is over the token threshold but
 // under threshold_messages, the inner gate in compact_agent_session_with_id
 // must NOT return "No compaction needed" — it must proceed to the compactor.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compact_session_serializes_with_message_writers_without_self_deadlock() {
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+    let kernel = Arc::new(
+        LibreFangKernel::boot_with_config(KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        })
+        .expect("kernel should boot"),
+    );
+
+    let manifest = AgentManifest {
+        name: "compact-session-lock-test".to_string(),
+        description: "test".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+    let session_id = kernel
+        .agents
+        .registry
+        .get(agent_id)
+        .expect("agent entry")
+        .session_id;
+
+    // The default-session entry point must wait behind an agent-scoped turn.
+    let agent_lock = kernel
+        .agents
+        .agent_msg_locks
+        .entry(agent_id)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+    let agent_guard = agent_lock.lock_owned().await;
+    let default_task = {
+        let kernel = Arc::clone(&kernel);
+        tokio::spawn(async move { kernel.compact_agent_session(agent_id, false).await })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !default_task.is_finished(),
+        "default-session compaction must wait for the agent message lock"
+    );
+    drop(agent_guard);
+    let default_result = tokio::time::timeout(std::time::Duration::from_secs(2), default_task)
+        .await
+        .expect("default compaction should finish after lock release")
+        .expect("compaction task should not panic")
+        .expect("empty-session compaction should succeed");
+    assert!(default_result.starts_with("No compaction needed"));
+
+    // An explicit channel/session entry point must wait behind that session's
+    // override-scoped writer rather than the unrelated agent lock.
+    let session_lock = kernel
+        .agents
+        .session_msg_locks
+        .entry(session_id)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+    let session_guard = session_lock.lock_owned().await;
+    let explicit_task = {
+        let kernel = Arc::clone(&kernel);
+        tokio::spawn(async move {
+            kernel
+                .compact_agent_session_with_id(agent_id, Some(session_id), false)
+                .await
+        })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !explicit_task.is_finished(),
+        "explicit-session compaction must wait for the session message lock"
+    );
+    drop(session_guard);
+    tokio::time::timeout(std::time::Duration::from_secs(2), explicit_task)
+        .await
+        .expect("explicit compaction should finish after lock release")
+        .expect("compaction task should not panic")
+        .expect("empty-session compaction should succeed");
+
+    // Automatic compaction is called inside the turn that already owns the
+    // lock. Its task-local registration must make the compactor skip a second
+    // acquisition of the same non-reentrant mutex.
+    let kernel_for_scope = Arc::clone(&kernel);
+    librefang_runtime::held_agent_locks::scope(async move {
+        let lock = kernel_for_scope
+            .agents
+            .agent_msg_locks
+            .get(&agent_id)
+            .expect("agent lock")
+            .clone();
+        let _lock_guard = lock.lock_owned().await;
+        let _held_guard = librefang_runtime::held_agent_locks::HeldLockGuard::register(agent_id);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            kernel_for_scope.compact_agent_session(agent_id, false),
+        )
+        .await
+        .expect("re-entrant automatic compaction must not self-deadlock")
+        .expect("empty-session compaction should succeed");
+    })
+    .await;
+
+    kernel.shutdown();
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_compact_gate_passes_when_tokens_above_threshold_but_messages_below() {
     use librefang_memory::session::Session as MemSession;


### PR DESCRIPTION
## Summary
- serialize LLM session compaction with the same agent- or session-scoped mutex used by message writers
- acquire the lock before loading the session snapshot so concurrent turns cannot be overwritten by a stale compaction result
- carry the message loop's actual lock domain into pre-loop and background post-loop compaction
- use the task-local held-lock registry to avoid self-deadlocking automatic compaction already running inside a turn
- add regression coverage for default-session blocking, explicit-session blocking, and same-task re-entry

## Verification
- `cargo test -p librefang-kernel --lib compact_session_serializes_with_message_writers_without_self_deadlock -- --nocapture`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The first test build was interrupted by a host `No space left on device` error. After removing 11.5 GiB of generated Cargo output from a completed sibling worktree with `cargo clean`, the same test and all checks above passed.

## Out of scope
- generic optimistic conflict detection in `MemorySubstrate::save_session` remains separate; this PR closes the concrete compaction read/await/write race through the kernel's existing lock discipline.