### PR TITLE
fix(kernel): clear approval lock poison

### DIFF
--- a/changelog.d/fixed/approval-lock-clear-poison.md
+++ b/changelog.d/fixed/approval-lock-clear-poison.md
@@ -1,0 +1,1 @@
+Clear approval policy and state lock poison after recovering preserved authorization state. (@xiaomo)

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -124,6 +124,7 @@ impl ApprovalManager {
     fn read_policy(&self) -> RwLockReadGuard<'_, ApprovalPolicy> {
         self.policy.read().unwrap_or_else(|poisoned| {
             warn!("approval policy read lock poisoned; recovering inner state");
+            self.policy.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -131,6 +132,7 @@ impl ApprovalManager {
     fn write_policy(&self) -> RwLockWriteGuard<'_, ApprovalPolicy> {
         self.policy.write().unwrap_or_else(|poisoned| {
             warn!("approval policy write lock poisoned; recovering inner state");
+            self.policy.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -141,6 +143,7 @@ impl ApprovalManager {
                 state,
                 "approval state lock poisoned; recovering inner state"
             );
+            mutex.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -2234,9 +2237,23 @@ mod tests {
                 .join()
         });
         assert!(policy_poison.is_err());
+        assert!(manager.policy.is_poisoned());
         assert!(manager.policy().require_approval.is_empty());
+        assert!(!manager.policy.is_poisoned());
+
+        let policy_poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let _policy = manager.policy.write().unwrap();
+                    panic!("poison approval policy before write recovery");
+                })
+                .join()
+        });
+        assert!(policy_poison.is_err());
+        assert!(manager.policy.is_poisoned());
 
         manager.update_policy(ApprovalPolicy::default());
+        assert!(!manager.policy.is_poisoned());
         assert!(!manager.policy().require_approval.is_empty());
 
         let recent_poison = std::thread::scope(|scope| {
@@ -2248,7 +2265,9 @@ mod tests {
                 .join()
         });
         assert!(recent_poison.is_err());
+        assert!(manager.recent.is_poisoned());
         assert!(manager.list_recent(1).is_empty());
+        assert!(!manager.recent.is_poisoned());
     }
 
     fn make_deferred(agent_id: &str) -> DeferredToolExecution {


### PR DESCRIPTION
## Summary

- clear approval policy `RwLock` poison after recovery through either the read or write helper
- clear approval state mutex poison after recovering recent approvals, TOTP state, or failure serialization
- strengthen the existing regression with held-lock panics proving policy read recovery, policy write recovery, and state recovery all clear poison before later ordinary access

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib poisoned_approval_state_locks_recover_and_remain_usable`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- approval policy semantics
- TOTP validation and replay behavior
- other poisoned kernel locks
