### PR TITLE
fix(wire): clear peer registry lock poison

### DIFF
--- a/changelog.d/fixed/peer-registry-clear-poison.md
+++ b/changelog.d/fixed/peer-registry-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the peer registry lock poison flag after recovering preserved peer state. (@xiaomo)

--- a/crates/librefang-wire/src/registry.rs
+++ b/crates/librefang-wire/src/registry.rs
@@ -64,6 +64,7 @@ impl PeerRegistry {
     fn read_peers(&self) -> RwLockReadGuard<'_, HashMap<String, PeerEntry>> {
         self.peers.read().unwrap_or_else(|poisoned| {
             tracing::warn!("peer registry read lock poisoned; recovering inner state");
+            self.peers.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -71,6 +72,7 @@ impl PeerRegistry {
     fn write_peers(&self) -> RwLockWriteGuard<'_, HashMap<String, PeerEntry>> {
         self.peers.write().unwrap_or_else(|poisoned| {
             tracing::warn!("peer registry write lock poisoned; recovering inner state");
+            self.peers.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -375,11 +377,24 @@ mod tests {
         })
         .join();
         assert!(joined.is_err());
+        assert!(registry.peers.is_poisoned());
 
-        // A poisoned registry remains available, but every recovery is now
-        // observable through the warning emitted by the centralized helpers.
+        // The first read recovers the preserved state and clears the poison
+        // flag so later reads and writes use the ordinary lock path.
         assert_eq!(registry.total_count(), 1);
+        assert!(!registry.peers.is_poisoned());
+
+        let poisoner = registry.clone();
+        let joined = std::thread::spawn(move || {
+            let _guard = poisoner.peers.write().unwrap();
+            panic!("poison peer registry before write recovery");
+        })
+        .join();
+        assert!(joined.is_err());
+        assert!(registry.peers.is_poisoned());
+
         registry.add_peer(make_peer("node-2", vec![]));
         assert_eq!(registry.total_count(), 2);
+        assert!(!registry.peers.is_poisoned());
     }
 }


### PR DESCRIPTION
## Summary

- clear the peer registry `RwLock` poison flag after recovering preserved peer state through either the read or write helper
- retain the recovered guard and existing registry contents
- strengthen the existing regression with separate held-write-lock panics proving both read recovery and write recovery clear poison before later ordinary access

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-wire --lib test_recovers_registry_state_after_lock_poisoning`
- `cargo clippy -p librefang-wire --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- peer handshake and rate-limiter locks
- other poisoned registries
- network protocol behavior
