### PR TITLE
fix(channels): clear router state lock poison

### DIFF
--- a/changelog.d/fixed/channel-router-clear-poison.md
+++ b/changelog.d/fixed/channel-router-clear-poison.md
@@ -1,0 +1,1 @@
+Clear channel router binding and broadcast lock poison after recovering routing state. (@xiaomo)

--- a/crates/librefang-channels/src/router.rs
+++ b/crates/librefang-channels/src/router.rs
@@ -64,6 +64,7 @@ impl AgentRouter {
     fn lock_bindings(&self) -> MutexGuard<'_, Vec<(AgentBinding, String)>> {
         self.bindings.lock().unwrap_or_else(|poisoned| {
             warn!("agent router bindings lock poisoned; recovering inner state");
+            self.bindings.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -71,6 +72,7 @@ impl AgentRouter {
     fn lock_broadcast(&self) -> MutexGuard<'_, BroadcastConfig> {
         self.broadcast.lock().unwrap_or_else(|poisoned| {
             warn!("agent router broadcast lock poisoned; recovering inner state");
+            self.broadcast.clear_poison();
             poisoned.into_inner()
         })
     }
@@ -586,11 +588,14 @@ mod tests {
                 .join()
         });
         assert!(binding_poison.is_err());
+        assert!(router.bindings.is_poisoned());
         assert_eq!(
             router.resolve(&ChannelType::Telegram, "vip_user", None),
             Some(agent_id)
         );
+        assert!(!router.bindings.is_poisoned());
         assert_eq!(router.bindings().len(), 1);
+        assert_eq!(router.bindings.lock().unwrap().len(), 1);
 
         let mut routes = std::collections::HashMap::new();
         routes.insert("vip_user".to_string(), vec!["support".to_string()]);
@@ -607,8 +612,16 @@ mod tests {
                 .join()
         });
         assert!(broadcast_poison.is_err());
+        assert!(router.broadcast.is_poisoned());
         assert!(router.has_broadcast("vip_user"));
+        assert!(!router.broadcast.is_poisoned());
         assert_eq!(router.resolve_broadcast("vip_user")[0].1, Some(agent_id));
+        assert!(router
+            .broadcast
+            .lock()
+            .unwrap()
+            .routes
+            .contains_key("vip_user"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clear agent-router binding and broadcast mutex poison after recovery
- preserve recovered routing state
- prove both locks allow later ordinary mutex access
- add a changelog fragment

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p librefang-channels --lib router::tests::test_recovers_routing_state_after_lock_poisoning`
- `cargo clippy -p librefang-channels --all-targets -- -D warnings`
- `cargo check --workspace --lib`

## Out of scope

- poison recovery in other channel state domains remains separate work