### PR TITLE
fix(api): fail closed on MCP reload errors

### DIFF
--- a/changelog.d/fixed/mcp-reload-errors.md
+++ b/changelog.d/fixed/mcp-reload-errors.md
@@ -1,0 +1,1 @@
+Fail MCP reload requests when the prerequisite config reload fails, and scrub internal reload errors from API responses. (@xiaomo)

--- a/crates/librefang-api/src/routes/skills/mcp.rs
+++ b/crates/librefang-api/src/routes/skills/mcp.rs
@@ -1023,7 +1023,7 @@ pub async fn reload_mcp_handler(State(state): State<Arc<AppState>>) -> impl Into
     // add/remove` does this, then POSTs /api/mcp/reload) the reload would
     // otherwise run against the stale snapshot and miss the change.
     if let Err(e) = state.kernel.reload_config().await {
-        tracing::warn!("Failed to reload config before MCP reload: {e}");
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     match state.kernel.clone().reload_mcp_servers().await {
@@ -1034,6 +1034,6 @@ pub async fn reload_mcp_handler(State(state): State<Arc<AppState>>) -> impl Into
                 "new_connections": connected,
             })),
         ),
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }


### PR DESCRIPTION
## Summary

- stop MCP reload requests when the prerequisite config reload fails instead of reconnecting from stale in-memory configuration
- scrub config and MCP reconnect internals from 500 responses while retaining full errors in server logs

## Validation

- `cargo test -p librefang-api --lib internal_scrub_returns_generic_message_not_source_error`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Gitleaks is not installed locally; CI remains the secret-scan gate.