### PR TITLE
fix(llm): clear OAuth token cache poison

### DIFF
--- a/changelog.d/fixed/oauth-token-cache-clear-poison.md
+++ b/changelog.d/fixed/oauth-token-cache-clear-poison.md
@@ -1,0 +1,1 @@
+Clear ChatGPT and Copilot OAuth token cache poison flags after preserving recovered credentials. (@xiaomo)

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -198,10 +198,15 @@ impl ChatGptTokenCache {
     }
 
     fn lock_cached(&self) -> MutexGuard<'_, Option<CachedSessionToken>> {
-        self.cached.lock().unwrap_or_else(|poisoned| {
-            warn!("ChatGPT token cache lock poisoned; recovering inner state");
-            poisoned.into_inner()
-        })
+        match self.cached.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn!("ChatGPT token cache lock poisoned; recovering inner state");
+                let guard = poisoned.into_inner();
+                self.cached.clear_poison();
+                guard
+            }
+        }
     }
 
     /// Get a valid cached token, or None if expired/missing.
@@ -1243,7 +1248,9 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(cache.cached.is_poisoned());
         assert_eq!(*cache.get().unwrap().token, "rejected");
+        assert!(!cache.cached.is_poisoned());
         cache.invalidate_if_matches("rejected");
         assert!(cache.get().is_none());
 
@@ -1252,6 +1259,10 @@ mod tests {
             expires_at: Instant::now() + Duration::from_secs(86400),
         });
         assert_eq!(*cache.get().unwrap().token, "fresh");
+        assert_eq!(
+            *cache.cached.lock().unwrap().as_ref().unwrap().token,
+            "fresh"
+        );
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/copilot.rs
+++ b/crates/librefang-llm-drivers/src/drivers/copilot.rs
@@ -51,10 +51,15 @@ impl CopilotTokenCache {
     }
 
     fn lock_cached(&self) -> MutexGuard<'_, Option<CachedToken>> {
-        self.cached.lock().unwrap_or_else(|poisoned| {
-            warn!("Copilot token cache lock poisoned; recovering inner state");
-            poisoned.into_inner()
-        })
+        match self.cached.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn!("Copilot token cache lock poisoned; recovering inner state");
+                let guard = poisoned.into_inner();
+                self.cached.clear_poison();
+                guard
+            }
+        }
     }
 
     /// Get a valid cached token, or None if expired/missing.
@@ -370,7 +375,9 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(cache.cached.is_poisoned());
         assert_eq!(*cache.get().unwrap().token, "old-token");
+        assert!(!cache.cached.is_poisoned());
         cache.set(CachedToken {
             token: Zeroizing::new("fresh-token".to_string()),
             expires_at: Instant::now() + Duration::from_secs(3600),
@@ -379,6 +386,10 @@ mod tests {
         let fresh = cache.get().unwrap();
         assert_eq!(*fresh.token, "fresh-token");
         assert_eq!(fresh.base_url, "https://proxy.example");
+        assert_eq!(
+            *cache.cached.lock().unwrap().as_ref().unwrap().token,
+            "fresh-token"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clear ChatGPT and Copilot token cache poison flags after recovering preserved credentials
- retain the existing observable recovery and replacement behavior
- strengthen both held-lock panic regressions to prove later ordinary lock acquisition succeeds

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-llm-drivers --lib drivers::chatgpt::tests::poisoned_token_cache_lock_recovers_and_cache_remains_usable`
- `cargo test -p librefang-llm-drivers --lib drivers::copilot::tests::poisoned_token_cache_lock_recovers_and_accepts_replacement`
- `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- other poisoned-lock audit findings
- CLI prompt transport covered by #7092 and #7093
- Claude CLI lifecycle cleanup pending #7071