### PR TITLE
fix(mcp): clear warning cache lock poison

### DIFF
--- a/changelog.d/fixed/mcp-warning-cache-clear-poison.md
+++ b/changelog.d/fixed/mcp-warning-cache-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the MCP unknown-rule warning cache poison flag after preserving recovered entries. (@xiaomo)

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -314,13 +314,18 @@ static UNKNOWN_RULE_SET_WARNED: std::sync::OnceLock<
 fn lock_unknown_rule_set_warnings(
     cell: &std::sync::Mutex<std::collections::HashSet<String>>,
 ) -> std::sync::MutexGuard<'_, std::collections::HashSet<String>> {
-    cell.lock().unwrap_or_else(|poisoned| {
-        warn!(
-            target: "librefang_runtime_mcp::taint",
-            "unknown taint rule-set warning cache lock poisoned; recovering inner state"
-        );
-        poisoned.into_inner()
-    })
+    match cell.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!(
+                target: "librefang_runtime_mcp::taint",
+                "unknown taint rule-set warning cache lock poisoned; recovering inner state"
+            );
+            let guard = poisoned.into_inner();
+            cell.clear_poison();
+            guard
+        }
+    }
 }
 
 fn warn_unknown_rule_set_once(set_name: &str, tool_name: &str) {
@@ -3723,11 +3728,13 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(warned.is_poisoned());
         let mut recovered = lock_unknown_rule_set_warnings(&warned);
         assert!(!recovered.insert("existing".to_string()));
         assert!(recovered.insert("new".to_string()));
         drop(recovered);
-        assert_eq!(lock_unknown_rule_set_warnings(&warned).len(), 2);
+        assert!(!warned.is_poisoned());
+        assert_eq!(warned.lock().unwrap().len(), 2);
     }
 
     // ── MCP outbound taint scanning ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- clear the MCP unknown-rule warning cache poison flag after recovering its preserved entries
- keep the existing recovery warning and deduplication behavior
- strengthen the panic-path test to prove ordinary future lock acquisition succeeds

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-runtime-mcp --lib tests::poisoned_unknown_rule_warning_cache_recovers_and_deduplicates`
- `cargo clippy -p librefang-runtime-mcp --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- other poisoned-lock audit findings
- Claude child-process cleanup tracked separately in #7077