### PR TITLE
fix(kernel): clear A2A registry lock poison

### DIFF
--- a/changelog.d/fixed/a2a-registry-clear-poison.md
+++ b/changelog.d/fixed/a2a-registry-clear-poison.md
@@ -1,0 +1,1 @@
+Clear the trusted A2A agent registry lock poison flag after recovering preserved entries. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/handles/a2a_registry.rs
+++ b/crates/librefang-kernel/src/kernel/handles/a2a_registry.rs
@@ -13,6 +13,7 @@ fn lock_a2a_agents(
 ) -> MutexGuard<'_, Vec<(String, AgentCard)>> {
     agents.lock().unwrap_or_else(|poisoned| {
         tracing::warn!("A2A registry lock poisoned; recovering trusted agent state");
+        agents.clear_poison();
         poisoned.into_inner()
     })
 }
@@ -82,11 +83,14 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(agents.is_poisoned());
         let mut recovered = lock_a2a_agents(&agents);
         assert_eq!(recovered.len(), 2);
         assert_eq!(recovered[0].1.name, "Trusted");
+        assert!(!agents.is_poisoned());
         recovered.retain(|(_, card)| card.name != "Backup");
         drop(recovered);
         assert_eq!(lock_a2a_agents(&agents).len(), 1);
+        assert!(!agents.is_poisoned());
     }
 }


### PR DESCRIPTION
## Summary

- clear the trusted A2A agent registry mutex poison flag after recovering preserved entries
- retain the recovered guard and existing trusted-agent state
- strengthen the held-lock panic regression to prove poison clears and subsequent ordinary access remains usable

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib poisoned_a2a_registry_lock_recovers_trusted_agents`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- A2A trust policy or URL canonicalization
- other poisoned kernel locks
- peer registry locking tracked separately by #7109
