### PR TITLE
fix(sidecar): harden websocket framing

### DIFF
--- a/changelog.d/fixed/python-websocket-frame-hardening.md
+++ b/changelog.d/fixed/python-websocket-frame-hardening.md
@@ -1,0 +1,1 @@
+Harden Python sidecar WebSocket fragmentation, message limits, socket timeouts, and TLS cleanup. (@xiaomo)

--- a/sdk/python/librefang/sidecar/ws.py
+++ b/sdk/python/librefang/sidecar/ws.py
@@ -120,7 +120,11 @@ class WebSocketClient:
         )
         if is_tls:
             ctx = ssl.create_default_context()
-            sock = ctx.wrap_socket(sock, server_hostname=host)
+            try:
+                sock = ctx.wrap_socket(sock, server_hostname=host)
+            except BaseException:
+                sock.close()
+                raise
         key = base64.b64encode(os.urandom(16)).decode("ascii")
         lines = [
             f"GET {path} HTTP/1.1",
@@ -164,6 +168,9 @@ class WebSocketClient:
         if got != expected:
             sock.close()
             raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
+        # ``create_connection`` leaves its handshake timeout installed.
+        # Steady-state reads are gated by ``wait_readable`` instead.
+        sock.settimeout(None)
         self._sock = sock
         self._leftover = leftover
         return self
@@ -226,15 +233,19 @@ class WebSocketClient:
                 buf.extend(self._leftover[:take])
                 self._leftover = self._leftover[take:]
                 continue
-            assert self._sock is not None
-            chunk = self._sock.recv(n - len(buf))
+            sock = self._sock
+            if sock is None:
+                raise RuntimeError("websocket not connected")
+            chunk = sock.recv(n - len(buf))
             if not chunk:
                 raise EOFError("websocket closed mid-frame")
             buf.extend(chunk)
         return bytes(buf)
 
     def _send_frame(self, opcode: int, payload: bytes) -> None:
-        assert self._sock is not None
+        sock = self._sock
+        if sock is None:
+            raise RuntimeError("websocket not connected")
         header = bytearray([0x80 | (opcode & 0x0F)])
         ln = len(payload)
         if ln < 126:
@@ -249,7 +260,7 @@ class WebSocketClient:
         header.extend(mask)
         masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
         with self._send_lock:
-            self._sock.sendall(bytes(header) + masked)
+            sock.sendall(bytes(header) + masked)
 
     def send_text(self, s: str) -> None:
         self._send_frame(OP_TEXT, s.encode("utf-8"))
@@ -260,13 +271,8 @@ class WebSocketClient:
         except OSError:
             pass
 
-    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
-        """Read one frame and return either ``(text, None)`` for a
-        completed text message, or ``(None, (close_code, reason))``
-        for a close frame the server sent. Pings are answered inline
-        and skipped. Returns ``(None, None)`` for non-text frames we
-        ignore (binary, pong).
-        """
+    def _recv_raw_frame(self) -> tuple[bool, int, bytes]:
+        """Read one complete wire frame with the per-frame size cap."""
         h2 = self._recv_exact(2)
         fin = (h2[0] & 0x80) != 0
         opcode = h2[0] & 0x0F
@@ -287,44 +293,64 @@ class WebSocketClient:
             payload = bytes(
                 b ^ mask_key[i % 4] for i, b in enumerate(payload)
             )
+        return fin, opcode, payload
+
+    @staticmethod
+    def _decode_close(payload: bytes) -> tuple[int, bytes]:
+        if len(payload) < 2:
+            return 1005, b""
+        return struct.unpack(">H", payload[:2])[0], payload[2:]
+
+    def _continue_message(
+        self, buf: bytearray,
+    ) -> Optional[tuple[int, bytes]]:
+        """Append continuations while servicing interleaved controls.
+
+        Returns a decoded close frame when the peer closes mid-message.
+        """
+        while True:
+            fin, opcode, payload = self._recv_raw_frame()
+            if opcode == OP_PING:
+                self._send_frame(OP_PONG, payload)
+                continue
+            if opcode == OP_PONG:
+                continue
+            if opcode == OP_CLOSE:
+                return self._decode_close(payload)
+            if opcode != OP_CONT:
+                raise RuntimeError(
+                    f"ws unexpected interleaved opcode {opcode}"
+                )
+            if len(buf) + len(payload) > MAX_FRAME_PAYLOAD:
+                raise RuntimeError(
+                    "websocket reassembled message exceeds cap "
+                    f"{MAX_FRAME_PAYLOAD}; failing the stream"
+                )
+            buf.extend(payload)
+            if fin:
+                return None
+
+    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
+        """Read one frame and return either ``(text, None)`` for a
+        completed text message, or ``(None, (close_code, reason))``
+        for a close frame the server sent. Pings are answered inline
+        and skipped. Returns ``(None, None)`` for non-text frames we
+        ignore (binary, pong).
+        """
+        fin, opcode, payload = self._recv_raw_frame()
         if opcode == OP_PING:
             self._send_frame(OP_PONG, payload)
             return None, None
         if opcode == OP_PONG:
             return None, None
         if opcode == OP_CLOSE:
-            code = 1005  # "no status received" if payload < 2 bytes
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, (code, reason)
+            return None, self._decode_close(payload)
         if opcode == OP_TEXT:
             buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(
-                        b ^ mk[i % 4] for i, b in enumerate(payload2)
-                    )
-                if opcode2 != OP_CONT:
-                    # Unexpected interleaved frame — bail.
-                    raise RuntimeError(
-                        f"ws unexpected interleaved opcode {opcode2}"
-                    )
-                buf.extend(payload2)
+            if not fin:
+                close = self._continue_message(buf)
+                if close is not None:
+                    return None, close
             return buf.decode("utf-8", "replace"), None
         # Binary / unknown — ignore.
         return None, None
@@ -340,63 +366,20 @@ class WebSocketClient:
         (Feishu gateway, etc.) use this; everyone else uses
         ``recv_frame`` which keeps the simpler 2-tuple shape.
         """
-        h2 = self._recv_exact(2)
-        fin = (h2[0] & 0x80) != 0
-        opcode = h2[0] & 0x0F
-        masked = (h2[1] & 0x80) != 0
-        ln = h2[1] & 0x7F
-        if ln == 126:
-            ln = struct.unpack(">H", self._recv_exact(2))[0]
-        elif ln == 127:
-            ln = struct.unpack(">Q", self._recv_exact(8))[0]
-        if ln > MAX_FRAME_PAYLOAD:
-            raise RuntimeError(
-                f"websocket frame payload {ln} exceeds cap "
-                f"{MAX_FRAME_PAYLOAD}; failing the stream"
-            )
-        mask_key = self._recv_exact(4) if masked else None
-        payload = self._recv_exact(ln)
-        if mask_key is not None:
-            payload = bytes(
-                b ^ mask_key[i % 4] for i, b in enumerate(payload)
-            )
+        fin, opcode, payload = self._recv_raw_frame()
         if opcode == OP_PING:
             self._send_frame(OP_PONG, payload)
             return None, None, None
         if opcode == OP_PONG:
             return None, None, None
         if opcode == OP_CLOSE:
-            code = 1005
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, None, (code, reason)
+            return None, None, self._decode_close(payload)
         if opcode in (OP_TEXT, OP_BIN):
             buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(
-                        b ^ mk[i % 4] for i, b in enumerate(payload2)
-                    )
-                if opcode2 != OP_CONT:
-                    raise RuntimeError(
-                        f"ws unexpected interleaved opcode {opcode2}"
-                    )
-                buf.extend(payload2)
+            if not fin:
+                close = self._continue_message(buf)
+                if close is not None:
+                    return None, None, close
             if opcode == OP_TEXT:
                 return buf.decode("utf-8", "replace"), None, None
             return None, bytes(buf), None

--- a/sdk/python/librefang/sidecar/ws.py
+++ b/sdk/python/librefang/sidecar/ws.py
@@ -352,6 +352,15 @@ class WebSocketClient:
                 if close is not None:
                     return None, close
             return buf.decode("utf-8", "replace"), None
+        if opcode == OP_BIN:
+            # This API intentionally ignores binary messages, but it still
+            # has to consume every continuation so the next call starts on a
+            # new message boundary and the aggregate size cap is enforced.
+            buf = bytearray(payload)
+            if not fin:
+                close = self._continue_message(buf)
+                if close is not None:
+                    return None, close
         # Binary / unknown — ignore.
         return None, None
 

--- a/sdk/python/tests/test_ws.py
+++ b/sdk/python/tests/test_ws.py
@@ -21,12 +21,18 @@ sufficient.
 """
 from __future__ import annotations
 
+import base64
+import hashlib
+import struct
+
 import pytest
 
+from librefang.sidecar import ws as ws_mod
 from librefang.sidecar.ws import (
     DEFAULT_HANDSHAKE_TIMEOUT_SECS,
     MAX_FRAME_PAYLOAD,
     OP_CLOSE,
+    OP_BIN,
     OP_CONT,
     OP_PING,
     OP_PONG,
@@ -132,3 +138,156 @@ def test_init_custom_handshake_timeout():
         "wss://example.com/", handshake_timeout=5.0,
     )
     assert ws._handshake_timeout == 5.0
+
+
+# ---- wire-frame parsing ---------------------------------------------
+
+
+def _server_frame(opcode, payload=b"", *, fin=True):
+    first = (0x80 if fin else 0) | opcode
+    length = len(payload)
+    if length < 126:
+        return bytes([first, length]) + payload
+    if length < 65536:
+        return bytes([first, 126]) + struct.pack(">H", length) + payload
+    return bytes([first, 127]) + struct.pack(">Q", length) + payload
+
+
+class _FakeSocket:
+    def __init__(self, incoming=b""):
+        self.incoming = bytearray(incoming)
+        self.sent = []
+        self.timeouts = []
+        self.closed = False
+
+    def recv(self, count):
+        chunk = bytes(self.incoming[:count])
+        del self.incoming[:count]
+        return chunk
+
+    def sendall(self, payload):
+        self.sent.append(payload)
+
+    def settimeout(self, timeout):
+        self.timeouts.append(timeout)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.parametrize("any_frame", [False, True])
+def test_ping_between_fragments_is_ponged_and_reassembly_continues(any_frame):
+    incoming = b"".join([
+        _server_frame(OP_TEXT, b"hel", fin=False),
+        _server_frame(OP_PING, b"beat"),
+        _server_frame(OP_PONG, b"ignored"),
+        _server_frame(OP_CONT, b"lo"),
+    ])
+    sock = _FakeSocket(incoming)
+    ws = WebSocketClient("ws://example.test")
+    ws._sock = sock
+
+    if any_frame:
+        assert ws.recv_any_frame() == ("hello", None, None)
+    else:
+        assert ws.recv_frame() == ("hello", None)
+
+    assert len(sock.sent) == 1
+    assert sock.sent[0][0] & 0x0F == OP_PONG
+
+
+def test_recv_any_frame_reassembles_fragmented_binary_with_ping():
+    incoming = b"".join([
+        _server_frame(OP_BIN, b"\x01", fin=False),
+        _server_frame(OP_PING, b"beat"),
+        _server_frame(OP_CONT, b"\x02"),
+    ])
+    sock = _FakeSocket(incoming)
+    ws = WebSocketClient("ws://example.test")
+    ws._sock = sock
+
+    assert ws.recv_any_frame() == (None, b"\x01\x02", None)
+    assert sock.sent[0][0] & 0x0F == OP_PONG
+
+
+@pytest.mark.parametrize("any_frame", [False, True])
+def test_close_between_fragments_surfaces_close(any_frame):
+    incoming = b"".join([
+        _server_frame(OP_TEXT, b"partial", fin=False),
+        _server_frame(OP_CLOSE, struct.pack(">H", 1001) + b"bye"),
+    ])
+    ws = WebSocketClient("ws://example.test")
+    ws._sock = _FakeSocket(incoming)
+
+    if any_frame:
+        assert ws.recv_any_frame() == (None, None, (1001, b"bye"))
+    else:
+        assert ws.recv_frame() == (None, (1001, b"bye"))
+
+
+@pytest.mark.parametrize("any_frame", [False, True])
+def test_reassembled_message_is_capped(monkeypatch, any_frame):
+    monkeypatch.setattr(ws_mod, "MAX_FRAME_PAYLOAD", 5)
+    incoming = b"".join([
+        _server_frame(OP_TEXT, b"abc", fin=False),
+        _server_frame(OP_CONT, b"def"),
+    ])
+    ws = WebSocketClient("ws://example.test")
+    ws._sock = _FakeSocket(incoming)
+
+    recv = ws.recv_any_frame if any_frame else ws.recv_frame
+    with pytest.raises(RuntimeError, match="reassembled message exceeds cap"):
+        recv()
+
+
+def test_disconnected_send_and_receive_raise_runtime_error():
+    ws = WebSocketClient("ws://example.test")
+    with pytest.raises(RuntimeError, match="not connected"):
+        ws.send_text("hello")
+    with pytest.raises(RuntimeError, match="not connected"):
+        ws._recv_exact(1)
+
+
+# ---- handshake resource lifecycle ----------------------------------
+
+
+def test_successful_handshake_restores_blocking_socket(monkeypatch):
+    key_bytes = b"0123456789abcdef"
+    key = base64.b64encode(key_bytes).decode("ascii")
+    accept = base64.b64encode(
+        hashlib.sha1((key + WS_GUID).encode("ascii")).digest()
+    )
+    response = (
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        b"Sec-WebSocket-Accept: " + accept + b"\r\n\r\n"
+    )
+    sock = _FakeSocket(response)
+    monkeypatch.setattr(ws_mod.os, "urandom", lambda _count: key_bytes)
+    monkeypatch.setattr(
+        ws_mod.socket, "create_connection", lambda *_args, **_kwargs: sock,
+    )
+
+    with WebSocketClient("ws://example.test") as ws:
+        assert ws._sock is sock
+        assert sock.timeouts == [None]
+
+
+def test_tls_wrap_failure_closes_raw_socket(monkeypatch):
+    raw_sock = _FakeSocket()
+
+    class _BrokenContext:
+        def wrap_socket(self, _sock, *, server_hostname):
+            assert server_hostname == "example.test"
+            raise OSError("TLS setup failed")
+
+    monkeypatch.setattr(
+        ws_mod.socket, "create_connection",
+        lambda *_args, **_kwargs: raw_sock,
+    )
+    monkeypatch.setattr(
+        ws_mod.ssl, "create_default_context", lambda: _BrokenContext(),
+    )
+
+    with pytest.raises(OSError, match="TLS setup failed"):
+        WebSocketClient("wss://example.test").__enter__()
+    assert raw_sock.closed is True

--- a/sdk/python/tests/test_ws.py
+++ b/sdk/python/tests/test_ws.py
@@ -210,6 +210,35 @@ def test_recv_any_frame_reassembles_fragmented_binary_with_ping():
     assert sock.sent[0][0] & 0x0F == OP_PONG
 
 
+def test_recv_frame_drains_ignored_fragmented_binary_before_next_message():
+    incoming = b"".join([
+        _server_frame(OP_BIN, b"\x01", fin=False),
+        _server_frame(OP_PING, b"beat"),
+        _server_frame(OP_CONT, b"\x02"),
+        _server_frame(OP_TEXT, b"next"),
+    ])
+    sock = _FakeSocket(incoming)
+    ws = WebSocketClient("ws://example.test")
+    ws._sock = sock
+
+    assert ws.recv_frame() == (None, None)
+    assert ws.recv_frame() == ("next", None)
+    assert sock.sent[0][0] & 0x0F == OP_PONG
+
+
+def test_recv_frame_caps_ignored_fragmented_binary(monkeypatch):
+    monkeypatch.setattr(ws_mod, "MAX_FRAME_PAYLOAD", 5)
+    incoming = b"".join([
+        _server_frame(OP_BIN, b"abc", fin=False),
+        _server_frame(OP_CONT, b"def"),
+    ])
+    ws = WebSocketClient("ws://example.test")
+    ws._sock = _FakeSocket(incoming)
+
+    with pytest.raises(RuntimeError, match="reassembled message exceeds cap"):
+        ws.recv_frame()
+
+
 @pytest.mark.parametrize("any_frame", [False, True])
 def test_close_between_fragments_surfaces_close(any_frame):
     incoming = b"".join([


### PR DESCRIPTION
## Changes

- centralize inbound WebSocket frame decoding behind the existing 4 MiB per-frame cap
- service interleaved ping/pong/close control frames while reassembling fragmented text or binary messages
- drain ignored fragmented binary messages in the text-only API so the next read starts on a message boundary
- cap complete reassembled messages, including ignored binary messages, at 4 MiB
- restore blocking socket mode after the bounded handshake so steady-state reads remain governed by `wait_readable`
- replace optimization-sensitive socket assertions with explicit runtime errors
- close the raw socket when TLS wrapping fails

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_ws.py` (25 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2,008 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/python -O -c ...` (disconnected send/receive guards verified with assertions disabled before follow-up)
- `python3 -m py_compile sdk/python/librefang/sidecar/ws.py sdk/python/tests/test_ws.py`
- `git diff --check`

## Out of scope

- changing the 4 MiB protocol limit
- adding application-level keepalive policy to individual adapters
- stricter rejection of other non-compliant RFC 6455 frame shapes