### PR TITLE
fix(runtime): clear shutdown state lock poison

### DIFF
--- a/changelog.d/fixed/shutdown-state-clear-poison.md
+++ b/changelog.d/fixed/shutdown-state-clear-poison.md
@@ -1,0 +1,1 @@
+Clear shutdown coordinator state lock poison after recovering shutdown progress. (@xiaomo)

--- a/crates/librefang-runtime/src/graceful_shutdown.rs
+++ b/crates/librefang-runtime/src/graceful_shutdown.rs
@@ -120,6 +120,7 @@ fn lock_shutdown_state<'a, T>(mutex: &'a Mutex<T>, state: &'static str) -> Mutex
             state,
             "shutdown state lock poisoned; recovering inner state"
         );
+        mutex.clear_poison();
         poisoned.into_inner()
     })
 }
@@ -264,6 +265,7 @@ mod tests {
                 .join()
         });
         assert!(started_at_poison.is_err());
+        assert!(coord.started_at.is_poisoned());
 
         let phase_log_poison = std::thread::scope(|scope| {
             scope
@@ -274,14 +276,19 @@ mod tests {
                 .join()
         });
         assert!(phase_log_poison.is_err());
+        assert!(coord.phase_log.is_poisoned());
 
         assert!(coord.initiate());
         coord.advance_phase(ShutdownPhase::Draining, true, None);
+        assert!(!coord.started_at.is_poisoned());
+        assert!(!coord.phase_log.is_poisoned());
         let status = coord.status();
         assert!(status.is_shutting_down);
         assert_eq!(status.current_phase, "draining");
         assert_eq!(status.phases_completed.len(), 1);
         assert!(!coord.is_timeout_exceeded());
+        assert!(coord.started_at.lock().unwrap().is_some());
+        assert_eq!(coord.phase_log.lock().unwrap().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clear shutdown coordinator mutex poison after recovering progress state
- verify start-time and phase-log recovery permit later ordinary lock access
- add a changelog fragment

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-runtime --lib graceful_shutdown::tests::poisoned_shutdown_state_locks_recover_and_shutdown_continues`
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- poison recovery in other runtime state domains remains separate work