### PR TITLE
fix(audit): fail closed after reload errors

### DIFF
--- a/changelog.d/fixed/7179-audit-reload-fail-closed.md
+++ b/changelog.d/fixed/7179-audit-reload-fail-closed.md
@@ -1,0 +1,1 @@
+Disable durable audit appends after an incomplete database reload and reject unknown persisted actions without coercion (#7179) (@houko)

--- a/changelog.d/fixed/audit-reload-fail-closed.md
+++ b/changelog.d/fixed/audit-reload-fail-closed.md
@@ -1,1 +1,0 @@
-Disable durable audit appends after an incomplete database reload and reject unknown persisted actions without coercion. (@xiaomo)

--- a/changelog.d/fixed/audit-reload-fail-closed.md
+++ b/changelog.d/fixed/audit-reload-fail-closed.md
@@ -1,0 +1,1 @@
+Disable durable audit appends after an incomplete database reload and reject unknown persisted actions without coercion. (@xiaomo)

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -532,6 +532,14 @@ impl AuditLog {
         let mut log = Self::with_db(pool);
         log.anchor_path = Some(anchor_path.clone());
 
+        if log.db.is_none() {
+            tracing::error!(
+                path = ?anchor_path,
+                "Audit anchor verification and initialization skipped because database reload was incomplete"
+            );
+            return log;
+        }
+
         // Compare against the anchor file (if any) and warn loudly on
         // divergence. The call to `verify_integrity` below will also
         // return `Err` in that case so `/api/audit/verify` surfaces it.
@@ -650,15 +658,13 @@ impl AuditLog {
                             // any coercion recomputes a different `action.to_string()`
                             // than the persisted one and would trip `verify_integrity`
                             // with a false hash mismatch on every subsequent boot.
-                            let action = action_str.parse::<AuditAction>().unwrap_or_else(|e| {
-                                tracing::warn!(
-                                    seq = row.get::<_, i64>(0).unwrap_or_default(),
-                                    "Audit reload hit {e}; retaining the row but its hash \
-                             will not recompute until this binary is upgraded to a \
-                             version that knows the action"
-                                );
-                                AuditAction::ToolInvoke
-                            });
+                            let action = action_str.parse::<AuditAction>().map_err(|e| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    3,
+                                    rusqlite::types::Type::Text,
+                                    Box::new(e),
+                                )
+                            })?;
                             let seq_raw: i64 = row.get(0)?;
                             let seq = u64::try_from(seq_raw).map_err(|_| {
                                 rusqlite::Error::IntegralValueOutOfRange(0, seq_raw)
@@ -729,10 +735,23 @@ impl AuditLog {
             _ => None,
         };
 
+        // A partial reload cannot safely derive the next persisted sequence or
+        // chain tip. Keep the decoded rows available for inspection, but detach
+        // the database so later records cannot overwrite or extend an unknown
+        // on-disk tail.
+        let db = if load_error.is_some() {
+            tracing::error!(
+                "Audit database reload was incomplete; durable appends are disabled for this process"
+            );
+            None
+        } else {
+            Some(pool)
+        };
+
         let log = Self {
             entries: Mutex::new(entries),
             tip: Mutex::new(tip),
-            db: Some(pool),
+            db,
             anchor_path: None,
             chain_anchor: Mutex::new(recovered_anchor),
             max_in_memory_entries: AtomicUsize::new(0),
@@ -999,13 +1018,15 @@ impl AuditLog {
         // append because of a filesystem hiccup would lose an audit
         // record, which is strictly worse than an anchor that trails by
         // one tick.
-        if let Some(ref anchor_path) = self.anchor_path {
-            let count = self.persisted_rows.load(Ordering::Relaxed) as u64;
-            if let Err(e) = Self::write_anchor(anchor_path, count, &hash) {
-                tracing::warn!(
-                    path = ?anchor_path,
-                    "Failed to update audit anchor (entry still persisted): {e}"
-                );
+        if self.db.is_some() {
+            if let Some(ref anchor_path) = self.anchor_path {
+                let count = self.persisted_rows.load(Ordering::Relaxed) as u64;
+                if let Err(e) = Self::write_anchor(anchor_path, count, &hash) {
+                    tracing::warn!(
+                        path = ?anchor_path,
+                        "Failed to update audit anchor (entry still persisted): {e}"
+                    );
+                }
             }
         }
 

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -221,12 +221,77 @@ fn malformed_persisted_row_fails_integrity_verification() {
         .unwrap();
     }
 
-    let log = AuditLog::with_db(pool);
+    let log = AuditLog::with_db(pool.clone());
 
     assert_eq!(log.len(), 0, "malformed rows must not enter the chain");
+    assert!(
+        log.db.is_none(),
+        "an incomplete reload must disable durable appends"
+    );
     let error = log.verify_integrity().unwrap_err();
     assert!(error.contains("only partially loaded"), "{error}");
     assert!(error.contains("ordered index 0"), "{error}");
+
+    log.record("agent-2", AuditAction::ShellExec, "after reload", "ok");
+    assert_eq!(log.len(), 1, "in-memory auditing should remain available");
+    let persisted: i64 = pool
+        .get()
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM audit_entries", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(persisted, 1, "the damaged database must not be extended");
+}
+
+#[test]
+fn unknown_persisted_action_is_not_coerced_or_extended() {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(SqliteConnectionManager::memory())
+        .unwrap();
+    pool.get()
+        .unwrap()
+        .execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            );
+            INSERT INTO audit_entries VALUES (
+                0, '2026-01-01T00:00:00Z', 'agent-1', 'FutureAction', 'detail', 'ok',
+                NULL, NULL,
+                '0000000000000000000000000000000000000000000000000000000000000000',
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            );",
+        )
+        .unwrap();
+
+    let anchor_dir = tempfile::tempdir().unwrap();
+    let anchor_path = anchor_dir.path().join("audit.anchor");
+    let log = AuditLog::with_db_anchored(pool.clone(), anchor_path.clone());
+    assert_eq!(log.len(), 0, "unknown actions must not enter the chain");
+    assert!(log.db.is_none());
+    assert!(
+        !anchor_path.exists(),
+        "a partial reload must not seed an anchor from an incomplete chain"
+    );
+    let error = log.verify_integrity().unwrap_err();
+    assert!(error.contains("only partially loaded"), "{error}");
+    assert!(error.contains("unknown audit action"), "{error}");
+
+    log.record("agent-2", AuditAction::ToolInvoke, "after reload", "ok");
+    let persisted: i64 = pool
+        .get()
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM audit_entries", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(persisted, 1, "the unknown-action row must remain untouched");
 }
 
 #[test]


### PR DESCRIPTION
## Changes

- turn unknown persisted audit actions into row decode failures instead of coercing them to `ToolInvoke`
- detach the SQLite backend after any incomplete reload so an uncertain sequence/tip cannot be persisted
- keep decoded audit rows and in-memory recording available for inspection while integrity verification remains failed
- skip anchor comparison, initialization, and updates when the durable backend was detached
- cover malformed rows and future action values with real SQLite regressions

## Verification

- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-audit-reload cargo test -p librefang-runtime-audit` (41 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-audit-reload cargo clippy -p librefang-runtime-audit --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/librefang-target-audit-reload cargo check --workspace --lib`
- `git diff --check`

## Out of scope

- narrowing mutex scope around synchronous SQLite retention operations remains separate work
- anchor temporary-file naming and timestamp retention comparison remain separate findings