### PR TITLE
fix(api): restore Windows warning-free build

### DIFF
--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -110,7 +110,6 @@ async fn current_process_rss_mb() -> Option<u64> {
     }
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         tokio::process::Command::new("tasklist")
             .args([


### PR DESCRIPTION
## Changes
- remove the redundant Windows `CommandExt` import from the RSS probe
- preserve the existing Tokio `creation_flags` call and behavior
- restore Windows builds under `-D warnings`

## Verification
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/librefang-cargo-target cargo check -p librefang-api --lib`
- confirmed both failed main Windows shards identify this exact unused import
- Windows cross-target validation is left to CI because the target is not installed locally

## Out of scope
- no other process-launch behavior changes