### PR TITLE
fix(kernel): clear dream abort slot lock poison

### DIFF
--- a/changelog.d/fixed/dream-abort-slot-clear-poison.md
+++ b/changelog.d/fixed/dream-abort-slot-clear-poison.md
@@ -1,0 +1,1 @@
+Clear auto-dream abort slot lock poison after recovering the pending abort sender. (@xiaomo)

--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -32,7 +32,7 @@ use crate::AgentSubsystemApi;
 use crate::MemorySubsystemApi;
 use crate::MeteringSubsystemApi;
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -173,6 +173,14 @@ static DREAM_PROGRESS: LazyLock<DashMap<AgentId, DreamProgress>> = LazyLock::new
 /// flight". Wrapped in a `std::sync::Mutex` because DashMap entries are
 /// accessed through shared references and `Sender::send` consumes self.
 type AbortSlot = Mutex<Option<oneshot::Sender<()>>>;
+
+fn lock_abort_slot(slot: &AbortSlot) -> MutexGuard<'_, Option<oneshot::Sender<()>>> {
+    slot.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("auto-dream abort slot lock poisoned; recovering sender state");
+        slot.clear_poison();
+        poisoned.into_inner()
+    })
+}
 
 /// Abort channels for in-flight manually-triggered dreams. Sending on the
 /// oneshot notifies `run_dream`'s drain loop to break out and run the
@@ -1260,12 +1268,7 @@ pub async fn abort_dream(agent_id: AgentId) -> AbortOutcome {
             reason: "no abort-capable dream in flight for this agent".to_string(),
         };
     };
-    let sender = match slot_ref.lock() {
-        Ok(mut g) => g.take(),
-        // A poisoned mutex would mean a prior panic while the sender was
-        // held; recover the inner data and continue rather than deadlock.
-        Err(poisoned) => poisoned.into_inner().take(),
-    };
+    let sender = lock_abort_slot(&slot_ref).take();
     let Some(tx) = sender else {
         return AbortOutcome {
             aborted: false,
@@ -1304,6 +1307,27 @@ mod hook_tests {
     use super::*;
     use librefang_runtime::hooks::{HookContext, HookHandler};
     use librefang_types::agent::HookEvent;
+
+    #[tokio::test]
+    async fn poisoned_abort_slot_recovers_sender_and_clears_poison() {
+        let (sender, receiver) = oneshot::channel();
+        let slot = Mutex::new(Some(sender));
+        let poison = std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let _sender = slot.lock().unwrap();
+                    panic!("poison auto-dream abort slot");
+                })
+                .join()
+        });
+
+        assert!(poison.is_err());
+        assert!(slot.is_poisoned());
+        lock_abort_slot(&slot).take().unwrap().send(()).unwrap();
+        assert!(!slot.is_poisoned());
+        assert_eq!(receiver.await, Ok(()));
+        assert!(slot.lock().unwrap().is_none());
+    }
 
     /// Hook must handle a dangling `Weak<LibreFangKernel>` (the kernel was
     /// dropped, e.g. shutdown between turn end and hook dispatch) without


### PR DESCRIPTION
## Summary

- centralize auto-dream abort slot locking in a poison-recovery helper
- clear mutex poison while preserving the pending abort sender
- verify the recovered sender still signals its receiver and ordinary locking resumes
- add a changelog fragment

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-kernel --lib auto_dream::hook_tests::poisoned_abort_slot_recovers_sender_and_clears_poison`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- poison recovery in other kernel state domains remains separate work