### PR TITLE
fix(api): classify auto-dream update errors

### DIFF
--- a/changelog.d/fixed/auto-dream-errors.md
+++ b/changelog.d/fixed/auto-dream-errors.md
@@ -1,0 +1,1 @@
+Return accurate, scrubbed status codes for auto-dream opt-in update failures. (@xiaomo)

--- a/crates/librefang-api/src/routes/auto_dream.rs
+++ b/crates/librefang-api/src/routes/auto_dream.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 
 use super::AppState;
 use crate::extractors::AgentIdPath;
+use librefang_types::error::LibreFangError;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
@@ -96,6 +97,13 @@ pub struct SetEnabledRequest {
     pub enabled: bool,
 }
 
+fn set_enabled_error_response(error: &LibreFangError) -> (StatusCode, &'static str) {
+    match error {
+        LibreFangError::AgentNotFound(_) => (StatusCode::NOT_FOUND, "agent not found"),
+        _ => (StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
+    }
+}
+
 #[utoipa::path(
     put,
     path = "/api/auto-dream/agents/{id}/enabled",
@@ -118,12 +126,37 @@ pub async fn auto_dream_set_enabled(
             "enabled": req.enabled,
         }))
         .into_response(),
-        Err(e) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": e.to_string()})),
-        )
-            .into_response(),
+        Err(error) => {
+            let (status, message) = set_enabled_error_response(&error);
+            if status.is_server_error() {
+                tracing::error!(%agent_id, %error, "failed to update auto-dream opt-in");
+            }
+            (status, Json(serde_json::json!({"error": message}))).into_response()
+        }
     };
     // #3511: tag response with agent_id for the access-log middleware.
     crate::extensions::with_agent_id(agent_id, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_enabled_error_response_distinguishes_missing_agent() {
+        let missing = LibreFangError::AgentNotFound("agent-id".to_string());
+        assert_eq!(
+            set_enabled_error_response(&missing),
+            (StatusCode::NOT_FOUND, "agent not found")
+        );
+    }
+
+    #[test]
+    fn set_enabled_error_response_scrubs_internal_errors() {
+        let internal = LibreFangError::Internal("sensitive backend detail".to_string());
+        assert_eq!(
+            set_enabled_error_response(&internal),
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        );
+    }
 }

--- a/crates/librefang-api/tests/auto_dream_routes_integration.rs
+++ b/crates/librefang-api/tests/auto_dream_routes_integration.rs
@@ -315,10 +315,7 @@ async fn auto_dream_set_enabled_unknown_agent_is_404() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
-    assert!(
-        !body["error"].as_str().unwrap_or("").is_empty(),
-        "expected an error string: {body:?}"
-    );
+    assert_eq!(body["error"], "agent not found");
 }
 
 /// Missing `enabled` field in the JSON body is a deserialization failure


### PR DESCRIPTION
## Substantive changes
- preserve 404 only for missing agents when updating auto-dream opt-in
- map other kernel failures to 500 and log their full diagnostic server-side
- return fixed client messages so internal paths and backend details are not exposed
- strengthen the missing-agent HTTP contract and add direct error-classification tests

## Verification
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-auto-dream-errors cargo test -p librefang-api set_enabled_error_response` (2 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-auto-dream-errors cargo test -p librefang-api --test auto_dream_routes_integration auto_dream_set_enabled_unknown_agent_is_404` (1 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-auto-dream-errors cargo test -p librefang-api --test auto_dream_routes_integration` (10 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-auto-dream-errors cargo clippy -p librefang-api --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-auto-dream-errors cargo check --workspace --lib`
- `cargo fmt --all`
- `git diff --check`

## Out of scope
- manual-trigger rate limiting and auto-dream scheduling policy remain unchanged.