### PR TITLE
fix(dingtalk): bound session webhook retention

### DIFF
--- a/changelog.d/fixed/dingtalk-session-webhook-retention.md
+++ b/changelog.d/fixed/dingtalk-session-webhook-retention.md
@@ -1,0 +1,1 @@
+Bound DingTalk's pending session webhook cache and discard expired reply URLs. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/dingtalk.py
+++ b/sdk/python/librefang/sidecar/adapters/dingtalk.py
@@ -69,6 +69,7 @@ Behaviour parity with the deleted Rust stream path:
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 import json
 import os
 import queue
@@ -109,6 +110,9 @@ READ_TICK_SECS = 1.0
 #: Bounded dedupe envelope.
 SEEN_MESSAGES_MAX = 10_000
 SEEN_MESSAGES_EVICT = 5_000
+
+#: Maximum pending per-message reply URLs retained when callers never reply.
+SESSION_WEBHOOKS_MAX = 10_000
 
 #: Inter-chunk delay (Rust: dingtalk.rs:831).
 INTER_CHUNK_DELAY_SECS = 0.2
@@ -354,7 +358,8 @@ class DingTalkAdapter(SidecarAdapter):
         # cmd.channel_id (= the message_id, since DingTalk's reply
         # path is per-message, not per-user). Stored briefly until
         # the next inbound from the same user / message.
-        self._session_webhooks: dict[str, str] = {}
+        self._session_webhooks: OrderedDict[str, str] = OrderedDict()
+        self._session_webhook_expiries: dict[str, int] = {}
         self._session_lock = threading.Lock()
 
         # Inbound dedupe on messageId (improvement #1).
@@ -371,6 +376,52 @@ class DingTalkAdapter(SidecarAdapter):
 
     def _mark_seen(self, msg_id: Optional[str]) -> bool:
         return self._seen.mark(msg_id)
+
+    # ---- sessionWebhook retention -----------------------------------
+
+    def _prune_session_webhooks(self, now_ms: int) -> None:
+        """Drop expired URLs and cap unanswered callbacks.
+
+        Caller must hold ``_session_lock``.
+        """
+        expired = [
+            msg_id
+            for msg_id, expires_at in self._session_webhook_expiries.items()
+            if expires_at <= now_ms
+        ]
+        for msg_id in expired:
+            self._session_webhooks.pop(msg_id, None)
+            self._session_webhook_expiries.pop(msg_id, None)
+
+        while len(self._session_webhooks) > SESSION_WEBHOOKS_MAX:
+            msg_id, _ = self._session_webhooks.popitem(last=False)
+            self._session_webhook_expiries.pop(msg_id, None)
+
+    def _cache_session_webhook(
+        self, msg_id: str, session_webhook: str, expires_at: Any,
+    ) -> None:
+        now_ms = time.time_ns() // 1_000_000
+        with self._session_lock:
+            self._prune_session_webhooks(now_ms)
+            if (
+                isinstance(expires_at, int)
+                and expires_at > 0
+                and expires_at <= now_ms
+            ):
+                return
+            self._session_webhooks[msg_id] = session_webhook
+            self._session_webhooks.move_to_end(msg_id)
+            if isinstance(expires_at, int) and expires_at > 0:
+                self._session_webhook_expiries[msg_id] = expires_at
+            else:
+                self._session_webhook_expiries.pop(msg_id, None)
+            self._prune_session_webhooks(now_ms)
+
+    def _pop_session_webhook(self, msg_id: str) -> Optional[str]:
+        with self._session_lock:
+            self._prune_session_webhooks(time.time_ns() // 1_000_000)
+            self._session_webhook_expiries.pop(msg_id, None)
+            return self._session_webhooks.pop(msg_id, None)
 
     # ---- HTTP helpers -------------------------------------------------
 
@@ -567,8 +618,12 @@ class DingTalkAdapter(SidecarAdapter):
                 "session_webhook"
             )
             if session_webhook and isinstance(msg_id, str):
-                with self._session_lock:
-                    self._session_webhooks[msg_id] = session_webhook
+                expires_at = event["params"].get("metadata", {}).get(
+                    "session_webhook_expired_time"
+                )
+                self._cache_session_webhook(
+                    msg_id, session_webhook, expires_at,
+                )
 
             emit(event)
 
@@ -626,8 +681,7 @@ class DingTalkAdapter(SidecarAdapter):
         session_webhook = None
         msg_id = cmd.channel_id or ""
         if msg_id:
-            with self._session_lock:
-                session_webhook = self._session_webhooks.pop(msg_id, None)
+            session_webhook = self._pop_session_webhook(msg_id)
         if not session_webhook and cmd.user:
             librefang_user = cmd.user.get("librefang_user")
             if isinstance(librefang_user, str) and librefang_user.startswith(

--- a/sdk/python/librefang/sidecar/adapters/dingtalk.py
+++ b/sdk/python/librefang/sidecar/adapters/dingtalk.py
@@ -408,6 +408,10 @@ class DingTalkAdapter(SidecarAdapter):
                 and expires_at > 0
                 and expires_at <= now_ms
             ):
+                # An expired replacement for an existing message ID must
+                # invalidate the previously cached reply URL as well.
+                self._session_webhooks.pop(msg_id, None)
+                self._session_webhook_expiries.pop(msg_id, None)
                 return
             self._session_webhooks[msg_id] = session_webhook
             self._session_webhooks.move_to_end(msg_id)

--- a/sdk/python/tests/test_dingtalk_adapter.py
+++ b/sdk/python/tests/test_dingtalk_adapter.py
@@ -425,6 +425,21 @@ def test_session_webhook_cache_drops_expired_urls(monkeypatch):
     assert "live" not in a._session_webhook_expiries
 
 
+def test_expired_session_webhook_update_invalidates_existing_url():
+    now_ms = time.time_ns() // 1_000_000
+    a = _adapter()
+    a._cache_session_webhook(
+        "same-message", "https://example.test/live", now_ms + 60_000,
+    )
+
+    a._cache_session_webhook(
+        "same-message", "https://example.test/expired", now_ms - 1,
+    )
+
+    assert a._pop_session_webhook("same-message") is None
+    assert "same-message" not in a._session_webhook_expiries
+
+
 # ─── on_send routing ─────────────────────────────────────────────────
 
 

--- a/sdk/python/tests/test_dingtalk_adapter.py
+++ b/sdk/python/tests/test_dingtalk_adapter.py
@@ -191,7 +191,7 @@ def _callback_frame(payload_overrides=None, **frame_overrides):
         "conversationId": "cid1",
         "conversationType": "1",
         "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
-        "sessionWebhookExpiredTime": 1735000000000,
+        "sessionWebhookExpiredTime": 4102444800000,
         "msgId": "m1",
     }
     if payload_overrides:
@@ -405,6 +405,24 @@ def test_mark_seen_empty_always_true():
     a = _adapter()
     assert a._mark_seen("") is True
     assert a._mark_seen(None) is True
+
+
+def test_session_webhook_cache_evicts_oldest_at_limit(monkeypatch):
+    monkeypatch.setattr(dt_mod, "SESSION_WEBHOOKS_MAX", 3)
+    a = _adapter()
+    for i in range(4):
+        a._cache_session_webhook(f"m{i}", f"https://example.test/{i}", 0)
+    assert list(a._session_webhooks) == ["m1", "m2", "m3"]
+
+
+def test_session_webhook_cache_drops_expired_urls(monkeypatch):
+    now_ms = time.time_ns() // 1_000_000
+    a = _adapter()
+    a._cache_session_webhook("expired", "https://example.test/old", now_ms - 1)
+    a._cache_session_webhook("live", "https://example.test/new", now_ms + 60_000)
+    assert list(a._session_webhooks) == ["live"]
+    assert a._pop_session_webhook("live") == "https://example.test/new"
+    assert "live" not in a._session_webhook_expiries
 
 
 # ─── on_send routing ─────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

- bound unanswered DingTalk `sessionWebhook` entries to 10,000 with oldest-first eviction
- retain and enforce DingTalk `sessionWebhookExpiredTime` before caching and before reply lookup
- invalidate an existing cached URL when an expired update arrives for the same message ID
- remove expiration metadata when a cached reply URL is consumed
- add regressions for capacity eviction, expired URL rejection, and expired replacement invalidation

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1,998 passed before follow-up)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-venv/bin/pytest -q sdk/python/tests/test_dingtalk_adapter.py` (65 passed)
- `python3 -m py_compile sdk/python/librefang/sidecar/adapters/dingtalk.py sdk/python/tests/test_dingtalk_adapter.py`
- `git diff --check`

## Out of scope

- DingTalk outbound chunk scheduling, reconnect behavior, and session webhook host validation remain unchanged.