### PR TITLE
fix(security): block IPv4-compatible IPv6 SSRF

### DIFF
--- a/changelog.d/security/ipv4-compatible-ipv6-ssrf.md
+++ b/changelog.d/security/ipv4-compatible-ipv6-ssrf.md
@@ -1,0 +1,1 @@
+Reject IPv4-compatible IPv6 literals such as `::127.0.0.1` across outbound URL guards, closing a private-network SSRF bypass. (@xiaomo)

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -689,14 +689,12 @@ fn is_url_safe_for_ssrf(raw_url: &str, allowed_hosts: &[String]) -> Result<(), S
     Ok(())
 }
 
-/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// Unwrap IPv4-mapped or IPv4-compatible IPv6 to its IPv4 form. All other
 /// addresses are returned unchanged.
 fn canonical_ip(ip: &IpAddr) -> IpAddr {
     match ip {
-        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => IpAddr::V4(v4),
-            None => IpAddr::V6(*v6),
-        },
+        IpAddr::V6(v6) if v6.is_unspecified() || v6.is_loopback() => IpAddr::V6(*v6),
+        IpAddr::V6(v6) => v6.to_ipv4().map_or(IpAddr::V6(*v6), IpAddr::V4),
         IpAddr::V4(_) => *ip,
     }
 }
@@ -2353,6 +2351,16 @@ mod tests {
         // Real IPv6 is left alone.
         let real_v6: IpAddr = "2001:db8::1".parse().unwrap();
         assert_eq!(canonical_ip(&real_v6), real_v6);
+    }
+
+    #[test]
+    fn canonical_ip_unwraps_ipv4_compatible_v6() {
+        let compatible: IpAddr = "::127.0.0.1".parse().unwrap();
+        assert_eq!(canonical_ip(&compatible), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let loopback: IpAddr = "::1".parse().unwrap();
+        assert_eq!(canonical_ip(&loopback), loopback);
+        let unspecified: IpAddr = "::".parse().unwrap();
+        assert_eq!(canonical_ip(&unspecified), unspecified);
     }
 
     #[test]

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -291,14 +291,14 @@ fn is_blocked_domain(lower: &str) -> bool {
         || lower.ends_with(".internal")
 }
 
-/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// Unwrap IPv4-mapped or IPv4-compatible IPv6 to its IPv4 form. All other
 /// addresses are returned unchanged.
 fn canonical_ip(ip: std::net::IpAddr) -> std::net::IpAddr {
     match ip {
-        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => std::net::IpAddr::V4(v4),
-            None => std::net::IpAddr::V6(v6),
-        },
+        std::net::IpAddr::V6(v6) if v6.is_unspecified() || v6.is_loopback() => ip,
+        std::net::IpAddr::V6(v6) => v6
+            .to_ipv4()
+            .map_or(std::net::IpAddr::V6(v6), std::net::IpAddr::V4),
         std::net::IpAddr::V4(_) => ip,
     }
 }
@@ -704,6 +704,14 @@ mod tests {
         // these before the guard runs.
         assert!(validate_webhook_url("http://[::ffff:127.0.0.1]/hook").is_err());
         assert!(validate_webhook_url("http://[::ffff:7f00:1]/hook").is_err());
+    }
+
+    #[test]
+    fn validate_webhook_url_blocks_ipv4_compatible_ipv6_loopback() {
+        assert!(validate_webhook_url("http://[::127.0.0.1]/hook").is_err());
+        assert!(validate_webhook_url("http://[::7f00:1]/hook").is_err());
+        assert!(validate_webhook_url("http://[::1]/hook").is_err());
+        assert!(validate_webhook_url("http://[::]/hook").is_err());
     }
 
     #[test]

--- a/crates/librefang-channels/src/http_client.rs
+++ b/crates/librefang-channels/src/http_client.rs
@@ -296,10 +296,13 @@ fn is_private_ipv6(v6: Ipv6Addr) -> bool {
 
 /// Extract an IPv4 address embedded in an IPv6 in the two ways an
 /// attacker can use to reach an IPv4 endpoint via an IPv6 host:
-/// IPv4-mapped (`::ffff:x.x.x.x`, RFC 4291 §2.5.5.2) and NAT64
+/// IPv4-mapped/compatible (`::ffff:x.x.x.x` / `::x.x.x.x`) and NAT64
 /// (`64:ff9b::x.x.x.x`, RFC 6052).
 fn ipv6_embedded_ipv4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
-    if let Some(v4) = v6.to_ipv4_mapped() {
+    if v6.is_unspecified() || v6.is_loopback() {
+        return None;
+    }
+    if let Some(v4) = v6.to_ipv4() {
         return Some(v4);
     }
     let s = v6.segments();
@@ -586,6 +589,8 @@ mod tests {
             "http://[::ffff:7f00:1]/",
             "http://[::ffff:10.0.0.1]/",
             "http://[::ffff:169.254.169.254]/",
+            "http://[::127.0.0.1]/",
+            "http://[::7f00:1]/",
             "http://[64:ff9b::7f00:1]/",
             "http://[ff02::1]/", // multicast
         ] {

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -243,14 +243,17 @@ fn is_ssrf_blocked_host_impl(host: &str, metadata_only: bool) -> bool {
 
     /// IPv4 embedded in an IPv6 address through one of the two forms
     /// that route packets to an IPv4 endpoint on the wire:
-    ///   * IPv4-mapped: `::ffff:x.x.x.x` (RFC 4291 §2.5.5.2)
+    ///   * IPv4-mapped/compatible: `::ffff:x.x.x.x` / `::x.x.x.x`
     ///   * NAT64:       `64:ff9b::x.x.x.x` (RFC 6052)
     ///
     /// Without these, `http://[::ffff:7f00:0001]/` bypasses the V4
     /// loopback check entirely — the daemon happily connects to
     /// 127.0.0.1 over an IPv6 socket.
     fn ipv6_embedded_ipv4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
-        if let Some(v4) = v6.to_ipv4_mapped() {
+        if v6.is_unspecified() || v6.is_loopback() {
+            return None;
+        }
+        if let Some(v4) = v6.to_ipv4() {
             return Some(v4);
         }
         let s = v6.segments();
@@ -1260,6 +1263,12 @@ mod tests {
     fn well_known_url_blocks_ipv4_mapped_ipv6_loopback() {
         assert!(well_known_url("http://[::ffff:7f00:0001]/mcp").is_none());
         assert!(well_known_url("http://[::ffff:127.0.0.1]/mcp").is_none());
+    }
+
+    #[test]
+    fn well_known_url_blocks_ipv4_compatible_ipv6_loopback() {
+        assert!(well_known_url("http://[::127.0.0.1]/mcp").is_none());
+        assert!(well_known_url("http://[::7f00:1]/mcp").is_none());
     }
 
     #[test]

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -581,12 +581,14 @@ pub(crate) fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
     }
 }
 
-/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) and the NAT64 well-known
+/// Unwrap IPv4-mapped/compatible IPv6 (`::ffff:X.X.X.X` / `::X.X.X.X`)
+/// and the NAT64 well-known
 /// prefix (`64:ff9b::/96`, RFC 6052) to the IPv4 address the connection
 /// will actually reach. All other addresses are returned unchanged.
 ///
-/// IPv4-mapped is translated by the OS itself; NAT64 is translated by a
-/// network gateway when one is deployed. Both forms must be unwrapped
+/// IPv4-mapped and deprecated compatible forms can be translated to IPv4 by
+/// the network stack; NAT64 is translated by a network gateway when one is
+/// deployed. All forms must be unwrapped
 /// before SSRF checks so an attacker can't smuggle loopback / RFC1918 /
 /// cloud-metadata IPs through them.
 ///
@@ -595,7 +597,13 @@ pub(crate) fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
 pub(crate) fn canonical_ip(ip: &IpAddr) -> IpAddr {
     match ip {
         IpAddr::V6(v6) => {
-            if let Some(v4) = v6.to_ipv4_mapped() {
+            // `to_ipv4()` also represents the native IPv6 special addresses
+            // `::` and `::1` as 0.0.0.0 and 0.0.0.1. Preserve them so the
+            // IPv6 unspecified/loopback checks still see their true class.
+            if v6.is_unspecified() || v6.is_loopback() {
+                return IpAddr::V6(*v6);
+            }
+            if let Some(v4) = v6.to_ipv4() {
                 return IpAddr::V4(v4);
             }
             if let Some(v4) = extract_nat64_well_known(v6) {
@@ -1268,6 +1276,12 @@ mod tests {
     }
 
     #[test]
+    fn test_ssrf_blocks_ipv4_compatible_ipv6_loopback() {
+        assert!(check_ssrf("http://[::127.0.0.1]/", &[]).is_err());
+        assert!(check_ssrf("http://[::7f00:1]/", &[]).is_err());
+    }
+
+    #[test]
     fn test_ssrf_blocks_ipv4_mapped_ipv6_metadata() {
         // 169.254.169.254 expressed as an IPv4-mapped IPv6 address reaches
         // the AWS EC2 instance metadata service on real hosts.
@@ -1293,6 +1307,17 @@ mod tests {
         // Real IPv6 is left alone.
         let real_v6: IpAddr = "2001:db8::1".parse().unwrap();
         assert_eq!(canonical_ip(&real_v6), real_v6);
+    }
+
+    #[test]
+    fn test_canonical_ip_unwraps_compatible() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let compatible: IpAddr = "::127.0.0.1".parse().unwrap();
+        assert_eq!(canonical_ip(&compatible), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let loopback: IpAddr = "::1".parse().unwrap();
+        assert_eq!(canonical_ip(&loopback), loopback);
+        let unspecified: IpAddr = "::".parse().unwrap();
+        assert_eq!(canonical_ip(&unspecified), unspecified);
     }
 
     #[test]

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -888,14 +888,12 @@ fn is_zeronet_v4(ip: IpAddr) -> bool {
     matches!(ip, IpAddr::V4(v4) if v4.octets()[0] == 0)
 }
 
-/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// Unwrap IPv4-mapped or IPv4-compatible IPv6 to its IPv4 form. All other
 /// addresses are returned unchanged.
 fn canonical_ip(ip: IpAddr) -> IpAddr {
     match ip {
-        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => IpAddr::V4(v4),
-            None => IpAddr::V6(v6),
-        },
+        IpAddr::V6(v6) if v6.is_unspecified() || v6.is_loopback() => ip,
+        IpAddr::V6(v6) => v6.to_ipv4().map_or(IpAddr::V6(v6), IpAddr::V4),
         IpAddr::V4(_) => ip,
     }
 }
@@ -1544,6 +1542,14 @@ mod tests {
         assert_webhook_rejected("http://[::ffff:127.0.0.1]/");
         // ::ffff:7f00:1 — same address in compact hex form.
         assert_webhook_rejected("http://[::ffff:7f00:1]/");
+    }
+
+    #[test]
+    fn webhook_v4_compatible_v6_rejected() {
+        assert_webhook_rejected("http://[::127.0.0.1]/");
+        assert_webhook_rejected("http://[::7f00:1]/");
+        assert_webhook_rejected("http://[::1]/");
+        assert_webhook_rejected("http://[::]/");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- canonicalize deprecated IPv4-compatible IPv6 literals before outbound URL safety checks
- apply the fix consistently across runtime fetches, API network/webhook guards, scheduler webhooks, channel fetches, and MCP OAuth discovery
- preserve native `::` and `::1` classification while adding regression coverage for `::127.0.0.1` and compact `::7f00:1` forms

## Validation

- targeted unit tests in `librefang-runtime`, `librefang-api`, `librefang-types`, `librefang-channels`, and `librefang-runtime-mcp`
- `cargo clippy -p librefang-runtime -p librefang-api -p librefang-types -p librefang-channels -p librefang-runtime-mcp --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Gitleaks is not installed locally; CI remains the secret-scan gate.