### PR TITLE
fix(whatsapp): scope echo tracking by chat

### DIFF
--- a/changelog.d/fixed/whatsapp-echo-tracker-scope.md
+++ b/changelog.d/fixed/whatsapp-echo-tracker-scope.md
@@ -1,0 +1,1 @@
+Scope WhatsApp echo detection by conversation and expire stale outbound fingerprints. (@xiaomo)

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -1417,7 +1417,7 @@ async function executeRelay(relay) {
 
   try {
     const sentRelay = await sock.sendMessage(jid, { text: markdownToWhatsApp(message) });
-    if (ECHO_TRACKER_ENABLED) echoTracker.track(message);
+    if (ECHO_TRACKER_ENABLED) echoTracker.track(jid, message);
 
     // F4: Audit log
     console.log(`[gateway] RELAY SENT | to: ${convo.pushName} (${convo.phone}) [${jid}] | message: "${message.substring(0, 100)}" | timestamp: ${new Date().toISOString()}`);
@@ -2056,7 +2056,7 @@ async function startConnection() {
       // (self-loop prevention when WhatsApp reflects our own message back
       // via sync/cross-device mirror). Flag `LIBREFANG_ECHO_TRACKER=off`
       // disables this gate. Only checks text bodies (never attachments).
-      if (ECHO_TRACKER_ENABLED && messageText && echoTracker.isEcho(messageText)) {
+      if (ECHO_TRACKER_ENABLED && messageText && echoTracker.isEcho(sender, messageText)) {
         console.log(JSON.stringify({
           event: 'echo_drop',
           body_excerpt: EchoTracker.normalize(messageText).slice(0, 80),
@@ -2272,7 +2272,7 @@ async function startConnection() {
               await localSock.sendMessage(sender, { text: formatted, edit: streamMsgKey });
             }
             streamEditFailures = 0;
-            if (ECHO_TRACKER_ENABLED) echoTracker.track(cleaned);
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(sender, cleaned);
           } catch (err) {
             streamEditFailures += 1;
             console.warn(JSON.stringify({
@@ -2362,7 +2362,7 @@ async function startConnection() {
             // accept the last visible chunk as final instead.
             try {
               await s.sendMessage(jid, { text: finalText, edit: streamMsgKey });
-              if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+              if (ECHO_TRACKER_ENABLED) echoTracker.track(jid, finalText);
               console.log(JSON.stringify({
                 event: 'send_message_outbound',
                 kind: 'edit_final',
@@ -2394,7 +2394,7 @@ async function startConnection() {
           // already handles when sendOrEdit's entry-snapshot was null).
           try {
             const sent = await s.sendMessage(jid, { text: finalText });
-            if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(jid, finalText);
             console.log(JSON.stringify({
               event: 'send_message_outbound',
               kind: 'new_message',
@@ -2449,7 +2449,7 @@ async function startConnection() {
 
               // Send notification to primary owner
               await sock.sendMessage(OWNER_JID, { text: ownerNotif });
-              if (ECHO_TRACKER_ENABLED) echoTracker.track(ownerNotif);
+              if (ECHO_TRACKER_ENABLED) echoTracker.track(OWNER_JID, ownerNotif);
               console.log(`[gateway] NOTIFY_OWNER sent for ${pushName}: ${notif.reason}`);
             }
 
@@ -3404,7 +3404,7 @@ async function runCatchUpSweep() {
         try {
           const formatted = markdownToWhatsApp(response);
           await sock.sendMessage(msg.jid, { text: formatted });
-          if (ECHO_TRACKER_ENABLED) echoTracker.track(response);
+          if (ECHO_TRACKER_ENABLED) echoTracker.track(msg.jid, response);
           dbSaveMessage({ id: randomUUID(), jid: msg.jid, senderJid: ownJid, pushName: null, phone: msg.phone, text: response, direction: 'outbound', timestamp: Date.now(), processed: 1, rawType: 'text' });
         } catch (sendErr) {
           console.warn(`[gateway][catchup] Could not send catch-up reply to ${msg.jid}: ${sendErr.message}`);
@@ -3464,7 +3464,7 @@ async function sendMessage(to, text) {
 
   const formatted = markdownToWhatsApp(text);
   const sent = await sock.sendMessage(jid, { text: formatted });
-  if (ECHO_TRACKER_ENABLED) echoTracker.track(text);
+  if (ECHO_TRACKER_ENABLED) echoTracker.track(jid, text);
   // Save outbound message to DB (store formatted text to match what was delivered)
   dbSaveMessage({
     id: sent?.key?.id || randomUUID(),

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -682,28 +682,36 @@ describe('echo tracker wiring (Phase 3 §A)', () => {
   it('integration: outbound track then inbound echo would drop (raw body)', () => {
     echoTracker.reset();
     // Simulate the outbound wire-in (every sock.sendMessage({ text }) is followed by track)
-    echoTracker.track('ciao');
+    echoTracker.track('alice@s.whatsapp.net', 'ciao');
     // Simulate the inbound gate condition with the same body
-    assert.equal(echoTracker.isEcho('ciao'), true,
+    assert.equal(echoTracker.isEcho('alice@s.whatsapp.net', 'ciao'), true,
       'inbound echo of just-sent message must be detected');
     assert.equal(echoTracker.size(), 1);
   });
 
   it('integration: normalization works through wiring (Hello. -> hello)', () => {
     echoTracker.reset();
-    echoTracker.track('Hello.');
-    assert.equal(echoTracker.isEcho('hello'), true,
+    echoTracker.track('alice@s.whatsapp.net', 'Hello.');
+    assert.equal(echoTracker.isEcho('alice@s.whatsapp.net', 'hello'), true,
       'normalized echo (case + trailing punct) must drop');
-    assert.equal(echoTracker.isEcho('HELLO!'), true);
+    assert.equal(echoTracker.isEcho('alice@s.whatsapp.net', 'HELLO!'), true);
   });
 
   it('integration: unrelated inbound is NOT dropped (no false positive)', () => {
     echoTracker.reset();
-    echoTracker.track('ciao');
-    assert.equal(echoTracker.isEcho('something else'), false,
+    echoTracker.track('alice@s.whatsapp.net', 'ciao');
+    assert.equal(echoTracker.isEcho('alice@s.whatsapp.net', 'something else'), false,
       'unrelated message must pass through (forwardToLibreFang would be called)');
     // tracker unchanged for non-matching probe
     assert.equal(echoTracker.size(), 1);
+  });
+
+  it('integration: identical short text in another JID is not an echo', () => {
+    echoTracker.reset();
+    echoTracker.track('alice@s.whatsapp.net', 'ok');
+    assert.equal(echoTracker.isEcho('bob@s.whatsapp.net', 'OK!'), false,
+      'echo fingerprints must not cross conversation boundaries');
+    assert.equal(echoTracker.isEcho('alice@s.whatsapp.net', 'OK!'), true);
   });
 
   it('flag gate: when LIBREFANG_ECHO_TRACKER=off, gate is bypassed', () => {
@@ -712,7 +720,7 @@ describe('echo tracker wiring (Phase 3 §A)', () => {
     const src = require('node:fs').readFileSync(require('node:path').join(__dirname, 'index.js'), 'utf8');
     // The gate must be wrapped in an ECHO_TRACKER_ENABLED check.
     assert.match(src,
-      /if\s*\(\s*ECHO_TRACKER_ENABLED\s*&&\s*messageText\s*&&\s*echoTracker\.isEcho/,
+      /if\s*\(\s*ECHO_TRACKER_ENABLED\s*&&\s*messageText\s*&&\s*echoTracker\.isEcho\(sender,/,
       'inbound gate must be flag-gated by ECHO_TRACKER_ENABLED');
     // Each track call must also be flag-gated.
     const trackCalls = src.match(/echoTracker\.track\(/g) || [];
@@ -740,6 +748,9 @@ describe('echo tracker wiring (Phase 3 §A)', () => {
     const trackCount = (src.match(/echoTracker\.track\(/g) || []).length;
     assert.equal(trackCount, 7,
       `expected 7 echoTracker.track() calls (one per outbound text site), got ${trackCount}`);
+    const scopedTrackCount = (src.match(/echoTracker\.track\([^,]+,/g) || []).length;
+    assert.equal(scopedTrackCount, 7,
+      'every outbound fingerprint must include its destination JID');
     });
 });
 

--- a/packages/whatsapp-gateway/lib/echo-tracker.js
+++ b/packages/whatsapp-gateway/lib/echo-tracker.js
@@ -10,13 +10,21 @@
  *
  * Decisions (see .planning/phases/03-chat-isolation-layer/03-CONTEXT.md §A):
  * - In-memory only, no persistence (Q6 locked).
+ * - Process-local correctness assumes one gateway worker/instance. A shared
+ *   store is required before horizontally-scaled workers can detect each
+ *   other's reflected sends.
  * - maxSize=100 default, LRU eviction on insertion-order.
+ * - Entries expire after five minutes even when traffic stays below maxSize.
+ * - Keys include the destination JID so common replies in separate chats do
+ *   not suppress each other.
  * - Normalization: lowercase + emoji strip + whitespace collapse + trailing
  *   punctuation strip so minor echo rewrites still match.
  */
 class EchoTracker {
-  constructor(maxSize = 100) {
+  constructor(maxSize = 100, ttlMs = 5 * 60 * 1000, now = Date.now) {
     this.max = Math.max(1, Number(maxSize) || 100);
+    this.ttlMs = Math.max(1, Number(ttlMs) || 5 * 60 * 1000);
+    this.now = now;
     this.map = new Map();
     this.lastSentAt = 0;
   }
@@ -31,31 +39,48 @@ class EchoTracker {
       .replace(/[.!?]+$/, '');
   }
 
-  track(body) {
-    const key = EchoTracker.normalize(body);
+  static key(recipientJid, body) {
+    const scope = typeof recipientJid === 'string' ? recipientJid.trim() : '';
+    const normalized = EchoTracker.normalize(body);
+    if (!scope || !normalized) return '';
+    return JSON.stringify([scope, normalized]);
+  }
+
+  pruneExpired(now) {
+    for (const [key, sentAt] of this.map) {
+      if (now - sentAt >= this.ttlMs) this.map.delete(key);
+    }
+  }
+
+  track(recipientJid, body) {
+    const key = EchoTracker.key(recipientJid, body);
     if (!key) return;
+    const now = this.now();
+    this.pruneExpired(now);
     // Refresh insertion order on re-track.
     if (this.map.has(key)) this.map.delete(key);
-    this.map.set(key, Date.now());
-    this.lastSentAt = Date.now();
+    this.map.set(key, now);
+    this.lastSentAt = now;
     while (this.map.size > this.max) {
       const oldest = this.map.keys().next().value;
       this.map.delete(oldest);
     }
   }
 
-  isEcho(body) {
-    const key = EchoTracker.normalize(body);
+  isEcho(recipientJid, body) {
+    const key = EchoTracker.key(recipientJid, body);
     if (!key) return false;
+    this.pruneExpired(this.now());
     return this.map.has(key);
   }
 
   size() {
+    this.pruneExpired(this.now());
     return this.map.size;
   }
 
   elapsedSinceLastSent() {
-    return this.lastSentAt ? Date.now() - this.lastSentAt : -1;
+    return this.lastSentAt ? this.now() - this.lastSentAt : -1;
   }
 
   reset() {

--- a/packages/whatsapp-gateway/test/echo-tracker.test.js
+++ b/packages/whatsapp-gateway/test/echo-tracker.test.js
@@ -31,72 +31,93 @@ describe('EchoTracker.normalize', () => {
 describe('EchoTracker.track / isEcho', () => {
   it('track("Hello!") then isEcho("hello") is true (normalization)', () => {
     const t = new EchoTracker();
-    t.track('Hello!');
-    assert.equal(t.isEcho('hello'), true);
-    assert.equal(t.isEcho('HELLO'), true);
+    t.track('alice@s.whatsapp.net', 'Hello!');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'hello'), true);
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'HELLO'), true);
   });
 
   it('whitespace and case collapse through wiring', () => {
     const t = new EchoTracker();
-    t.track('  foo   bar  ');
-    assert.equal(t.isEcho('FOO BAR'), true);
+    t.track('alice@s.whatsapp.net', '  foo   bar  ');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'FOO BAR'), true);
   });
 
   it('emoji strip matches echo without emoji', () => {
     const t = new EchoTracker();
-    t.track('ciao 👋');
-    assert.equal(t.isEcho('ciao'), true);
+    t.track('alice@s.whatsapp.net', 'ciao 👋');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'ciao'), true);
   });
 
   it('returns false for never-tracked text', () => {
     const t = new EchoTracker();
-    t.track('hello');
-    assert.equal(t.isEcho('never-sent'), false);
+    t.track('alice@s.whatsapp.net', 'hello');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'never-sent'), false);
+  });
+
+  it('does not match the same short body in another conversation', () => {
+    const t = new EchoTracker();
+    t.track('alice@s.whatsapp.net', 'ok');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'OK!'), true);
+    assert.equal(t.isEcho('bob@s.whatsapp.net', 'ok'), false);
   });
 
   it('track(null), track(""), track(undefined) are no-ops', () => {
     const t = new EchoTracker();
-    t.track(null);
-    t.track('');
-    t.track(undefined);
+    t.track('alice@s.whatsapp.net', null);
+    t.track('alice@s.whatsapp.net', '');
+    t.track('alice@s.whatsapp.net', undefined);
+    t.track('', 'hello');
     assert.equal(t.size(), 0);
-    assert.equal(t.isEcho(''), false);
+    assert.equal(t.isEcho('alice@s.whatsapp.net', ''), false);
   });
 });
 
 describe('EchoTracker LRU eviction', () => {
   it('evicts oldest when size exceeds max (100 default)', () => {
     const t = new EchoTracker(100);
-    for (let i = 0; i < 100; i++) t.track(`msg-${i}`);
+    for (let i = 0; i < 100; i++) t.track('alice@s.whatsapp.net', `msg-${i}`);
     assert.equal(t.size(), 100);
-    assert.equal(t.isEcho('msg-0'), true);
-    t.track('msg-100');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'msg-0'), true);
+    t.track('alice@s.whatsapp.net', 'msg-100');
     assert.equal(t.size(), 100);
-    assert.equal(t.isEcho('msg-0'), false, 'oldest should be evicted');
-    assert.equal(t.isEcho('msg-100'), true, 'newest should be present');
-    assert.equal(t.isEcho('msg-1'), true, 'second-oldest should still be present');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'msg-0'), false, 'oldest should be evicted');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'msg-100'), true, 'newest should be present');
+    assert.equal(t.isEcho('alice@s.whatsapp.net', 'msg-1'), true, 'second-oldest should still be present');
   });
 
   it('re-tracking refreshes insertion order (prevents premature eviction)', () => {
     const t = new EchoTracker(3);
-    t.track('a');
-    t.track('b');
-    t.track('c');
-    t.track('a'); // refresh a
-    t.track('d'); // should evict b, not a
-    assert.equal(t.isEcho('a'), true);
-    assert.equal(t.isEcho('b'), false);
-    assert.equal(t.isEcho('c'), true);
-    assert.equal(t.isEcho('d'), true);
+    t.track('chat', 'a');
+    t.track('chat', 'b');
+    t.track('chat', 'c');
+    t.track('chat', 'a'); // refresh a
+    t.track('chat', 'd'); // should evict b, not a
+    assert.equal(t.isEcho('chat', 'a'), true);
+    assert.equal(t.isEcho('chat', 'b'), false);
+    assert.equal(t.isEcho('chat', 'c'), true);
+    assert.equal(t.isEcho('chat', 'd'), true);
   });
 
   it('honors small maxSize', () => {
     const t = new EchoTracker(2);
-    t.track('x');
-    t.track('y');
-    t.track('z');
+    t.track('chat', 'x');
+    t.track('chat', 'y');
+    t.track('chat', 'z');
     assert.equal(t.size(), 2);
-    assert.equal(t.isEcho('x'), false);
+    assert.equal(t.isEcho('chat', 'x'), false);
+  });
+});
+
+describe('EchoTracker TTL', () => {
+  it('expires stale entries below the LRU capacity', () => {
+    let now = 1_000;
+    const t = new EchoTracker(100, 500, () => now);
+    t.track('chat', 'hello');
+    now += 499;
+    assert.equal(t.isEcho('chat', 'hello'), true);
+    now += 1;
+    assert.equal(t.isEcho('chat', 'hello'), false);
+    assert.equal(t.size(), 0);
   });
 });
 
@@ -104,16 +125,16 @@ describe('EchoTracker observability', () => {
   it('size() reports current count', () => {
     const t = new EchoTracker();
     assert.equal(t.size(), 0);
-    t.track('one');
+    t.track('chat', 'one');
     assert.equal(t.size(), 1);
-    t.track('two');
+    t.track('chat', 'two');
     assert.equal(t.size(), 2);
   });
 
   it('elapsedSinceLastSent returns -1 before any track, positive after', async () => {
     const t = new EchoTracker();
     assert.equal(t.elapsedSinceLastSent(), -1);
-    t.track('hello');
+    t.track('chat', 'hello');
     await new Promise((r) => setTimeout(r, 5));
     const elapsed = t.elapsedSinceLastSent();
     assert.ok(elapsed >= 0, `expected >= 0, got ${elapsed}`);
@@ -122,12 +143,12 @@ describe('EchoTracker observability', () => {
 
   it('reset() clears map and lastSentAt', () => {
     const t = new EchoTracker();
-    t.track('a');
-    t.track('b');
+    t.track('chat', 'a');
+    t.track('chat', 'b');
     assert.equal(t.size(), 2);
     t.reset();
     assert.equal(t.size(), 0);
     assert.equal(t.elapsedSinceLastSent(), -1);
-    assert.equal(t.isEcho('a'), false);
+    assert.equal(t.isEcho('chat', 'a'), false);
   });
 });


### PR DESCRIPTION
## Changes
- key outbound echo fingerprints by destination JID and normalized body so identical short replies in unrelated conversations cannot suppress each other
- pass the destination JID through all seven outbound tracking sites and the inbound echo gate
- expire fingerprints after five minutes even below the LRU capacity
- document the tracker's single-process deployment assumption
- add cross-conversation, TTL, and complete wiring regressions

## Verification
- `node --test packages/whatsapp-gateway/test/echo-tracker.test.js` (17 passed)
- `NODE_PATH=/Volumes/Lexar/worktrees/audit-whatsapp-jid-validation/packages/whatsapp-gateway/node_modules node --test --test-name-pattern='echo tracker wiring' packages/whatsapp-gateway/index.test.js` (8 passed)
- `node --check packages/whatsapp-gateway/index.js`
- `node --check packages/whatsapp-gateway/lib/echo-tracker.js`
- `node --check packages/whatsapp-gateway/index.test.js`
- `git diff --check`

The complete `index.test.js` still has the pre-existing dispatch source-count failure and mock HTTP `ECONNRESET` described in #7181; all echo-tracker cases pass independently.

## Out of scope
- cross-process/shared echo state for horizontally scaled gateways
- changing the existing body normalization rules
- unrelated WhatsApp gateway test lifecycle failures