### PR TITLE
fix(api): scrub TOTP internal errors

### DIFF
--- a/changelog.d/security/totp-internal-error-scrub.md
+++ b/changelog.d/security/totp-internal-error-scrub.md
@@ -1,0 +1,1 @@
+- Scrub TOTP setup, confirmation, approval, and revocation 500 responses so vault, replay-store, and QR-generation details remain server-side. (@xiaomo)

--- a/crates/librefang-api/src/routes/approvals.rs
+++ b/crates/librefang-api/src/routes/approvals.rs
@@ -451,7 +451,7 @@ pub async fn approve_request(
                                 .into_response();
                         }
                         Err(e) => {
-                            return ApiErrorResponse::internal(e)
+                            return ApiErrorResponse::internal_scrub(e)
                                 .into_json_tuple()
                                 .into_response();
                         }
@@ -1173,7 +1173,7 @@ pub async fn totp_setup(
                     match state.kernel.vault_redeem_recovery_code(code) {
                         Ok(matched) => matched,
                         Err(e) => {
-                            return ApiErrorResponse::internal(e).into_json_tuple();
+                            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
                         }
                     }
                 } else {
@@ -1261,7 +1261,7 @@ pub async fn totp_setup(
     {
         Ok(v) => v,
         Err(e) => {
-            return ApiErrorResponse::internal(e).into_json_tuple();
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     };
     let qr_data_uri = format!("data:image/png;base64,{qr_base64}");
@@ -1272,16 +1272,16 @@ pub async fn totp_setup(
 
     // Store secret and recovery codes in vault (not yet active — totp_confirmed = false)
     if let Err(e) = state.kernel.vault_set("totp_secret", &secret_base32) {
-        return ApiErrorResponse::internal(e).into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     if let Err(e) = state.kernel.vault_set("totp_confirmed", "false") {
-        return ApiErrorResponse::internal(e).into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     if let Err(e) = state
         .kernel
         .vault_set("totp_recovery_codes", &recovery_json)
     {
-        return ApiErrorResponse::internal(e).into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     (
@@ -1340,7 +1340,7 @@ pub async fn totp_confirm(
                 Err(error) => return ApiErrorResponse::internal_scrub(error).into_json_tuple(),
             }
             if let Err(e) = state.kernel.vault_set("totp_confirmed", "true") {
-                return ApiErrorResponse::internal(e).into_json_tuple();
+                return ApiErrorResponse::internal_scrub(e).into_json_tuple();
             }
             (
                 StatusCode::OK,
@@ -1373,7 +1373,7 @@ pub async fn totp_confirm(
             )
             .into_json_tuple()
         }
-        Err(e) => ApiErrorResponse::internal(e).into_json_tuple(),
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }
 
@@ -1448,7 +1448,7 @@ pub async fn totp_revoke(
         match state.kernel.vault_redeem_recovery_code(&body.code) {
             Ok(matched) => matched,
             Err(e) => {
-                return ApiErrorResponse::internal(e).into_json_tuple();
+                return ApiErrorResponse::internal_scrub(e).into_json_tuple();
             }
         }
     } else {
@@ -1537,10 +1537,13 @@ pub async fn totp_revoke(
         failures.push(format!("totp_confirmed: {e}"));
     }
     if !failures.is_empty() {
-        return ApiErrorResponse::internal(format!(
-            "TOTP revocation partially failed; the secret and recovery codes have been wiped first so 2FA is no longer verifiable, but vault state is inconsistent. Retry. Details: {}",
-            failures.join("; ")
-        ))
+        tracing::error!(
+            errors = %failures.join("; "),
+            "TOTP revocation left inconsistent vault state; retry required"
+        );
+        return ApiErrorResponse::internal(
+            "TOTP revocation partially failed; vault state may be inconsistent. Retry.",
+        )
         .into_json_tuple();
     }
 

--- a/crates/librefang-api/tests/totp_flow_test.rs
+++ b/crates/librefang-api/tests/totp_flow_test.rs
@@ -269,6 +269,8 @@ async fn setup_reset_does_not_rotate_when_replay_claim_persistence_fails() {
     .await;
 
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "got: {body}");
+    assert_eq!(body["error"]["message"], "Internal server error");
+    assert!(!body.to_string().contains("totp_used_codes"));
     assert_eq!(
         h.state.kernel.vault_get("totp_secret").as_deref(),
         Some(original_secret.as_str()),
@@ -376,6 +378,8 @@ async fn confirm_does_not_activate_when_replay_claim_persistence_fails() {
     .await;
 
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "got: {body}");
+    assert_eq!(body["error"]["message"], "Internal server error");
+    assert!(!body.to_string().contains("totp_used_codes"));
     assert_eq!(
         h.state.kernel.vault_get("totp_confirmed").as_deref(),
         Some("false")
@@ -529,6 +533,8 @@ async fn revoke_does_not_disable_totp_when_replay_claim_persistence_fails() {
     .await;
 
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "got: {body}");
+    assert_eq!(body["error"]["message"], "Internal server error");
+    assert!(!body.to_string().contains("totp_used_codes"));
     assert_eq!(
         h.state.kernel.vault_get("totp_confirmed").as_deref(),
         Some("true")


### PR DESCRIPTION
## Summary

- scrub dynamic TOTP approval, setup, confirmation, and revocation failures from 500 responses
- retain detailed vault, replay-store, QR-generation, and verification errors in server logs
- keep an actionable retry message for partially failed revocation without exposing vault field names or error chains
- strengthen fault-injection regressions to pin the standard internal-error body and preserved security state

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-totp-scrub-target cargo test -p librefang-api --test totp_flow_test`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-totp-scrub-target cargo clippy -p librefang-api --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-totp-scrub-target cargo check --workspace --lib`
- structural audit confirms no `ApiErrorResponse::internal(e/error/format!(...))` remains in `routes/approvals.rs`

## Out of scope

- fixed non-dynamic TOTP persistence messages that do not include underlying error details
- unrelated approval-route behavior and synchronization domains