### PR TITLE
fix(kernel): clear quality regex cache poison

### DIFF
--- a/changelog.d/fixed/quality-regex-cache-clear-poison.md
+++ b/changelog.d/fixed/quality-regex-cache-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the workflow quality regex cache poison flag after preserving compiled patterns. (@xiaomo)

--- a/crates/librefang-kernel/src/orchestration.rs
+++ b/crates/librefang-kernel/src/orchestration.rs
@@ -235,10 +235,15 @@ static QUALITY_REGEX_CACHE: std::sync::OnceLock<
 fn lock_quality_regex_cache(
     cache: &std::sync::Mutex<HashMap<String, regex_lite::Regex>>,
 ) -> std::sync::MutexGuard<'_, HashMap<String, regex_lite::Regex>> {
-    cache.lock().unwrap_or_else(|poisoned| {
-        tracing::warn!("quality regex cache lock poisoned; recovering compiled patterns");
-        poisoned.into_inner()
-    })
+    match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            tracing::warn!("quality regex cache lock poisoned; recovering compiled patterns");
+            let guard = poisoned.into_inner();
+            cache.clear_poison();
+            guard
+        }
+    }
 }
 
 fn matches_quality_regex(pattern: &str, output: &str) -> bool {
@@ -478,11 +483,13 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(cache.is_poisoned());
         let mut recovered = lock_quality_regex_cache(&cache);
         assert!(recovered["old"].is_match("old value"));
         recovered.insert("new".to_string(), regex_lite::Regex::new("new").unwrap());
         drop(recovered);
-        assert!(lock_quality_regex_cache(&cache)["new"].is_match("new value"));
+        assert!(!cache.is_poisoned());
+        assert!(cache.lock().unwrap()["new"].is_match("new value"));
     }
 
     // -- QualityCheck -------------------------------------------------------


### PR DESCRIPTION
## Summary

- clear the workflow quality regex cache poison flag after recovering compiled patterns
- preserve cached regexes and the existing observable recovery behavior
- strengthen the held-lock panic regression to prove later ordinary lock acquisition succeeds

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib orchestration::tests::poisoned_quality_regex_cache_recovers_and_remains_usable`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- other poisoned-lock audit findings
- API internal-error scrubbing
- Claude CLI lifecycle cleanup pending #7071