### PR TITLE
fix(desktop): clear server handle lock poison

### DIFF
--- a/changelog.d/fixed/desktop-server-handle-clear-poison.md
+++ b/changelog.d/fixed/desktop-server-handle-clear-poison.md
@@ -1,0 +1,1 @@
+Preserve the embedded desktop server handle while clearing recovered lifecycle lock poison. (@xiaomo)

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -218,7 +218,7 @@ pub async fn start_local(
 
     // Store the ServerHandle for shutdown
     if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
-        let mut guard = holder.0.lock().expect("ServerHandleHolder lock poisoned");
+        let mut guard = crate::lock_server_handle(&holder.0);
         *guard = Some(handle);
     }
 

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -160,6 +160,14 @@ pub struct RemoteMode(pub std::sync::RwLock<bool>);
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub struct ServerHandleHolder(pub std::sync::Mutex<Option<server::ServerHandle>>);
 
+fn lock_server_handle<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("desktop server handle lock poisoned; recovering server state");
+        mutex.clear_poison();
+        poisoned.into_inner()
+    })
+}
+
 /// Forward critical kernel events as native OS notifications.
 ///
 /// Only truly critical events — crashes, hard quota limits, and kernel shutdown.
@@ -378,7 +386,7 @@ pub fn run(server_url: Option<String>, force_local: bool) {
     let (init_port, init_kernel_inner, init_url, init_remote) = match &mode {
         StartupMode::Remote(_) => (None, None, initial_url.clone(), true),
         StartupMode::Local => {
-            let guard = holder.0.lock().expect("ServerHandleHolder lock poisoned");
+            let guard = lock_server_handle(&holder.0);
             let (p, k) = if let Some(ref handle) = *guard {
                 (
                     Some(handle.port),
@@ -581,7 +589,28 @@ pub fn run(server_url: Option<String>, force_local: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_server_url;
+    use super::{lock_server_handle, validate_server_url};
+
+    #[test]
+    fn poisoned_server_handle_lock_recovers_state_and_remains_usable() {
+        let holder = std::sync::Mutex::new(Some("running"));
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let mut state = holder.lock().unwrap();
+                    *state = Some("replacement");
+                    panic!("poison desktop server handle lock");
+                })
+                .join()
+        });
+        assert!(poison.is_err());
+        assert!(holder.is_poisoned());
+        assert_eq!(*lock_server_handle(&holder), Some("replacement"));
+        assert!(!holder.is_poisoned());
+
+        *lock_server_handle(&holder) = None;
+        assert_eq!(*holder.lock().unwrap(), None);
+    }
 
     #[test]
     fn https_remote_host_accepted() {

--- a/crates/librefang-desktop/src/tray.rs
+++ b/crates/librefang-desktop/src/tray.rs
@@ -48,7 +48,7 @@ fn open_browser(app: &tauri::AppHandle) {
 fn change_server(app: &tauri::AppHandle) {
     // Shut down existing local server if running.
     if let Some(holder) = app.try_state::<crate::ServerHandleHolder>() {
-        let mut guard = holder.0.lock().unwrap_or_else(|p| p.into_inner());
+        let mut guard = crate::lock_server_handle(&holder.0);
         if let Some(handle) = guard.take() {
             std::thread::spawn(move || handle.shutdown());
         }


### PR DESCRIPTION
## Summary

- route every desktop embedded-server handle mutex access through one recovery helper
- preserve the current handle, log recovery, and clear poison instead of panicking during startup or local-server installation
- use the same recovery path when the tray switches away from a local server
- add a held-lock panic regression proving preserved replacement state and later ordinary shutdown mutation

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-desktop --lib poisoned_server_handle_lock_recovers_state_and_remains_usable`
- `cargo clippy -p librefang-desktop --all-targets -- -D warnings`
- `cargo check --workspace --lib`
- structural search confirms all three `ServerHandleHolder` access sites use `lock_server_handle`

## Out of scope

- desktop port, kernel, server URL, and remote-mode RwLocks
- other desktop lifecycle state