### PR TITLE
fix(metering): clear reservation ledger poison

### DIFF
--- a/changelog.d/fixed/metering-ledger-clear-poison.md
+++ b/changelog.d/fixed/metering-ledger-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the metering reservation ledger poison flag after preserving pending budget state. (@xiaomo)

--- a/crates/librefang-kernel-metering/src/lib.rs
+++ b/crates/librefang-kernel-metering/src/lib.rs
@@ -40,10 +40,15 @@ struct CostReservationLedger {
 
 impl CostReservationLedger {
     fn lock_reserved(&self) -> MutexGuard<'_, f64> {
-        self.reserved_usd.lock().unwrap_or_else(|poisoned| {
-            warn!("cost reservation ledger lock poisoned; recovering pending budget state");
-            poisoned.into_inner()
-        })
+        match self.reserved_usd.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn!("cost reservation ledger lock poisoned; recovering pending budget state");
+                let guard = poisoned.into_inner();
+                self.reserved_usd.clear_poison();
+                guard
+            }
+        }
     }
 
     fn current(&self) -> f64 {
@@ -847,7 +852,9 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(ledger.reserved_usd.is_poisoned());
         assert_eq!(ledger.current(), 0.4);
+        assert!(!ledger.reserved_usd.is_poisoned());
         let (pending_before, added) = ledger.check_and_add(0.5, &[(1.0, 0.0)]).unwrap();
         assert_eq!(pending_before, 0.4);
         assert_eq!(added, 0.5);
@@ -855,6 +862,7 @@ mod tests {
         assert!(ledger.check_and_add(0.2, &[(1.0, 0.0)]).is_err());
         ledger.release(0.5);
         assert!((ledger.current() - 0.4).abs() < f64::EPSILON);
+        assert!((*ledger.reserved_usd.lock().unwrap() - 0.4).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clear the cost reservation ledger poison flag after recovering pending budget state
- preserve in-flight reservation accounting across the recovery path
- strengthen the held-lock panic regression to prove later ordinary lock acquisition succeeds

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel-metering --lib tests::poisoned_cost_ledger_lock_recovers_and_preserves_budget_accounting`
- `cargo clippy -p librefang-kernel-metering --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- other poisoned-lock audit findings
- API internal-error scrubbing
- Claude CLI lifecycle cleanup pending #7071