### PR TITLE
fix(kernel): clear agent binding lock poison

### DIFF
--- a/changelog.d/fixed/agent-bindings-clear-poison.md
+++ b/changelog.d/fixed/agent-bindings-clear-poison.md
@@ -1,0 +1,1 @@
+Clear agent-binding mutex poison after preserving runtime routing state across inbound and outbound access. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/bindings_and_handle.rs
+++ b/crates/librefang-kernel/src/kernel/bindings_and_handle.rs
@@ -13,11 +13,12 @@
 
 use super::*;
 
-fn lock_bindings(
+pub(super) fn lock_bindings(
     bindings: &std::sync::Mutex<Vec<librefang_types::config::AgentBinding>>,
 ) -> std::sync::MutexGuard<'_, Vec<librefang_types::config::AgentBinding>> {
     bindings.lock().unwrap_or_else(|poisoned| {
         tracing::warn!("agent bindings lock poisoned; recovering inner state");
+        bindings.clear_poison();
         poisoned.into_inner()
     })
 }
@@ -241,11 +242,13 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(bindings.is_poisoned());
         let mut recovered = lock_bindings(&bindings);
+        assert!(!bindings.is_poisoned());
         assert_eq!(recovered.len(), 2);
         assert_eq!(recovered.remove(0).agent, "first");
         recovered.push(binding("third", "discord"));
         drop(recovered);
-        assert_eq!(lock_bindings(&bindings).len(), 2);
+        assert_eq!(bindings.lock().unwrap().len(), 2);
     }
 }

--- a/crates/librefang-kernel/src/kernel/handles/channel_sender.rs
+++ b/crates/librefang-kernel/src/kernel/handles/channel_sender.rs
@@ -416,7 +416,7 @@ impl kernel_handle::ChannelSender for LibreFangKernel {
         // the first equal-specificity match — `max_by_key` would keep the
         // *last*, drifting from inbound on a tie.
         let bound_agent = {
-            let bindings = self.mesh.bindings.lock().unwrap_or_else(|e| e.into_inner());
+            let bindings = super::super::bindings_and_handle::lock_bindings(&self.mesh.bindings);
             let mut best: Option<&librefang_types::config::AgentBinding> = None;
             for b in bindings
                 .iter()


### PR DESCRIPTION
## Summary

- clear the agent-binding mutex poison flag after recovering preserved routing state
- route outbound channel binding selection through the same helper used by binding list/add/remove operations
- strengthen the existing held-lock panic regression to assert poison clears before ordinary mutex access

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib poisoned_bindings_lock_recovers_and_list_remains_mutable`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`
- structural search confirms no remaining direct `mesh.bindings.lock()` access

## Out of scope

- channel adapter locks
- other mesh subsystem state