### PR TITLE
fix(whatsapp): validate outbound JID shapes

### DIFF
--- a/changelog.d/fixed/whatsapp-jid-validation.md
+++ b/changelog.d/fixed/whatsapp-jid-validation.md
@@ -1,0 +1,1 @@
+Validate outbound WhatsApp JID shapes and normalize cached device-scoped phone identities. (@xiaomo)

--- a/packages/whatsapp-gateway/lib/identity.js
+++ b/packages/whatsapp-gateway/lib/identity.js
@@ -17,8 +17,10 @@
 
 const LID_SUFFIX_RE = /@(lid|hosted\.lid)$/;
 const GROUP_SUFFIX_RE = /@g\.us$/;
-const DEVICE_SUFFIX_RE = /:(\d+)@/;
+const DEVICE_SUFFIX_RE = /:(\d+)@s\.whatsapp\.net$/;
 const E164_JID_RE = /^(\d+)@s\.whatsapp\.net$/;
+const SENDABLE_JID_RE = /^(?:\d+(?::\d+)?@s\.whatsapp\.net|\d+-\d+@g\.us|\d+@(?:lid|hosted\.lid))$/;
+const PHONE_NUMBER_RE = /^\+?\d+$/;
 
 function isLidJid(jid) {
   if (!jid || typeof jid !== 'string') return false;
@@ -35,7 +37,7 @@ function isGroupJid(jid) {
 function normalizeDeviceScopedJid(jid) {
   if (!jid || typeof jid !== 'string') return jid || '';
   if (isGroupJid(jid)) return jid;
-  return jid.replace(DEVICE_SUFFIX_RE, '@');
+  return jid.replace(DEVICE_SUFFIX_RE, '@s.whatsapp.net');
 }
 
 // Returns '+<digits>' for phone JIDs, empty string otherwise.
@@ -48,11 +50,13 @@ function extractE164(jid) {
 }
 
 // Accepts '+391234', '391234', '123@s.whatsapp.net', '123-456@g.us'.
-// Returns a sendable Baileys JID. Group JIDs and existing JIDs passthrough.
+// Returns a sendable Baileys JID. Only known WhatsApp JID shapes passthrough.
 function phoneToJid(phoneOrJid) {
   if (!phoneOrJid || typeof phoneOrJid !== 'string') return '';
-  if (isGroupJid(phoneOrJid)) return phoneOrJid;
-  if (phoneOrJid.includes('@')) return phoneOrJid;
+  if (phoneOrJid.includes('@')) {
+    return SENDABLE_JID_RE.test(phoneOrJid) ? phoneOrJid : '';
+  }
+  if (!PHONE_NUMBER_RE.test(phoneOrJid)) return '';
   return phoneOrJid.replace(/^\+/, '') + '@s.whatsapp.net';
 }
 
@@ -84,6 +88,8 @@ function resolvePeerId(jid, opts) {
   const participant = options.participant || '';
   const cache = options.lidToPnCache || null;
 
+  // senderPn identifies the individual author of a group message. It
+  // intentionally takes precedence; callers needing the group peer omit it.
   if (senderPn) {
     return { peer: senderPn, confidence: 'direct' };
   }
@@ -91,7 +97,7 @@ function resolvePeerId(jid, opts) {
     return { peer: jid, confidence: 'group' };
   }
   if (isLidJid(jid) && cache && typeof cache.has === 'function' && cache.has(jid)) {
-    return { peer: cache.get(jid), confidence: 'cache' };
+    return { peer: normalizeDeviceScopedJid(cache.get(jid)), confidence: 'cache' };
   }
   if (jid && !isLidJid(jid) && !isGroupJid(jid)) {
     return { peer: normalizeDeviceScopedJid(jid), confidence: 'direct' };

--- a/packages/whatsapp-gateway/lib/identity.js
+++ b/packages/whatsapp-gateway/lib/identity.js
@@ -12,14 +12,14 @@
 //   - '<digits>:<device>@s.whatsapp.net'   — device-scoped multi-device JID
 //   - '<digits>@lid'                       — WhatsApp anonymous LID (opaque)
 //   - '<digits>@hosted.lid'                — hosted LID (Baileys docs; guard)
-//   - '<digits>-<digits>@g.us'             — group JID
+//   - '<digits>[-<digits>]@g.us'            — group JID
 // ---------------------------------------------------------------------------
 
 const LID_SUFFIX_RE = /@(lid|hosted\.lid)$/;
 const GROUP_SUFFIX_RE = /@g\.us$/;
 const DEVICE_SUFFIX_RE = /:(\d+)@s\.whatsapp\.net$/;
 const E164_JID_RE = /^(\d+)@s\.whatsapp\.net$/;
-const SENDABLE_JID_RE = /^(?:\d+(?::\d+)?@s\.whatsapp\.net|\d+-\d+@g\.us|\d+@(?:lid|hosted\.lid))$/;
+const SENDABLE_JID_RE = /^(?:\d+(?::\d+)?@(?:s\.whatsapp\.net|lid|hosted\.lid)|\d+(?:-\d+)?@g\.us)$/;
 const PHONE_NUMBER_RE = /^\+?\d+$/;
 
 function isLidJid(jid) {

--- a/packages/whatsapp-gateway/test/identity.test.js
+++ b/packages/whatsapp-gateway/test/identity.test.js
@@ -111,9 +111,14 @@ describe('phoneToJid', () => {
   it('known LID and hosted LID shapes passthrough', () => {
     assert.equal(phoneToJid('123@lid'), '123@lid');
     assert.equal(phoneToJid('123@hosted.lid'), '123@hosted.lid');
+    assert.equal(phoneToJid('123:45@lid'), '123:45@lid');
+  });
+  it('legacy and modern group JID shapes passthrough', () => {
+    assert.equal(phoneToJid('123-456@g.us'), '123-456@g.us');
+    assert.equal(phoneToJid('120363000000000000@g.us'), '120363000000000000@g.us');
   });
   it('rejects unknown or malformed JIDs and non-numeric phones', () => {
-    for (const value of ['x@evil.com', '@bad', '<script>@x', 'abc', '+', '123@g.us']) {
+    for (const value of ['x@evil.com', '@bad', '<script>@x', 'abc', '+', '123-@g.us']) {
       assert.equal(phoneToJid(value), '', value);
     }
   });

--- a/packages/whatsapp-gateway/test/identity.test.js
+++ b/packages/whatsapp-gateway/test/identity.test.js
@@ -60,8 +60,8 @@ describe('normalizeDeviceScopedJid', () => {
   it('passthrough plain phone JID', () => {
     assert.equal(normalizeDeviceScopedJid('123@s.whatsapp.net'), '123@s.whatsapp.net');
   });
-  it('strips :<device> from LID', () => {
-    assert.equal(normalizeDeviceScopedJid('123:45@lid'), '123@lid');
+  it('does not rewrite colon-bearing non-phone JIDs', () => {
+    assert.equal(normalizeDeviceScopedJid('123:45@lid'), '123:45@lid');
   });
   it('leaves group JID untouched', () => {
     assert.equal(normalizeDeviceScopedJid('123-456@g.us'), '123-456@g.us');
@@ -108,6 +108,15 @@ describe('phoneToJid', () => {
   it('already-formed phone JID passthrough', () => {
     assert.equal(phoneToJid('123@s.whatsapp.net'), '123@s.whatsapp.net');
   });
+  it('known LID and hosted LID shapes passthrough', () => {
+    assert.equal(phoneToJid('123@lid'), '123@lid');
+    assert.equal(phoneToJid('123@hosted.lid'), '123@hosted.lid');
+  });
+  it('rejects unknown or malformed JIDs and non-numeric phones', () => {
+    for (const value of ['x@evil.com', '@bad', '<script>@x', 'abc', '+', '123@g.us']) {
+      assert.equal(phoneToJid(value), '', value);
+    }
+  });
   it('empty / null -> empty', () => {
     assert.equal(phoneToJid(''), '');
     assert.equal(phoneToJid(null), '');
@@ -150,6 +159,12 @@ describe('resolvePeerId', () => {
   });
   it('step 3: LID in cache -> cache', () => {
     const cache = new Map([['123@lid', '391234@s.whatsapp.net']]);
+    const r = resolvePeerId('123@lid', { lidToPnCache: cache });
+    assert.equal(r.confidence, 'cache');
+    assert.equal(r.peer, '391234@s.whatsapp.net');
+  });
+  it('step 3: normalizes a device-scoped cached phone JID', () => {
+    const cache = new Map([['123@lid', '391234:45@s.whatsapp.net']]);
     const r = resolvePeerId('123@lid', { lidToPnCache: cache });
     assert.equal(r.confidence, 'cache');
     assert.equal(r.peer, '391234@s.whatsapp.net');


### PR DESCRIPTION
## Changes

- accept only numeric phones or known WhatsApp phone, group, LID, and hosted-LID JID shapes for outbound addressing
- preserve both legacy hyphenated and modern numeric-only group JIDs
- preserve valid device-scoped phone and LID addresses while rejecting malformed/unknown-host JIDs
- restrict device-suffix stripping to `@s.whatsapp.net` identities
- normalize device-scoped phone JIDs returned from the LID cache
- document intentional `senderPn` precedence for group messages

## Verification

- `node --test test/identity.test.js` (45 passed)
- `node --check lib/identity.js`
- `node --check test/identity.test.js`
- `git diff --check`

## Full-suite note

After `npm ci --ignore-scripts` and rebuilding `better-sqlite3`, `node --test` reached 267 passing tests but did not provide a clean gate: an existing structural dispatch-log assertion reported 0 expected source matches, a later HTTP test was interrupted with `ECONNRESET`, and `group-roster.test.js` retained a pending promise/long-lived gateway handle. None of those failures touches `lib/identity.js`; the focused identity suite exits cleanly.

## Out of scope

- validation of inbound `senderPn` and participant values remains unchanged
- broader gateway test-process lifecycle cleanup remains separate work