### PR TITLE
fix(kernel): clear config override lock poison

### DIFF
--- a/changelog.d/fixed/config-override-lock-clear-poison.md
+++ b/changelog.d/fixed/config-override-lock-clear-poison.md
@@ -1,0 +1,1 @@
+Preserve hot-reloaded model and tool-policy state while clearing recovered configuration override lock poison. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -612,11 +612,10 @@ impl LibreFangKernel {
             let is_default_model =
                 manifest.model.model.is_empty() || manifest.model.model == "default";
             if is_default_provider && is_default_model {
-                let override_guard = self
-                    .llm
-                    .default_model_override
-                    .read()
-                    .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+                let override_guard = read_config_override(
+                    &self.llm.default_model_override,
+                    "default_model_override",
+                );
                 let dm = override_guard.as_ref().unwrap_or(&cfg.default_model);
                 if !dm.provider.is_empty() {
                     manifest.model.provider = dm.provider.clone();

--- a/crates/librefang-kernel/src/kernel/config_reload_ops.rs
+++ b/crates/librefang-kernel/src/kernel/config_reload_ops.rs
@@ -229,11 +229,10 @@ impl LibreFangKernel {
                     );
                     // Invalidate cached drivers — the default provider may have changed.
                     self.llm.driver_cache.clear();
-                    let mut guard = self
-                        .llm
-                        .default_model_override
-                        .write()
-                        .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+                    let mut guard = write_config_override(
+                        &self.llm.default_model_override,
+                        "default_model_override",
+                    );
                     *guard = Some(new_config.default_model.clone());
                 }
                 HotAction::UpdateToolPolicy => {
@@ -242,10 +241,8 @@ impl LibreFangKernel {
                         new_config.tool_policy.global_rules.len(),
                         new_config.tool_policy.agent_rules.len(),
                     );
-                    let mut guard = self
-                        .tool_policy_override
-                        .write()
-                        .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+                    let mut guard =
+                        write_config_override(&self.tool_policy_override, "tool_policy_override");
                     *guard = Some(new_config.tool_policy.clone());
                 }
                 HotAction::UpdateProactiveMemory => {

--- a/crates/librefang-kernel/src/kernel/llm_drivers.rs
+++ b/crates/librefang-kernel/src/kernel/llm_drivers.rs
@@ -169,11 +169,8 @@ impl LibreFangKernel {
         // over the boot-time config. This ensures that when a user saves a new
         // API key via the dashboard and the default provider is switched,
         // resolve_driver sees the updated provider/model/api_key_env.
-        let override_guard = self
-            .llm
-            .default_model_override
-            .read()
-            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+        let override_guard =
+            read_config_override(&self.llm.default_model_override, "default_model_override");
         let effective_default = override_guard.as_ref().unwrap_or(&cfg.default_model);
         let default_provider = &effective_default.provider;
 

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -58,6 +58,34 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, OnceLock, Weak};
 use tracing::{debug, error, info, instrument, warn};
 
+fn read_config_override<'a, T>(
+    lock: &'a std::sync::RwLock<T>,
+    state: &'static str,
+) -> std::sync::RwLockReadGuard<'a, T> {
+    lock.read().unwrap_or_else(|poisoned| {
+        warn!(
+            state,
+            "kernel config override read lock poisoned; recovering inner state"
+        );
+        lock.clear_poison();
+        poisoned.into_inner()
+    })
+}
+
+fn write_config_override<'a, T>(
+    lock: &'a std::sync::RwLock<T>,
+    state: &'static str,
+) -> std::sync::RwLockWriteGuard<'a, T> {
+    lock.write().unwrap_or_else(|poisoned| {
+        warn!(
+            state,
+            "kernel config override write lock poisoned; recovering inner state"
+        );
+        lock.clear_poison();
+        poisoned.into_inner()
+    })
+}
+
 /// Per-trait `kernel_handle::*` impls live in their own files under
 /// `kernel/handles/` to keep this file from doubling as a trait-impl
 /// dumping ground. The submodules are descendants of `kernel`, so they

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -631,6 +631,45 @@ fn test_manifest_to_capabilities_profile_overridden_by_explicit_tools() {
 }
 
 #[test]
+fn poisoned_config_override_locks_recover_and_remain_usable() {
+    let default_model = std::sync::RwLock::new(vec!["loaded"]);
+    let poison = std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let mut state = default_model.write().unwrap();
+                state.push("preserved");
+                panic!("poison default model override before read recovery");
+            })
+            .join()
+    });
+    assert!(poison.is_err());
+    assert!(default_model.is_poisoned());
+    assert_eq!(
+        &*read_config_override(&default_model, "default_model_override"),
+        &["loaded", "preserved"]
+    );
+    assert!(!default_model.is_poisoned());
+
+    let tool_policy = std::sync::RwLock::new(vec!["old"]);
+    let poison = std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let _state = tool_policy.write().unwrap();
+                panic!("poison tool policy override before write recovery");
+            })
+            .join()
+    });
+    assert!(poison.is_err());
+    assert!(tool_policy.is_poisoned());
+    write_config_override(&tool_policy, "tool_policy_override").push("new");
+    assert!(!tool_policy.is_poisoned());
+    assert_eq!(
+        &*read_config_override(&tool_policy, "tool_policy_override"),
+        &["old", "new"]
+    );
+}
+
+#[test]
 fn test_spawn_agent_applies_local_default_model_override() {
     let tmp = tempfile::tempdir().unwrap();
     let home_dir = tmp.path().join("librefang-kernel-local-model-test");

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -359,11 +359,8 @@ impl LibreFangKernel {
         // Step 5: Apply global tool_policy rules (deny/allow with glob patterns).
         // This filters tools based on the kernel-wide tool policy from config.toml.
         // Check hot-reloadable override first, then fall back to initial config.
-        let effective_policy = self
-            .tool_policy_override
-            .read()
-            .ok()
-            .and_then(|guard| guard.clone());
+        let effective_policy =
+            read_config_override(&self.tool_policy_override, "tool_policy_override").clone();
         let effective_policy = effective_policy.as_ref().unwrap_or(&cfg.tool_policy);
         if !effective_policy.is_empty() {
             all_tools.retain(|t| {


### PR DESCRIPTION
## Summary

- recover default-model and tool-policy override reads through named helpers that preserve state, log the recovery, and clear poison
- recover hot-reload writes through the same lock policy so later accesses return to the ordinary path
- stop silently bypassing a hot-reloaded tool policy when its lock was poisoned
- add held-lock panic regressions for read and write recovery

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib poisoned_config_override_locks_recover_and_remain_usable`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- skill-registry lock recovery
- other kernel lock domains