### PR TITLE
fix(kernel): clear user vault lock poison

### DIFF
--- a/changelog.d/fixed/user-provider-vault-clear-poison.md
+++ b/changelog.d/fixed/user-provider-vault-clear-poison.md
@@ -1,0 +1,1 @@
+Clear user provider credential vault lock poison after recovering encrypted credential state. (@xiaomo)

--- a/crates/librefang-kernel/src/user_provider_credentials.rs
+++ b/crates/librefang-kernel/src/user_provider_credentials.rs
@@ -15,6 +15,7 @@ use librefang_types::agent::UserId;
 fn read_vault_state<'a, T>(lock: &'a std::sync::RwLock<T>) -> std::sync::RwLockReadGuard<'a, T> {
     lock.read().unwrap_or_else(|poisoned| {
         tracing::warn!("user provider credential vault read lock poisoned; recovering inner state");
+        lock.clear_poison();
         poisoned.into_inner()
     })
 }
@@ -24,6 +25,7 @@ fn write_vault_state<'a, T>(lock: &'a std::sync::RwLock<T>) -> std::sync::RwLock
         tracing::warn!(
             "user provider credential vault write lock poisoned; recovering inner state"
         );
+        lock.clear_poison();
         poisoned.into_inner()
     })
 }
@@ -144,8 +146,23 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(state.is_poisoned());
         assert_eq!(&*read_vault_state(&state), &["openai", "anthropic"]);
+        assert!(!state.is_poisoned());
+
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let _state = state.write().unwrap();
+                    panic!("poison user provider vault before write recovery");
+                })
+                .join()
+        });
+        assert!(poison.is_err());
+        assert!(state.is_poisoned());
+
         write_vault_state(&state).push("gemini");
+        assert!(!state.is_poisoned());
         assert_eq!(read_vault_state(&state).len(), 3);
     }
 


### PR DESCRIPTION
## Summary

- clear the user provider credential vault `RwLock` poison flag after recovering encrypted credential state through either helper
- retain the recovered guard and preserved vault contents
- strengthen the existing regression with separate held-write-lock panics proving both read and write recovery clear poison before later ordinary access

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib poisoned_vault_lock_helpers_recover_read_and_write_access`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- credential encryption or persistence behavior
- OAuth token caches tracked separately by #7096
- other poisoned kernel locks
