### PR TITLE
fix(kernel): clear trigger persistence lock poison

### DIFF
--- a/changelog.d/fixed/trigger-persistence-clear-poison.md
+++ b/changelog.d/fixed/trigger-persistence-clear-poison.md
@@ -1,0 +1,1 @@
+Clear trigger persistence lock poison after recovering write serialization. (@xiaomo)

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -337,6 +337,7 @@ pub struct TriggerEngine {
 fn lock_trigger_persistence(lock: &std::sync::Mutex<()>) -> std::sync::MutexGuard<'_, ()> {
     lock.lock().unwrap_or_else(|poisoned| {
         warn!("trigger persistence lock poisoned; recovering write serialization");
+        lock.clear_poison();
         poisoned.into_inner()
     })
 }
@@ -1820,11 +1821,13 @@ mod tests {
         });
 
         assert!(poison.is_err());
+        assert!(lock.is_poisoned());
         let recovered = lock_trigger_persistence(&lock);
+        assert!(!lock.is_poisoned());
         assert!(lock.try_lock().is_err());
         drop(recovered);
-        let recovered_again = lock_trigger_persistence(&lock);
-        drop(recovered_again);
+        let ordinary_guard = lock.lock().unwrap();
+        drop(ordinary_guard);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clear trigger persistence mutex poison after recovering write serialization
- preserve mutual exclusion during recovery
- prove later ordinary mutex access succeeds
- add a changelog fragment

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib triggers::tests::poisoned_trigger_persistence_lock_recovers_and_remains_exclusive`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- poison recovery in other kernel state domains remains separate work