### PR TITLE
fix(api): clear skill count cache poison

### DIFF
--- a/changelog.d/fixed/skill-count-cache-clear-poison.md
+++ b/changelog.d/fixed/skill-count-cache-clear-poison.md
@@ -1,0 +1,1 @@
+Clear dashboard skill-count cache lock poison after preserving the recovered cached value. (@xiaomo)

--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -1139,9 +1139,7 @@ async fn dashboard_snapshot_compute(state: &Arc<AppState>) -> serde_json::Value 
     static SKILL_COUNT_CACHE: std::sync::Mutex<Option<(usize, std::time::Instant)>> =
         std::sync::Mutex::new(None);
     let skill_count = {
-        let cached = SKILL_COUNT_CACHE
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
+        let cached = lock_skill_count_cache(&SKILL_COUNT_CACHE)
             .as_ref()
             .and_then(|(n, t)| {
                 if t.elapsed() < std::time::Duration::from_secs(30) {
@@ -1163,8 +1161,7 @@ async fn dashboard_snapshot_compute(state: &Arc<AppState>) -> serde_json::Value 
                     .read()
                     .map(|r| r.list().len())
                     .unwrap_or(0);
-                *SKILL_COUNT_CACHE.lock().unwrap_or_else(|p| p.into_inner()) =
-                    Some((n, std::time::Instant::now()));
+                *lock_skill_count_cache(&SKILL_COUNT_CACHE) = Some((n, std::time::Instant::now()));
                 n
             }
         }
@@ -1194,6 +1191,41 @@ async fn dashboard_snapshot_compute(state: &Arc<AppState>) -> serde_json::Value 
         "workflowCount": workflow_count,
         "webSearchAvailable": web_search_available,
     })
+}
+
+fn lock_skill_count_cache<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("dashboard skill count cache lock poisoned; recovering cached value");
+        mutex.clear_poison();
+        poisoned.into_inner()
+    })
+}
+
+#[cfg(test)]
+mod skill_count_cache_lock_tests {
+    use super::lock_skill_count_cache;
+    use std::sync::Mutex;
+
+    #[test]
+    fn poisoned_cache_lock_recovers_preserved_value_and_remains_usable() {
+        let cache = Mutex::new(Some(7usize));
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let mut value = cache.lock().unwrap();
+                    *value = Some(11);
+                    panic!("poison skill count cache lock");
+                })
+                .join()
+        });
+        assert!(poison.is_err());
+        assert!(cache.is_poisoned());
+        assert_eq!(*lock_skill_count_cache(&cache), Some(11));
+        assert!(!cache.is_poisoned());
+
+        *lock_skill_count_cache(&cache) = Some(13);
+        assert_eq!(*cache.lock().unwrap(), Some(13));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- recover the dashboard overview skill-count cache through a named mutex helper
- preserve the cached count, log recovery, and clear poison before subsequent poll cycles
- route both TTL reads and cache refresh writes through the same recovery path
- add a held-lock panic regression proving preserved state and later ordinary access

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-api --lib poisoned_cache_lock_recovers_preserved_value_and_remains_usable`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- the skill registry itself
- other dashboard and API caches