### PR TITLE
fix(api): fail MCP OAuth on vault errors

### DIFF
--- a/changelog.d/fixed/mcp-oauth-vault-failures.md
+++ b/changelog.d/fixed/mcp-oauth-vault-failures.md
@@ -1,1 +1,1 @@
-Fail MCP OAuth flows promptly when required credential-vault reads or writes fail. (@xiaomo)
+Fail MCP OAuth flows promptly when required credential-vault reads or writes, including per-flow client IDs, fail. (@xiaomo)

--- a/changelog.d/fixed/mcp-oauth-vault-failures.md
+++ b/changelog.d/fixed/mcp-oauth-vault-failures.md
@@ -1,0 +1,1 @@
+Fail MCP OAuth flows promptly when required credential-vault reads or writes fail. (@xiaomo)

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -559,8 +559,9 @@ pub async fn auth_start(
     let pkce_state = format!("{flow_id}.{pkce_random}");
 
     // Store PKCE state in vault under per-flow keys for the callback to retrieve.
-    let flow_vault_key =
-        |field: &str| KernelOAuthProvider::vault_key(&format!("{server_url}:{flow_id}"), field);
+    let flow_key_prefix = format!("{server_url}:{flow_id}");
+    let mut flow_cleanup = FlowVaultCleanup::new(&provider, flow_key_prefix.clone());
+    let flow_vault_key = |field: &str| KernelOAuthProvider::vault_key(&flow_key_prefix, field);
     let store =
         |field: &str, value: &str| -> Result<(), librefang_kernel::mcp_oauth::McpOAuthError> {
             provider.vault_set(&flow_vault_key(field), value)
@@ -606,6 +607,9 @@ pub async fn auth_start(
             return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     }
+    // The callback now owns cleanup. Disarm only after every required field
+    // has been persisted; any earlier return removes partial PKCE state.
+    flow_cleanup.disarm();
 
     // Build authorization URL
     let mut auth_url = format!(
@@ -661,20 +665,38 @@ pub struct AuthCallbackParams {
 
 /// RAII cleanup for the per-flow vault entries written by `auth_start`.
 ///
+/// `auth_start` can fail after writing only part of the flow state, and
 /// `auth_callback` has many early returns (state mismatch, missing PKCE,
 /// SSRF block, token-exchange / parse failures, …) — previously only the
-/// success path removed the per-flow keys, so every failed or abandoned
-/// flow leaked the PKCE verifier and its metadata into the vault forever
-/// (the vault has no TTL). Dropping this guard removes all per-flow fields
-/// on ANY exit once `flow_key_prefix` is known. `vault_remove` is sync, so
-/// it is safe to call from `Drop`.
+/// success path removed the per-flow keys. Dropping an armed guard removes
+/// all per-flow fields on any start or callback failure once
+/// `flow_key_prefix` is known. `vault_remove` is sync, so it is safe to call
+/// from `Drop`.
 struct FlowVaultCleanup<'a> {
     provider: &'a KernelOAuthProvider,
     prefix: String,
+    armed: bool,
+}
+
+impl<'a> FlowVaultCleanup<'a> {
+    fn new(provider: &'a KernelOAuthProvider, prefix: String) -> Self {
+        Self {
+            provider,
+            prefix,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
 }
 
 impl Drop for FlowVaultCleanup<'_> {
     fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
         // Every field `auth_start` writes under `{server_url}:{flow_id}`.
         // `issuer_host` was previously omitted from the success-path cleanup
         // and leaked even on success (#5885-cluster low item).
@@ -779,10 +801,7 @@ pub async fn auth_callback(
     // Remove the per-flow vault entries on every exit from here on — failure,
     // abandonment, or success — not just the happy path. Declared after
     // `provider` so it drops first (while `provider` is still alive).
-    let _flow_cleanup = FlowVaultCleanup {
-        provider: &provider,
-        prefix: flow_key_prefix.clone(),
-    };
+    let _flow_cleanup = FlowVaultCleanup::new(&provider, flow_key_prefix.clone());
     let load = |field: &str| match provider
         .vault_get(&KernelOAuthProvider::vault_key(&flow_key_prefix, field))
     {
@@ -1902,10 +1921,7 @@ mod tests {
         // every per-flow field — including issuer_host, which the old
         // success-only loop omitted.
         {
-            let _guard = FlowVaultCleanup {
-                provider: &provider,
-                prefix: prefix.clone(),
-            };
+            let _guard = FlowVaultCleanup::new(&provider, prefix.clone());
         }
 
         for f in fields {
@@ -1918,6 +1934,30 @@ mod tests {
             );
         }
 
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn disarmed_flow_vault_cleanup_preserves_callback_state() {
+        std::env::set_var(
+            "LIBREFANG_VAULT_KEY",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        );
+        let home =
+            std::env::temp_dir().join(format!("lf-vault-disarm-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&home).unwrap();
+        let provider = KernelOAuthProvider::new(home.clone());
+        let prefix = "https://mcp.example.com:caller-flow456".to_string();
+        let key = KernelOAuthProvider::vault_key(&prefix, "pkce_state");
+        provider.vault_set(&key, "state").unwrap();
+
+        {
+            let mut guard = FlowVaultCleanup::new(&provider, prefix);
+            guard.disarm();
+        }
+
+        assert_eq!(provider.vault_get(&key).unwrap().as_deref(), Some("state"));
+        provider.vault_remove(&key).unwrap();
         let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -602,7 +602,8 @@ pub async fn auth_start(
     }
     if let Some(ref cid) = client_id {
         if let Err(e) = store("client_id", cid) {
-            tracing::warn!(error = %e, "Failed to store client_id in vault");
+            tracing::error!(error = %e, "Failed to store client_id in vault");
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     }
 

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -577,7 +577,8 @@ pub async fn auth_start(
         return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     if let Err(e) = store("token_endpoint", &metadata.token_endpoint) {
-        tracing::warn!(error = %e, "Failed to store token_endpoint in vault");
+        tracing::error!(error = %e, "Failed to store token_endpoint in vault");
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     // #3713: persist the original authorization-server host so the callback
     // can re-verify that the stored `token_endpoint` still resolves to the
@@ -589,13 +590,15 @@ pub async fn auth_start(
     // in the flow that the attacker cannot influence.
     if let Some(issuer_host) = url_host_lower(&server_url) {
         if let Err(e) = store("issuer_host", &issuer_host) {
-            tracing::warn!(error = %e, "Failed to store issuer_host in vault");
+            tracing::error!(error = %e, "Failed to store issuer_host in vault");
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     } else {
         tracing::warn!(server_url = %server_url, "server_url has no host — cannot pin issuer for callback");
     }
     if let Err(e) = store("redirect_uri", &redirect_uri) {
-        tracing::warn!(error = %e, "Failed to store redirect_uri in vault");
+        tracing::error!(error = %e, "Failed to store redirect_uri in vault");
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     if let Some(ref cid) = client_id {
         if let Err(e) = store("client_id", cid) {
@@ -779,27 +782,23 @@ pub async fn auth_callback(
         provider: &provider,
         prefix: flow_key_prefix.clone(),
     };
-    // #3750: collapse vault Result into Option for callers below — a vault
-    // storage failure during callback is logged and treated the same as
-    // "value missing", since the recovery path (retry from dashboard) is
-    // identical for both cases.
-    let load = |field: &str| -> Option<String> {
-        match provider.vault_get(&KernelOAuthProvider::vault_key(&flow_key_prefix, field)) {
-            Ok(opt) => opt,
-            Err(e) => {
-                tracing::warn!(
-                    field = %field,
-                    error = %e,
-                    "vault_get failed during OAuth callback"
-                );
-                None
-            }
+    let load = |field: &str| match provider
+        .vault_get(&KernelOAuthProvider::vault_key(&flow_key_prefix, field))
+    {
+        Ok(opt) => Ok(opt),
+        Err(e) => {
+            tracing::error!(
+                field = %field,
+                error = %e,
+                "vault_get failed during OAuth callback"
+            );
+            Err(e)
         }
     };
 
     let stored_state = match load("pkce_state") {
-        Some(s) => s,
-        None => {
+        Ok(Some(s)) => s,
+        Ok(None) => {
             tracing::error!(
                 server = %name,
                 server_url = %server_url,
@@ -812,6 +811,7 @@ pub async fn auth_callback(
                  Check that LIBREFANG_VAULT_KEY is set in your environment.",
             );
         }
+        Err(_) => return auth_failed("Failed to read OAuth state from the credential vault."),
     };
 
     // #3730: The stored state encodes the flow_id and a random nonce; the
@@ -860,17 +860,19 @@ pub async fn auth_callback(
     let code = code_param;
 
     let pkce_verifier = match load("pkce_verifier") {
-        Some(v) => v,
-        None => {
+        Ok(Some(v)) => v,
+        Ok(None) => {
             return auth_failed("PKCE verifier missing from vault.");
         }
+        Err(_) => return auth_failed("Failed to read OAuth state from the credential vault."),
     };
 
     let token_endpoint = match load("token_endpoint") {
-        Some(t) => t,
-        None => {
+        Ok(Some(t)) => t,
+        Ok(None) => {
             return auth_failed("Token endpoint missing from vault.");
         }
+        Err(_) => return auth_failed("Failed to read OAuth state from the credential vault."),
     };
     // SSRF guard (#3623): re-validate the stored token_endpoint before the
     // outbound code exchange.  The parser checks at discovery time, but the
@@ -891,8 +893,8 @@ pub async fn auth_callback(
     // match `token_endpoint.host()`, refuse the exchange — never POST the
     // code to an unverified host.
     let issuer_host = match load("issuer_host") {
-        Some(h) if !h.is_empty() => h,
-        _ => {
+        Ok(Some(h)) if !h.is_empty() => h,
+        Ok(_) => {
             tracing::error!(
                 server = %name,
                 token_endpoint = %token_endpoint,
@@ -902,6 +904,7 @@ pub async fn auth_callback(
                 "Authorization server host pin missing from vault — refusing to exchange the auth code. Please retry the sign-in from the dashboard.",
             );
         }
+        Err(_) => return auth_failed("Failed to read OAuth state from the credential vault."),
     };
     if !token_endpoint_host_matches(&token_endpoint, &issuer_host) {
         let token_host = url_host_lower(&token_endpoint).unwrap_or_default();
@@ -924,15 +927,19 @@ pub async fn auth_callback(
         );
     }
 
-    let client_id = load("client_id");
+    let client_id = match load("client_id") {
+        Ok(value) => value,
+        Err(_) => return auth_failed("Failed to read OAuth state from the credential vault."),
+    };
     let redirect_uri = match load("redirect_uri") {
-        Some(r) if !r.is_empty() => r,
-        _ => {
+        Ok(Some(r)) if !r.is_empty() => r,
+        Ok(_) => {
             return auth_failed(
                 "Redirect URI missing from vault — auth flow state was lost. \
                  Please retry from the dashboard.",
             );
         }
+        Err(_) => return auth_failed("Failed to read OAuth state from the credential vault."),
     };
 
     // Exchange authorization code for tokens.
@@ -949,11 +956,16 @@ pub async fn auth_callback(
         form_params.push(("client_id", cid.clone()));
     }
     // Persisted at auth_start when McpOAuthConfig::client_secret_env was set.
-    if let Some(secret) = provider.vault_get_or_warn(&KernelOAuthProvider::vault_key(
+    match provider.vault_get(&KernelOAuthProvider::vault_key(
         &server_url,
         "client_secret",
     )) {
-        form_params.push(("client_secret", secret));
+        Ok(Some(secret)) => form_params.push(("client_secret", secret)),
+        Ok(None) => {}
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to read OAuth client secret from vault");
+            return auth_failed("Failed to read OAuth credentials from the credential vault.");
+        }
     }
 
     // #3730: user-visible errors must NOT leak the token endpoint URL or the
@@ -1084,7 +1096,16 @@ pub async fn auth_callback(
     // Store tokens via the trait provider
     let trait_provider = state.kernel.oauth_provider_ref();
     if let Err(e) = trait_provider.store_tokens(&server_url, tokens).await {
-        tracing::warn!(error = %e, "Failed to store OAuth tokens");
+        tracing::error!(error = %e, "Failed to store OAuth tokens");
+        let message = "OAuth succeeded, but tokens could not be stored in the credential vault. Fix vault access and retry sign-in.";
+        let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
+        auth_states.insert(
+            name.clone(),
+            McpAuthState::Error {
+                message: message.to_string(),
+            },
+        );
+        return auth_failed(message);
     }
 
     // Promote `token_endpoint` (and `client_id` if registered via DCR) from

--- a/crates/librefang-api/tests/mcp_auth_routes_extra_test.rs
+++ b/crates/librefang-api/tests/mcp_auth_routes_extra_test.rs
@@ -245,7 +245,7 @@ async fn auth_callback_stdio_transport_returns_no_http_sse_message() {
 }
 
 /// Callback whose `state` is well-formed (`flow.nonce`) but whose
-/// PKCE state is absent from the vault must fail with an explanatory
+/// PKCE state cannot be read from the vault must fail with an explanatory
 /// message. This is the dominant real-world failure mode when
 /// `LIBREFANG_VAULT_KEY` is missing — the user retries from the
 /// dashboard and the message tells them why.
@@ -263,11 +263,9 @@ async fn auth_callback_valid_format_but_no_pkce_state_in_vault_fails() {
         body.contains("Authorization Failed"),
         "expected failure text, got: {body}"
     );
-    // The current handler surfaces "No pending auth flow" with a
-    // LIBREFANG_VAULT_KEY hint.
     assert!(
-        body.contains("No pending auth flow") || body.to_lowercase().contains("pkce"),
-        "expected pkce/missing-flow detail, got: {body}"
+        body.contains("Failed to read OAuth state from the credential vault"),
+        "expected credential-vault detail, got: {body}"
     );
 }
 


### PR DESCRIPTION
## Substantive changes
- fail OAuth startup when required callback state cannot be persisted
- require per-flow client ID persistence whenever a client ID is used in the authorization request
- remove partially persisted PKCE and callback state when OAuth startup fails
- distinguish credential-vault read failures from missing public-client values during callback and token exchange
- fail the callback and record an error state when exchanged tokens cannot be persisted
- update the callback route regression test for the strict vault-error diagnostic

## Verification
- cargo fmt --all -- --check
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-mcp-vault cargo test -p librefang-api --test mcp_oauth_flow_test (9 passed)
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-mcp-vault cargo test -p librefang-api --test mcp_auth_routes_extra_test (9 passed)
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-mcp-vault cargo test -p librefang-api flow_vault_cleanup --lib (2 passed)
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-mcp-vault cargo clippy -p librefang-api --all-targets -- -D warnings
- git diff --check

## Out of scope
- optional dynamic-client-registration client_id absence remains supported for public clients
- best-effort refresh metadata persistence remains unchanged
