### PR TITLE
fix(runtime): clear registry sync lock poison

### DIFF
--- a/changelog.d/fixed/registry-sync-clear-poison.md
+++ b/changelog.d/fixed/registry-sync-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the registry sync lock poison flag after recovering write serialization. (@xiaomo)

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -88,10 +88,17 @@ pub const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
 static SYNC_LOCK: Mutex<()> = Mutex::new(());
 
 fn lock_registry_sync(mutex: &Mutex<()>) -> MutexGuard<'_, ()> {
-    mutex.lock().unwrap_or_else(|poisoned| {
-        tracing::warn!("registry sync lock poisoned; recovering and serializing subsequent writes");
-        poisoned.into_inner()
-    })
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            tracing::warn!(
+                "registry sync lock poisoned; recovering and serializing subsequent writes"
+            );
+            let guard = poisoned.into_inner();
+            mutex.clear_poison();
+            guard
+        }
+    }
 }
 
 /// Refresh only the `~/.librefang/registry/` checkout from upstream —
@@ -908,11 +915,13 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(mutex.is_poisoned());
         let guard = lock_registry_sync(&mutex);
         assert!(mutex.try_lock().is_err());
         drop(guard);
-        let recovered_again = lock_registry_sync(&mutex);
-        drop(recovered_again);
+        assert!(!mutex.is_poisoned());
+        let ordinary_guard = mutex.lock().unwrap();
+        drop(ordinary_guard);
     }
 
     /// The offline switch is truthy for anything except unset / empty / `0` / `false` (#6404).


### PR DESCRIPTION
## Summary

- clear the registry sync lock poison flag after recovering write serialization
- preserve exclusive access across registry checkout and installation writes
- strengthen the held-lock panic regression to prove later ordinary lock acquisition succeeds

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-runtime --lib registry_sync::tests::poisoned_registry_sync_lock_recovers_and_remains_exclusive`
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- other poisoned-lock audit findings
- API internal-error scrubbing
- Claude CLI lifecycle cleanup pending #7071