### PR TITLE
fix(desktop): drain dashboard sync on shutdown

### DIFF
--- a/changelog.d/fixed/desktop-dashboard-task-drain.md
+++ b/changelog.d/fixed/desktop-dashboard-task-drain.md
@@ -1,0 +1,1 @@
+Drain the desktop dashboard sync task during embedded-server shutdown instead of dropping its JoinHandle and cancelling runtime work implicitly. (@xiaomo)

--- a/crates/librefang-desktop/src/server.rs
+++ b/crates/librefang-desktop/src/server.rs
@@ -130,13 +130,15 @@ async fn run_embedded_server(
     // Desktop embeds the router directly, so it must start the same task here or live provider catalogs (notably OpenRouter) never refresh.
     kernel.clone().spawn_key_validation();
 
-    // Sync dashboard assets in background (downloads from release if outdated)
-    {
+    // Sync dashboard assets in background (downloads from release if outdated).
+    // Keep the handle so shutdown does not destroy the embedded runtime while
+    // the one-shot install is still updating the dashboard directory.
+    let dashboard_sync = {
         let home = kernel.home_dir().to_path_buf();
         tokio::spawn(async move {
             librefang_api::webchat::sync_dashboard(&home).await;
-        });
-    }
+        })
+    };
 
     // Convert std TcpListener → tokio TcpListener
     std_listener
@@ -158,6 +160,10 @@ async fn run_embedded_server(
 
     if let Err(e) = server.await {
         error!("Embedded server error: {e}");
+    }
+
+    if let Err(e) = dashboard_sync.await {
+        error!("Dashboard sync task failed: {e}");
     }
 
     // Clean up channel bridges. Swap out atomically then stop with owned access.


### PR DESCRIPTION
## Summary

- retain the desktop dashboard sync task handle instead of detaching it
- await the one-shot sync after the embedded HTTP server exits so runtime teardown cannot cancel an in-progress dashboard install
- log task panics/cancellation explicitly

## Validation

- `cargo clippy -p librefang-desktop --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Gitleaks is not installed locally; CI remains the secret-scan gate.