### PR TITLE
fix(security): block IPv4 zero network SSRF

### DIFF
--- a/changelog.d/security/ipv4-zero-net-ssrf.md
+++ b/changelog.d/security/ipv4-zero-net-ssrf.md
@@ -1,0 +1,1 @@
+Block the full IPv4 0.0.0.0/8 "this" network across SSRF validators. (@xiaomo)

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -794,7 +794,7 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                 || v4.is_private()         // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
                 || v4.is_link_local()      // 169.254.0.0/16 (cloud metadata)
                 || v4.is_broadcast()       // 255.255.255.255
-                || v4.is_unspecified()     // 0.0.0.0
+                || v4.octets()[0] == 0     // 0.0.0.0/8 ("this" network)
                 || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 (CGNAT)
         }
         IpAddr::V6(v6) => {
@@ -2372,6 +2372,8 @@ mod tests {
         assert!(is_private_ip(&"::ffff:169.254.169.254".parse().unwrap()));
         assert!(is_private_ip(&"::ffff:192.168.1.1".parse().unwrap()));
         assert!(is_private_ip(&"::ffff:100.64.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"0.1.2.3".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:0.1.2.3".parse().unwrap()));
     }
 
     #[test]

--- a/crates/librefang-rl-export/src/ssrf.rs
+++ b/crates/librefang-rl-export/src/ssrf.rs
@@ -296,7 +296,7 @@ fn blocked_v4(v4: Ipv4Addr) -> bool {
     // `loopback_or_private_v4`, so they are rejected even on the Atropos
     // loopback path. Kept in step with
     // `librefang_runtime_mcp::mcp_oauth::is_ssrf_blocked_host`.
-    (o[0] == 0 && o[1] == 0 && o[2] == 0 && o[3] == 0)          // 0.0.0.0 unspecified → loopback
+    o[0] == 0                                                   // 0.0.0.0/8 "this" network
         || (o[0] == 100 && (o[1] & 0xc0) == 64)                // 100.64.0.0/10 CGNAT (Alibaba IMDS)
         || (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] == 192) // 192.0.0.192 Azure IMDS
         || o[0] == 127
@@ -394,6 +394,8 @@ mod tests {
         // including the Atropos loopback path, since none are RFC-1918 private.
         for url in [
             "http://0.0.0.0:8000/",          // unspecified → routes to loopback
+            "http://0.1.2.3:8000/",          // 0.0.0.0/8 "this" network
+            "http://[::ffff:0.1.2.3]:8000/", // embedded 0.0.0.0/8
             "http://100.100.100.200/",       // Alibaba Cloud IMDS (100.64/10 CGNAT)
             "http://192.0.0.192/",           // Azure IMDS alternative endpoint
             "http://metadata.aws.internal/", // AWS IMDS hostname

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -174,7 +174,7 @@ pub fn extract_metadata_url(params: &HashMap<String, String>, server_url: &str) 
 /// * Exact hostnames:   `localhost`, `ip6-localhost`, `metadata.google.internal`,
 ///   `metadata.aws.internal`, `instance-data`
 /// * IPv4 loopback      127.0.0.0/8
-/// * IPv4 unspecified   0.0.0.0
+/// * IPv4 "this" net   0.0.0.0/8
 /// * IPv4 private       10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
 /// * IPv4 CGNAT         100.64.0.0/10 (incl. Alibaba Cloud IMDS 100.100.100.200)
 /// * IPv4 link-local    169.254.0.0/16 (covers IMDS 169.254.169.254)
@@ -192,7 +192,7 @@ pub fn extract_metadata_url(params: &HashMap<String, String>, server_url: &str) 
 ///   essential. This is the historical behaviour for every caller.
 /// * `true`  — block only the cloud-metadata pivots that are *never* a
 ///   legitimate operator-configured backend (IMDS hostnames,
-///   `0.0.0.0`, `169.254/16`, `100.64/10`, `192.0.0.192`, and their
+///   `0.0.0.0/8`, `169.254/16`, `100.64/10`, `192.0.0.192`, and their
 ///   IPv6-embedded forms). Loopback / RFC1918 are allowed. Used by the
 ///   operator-configured MCP connect URL (`McpConnection::check_ssrf`),
 ///   where pointing at a local MCP server on `127.0.0.1` /
@@ -216,8 +216,8 @@ fn is_ssrf_blocked_host_impl(host: &str, metadata_only: bool) -> bool {
         // Cloud-metadata pivots — never a legitimate operator backend,
         // blocked on every path including connect.
         let meta =
-            // 0.0.0.0 unspecified — connects to every interface incl. loopback
-            (o[0] == 0 && o[1] == 0 && o[2] == 0 && o[3] == 0)
+            // 0.0.0.0/8 "this" network — can resolve to a local interface
+            o[0] == 0
             // 100.64.0.0/10 CGNAT (also Alibaba Cloud IMDS at 100.100.100.200)
             || (o[0] == 100 && (o[1] & 0xc0) == 64)
             // 169.254.0.0/16 link-local (incl. cloud IMDS 169.254.169.254)
@@ -1603,6 +1603,17 @@ mod tests {
     fn is_ssrf_blocked_url_allows_plain_public() {
         assert!(is_ssrf_blocked_url("https://auth.example.com/token").is_ok());
         assert!(is_ssrf_blocked_url("http://auth.example.com:8443/authorize").is_ok());
+    }
+
+    #[test]
+    fn is_ssrf_blocked_url_rejects_ipv4_zero_network() {
+        for url in ["http://0.1.2.3/", "http://[::ffff:0.1.2.3]/"] {
+            assert!(is_ssrf_blocked_url(url).is_err(), "must reject {url}");
+            assert!(
+                is_ssrf_blocked_url_for_connect(url).is_err(),
+                "connect mode must reject {url}"
+            );
+        }
     }
 
     #[test]

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -730,7 +730,7 @@ pub(crate) fn is_private_ip(ip: &IpAddr) -> bool {
             let octets = v4.octets();
             matches!(
                 octets,
-                [10, ..] | [172, 16..=31, ..] | [192, 168, ..] | [169, 254, ..]
+                [0, ..] | [10, ..] | [172, 16..=31, ..] | [192, 168, ..] | [169, 254, ..]
             )
         }
         IpAddr::V6(v6) => {
@@ -1258,6 +1258,8 @@ mod tests {
     #[test]
     fn test_ssrf_blocks_zero_ip() {
         assert!(check_ssrf("http://0.0.0.0/", &[]).is_err());
+        assert!(check_ssrf("http://0.1.2.3/", &[]).is_err());
+        assert!(check_ssrf("http://[::ffff:0.1.2.3]/", &[]).is_err());
     }
 
     #[test]
@@ -1327,6 +1329,8 @@ mod tests {
         assert!(is_private_ip(&mapped_private));
         let mapped_link_local: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
         assert!(is_private_ip(&mapped_link_local));
+        assert!(is_private_ip(&"0.1.2.3".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:0.1.2.3".parse().unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject the full IPv4 `0.0.0.0/8` "this" network in API network and runtime web-fetch SSRF checks
- keep MCP OAuth and RL export validators aligned, including IPv4-mapped IPv6 forms
- add focused regressions for `0.1.2.3` and `::ffff:0.1.2.3`

## Verification
- `cargo test -p librefang-api --lib routes::network::tests::is_private_ip_recognises_ipv4_mapped_v6`
- `cargo test -p librefang-runtime --lib web_fetch::tests::test_ssrf_blocks_zero_ip`
- `cargo test -p librefang-runtime-mcp --lib mcp_oauth::tests::is_ssrf_blocked_url_rejects_ipv4_zero_network`
- `cargo test -p librefang-rl-export --lib ssrf::tests::rejects_metadata_pivots_that_diverged_from_the_mirror`
- `cargo check --workspace --lib`
- `cargo clippy -p librefang-api -p librefang-runtime -p librefang-runtime-mcp -p librefang-rl-export --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- other remaining OCR audit findings stay separate follow-up work
- Claude child reaping remains deferred until #7071 merges