### PR TITLE
fix(google-chat): preserve static token lifetime

### DIFF
--- a/changelog.d/fixed/google-chat-static-token-lifetime.md
+++ b/changelog.d/fixed/google-chat-static-token-lifetime.md
@@ -1,0 +1,1 @@
+Keep operator-supplied Google Chat access tokens valid until configuration rotation. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/google_chat.py
+++ b/sdk/python/librefang/sidecar/adapters/google_chat.py
@@ -493,12 +493,6 @@ class GoogleChatAdapter(SidecarAdapter):
             )
 
         self._token_cache = _TokenCache()
-        # Seed the cache with the pre-supplied access_token if that's
-        # the only auth source — keeps the JWT-less path simple.
-        if self._sa.access_token and self._rsa_key is None:
-            self._token_cache.set(
-                self._sa.access_token, DEFAULT_TOKEN_LIFETIME_SECS
-            )
 
         # Server handle for clean shutdown.
         self._httpd: Optional[socketserver.ThreadingTCPServer] = None
@@ -515,17 +509,16 @@ class GoogleChatAdapter(SidecarAdapter):
     # ---- Token resolution ------------------------------------------
 
     def _get_access_token(self) -> str:
+        # Operator-supplied tokens have no expiry metadata or refresh
+        # credentials. Trust the configured value until the operator rotates
+        # it instead of inventing the JWT token lifetime for this path.
+        if self._rsa_key is None and self._sa.access_token:
+            return self._sa.access_token
         cached = self._token_cache.get()
         if cached:
             return cached
         if self._rsa_key is None:
-            # No JWT auth configured AND the pre-supplied token expired
-            # (only happens after DEFAULT_TOKEN_LIFETIME_SECS). The
-            # pre-supplied path doesn't refresh — surface clearly.
-            raise RuntimeError(
-                "pre-supplied access_token expired and no JWT auth "
-                "configured to refresh it"
-            )
+            raise RuntimeError("Google Chat has no usable authentication")
         n, d = self._rsa_key
         now = int(time.time())
         claims = {
@@ -589,8 +582,8 @@ class GoogleChatAdapter(SidecarAdapter):
                 self._send_chunk(url, token, chunk, retry_429=False)
                 return
             text_body = (e.read() or b"").decode("utf-8", errors="replace")
-            # 401 likely means the cached token went stale early —
-            # clear and let the next send retry from JWT auth.
+            # A JWT token may have gone stale early. Static tokens bypass the
+            # cache and remain operator-managed, so this is harmless there.
             if e.code == 401:
                 self._token_cache.clear()
             raise RuntimeError(

--- a/sdk/python/tests/test_google_chat_adapter.py
+++ b/sdk/python/tests/test_google_chat_adapter.py
@@ -118,8 +118,16 @@ def test_missing_auth_paths_raises():
 def test_pre_supplied_token_path_constructs():
     _set_env(sa_blob=_service_account_blob(with_jwt=False, with_token=True))
     a = gc.GoogleChatAdapter()
-    # Pre-supplied path seeds the cache so _get_access_token doesn't
-    # need to sign anything.
+    # Pre-supplied tokens bypass the expiring JWT cache.
+    assert a._get_access_token() == "pre-supplied-token"
+    assert a._token_cache.get() is None
+
+
+def test_pre_supplied_token_does_not_expire_with_jwt_lifetime(monkeypatch):
+    _set_env(sa_blob=_service_account_blob(with_jwt=False, with_token=True))
+    a = gc.GoogleChatAdapter()
+    monkeypatch.setattr(gc.time, "time", lambda: 10**12)
+    a._token_cache.clear()
     assert a._get_access_token() == "pre-supplied-token"
 
 
@@ -377,12 +385,13 @@ def test_send_text_chunks_oversize_payload(monkeypatch):
     assert sum(len(p["text"]) for p in payloads) == len(text)
 
 
-def test_send_text_401_clears_token_cache(monkeypatch):
+def test_send_text_401_clears_jwt_cache_but_keeps_static_token(monkeypatch):
     _set_env(
         sa_blob=_service_account_blob(with_jwt=False, with_token=True),
     )
     a = gc.GoogleChatAdapter()
-    assert a._token_cache.get() == "pre-supplied-token"
+    a._token_cache.set("stale-jwt-token", 3600)
+    assert a._token_cache.get() == "stale-jwt-token"
 
     def fake_urlopen(req, timeout=None):
         import urllib.error
@@ -395,8 +404,9 @@ def test_send_text_401_clears_token_cache(monkeypatch):
     monkeypatch.setattr(gc.urllib.request, "urlopen", fake_urlopen)
     with pytest.raises(RuntimeError, match="Google Chat API error 401"):
         a._send_text("spaces/AAAA", "hi")
-    # 401 should have cleared the cache so the next send re-runs auth.
+    # Static tokens bypass the JWT cache and remain operator-managed.
     assert a._token_cache.get() is None
+    assert a._get_access_token() == "pre-supplied-token"
 
 
 # ---- JWT signing end-to-end against the test PEM ----------------------


### PR DESCRIPTION
## Changes
- bypass the expiring JWT cache for operator-supplied Google Chat access tokens
- keep static tokens usable until configuration rotation instead of inventing a one-hour lifetime
- retain 401-driven JWT cache invalidation without invalidating the independently configured static token
- add a regression that advances the clock far beyond the prior expiry window

## Verification
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_google_chat_adapter.py` (45 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1,997 passed)
- `python3 -m py_compile sdk/python/librefang/sidecar/adapters/google_chat.py sdk/python/tests/test_google_chat_adapter.py`
- `git diff --check`

## Out of scope
- Google Chat webhook listener authentication and bind defaults
- JWT refresh single-flight coordination
- malformed PKCS#8 error classification