### PR TITLE
fix(kernel): clear goal runner lock poison

### DIFF
--- a/changelog.d/fixed/goal-runner-clear-poison.md
+++ b/changelog.d/fixed/goal-runner-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the goal runner start/stop serialization lock poison flag after recovery. (@xiaomo)

--- a/crates/librefang-kernel/src/goal_runner.rs
+++ b/crates/librefang-kernel/src/goal_runner.rs
@@ -42,6 +42,18 @@ use librefang_types::goal::{
 
 use crate::background::{classify_tick_error, TickOutcome};
 
+fn lock_goal_run_start_stop(lock: &std::sync::Mutex<()>) -> std::sync::MutexGuard<'_, ()> {
+    match lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("goal runner start/stop lock poisoned; recovering serialization");
+            let guard = poisoned.into_inner();
+            lock.clear_poison();
+            guard
+        }
+    }
+}
+
 /// Pause between iterations. Short — the agent turn itself dominates wall-clock;
 /// this just yields and lets shutdown / stop signals be observed promptly.
 const TICK_INTERVAL: Duration = Duration::from_secs(2);
@@ -286,12 +298,8 @@ impl GoalRunner {
     pub fn stop(&self, goal_id: GoalId) -> bool {
         // Serialize against `start()` so the two never interleave on the same
         // goal id. The critical section is synchronous, so this std guard never
-        // spans an await point. Poison is irrelevant for a `Mutex<()>` used
-        // purely for mutual exclusion — recover the guard rather than panic.
-        let _guard = self
-            .start_lock
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // spans an await point. Recover the exclusion guard rather than panic.
+        let _guard = lock_goal_run_start_stop(&self.start_lock);
         self.stop_locked(goal_id)
     }
 
@@ -336,10 +344,7 @@ impl GoalRunner {
         // orphaned loop. The sequence is synchronous (no `.await`), so this std
         // guard is never held across an await point; `tokio::spawn` only
         // enqueues the task and does not block.
-        let _guard = self
-            .start_lock
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _guard = lock_goal_run_start_stop(&self.start_lock);
 
         // Replace any prior run for this goal. `stop_locked` (not `stop`)
         // because we already hold `start_lock`, which is non-reentrant.
@@ -693,6 +698,24 @@ async fn run_loop<F, Fut>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn poisoned_goal_run_start_stop_lock_recovers_and_clears_poison() {
+        let lock = std::sync::Mutex::new(());
+        let poison = std::panic::catch_unwind(|| {
+            let _guard = lock.lock().unwrap();
+            panic!("poison goal runner start/stop lock");
+        });
+
+        assert!(poison.is_err());
+        assert!(lock.is_poisoned());
+        let recovered = lock_goal_run_start_stop(&lock);
+        assert!(lock.try_lock().is_err());
+        drop(recovered);
+        assert!(!lock.is_poisoned());
+        let ordinary_guard = lock.lock().unwrap();
+        drop(ordinary_guard);
+    }
 
     #[test]
     fn parse_tick_extracts_progress_done_blocked() {


### PR DESCRIPTION
## Summary

- recover the goal runner start/stop serialization mutex through one observable helper
- clear its poison flag while retaining the recovered exclusion guard
- add a real held-lock panic regression proving exclusivity and later ordinary acquisition

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib goal_runner::tests::poisoned_goal_run_start_stop_lock_recovers_and_clears_poison`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- other poisoned mutex recovery sites
- API raw internal-error responses
- Claude CLI child lifecycle changes pending #7071
