### PR TITLE
fix(api): scrub manual schedule run errors

### DIFF
--- a/changelog.d/security/schedule-run-error-scrub.md
+++ b/changelog.d/security/schedule-run-error-scrub.md
@@ -1,0 +1,1 @@
+Scrub workflow and agent execution details from manual schedule-run HTTP 500 responses while retaining schedule and action context in server logs. (@xiaomo)

--- a/crates/librefang-api/src/routes/workflows/schedules.rs
+++ b/crates/librefang-api/src/routes/workflows/schedules.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+fn manual_run_internal_error(schedule_id: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({
+            "status": "failed",
+            "schedule_id": schedule_id,
+            "error": "Internal server error",
+        })),
+    )
+}
+
 /// GET /api/schedules — List all scheduled jobs.
 ///
 /// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
@@ -580,14 +591,15 @@ pub async fn run_schedule(
                         })),
                     )
                 }
-                Err(e) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "status": "failed",
-                        "schedule_id": id,
-                        "error": format!("{e}"),
-                    })),
-                ),
+                Err(error) => {
+                    tracing::error!(
+                        %error,
+                        schedule_id = %id,
+                        %workflow_id,
+                        "manual workflow schedule run failed"
+                    );
+                    manual_run_internal_error(&id)
+                }
             }
         }
         librefang_types::scheduler::CronAction::AgentTurn { message, .. } => {
@@ -620,14 +632,15 @@ pub async fn run_schedule(
                         })),
                     )
                 }
-                Err(e) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "status": "failed",
-                        "schedule_id": id,
-                        "error": format!("{e}"),
-                    })),
-                ),
+                Err(error) => {
+                    tracing::error!(
+                        %error,
+                        schedule_id = %id,
+                        %agent_id,
+                        "manual agent-turn schedule run failed"
+                    );
+                    manual_run_internal_error(&id)
+                }
             }
         }
         librefang_types::scheduler::CronAction::SystemEvent { text } => {
@@ -647,5 +660,23 @@ pub async fn run_schedule(
                 })),
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn manual_run_internal_errors_have_a_stable_scrubbed_body() {
+        let response = manual_run_internal_error("schedule-123").into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["schedule_id"], "schedule-123");
+        assert_eq!(body["error"], "Internal server error");
+        assert_eq!(body["status"], "failed");
     }
 }


### PR DESCRIPTION
## Summary
- keep manual workflow-run failures in structured server logs with schedule and workflow context
- keep manual agent-turn failures in structured logs with schedule and agent context
- return a stable generic HTTP 500 error while preserving the existing response shape
- add a regression test for the scrubbed error envelope

## Validation
- `cargo test -p librefang-api manual_run_internal_errors_have_a_stable_scrubbed_body`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`