### PR TITLE
fix(api): clear A2A registry lock poison

### DIFF
--- a/changelog.d/fixed/api-a2a-lock-clear-poison.md
+++ b/changelog.d/fixed/api-a2a-lock-clear-poison.md
@@ -1,0 +1,1 @@
+Preserve trusted A2A agent listings while clearing recovered API registry lock poison. (@xiaomo)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2252,11 +2252,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
     }
 
     async fn a2a_agents_text(&self) -> String {
-        let agents = self
-            .kernel
-            .a2a_agents()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let agents = crate::lock_a2a_agents(self.kernel.a2a_agents());
         if agents.is_empty() {
             return "No external A2A agents discovered.\nUse the dashboard or API to discover agents.".to_string();
         }

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -63,6 +63,41 @@ pub(crate) fn percent_decode(input: &str) -> String {
     std::hint::black_box(decoded)
 }
 
+fn lock_a2a_agents<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("API A2A agent registry lock poisoned; recovering trusted agent state");
+        mutex.clear_poison();
+        poisoned.into_inner()
+    })
+}
+
+#[cfg(test)]
+mod a2a_agent_lock_tests {
+    use super::lock_a2a_agents;
+    use std::sync::Mutex;
+
+    #[test]
+    fn poisoned_a2a_lock_recovers_preserved_agents_and_remains_usable() {
+        let agents = Mutex::new(vec!["trusted"]);
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let mut state = agents.lock().unwrap();
+                    state.push("discovered");
+                    panic!("poison API A2A registry lock");
+                })
+                .join()
+        });
+        assert!(poison.is_err());
+        assert!(agents.is_poisoned());
+        assert_eq!(&*lock_a2a_agents(&agents), &["trusted", "discovered"]);
+        assert!(!agents.is_poisoned());
+
+        lock_a2a_agents(&agents).push("later");
+        assert_eq!(agents.lock().unwrap().len(), 3);
+    }
+}
+
 fn hex_val(b: u8) -> Option<u8> {
     match b {
         b'0'..=b'9' => Some(b - b'0'),

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -585,11 +585,7 @@ pub async fn a2a_cancel_task(
     )
 )]
 pub async fn a2a_list_external_agents(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let agents = state
-        .kernel
-        .a2a_agents()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
+    let agents = crate::lock_a2a_agents(state.kernel.a2a_agents());
     let mut items: Vec<serde_json::Value> = agents
         .iter()
         .map(|(_, card)| {
@@ -822,11 +818,7 @@ pub async fn a2a_get_external_agent(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let agents = state
-        .kernel
-        .a2a_agents()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
+    let agents = crate::lock_a2a_agents(state.kernel.a2a_agents());
 
     let make_response = |(_, card): &(String, librefang_kernel::a2a::AgentCard)| {
         serde_json::json!({
@@ -918,11 +910,7 @@ pub async fn a2a_discover_external(
 
             // SECURITY (Bug #3786): Check for name collision with already-trusted agents.
             {
-                let agents = state
-                    .kernel
-                    .a2a_agents()
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
+                let agents = crate::lock_a2a_agents(state.kernel.a2a_agents());
                 // A different URL claiming the same name as an existing trusted agent is a
                 // potential impersonation attempt. Reject it to prevent confusion.
                 if let Some((existing_url, _)) = agents
@@ -1111,11 +1099,7 @@ async fn a2a_send_external_inner(state: Arc<AppState>, body_bytes: &[u8]) -> (St
     // URLs that have been explicitly approved (via /api/a2a/agents/{id}/approve
     // or seeded via static config) may receive tasks.
     {
-        let trusted = state
-            .kernel
-            .a2a_agents()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let trusted = crate::lock_a2a_agents(state.kernel.a2a_agents());
         if !trusted.iter().any(|(u, _)| u == &url) {
             return json_error_tuple(
                 StatusCode::BAD_REQUEST,
@@ -1204,11 +1188,7 @@ pub async fn a2a_external_task_status(
     // operator-approved A2A agents. Otherwise this endpoint doubles as an
     // SSRF probe surface against any URL the global SSRF allowlist accepts.
     {
-        let trusted = state
-            .kernel
-            .a2a_agents()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let trusted = crate::lock_a2a_agents(state.kernel.a2a_agents());
         if !trusted.iter().any(|(u, _)| u == &url) {
             return ApiErrorResponse::bad_request(
                 "Target URL is not a trusted A2A agent. \
@@ -1289,11 +1269,7 @@ pub async fn a2a_approve_external(
             let card_name = card.name.clone();
             // Promote to kernel's trusted list.
             {
-                let mut agents = state
-                    .kernel
-                    .a2a_agents()
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
+                let mut agents = crate::lock_a2a_agents(state.kernel.a2a_agents());
                 // Update existing entry (same URL) or append.
                 if let Some(existing) = agents.iter_mut().find(|(u, _)| u == &url) {
                     existing.1 = card;
@@ -1324,11 +1300,7 @@ pub async fn a2a_approve_external(
         }
         None => {
             // Also check if it's already trusted (idempotent re-approval).
-            let agents = state
-                .kernel
-                .a2a_agents()
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let agents = crate::lock_a2a_agents(state.kernel.a2a_agents());
             if agents.iter().any(|(u, _)| u == &url) {
                 return (
                     StatusCode::OK,

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -1867,11 +1867,7 @@ async fn handle_command(
             serde_json::json!({"type": "command_result", "command": cmd, "message": msg})
         }
         "a2a" => {
-            let agents = state
-                .kernel
-                .a2a_agents()
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let agents = crate::lock_a2a_agents(state.kernel.a2a_agents());
             let msg = if agents.is_empty() {
                 "No external A2A agents discovered.".to_string()
             } else {


### PR DESCRIPTION
## Summary

- route all API A2A trusted-agent mutex access through one recovery helper
- preserve trusted entries, log recovery, and clear poison before later channel, WebSocket, or network requests
- cover both read-only listings and network mutation paths
- add a held-lock panic regression proving preserved state and subsequent ordinary mutation

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-api --lib poisoned_a2a_lock_recovers_preserved_agents_and_remains_usable`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo check --workspace --lib`
- structural search confirms no remaining `a2a_agents().lock()` access in `librefang-api`

## Coordination

- `crates/librefang-api/src/routes/network.rs` is also touched by #7088, but that PR changes IPv4 validation while this PR changes only A2A registry lock sites

## Out of scope

- kernel-side A2A registry recovery covered by #7110
- other API lock domains