### PR TITLE
fix: recover event bus warning locks

### DIFF
--- a/changelog.d/fixed/event-bus-warning-poison-recovery.md
+++ b/changelog.d/fixed/event-bus-warning-poison-recovery.md
@@ -1,0 +1,1 @@
+- Recover poisoned kernel and plugin event-bus drop-warning locks so overload and consumer-lag diagnostics remain visible. (@xiaomo)

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -59,6 +59,14 @@ fn payload_kind(payload: &EventPayload) -> &'static str {
 }
 
 impl EventBus {
+    fn lock_drop_warning_timestamp(&self) -> std::sync::MutexGuard<'_, std::time::Instant> {
+        self.last_drop_warn.lock().unwrap_or_else(|poisoned| {
+            warn!("Event bus drop-warning lock poisoned; recovering rate-limit state");
+            self.last_drop_warn.clear_poison();
+            poisoned.into_inner()
+        })
+    }
+
     /// Create a new event bus.
     pub fn new() -> Self {
         // 4 096-event capacity for the global broadcast channel (up from 1 024).
@@ -120,17 +128,16 @@ impl EventBus {
                 if let Some(sender) = self.agent_channels.get(agent_id) {
                     if sender.send(Arc::clone(&event)).is_err() {
                         let total = self.dropped_count.fetch_add(1, Ordering::Relaxed) + 1;
-                        if let Ok(mut last) = self.last_drop_warn.lock() {
-                            if last.elapsed() >= std::time::Duration::from_secs(10) {
-                                warn!(
-                                    agent_id = %agent_id,
-                                    event_id = %event.id,
-                                    event_kind = payload_kind(&event.payload),
-                                    total_dropped = total,
-                                    "Event bus: agent has no active receiver, event dropped — check agent health",
-                                );
-                                *last = std::time::Instant::now();
-                            }
+                        let mut last = self.lock_drop_warning_timestamp();
+                        if last.elapsed() >= std::time::Duration::from_secs(10) {
+                            warn!(
+                                agent_id = %agent_id,
+                                event_id = %event.id,
+                                event_kind = payload_kind(&event.payload),
+                                total_dropped = total,
+                                "Event bus: agent has no active receiver, event dropped — check agent health",
+                            );
+                            *last = std::time::Instant::now();
                         }
                     }
                 }
@@ -152,16 +159,15 @@ impl EventBus {
                 if agent_drops > 0 {
                     let total =
                         self.dropped_count.fetch_add(agent_drops, Ordering::Relaxed) + agent_drops;
-                    if let Ok(mut last) = self.last_drop_warn.lock() {
-                        if last.elapsed() >= std::time::Duration::from_secs(10) {
-                            warn!(
-                                dropped = agent_drops,
-                                total_dropped = total,
-                                event_kind = payload_kind(&event.payload),
-                                "Event bus: broadcast reached agents with no active receivers, events dropped",
-                            );
-                            *last = std::time::Instant::now();
-                        }
+                    let mut last = self.lock_drop_warning_timestamp();
+                    if last.elapsed() >= std::time::Duration::from_secs(10) {
+                        warn!(
+                            dropped = agent_drops,
+                            total_dropped = total,
+                            event_kind = payload_kind(&event.payload),
+                            "Event bus: broadcast reached agents with no active receivers, events dropped",
+                        );
+                        *last = std::time::Instant::now();
                     }
                 }
             }
@@ -239,17 +245,16 @@ impl EventBus {
     /// otherwise hide missed triggers (issue #3630).
     pub fn record_consumer_lag(&self, n: u64, context: &'static str) {
         let total = self.dropped_count.fetch_add(n, Ordering::Relaxed) + n;
-        if let Ok(mut last) = self.last_drop_warn.lock() {
-            if last.elapsed() >= std::time::Duration::from_secs(10) {
-                error!(
-                    lagged = n,
-                    total_dropped = total,
-                    context = context,
-                    "Event bus: consumer lagged behind broadcast queue, events dropped — \
-                     receiver should be drained faster or buffer increased",
-                );
-                *last = std::time::Instant::now();
-            }
+        let mut last = self.lock_drop_warning_timestamp();
+        if last.elapsed() >= std::time::Duration::from_secs(10) {
+            error!(
+                lagged = n,
+                total_dropped = total,
+                context = context,
+                "Event bus: consumer lagged behind broadcast queue, events dropped — \
+                 receiver should be drained faster or buffer increased",
+            );
+            *last = std::time::Instant::now();
         }
     }
 
@@ -346,6 +351,23 @@ mod tests {
             after > before,
             "first lag burst must advance last_drop_warn — warmup regression"
         );
+    }
+
+    #[tokio::test]
+    async fn drop_warning_lock_recovers_after_held_lock_panic() {
+        let bus = EventBus::new();
+        let before = *bus.last_drop_warn.lock().unwrap();
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = bus.last_drop_warn.lock().unwrap();
+            panic!("poison event bus drop-warning lock");
+        });
+        assert!(bus.last_drop_warn.is_poisoned());
+
+        bus.record_consumer_lag(2, "poison_recovery_test");
+
+        assert_eq!(bus.dropped_count(), 2);
+        assert!(!bus.last_drop_warn.is_poisoned());
+        assert!(*bus.last_drop_warn.lock().unwrap() > before);
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -170,6 +170,16 @@ pub struct PluginEventBus {
 }
 
 impl PluginEventBus {
+    fn lock_drop_warning_timestamp(&self) -> std::sync::MutexGuard<'_, std::time::Instant> {
+        self.last_drop_warn.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                "Plugin event bus drop-warning lock poisoned; recovering rate-limit state"
+            );
+            self.last_drop_warn.clear_poison();
+            poisoned.into_inner()
+        })
+    }
+
     pub fn new(capacity: usize) -> Self {
         let (tx, _) = tokio::sync::broadcast::channel(capacity);
         // Initialise the rate-limit timestamp far enough in the past that
@@ -212,17 +222,16 @@ impl PluginEventBus {
             .dropped_count
             .fetch_add(n, std::sync::atomic::Ordering::Relaxed)
             + n;
-        if let Ok(mut last) = self.last_drop_warn.lock() {
-            if last.elapsed() >= std::time::Duration::from_secs(LAG_WARN_INTERVAL_SECS) {
-                tracing::error!(
-                    lagged = n,
-                    total_dropped = total,
-                    context = context,
-                    "Plugin event bus: consumer lagged behind broadcast queue, events dropped — \
-                     receiver should be drained faster or buffer increased",
-                );
-                *last = std::time::Instant::now();
-            }
+        let mut last = self.lock_drop_warning_timestamp();
+        if last.elapsed() >= std::time::Duration::from_secs(LAG_WARN_INTERVAL_SECS) {
+            tracing::error!(
+                lagged = n,
+                total_dropped = total,
+                context = context,
+                "Plugin event bus: consumer lagged behind broadcast queue, events dropped — \
+                 receiver should be drained faster or buffer increased",
+            );
+            *last = std::time::Instant::now();
         }
     }
 }

--- a/crates/librefang-runtime/src/context_engine/tests.rs
+++ b/crates/librefang-runtime/src/context_engine/tests.rs
@@ -121,6 +121,23 @@ async fn plugin_bus_first_lag_burst_advances_warn_timestamp() {
 }
 
 #[tokio::test]
+async fn plugin_bus_drop_warning_lock_recovers_after_held_lock_panic() {
+    let bus = PluginEventBus::new(8);
+    let before = *bus.last_drop_warn.lock().unwrap();
+    let _ = std::panic::catch_unwind(|| {
+        let _guard = bus.last_drop_warn.lock().unwrap();
+        panic!("poison plugin bus drop-warning lock");
+    });
+    assert!(bus.last_drop_warn.is_poisoned());
+
+    bus.record_consumer_lag(2, "poison_recovery_test");
+
+    assert_eq!(bus.dropped_count(), 2);
+    assert!(!bus.last_drop_warn.is_poisoned());
+    assert!(*bus.last_drop_warn.lock().unwrap() > before);
+}
+
+#[tokio::test]
 async fn test_ingest_stable_prefix_mode() {
     let config = ContextEngineConfig {
         stable_prefix_mode: true,


### PR DESCRIPTION
## Summary

- route kernel event-bus drop warnings through a poison-recovering timestamp lock helper
- recover the plugin event-bus lag-warning lock while preserving its rate-limit state
- cover both buses with held-lock panic regressions that verify count, timestamp, and poison recovery

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-event-bus-warning-target cargo test -p librefang-kernel event_bus::tests::`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-event-bus-warning-target cargo test -p librefang-runtime context_engine::tests::plugin_bus_ --lib`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-event-bus-warning-target cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-event-bus-warning-target cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-event-bus-warning-target cargo check --workspace --lib`

## Out of scope

- other mutex-poison recovery domains
- changes to event delivery or queue capacity