### PR TITLE
fix(google-chat): authenticate exposed webhooks

### DIFF
--- a/changelog.d/fixed/google-chat-webhook-auth.md
+++ b/changelog.d/fixed/google-chat-webhook-auth.md
@@ -1,0 +1,1 @@
+Secure Google Chat webhooks with loopback-only defaults and required verification tokens on exposed listeners. (@xiaomo)

--- a/changelog.d/fixed/google-chat-webhook-auth.md
+++ b/changelog.d/fixed/google-chat-webhook-auth.md
@@ -1,1 +1,1 @@
-Secure Google Chat webhooks with loopback-only defaults and required verification tokens on exposed listeners. (@xiaomo)
+Secure Google Chat webhooks with loopback-only defaults and required verification tokens on every listener. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/google_chat.py
+++ b/sdk/python/librefang/sidecar/adapters/google_chat.py
@@ -59,7 +59,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
-import ipaddress
 import json
 import os
 import socketserver
@@ -106,16 +105,10 @@ WEBHOOK_MAX_BODY_BYTES = 1 * 1024 * 1024
 
 HTTP_TIMEOUT_SECS = 30
 
-# Default to a local reverse-proxy boundary. A non-loopback listener is
-# permitted only when every event carries a configured verification token.
+# Default to a local reverse-proxy boundary as defense in depth. Requests are
+# authenticated independently because a public reverse proxy still reaches
+# this listener through a loopback connection.
 DEFAULT_BIND_HOST = "127.0.0.1"
-
-
-def _is_loopback_host(host: str) -> bool:
-    try:
-        return ipaddress.ip_address(host.strip()).is_loopback
-    except ValueError:
-        return False
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +430,7 @@ SCHEMA = Schema(
             "GOOGLE_CHAT_VERIFICATION_TOKEN",
             "Inbound event verification token",
             "secret",
+            required=True,
             advanced=True,
         ),
         Field(
@@ -489,13 +483,10 @@ class GoogleChatAdapter(SidecarAdapter):
         self._verification_token = os.environ.get(
             "GOOGLE_CHAT_VERIFICATION_TOKEN", "",
         ).strip()
-        if (
-            not _is_loopback_host(self._bind_host)
-            and not self._verification_token
-        ):
+        if not self._verification_token:
             raise RuntimeError(
-                "GOOGLE_CHAT_VERIFICATION_TOKEN is required when "
-                "GOOGLE_CHAT_BIND_HOST is not loopback"
+                "GOOGLE_CHAT_VERIFICATION_TOKEN is required for inbound "
+                "webhook authentication"
             )
         self.account_id = os.environ.get("GOOGLE_CHAT_ACCOUNT_ID") or None
 

--- a/sdk/python/librefang/sidecar/adapters/google_chat.py
+++ b/sdk/python/librefang/sidecar/adapters/google_chat.py
@@ -58,6 +58,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import hmac
+import ipaddress
 import json
 import os
 import socketserver
@@ -104,10 +106,16 @@ WEBHOOK_MAX_BODY_BYTES = 1 * 1024 * 1024
 
 HTTP_TIMEOUT_SECS = 30
 
-# Default webhook bind address. `0.0.0.0` matches the established
-# sidecar convention (teams / webhook); operators behind a reverse
-# proxy override via `GOOGLE_CHAT_BIND_HOST = "127.0.0.1"`.
-DEFAULT_BIND_HOST = "0.0.0.0"
+# Default to a local reverse-proxy boundary. A non-loopback listener is
+# permitted only when every event carries a configured verification token.
+DEFAULT_BIND_HOST = "127.0.0.1"
+
+
+def _is_loopback_host(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(host.strip()).is_loopback
+    except ValueError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -420,10 +428,16 @@ SCHEMA = Schema(
         ),
         Field(
             "GOOGLE_CHAT_BIND_HOST",
-            "Bind address (default 0.0.0.0; set 127.0.0.1 behind a reverse proxy)",
+            "Bind address (default 127.0.0.1 behind a reverse proxy)",
             "text",
             advanced=True,
             placeholder=DEFAULT_BIND_HOST,
+        ),
+        Field(
+            "GOOGLE_CHAT_VERIFICATION_TOKEN",
+            "Inbound event verification token",
+            "secret",
+            advanced=True,
         ),
         Field(
             "GOOGLE_CHAT_ACCOUNT_ID",
@@ -472,6 +486,17 @@ class GoogleChatAdapter(SidecarAdapter):
         self._bind_host = (
             os.environ.get("GOOGLE_CHAT_BIND_HOST", "").strip() or DEFAULT_BIND_HOST
         )
+        self._verification_token = os.environ.get(
+            "GOOGLE_CHAT_VERIFICATION_TOKEN", "",
+        ).strip()
+        if (
+            not _is_loopback_host(self._bind_host)
+            and not self._verification_token
+        ):
+            raise RuntimeError(
+                "GOOGLE_CHAT_VERIFICATION_TOKEN is required when "
+                "GOOGLE_CHAT_BIND_HOST is not loopback"
+            )
         self.account_id = os.environ.get("GOOGLE_CHAT_ACCOUNT_ID") or None
 
         # Pre-parse the RSA key once so a bad PEM fails at startup
@@ -785,6 +810,20 @@ def _make_webhook_handler(
                 self.send_response(400)
                 self.end_headers()
                 return
+            expected_token = adapter._verification_token
+            if expected_token:
+                supplied_token = payload.get("token")
+                if (
+                    not isinstance(supplied_token, str)
+                    or not hmac.compare_digest(
+                        supplied_token.encode("utf-8"),
+                        expected_token.encode("utf-8"),
+                    )
+                ):
+                    log.warn("google_chat rejected unauthenticated webhook")
+                    self.send_response(401)
+                    self.end_headers()
+                    return
 
             event = _parse_webhook_event(payload, adapter._space_ids)
             if event is not None:

--- a/sdk/python/tests/test_google_chat_adapter.py
+++ b/sdk/python/tests/test_google_chat_adapter.py
@@ -72,7 +72,8 @@ def _service_account_blob(*, with_jwt: bool = True, with_token: bool = False):
 
 
 def _set_env(*, sa_blob: str, spaces: str = "", port: str = "8090",
-             account_id: str = "", api_base: str = "", bind_host: str = ""):
+             account_id: str = "", api_base: str = "", bind_host: str = "",
+             verification_token: str = ""):
     os.environ["GOOGLE_CHAT_SERVICE_ACCOUNT_JSON"] = sa_blob
     os.environ["GOOGLE_CHAT_SPACE_IDS"] = spaces
     os.environ["GOOGLE_CHAT_WEBHOOK_PORT"] = port
@@ -85,6 +86,10 @@ def _set_env(*, sa_blob: str, spaces: str = "", port: str = "8090",
         os.environ["GOOGLE_CHAT_BIND_HOST"] = bind_host
     else:
         os.environ.pop("GOOGLE_CHAT_BIND_HOST", None)
+    if verification_token:
+        os.environ["GOOGLE_CHAT_VERIFICATION_TOKEN"] = verification_token
+    else:
+        os.environ.pop("GOOGLE_CHAT_VERIFICATION_TOKEN", None)
 
 
 # Module import — must be after env preset for SCHEMA-only use, but
@@ -561,10 +566,10 @@ async def test_on_send_empty_text_drops(monkeypatch):
 # ---- bind host knob ---------------------------------------------------
 
 
-def test_default_bind_host_is_0_0_0_0():
+def test_default_bind_host_is_loopback():
     _set_env(sa_blob=_service_account_blob(with_jwt=False, with_token=True))
     a = gc.GoogleChatAdapter()
-    assert a._bind_host == gc.DEFAULT_BIND_HOST == "0.0.0.0"
+    assert a._bind_host == gc.DEFAULT_BIND_HOST == "127.0.0.1"
 
 
 def test_bind_host_env_overrides_default():
@@ -593,6 +598,29 @@ def test_bind_host_empty_string_falls_back_to_default():
     assert a._bind_host == gc.DEFAULT_BIND_HOST
 
 
+@pytest.mark.parametrize(
+    "host", ["0.0.0.0", "::", "192.0.2.10", "localhost"],
+)
+def test_non_loopback_bind_requires_verification_token(host):
+    _set_env(
+        sa_blob=_service_account_blob(with_jwt=False, with_token=True),
+        bind_host=host,
+    )
+    with pytest.raises(RuntimeError, match="VERIFICATION_TOKEN.*required"):
+        gc.GoogleChatAdapter()
+
+
+def test_non_loopback_bind_accepts_verification_token():
+    _set_env(
+        sa_blob=_service_account_blob(with_jwt=False, with_token=True),
+        bind_host="0.0.0.0",
+        verification_token="shared-secret",
+    )
+    a = gc.GoogleChatAdapter()
+    assert a._bind_host == "0.0.0.0"
+    assert a._verification_token == "shared-secret"
+
+
 def test_bind_host_field_in_schema_marked_advanced():
     schema = gc.GoogleChatAdapter.SCHEMA.to_dict()
     bh = next(
@@ -600,6 +628,16 @@ def test_bind_host_field_in_schema_marked_advanced():
     )
     assert bh["advanced"] is True
     assert bh["required"] is False
+
+
+def test_verification_token_field_is_secret_and_advanced():
+    schema = gc.GoogleChatAdapter.SCHEMA.to_dict()
+    field = next(
+        f for f in schema["fields"]
+        if f["key"] == "GOOGLE_CHAT_VERIFICATION_TOKEN"
+    )
+    assert field["type"] == "secret"
+    assert field["advanced"] is True
 
 
 # ---- shutdown lifecycle ------------------------------------------------
@@ -844,6 +882,39 @@ def test_webhook_handler_dedupes_redelivered_event():
         "spaces/AAAA/messages/M1",
         "spaces/AAAA/messages/M2",
     ]
+
+
+@pytest.mark.parametrize("supplied", [None, "", "wrong-secret"])
+def test_webhook_handler_rejects_invalid_verification_token(supplied):
+    _set_env(
+        sa_blob=_service_account_blob(with_jwt=False, with_token=True),
+        verification_token="shared-secret",
+    )
+    a = gc.GoogleChatAdapter()
+    emitted: list[dict] = []
+    payload = _msg_event(text="forged")
+    if supplied is not None:
+        payload["token"] = supplied
+
+    status, _ = _post_to_webhook(a, payload, emit_target=emitted)
+    assert status == 401
+    assert emitted == []
+    assert len(a._seen.ids) == 0
+
+
+def test_webhook_handler_accepts_matching_verification_token():
+    _set_env(
+        sa_blob=_service_account_blob(with_jwt=False, with_token=True),
+        verification_token="shared-secret",
+    )
+    a = gc.GoogleChatAdapter()
+    emitted: list[dict] = []
+    payload = _msg_event(text="authentic")
+    payload["token"] = "shared-secret"
+
+    status, _ = _post_to_webhook(a, payload, emit_target=emitted)
+    assert status == 200
+    assert len(emitted) == 1
 
 
 def test_webhook_handler_does_not_consume_dedupe_slot_for_filtered_events():

--- a/sdk/python/tests/test_google_chat_adapter.py
+++ b/sdk/python/tests/test_google_chat_adapter.py
@@ -73,7 +73,7 @@ def _service_account_blob(*, with_jwt: bool = True, with_token: bool = False):
 
 def _set_env(*, sa_blob: str, spaces: str = "", port: str = "8090",
              account_id: str = "", api_base: str = "", bind_host: str = "",
-             verification_token: str = ""):
+             verification_token: str | None = "test-verification-token"):
     os.environ["GOOGLE_CHAT_SERVICE_ACCOUNT_JSON"] = sa_blob
     os.environ["GOOGLE_CHAT_SPACE_IDS"] = spaces
     os.environ["GOOGLE_CHAT_WEBHOOK_PORT"] = port
@@ -86,7 +86,7 @@ def _set_env(*, sa_blob: str, spaces: str = "", port: str = "8090",
         os.environ["GOOGLE_CHAT_BIND_HOST"] = bind_host
     else:
         os.environ.pop("GOOGLE_CHAT_BIND_HOST", None)
-    if verification_token:
+    if verification_token is not None:
         os.environ["GOOGLE_CHAT_VERIFICATION_TOKEN"] = verification_token
     else:
         os.environ.pop("GOOGLE_CHAT_VERIFICATION_TOKEN", None)
@@ -598,13 +598,12 @@ def test_bind_host_empty_string_falls_back_to_default():
     assert a._bind_host == gc.DEFAULT_BIND_HOST
 
 
-@pytest.mark.parametrize(
-    "host", ["0.0.0.0", "::", "192.0.2.10", "localhost"],
-)
-def test_non_loopback_bind_requires_verification_token(host):
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "0.0.0.0", "::"])
+def test_every_listener_requires_verification_token(host):
     _set_env(
         sa_blob=_service_account_blob(with_jwt=False, with_token=True),
         bind_host=host,
+        verification_token=None,
     )
     with pytest.raises(RuntimeError, match="VERIFICATION_TOKEN.*required"):
         gc.GoogleChatAdapter()
@@ -638,6 +637,7 @@ def test_verification_token_field_is_secret_and_advanced():
     )
     assert field["type"] == "secret"
     assert field["advanced"] is True
+    assert field["required"] is True
 
 
 # ---- shutdown lifecycle ------------------------------------------------
@@ -860,6 +860,7 @@ def test_webhook_handler_dedupes_redelivered_event():
     emitted: list[dict] = []
 
     payload = _msg_event(text="hi")
+    payload["token"] = a._verification_token
     # First delivery: emit fires + 200 OK returned to Google.
     status, _ = _post_to_webhook(a, payload, emit_target=emitted)
     assert status == 200
@@ -875,6 +876,7 @@ def test_webhook_handler_dedupes_redelivered_event():
 
     # A distinct message in the same space still emits.
     payload2 = _msg_event(text="round 2")
+    payload2["token"] = a._verification_token
     payload2["message"]["name"] = "spaces/AAAA/messages/M2"
     status, _ = _post_to_webhook(a, payload2, emit_target=emitted)
     assert status == 200
@@ -932,6 +934,7 @@ def test_webhook_handler_does_not_consume_dedupe_slot_for_filtered_events():
 
     # Event for a disallowed space → filtered out by `_parse_webhook_event`.
     blocked = _msg_event(text="hi", space_name="spaces/BBBB")
+    blocked["token"] = a._verification_token
     status, _ = _post_to_webhook(a, blocked, emit_target=emitted)
     assert status == 200
     assert emitted == []
@@ -940,7 +943,8 @@ def test_webhook_handler_does_not_consume_dedupe_slot_for_filtered_events():
 
     # Non-MESSAGE event → also filtered, also no _seen consumption.
     non_msg = {"type": "ADDED_TO_SPACE",
-               "space": {"name": "spaces/AAAA", "type": "ROOM"}}
+               "space": {"name": "spaces/AAAA", "type": "ROOM"},
+               "token": a._verification_token}
     status, _ = _post_to_webhook(a, non_msg, emit_target=emitted)
     assert status == 200
     assert emitted == []


### PR DESCRIPTION
## Changes

- change the Google Chat webhook default bind from `0.0.0.0` to `127.0.0.1` as defense in depth
- require `GOOGLE_CHAT_VERIFICATION_TOKEN` for every listener, including loopback listeners reached through a public reverse proxy
- verify the root event payload `token` with constant-time comparison before parsing, dedupe, or emit
- expose the verification token as a required advanced secret schema field
- return 401 for missing or invalid tokens without consuming dedupe capacity

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_google_chat_adapter.py` (54 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2,006 passed)
- `python3 -m py_compile sdk/python/librefang/sidecar/adapters/google_chat.py sdk/python/tests/test_google_chat_adapter.py`
- `git diff --check`

## Migration

All Google Chat deployments must set `GOOGLE_CHAT_VERIFICATION_TOKEN` and configure Google Chat to include the same verification token in the event payload. The loopback default protects the raw listener but does not replace request authentication when a reverse proxy exposes it.

## Out of scope

- Google-issued OIDC token validation, which would require a separate key-fetch/cache contract
- proxy trust and TLS termination policy
- outbound OAuth token behavior