### PR TITLE
fix(api): complete sidecar describe boundaries

### DIFF
--- a/changelog.d/fixed/sidecar-describe-utf8.md
+++ b/changelog.d/fixed/sidecar-describe-utf8.md
@@ -1,1 +1,1 @@
-Report invalid sidecar describe output encoding separately from malformed JSON. (@xiaomo)
+Classify sidecar describe failures, reject invalid output encoding, and prevent probe children from inheriting daemon secrets. (#7177) (@xiaomo)

--- a/changelog.d/fixed/sidecar-describe-utf8.md
+++ b/changelog.d/fixed/sidecar-describe-utf8.md
@@ -1,0 +1,1 @@
+Report invalid sidecar describe output encoding separately from malformed JSON. (@xiaomo)

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -699,7 +699,8 @@ pub async fn populate_sidecar_schema_cache(home_dir: &std::path::Path) {
                         "sidecar --describe failed; discovery card will have no form fields"
                     );
                     // Stash the failure reason so the discovery row can tell the operator *why* the form is empty (typically: Python sidecar SDK not installed).
-                    write_cache_recover(schema_error_cache(), "schema error").insert(entry.name, e);
+                    write_cache_recover(schema_error_cache(), "schema error")
+                        .insert(entry.name, e.to_string());
                 }
             }
         }

--- a/crates/librefang-api/src/routes/sidecar_describe.rs
+++ b/crates/librefang-api/src/routes/sidecar_describe.rs
@@ -9,6 +9,7 @@ use librefang_channels::sidecar::{
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::time::Duration;
+use thiserror::Error;
 use tokio::process::Command;
 
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
@@ -35,6 +36,51 @@ pub struct SidecarSchema {
     pub fields: Vec<SidecarSchemaField>,
 }
 
+#[derive(Debug, Error)]
+pub enum DescribeSidecarError {
+    #[error("`{command} ...--describe` timed out after 5s")]
+    Timeout { command: String },
+    #[error("spawn failed: {0}")]
+    Spawn(#[source] std::io::Error),
+    #[error("{0}")]
+    SdkMissing(String),
+    #[error("describe exited {code}: {stderr}")]
+    Exited { code: i32, stderr: String },
+    #[error("describe stdout was not valid UTF-8: {0}")]
+    InvalidUtf8(#[source] std::string::FromUtf8Error),
+    #[error("invalid describe JSON: {source}; raw stdout: {stdout}")]
+    InvalidJson {
+        #[source]
+        source: serde_json::Error,
+        stdout: String,
+    },
+}
+
+/// Preserve only non-secret process context needed to locate and run an
+/// interpreter. Callers must still supply catalog-controlled commands and
+/// arguments; this probe is not a general subprocess execution API.
+fn set_describe_environment(cmd: &mut Command) {
+    const ALLOWED: &[&str] = &[
+        "PATH",
+        "PYTHONPATH",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "SYSTEMROOT",
+        "WINDIR",
+        "PATHEXT",
+    ];
+    cmd.env_clear();
+    for name in ALLOWED {
+        if let Some(value) = std::env::var_os(name) {
+            cmd.env(name, value);
+        }
+    }
+}
+
 /// Spawn `<command> <args> --describe`, parse stdout as JSON.
 ///
 /// Timeout is 5s — describe should be sub-second; if it hangs (the
@@ -45,7 +91,7 @@ pub async fn describe_sidecar(
     command: &str,
     args: &[String],
     home_dir: &Path,
-) -> Result<SidecarSchema, String> {
+) -> Result<SidecarSchema, DescribeSidecarError> {
     let mut full_args: Vec<String> = args.to_vec();
     full_args.push("--describe".into());
 
@@ -55,6 +101,7 @@ pub async fn describe_sidecar(
     // — the timeout returns to the caller but the child keeps running
     // until it crashes on its own.
     let mut cmd = Command::new(command);
+    set_describe_environment(&mut cmd);
     cmd.args(&full_args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -71,8 +118,10 @@ pub async fn describe_sidecar(
 
     let out = tokio::time::timeout(Duration::from_secs(5), fut)
         .await
-        .map_err(|_| format!("`{command} ...--describe` timed out after 5s"))?
-        .map_err(|e| format!("spawn failed: {e}"))?;
+        .map_err(|_| DescribeSidecarError::Timeout {
+            command: command.to_string(),
+        })?
+        .map_err(DescribeSidecarError::Spawn)?;
 
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
@@ -82,10 +131,9 @@ pub async fn describe_sidecar(
             stderr.trim(),
         ));
     }
-    let stdout = String::from_utf8(out.stdout)
-        .map_err(|e| format!("describe stdout was not valid UTF-8: {e}"))?;
+    let stdout = String::from_utf8(out.stdout).map_err(DescribeSidecarError::InvalidUtf8)?;
     serde_json::from_str::<SidecarSchema>(stdout.trim())
-        .map_err(|e| format!("invalid describe JSON: {e}; raw stdout: {stdout}"))
+        .map_err(|source| DescribeSidecarError::InvalidJson { source, stdout })
 }
 
 /// Translate the cryptic Python-side failure mode that fires when
@@ -103,9 +151,12 @@ pub async fn describe_sidecar(
 /// `librefang_channels::sidecar::format_librefang_sdk_missing_hint`
 /// (and the `looks_like_librefang_sdk_missing` detector next to it)
 /// to update both paths in lockstep.
-fn translate_describe_error(command: &str, code: i32, stderr: &str) -> String {
+fn translate_describe_error(command: &str, code: i32, stderr: &str) -> DescribeSidecarError {
     if looks_like_librefang_sdk_missing(stderr) {
-        return format_librefang_sdk_missing_hint(command);
+        return DescribeSidecarError::SdkMissing(format_librefang_sdk_missing_hint(command));
     }
-    format!("describe exited {code}: {stderr}")
+    DescribeSidecarError::Exited {
+        code,
+        stderr: stderr.to_string(),
+    }
 }

--- a/crates/librefang-api/src/routes/sidecar_describe.rs
+++ b/crates/librefang-api/src/routes/sidecar_describe.rs
@@ -82,7 +82,8 @@ pub async fn describe_sidecar(
             stderr.trim(),
         ));
     }
-    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stdout = String::from_utf8(out.stdout)
+        .map_err(|e| format!("describe stdout was not valid UTF-8: {e}"))?;
     serde_json::from_str::<SidecarSchema>(stdout.trim())
         .map_err(|e| format!("invalid describe JSON: {e}; raw stdout: {stdout}"))
 }

--- a/crates/librefang-api/tests/sidecar_describe_test.rs
+++ b/crates/librefang-api/tests/sidecar_describe_test.rs
@@ -1,4 +1,6 @@
-use librefang_api::routes::sidecar_describe::{describe_sidecar, SidecarSchema};
+use librefang_api::routes::sidecar_describe::{
+    describe_sidecar, DescribeSidecarError, SidecarSchema,
+};
 
 #[tokio::test]
 async fn describe_telegram_returns_schema_or_skips_when_sdk_missing() {
@@ -35,7 +37,45 @@ async fn describe_failing_command_returns_err() {
         home.path(),
     )
     .await;
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(DescribeSidecarError::Exited { code: 2, .. })
+    ));
+}
+
+#[tokio::test]
+async fn describe_spawn_and_json_failures_are_typed() {
+    let home = tempfile::tempdir().unwrap();
+    let missing = format!("librefang-missing-command-{}", uuid::Uuid::new_v4());
+    assert!(matches!(
+        describe_sidecar(&missing, &[], home.path()).await,
+        Err(DescribeSidecarError::Spawn(_))
+    ));
+
+    assert!(matches!(
+        describe_sidecar(
+            "python3",
+            &["-c".into(), "print('not json')".into()],
+            home.path(),
+        )
+        .await,
+        Err(DescribeSidecarError::InvalidJson { .. })
+    ));
+}
+
+#[tokio::test]
+async fn describe_child_does_not_inherit_unapproved_environment() {
+    let home = tempfile::tempdir().unwrap();
+    let secret_name = format!("LIBREFANG_DESCRIBE_TEST_SECRET_{}", uuid::Uuid::new_v4());
+    std::env::set_var(&secret_name, "must-not-reach-child");
+    let script = format!(
+        "import json, os; print(json.dumps({{'name':'probe','display_name':'Probe','description':str(os.getenv({secret_name:?}) is None),'fields':[]}}))"
+    );
+    let result = describe_sidecar("python3", &["-c".into(), script], home.path()).await;
+    std::env::remove_var(&secret_name);
+
+    let schema = result.expect("probe should return a schema");
+    assert_eq!(schema.description, "True");
 }
 
 #[tokio::test]
@@ -51,6 +91,8 @@ async fn describe_invalid_utf8_stdout_reports_encoding_failure() {
     )
     .await;
     let err = result.expect_err("invalid UTF-8 stdout must fail");
+    assert!(matches!(err, DescribeSidecarError::InvalidUtf8(_)));
+    let err = err.to_string();
     assert!(
         err.contains("describe stdout was not valid UTF-8"),
         "expected an encoding diagnostic, got: {err}"
@@ -82,7 +124,9 @@ async fn describe_missing_sdk_returns_actionable_install_hint() {
         home.path(),
     )
     .await;
-    let err = result.expect_err("missing-SDK shape must surface as Err");
+    let err = result
+        .expect_err("missing-SDK shape must surface as Err")
+        .to_string();
     assert!(
         err.contains("librefang-sdk is not installed"),
         "expected install hint; got: {err}"
@@ -178,7 +222,9 @@ async fn describe_other_failure_modes_keep_raw_stderr() {
         home.path(),
     )
     .await;
-    let err = result.expect_err("non-SDK failure must surface as Err");
+    let err = result
+        .expect_err("non-SDK failure must surface as Err")
+        .to_string();
     assert!(
         !err.contains("librefang-sdk is not installed"),
         "install hint incorrectly fired for unrelated ImportError: {err}"

--- a/crates/librefang-api/tests/sidecar_describe_test.rs
+++ b/crates/librefang-api/tests/sidecar_describe_test.rs
@@ -39,6 +39,29 @@ async fn describe_failing_command_returns_err() {
 }
 
 #[tokio::test]
+async fn describe_invalid_utf8_stdout_reports_encoding_failure() {
+    let home = tempfile::tempdir().unwrap();
+    let result = describe_sidecar(
+        "python3",
+        &[
+            "-c".into(),
+            "import sys; sys.stdout.buffer.write(bytes([255]))".into(),
+        ],
+        home.path(),
+    )
+    .await;
+    let err = result.expect_err("invalid UTF-8 stdout must fail");
+    assert!(
+        err.contains("describe stdout was not valid UTF-8"),
+        "expected an encoding diagnostic, got: {err}"
+    );
+    assert!(
+        !err.contains("invalid describe JSON"),
+        "invalid bytes must not be misclassified as JSON syntax: {err}"
+    );
+}
+
+#[tokio::test]
 async fn describe_missing_sdk_returns_actionable_install_hint() {
     // Simulate the exact failure operators hit when librefang-sdk
     // isn't installed in the interpreter the daemon picked. The raw


### PR DESCRIPTION
## Changes

- decode successful sidecar `--describe` stdout with strict UTF-8 validation
- expose typed timeout, spawn, SDK, exit, encoding, and JSON failure variants
- clear the describe child environment and restore only a narrow non-secret runtime allowlist
- retain actionable display strings at the schema-cache boundary
- add subprocess regressions for encoding, typed failures, and environment isolation

## Verification

- `cargo test -p librefang-api --test sidecar_describe_test` (8 passed)
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

## Out of scope

- Runtime sidecar processes intentionally retain their configured environment and secrets; this PR only hardens the metadata probe.
- The describe API remains restricted to catalog-controlled commands and arguments.