### PR TITLE
fix(api): attribute authz denial endpoint

### DIFF
--- a/changelog.d/fixed/authz-denial-endpoint.md
+++ b/changelog.d/fixed/authz-denial-endpoint.md
@@ -1,0 +1,1 @@
+Attribute denied authorization checks to the correct API endpoint in audit records. (@xiaomo)

--- a/crates/librefang-api/src/routes/authz.rs
+++ b/crates/librefang-api/src/routes/authz.rs
@@ -52,14 +52,18 @@ pub fn router() -> axum::Router<Arc<AppState>> {
 /// don't blanket-trust an unauthenticated origin even on loopback. To
 /// use this endpoint in a no-auth deployment, configure at least one
 /// user with an admin api_key.
-fn require_admin(state: &AppState, api_user: Option<&AuthenticatedApiUser>) -> Option<Response> {
+fn require_admin(
+    state: &AppState,
+    api_user: Option<&AuthenticatedApiUser>,
+    endpoint: &str,
+) -> Option<Response> {
     match api_user {
         Some(u) if u.role >= UserRole::Admin => None,
         Some(u) => {
             state.kernel.audit().record_with_context(
                 "system",
                 librefang_kernel::audit::AuditAction::PermissionDenied,
-                format!("authz/effective endpoint denied for role {}", u.role),
+                format!("{endpoint} endpoint denied for role {}", u.role),
                 "denied",
                 Some(u.user_id),
                 Some("api".to_string()),
@@ -73,7 +77,7 @@ fn require_admin(state: &AppState, api_user: Option<&AuthenticatedApiUser>) -> O
             state.kernel.audit().record_with_context(
                 "system",
                 librefang_kernel::audit::AuditAction::PermissionDenied,
-                "authz/effective endpoint denied for anonymous caller",
+                format!("{endpoint} endpoint denied for anonymous caller"),
                 "denied",
                 None,
                 Some("api".to_string()),
@@ -115,7 +119,7 @@ pub async fn effective_permissions(
     api_user: Option<axum::Extension<AuthenticatedApiUser>>,
 ) -> Response {
     let api_user_ref = api_user.as_ref().map(|e| &e.0);
-    if let Some(deny) = require_admin(&state, api_user_ref) {
+    if let Some(deny) = require_admin(&state, api_user_ref, "authz/effective") {
         return deny;
     }
 
@@ -228,7 +232,7 @@ pub async fn check(
     api_user: Option<axum::Extension<AuthenticatedApiUser>>,
 ) -> Response {
     let api_user_ref = api_user.as_ref().map(|e| &e.0);
-    if let Some(deny) = require_admin(&state, api_user_ref) {
+    if let Some(deny) = require_admin(&state, api_user_ref, "authz/check") {
         return deny;
     }
 

--- a/crates/librefang-api/tests/authz_routes_integration.rs
+++ b/crates/librefang-api/tests/authz_routes_integration.rs
@@ -146,6 +146,29 @@ async fn authz_effective_viewer_role_is_forbidden() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn authz_check_viewer_denial_audit_names_check_endpoint() {
+    let h = boot_with_seed_users(vec![seed_user("Alice", "user")]);
+    let (status, _) = run(
+        &h,
+        req(
+            Method::GET,
+            "/api/authz/check?user=Alice&action=web_search",
+            Some(viewer_user("watcher")),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let entries = h._state.kernel.audit().recent(1);
+    assert_eq!(entries.len(), 1);
+    assert!(
+        entries[0].detail.contains("authz/check endpoint denied"),
+        "unexpected audit detail: {}",
+        entries[0].detail
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn authz_effective_admin_returns_snapshot_by_name() {
     let seed = UserConfig {
         name: "Alice".into(),


### PR DESCRIPTION
## Substantive changes
- pass the concrete authorization endpoint into the shared Admin gate
- record `/api/authz/check` denials as `authz/check` instead of mislabeling them as `authz/effective`
- add integration coverage that inspects the emitted audit detail

## Verification
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-authz-audit cargo test -p librefang-api --test authz_routes_integration authz_check_viewer_denial_audit_names_check_endpoint` (1 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-authz-audit cargo test -p librefang-api --test authz_routes_integration` (13 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-authz-audit cargo clippy -p librefang-api --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-authz-audit cargo check --workspace --lib`
- `cargo fmt --all`
- `git diff --check`

## Out of scope
- authorization policy and endpoint response behavior are unchanged.