### PR TITLE
fix(nextcloud): retry room discovery

### DIFF
--- a/changelog.d/fixed/nextcloud-room-discovery-retry.md
+++ b/changelog.d/fixed/nextcloud-room-discovery-retry.md
@@ -1,0 +1,1 @@
+Recover Nextcloud Talk polling after transient or initially empty room discovery. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/nextcloud.py
+++ b/sdk/python/librefang/sidecar/adapters/nextcloud.py
@@ -128,6 +128,13 @@ CHAT_FETCH_LIMIT = 100
 SEEN_MESSAGES_MAX = 10000
 SEEN_MESSAGES_EVICT = 5000
 
+
+class _RoomDiscoveryError(RuntimeError):
+    def __init__(self, message: str, *, retry_after: float | None = None):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
 def _parse_rooms(raw: str) -> list[str]:
     """Comma-separated room-token list. Strips whitespace and empty
     entries; preserves order. Empty input → empty list (means 'discover
@@ -374,9 +381,9 @@ class NextcloudAdapter(SidecarAdapter):
     def _list_joined_rooms(self) -> list[str]:
         """Discover joined room tokens via
         ``GET /ocs/v2.php/apps/spreed/api/v4/room?format=json``.
-        Returns an empty list (and logs a warning) on failure — the
-        producer loop then has nothing to poll and bails. Mirrors the
-        Rust adapter's `fetch_rooms` (nextcloud.rs:105-127)."""
+        Returns an empty list only when discovery succeeds and the bot has
+        joined no rooms. Transient and protocol failures are distinct so the
+        producer can apply the appropriate retry delay."""
         url = (
             f"{self.server_url}"
             f"/ocs/v2.php/apps/spreed/api/v4/room?format=json"
@@ -386,31 +393,23 @@ class NextcloudAdapter(SidecarAdapter):
                 url, headers=self._auth_headers(),
             )
         except urllib.error.URLError as e:
-            log.warn(
-                "nextcloud room list transport error",
-                error=str(e),
-            )
-            return []
+            raise _RoomDiscoveryError(
+                f"nextcloud room list transport error: {e}"
+            ) from e
         if status == 429:
-            # Same OCS bruteforce throttling can surface here. Sleeping
-            # is enough — discovery is one-shot, so we just yield no
-            # rooms and let the next producer-loop iteration retry.
             wait = self._retry_after_secs(resp_hdrs)
-            log.warn(
-                "nextcloud 429 on room discovery; sleeping",
-                retry_after_secs=wait,
+            raise _RoomDiscoveryError(
+                "nextcloud 429 on room discovery", retry_after=wait,
             )
-            time.sleep(wait)
-            return []
         if status != 200 or not isinstance(body, dict):
-            log.warn(
-                "nextcloud room list failed",
-                status=status,
+            raise _RoomDiscoveryError(
+                f"nextcloud room list failed with status {status}"
             )
-            return []
         data = body.get("ocs", {}).get("data")
         if not isinstance(data, list):
-            return []
+            raise _RoomDiscoveryError(
+                "nextcloud room list response missing ocs.data array"
+            )
         out: list[str] = []
         for room in data:
             if isinstance(room, dict):
@@ -418,6 +417,30 @@ class NextcloudAdapter(SidecarAdapter):
                 if isinstance(tok, str) and tok:
                     out.append(tok)
         return out
+
+    def _discover_rooms_until_available(self) -> list[str]:
+        """Retry transient discovery failures and genuine empty results."""
+        backoff = 1.0
+        while True:
+            try:
+                rooms = self._list_joined_rooms()
+            except _RoomDiscoveryError as e:
+                delay = e.retry_after if e.retry_after is not None else backoff
+                log.warn(
+                    "nextcloud room discovery failed; will retry",
+                    error=str(e), delay=delay,
+                )
+                time.sleep(delay)
+                backoff = min(backoff * 2, MAX_BACKOFF_SECS)
+                continue
+            if rooms:
+                return rooms
+            backoff = 1.0
+            log.warn(
+                "nextcloud: no joined rooms; discovery will retry",
+                delay=MAX_BACKOFF_SECS,
+            )
+            time.sleep(MAX_BACKOFF_SECS)
 
     # ---- dedupe ------------------------------------------------------
 
@@ -666,18 +689,7 @@ class NextcloudAdapter(SidecarAdapter):
         if self.allowed_rooms:
             rooms = list(self.allowed_rooms)
         else:
-            rooms = self._list_joined_rooms()
-            if not rooms:
-                log.warn(
-                    "nextcloud: no rooms to poll "
-                    "(no NEXTCLOUD_ROOMS configured and the room "
-                    "list endpoint returned empty); adapter will idle"
-                )
-                # Idle indefinitely — there's nothing useful to poll.
-                # The reader/shutdown path still terminates cleanly
-                # via the outer asyncio runtime.
-                while True:
-                    time.sleep(MAX_BACKOFF_SECS)
+            rooms = self._discover_rooms_until_available()
 
         # Initialise watermarks to 0 so the first poll uses
         # `lastKnownMessageId=0` (matching the Rust adapter's

--- a/sdk/python/tests/test_nextcloud_adapter.py
+++ b/sdk/python/tests/test_nextcloud_adapter.py
@@ -249,21 +249,75 @@ def test_list_joined_rooms_parses_tokens(monkeypatch):
     assert fake.calls[0]["headers"]["ocs-apirequest"] == "true"
 
 
-def test_list_joined_rooms_returns_empty_on_error(monkeypatch):
+def test_list_joined_rooms_raises_on_server_error(monkeypatch):
     a = _adapter()
     fake = _FakeUrlopen([(500, {"error": "boom"})])
     monkeypatch.setattr(nc.urllib.request, "urlopen", fake)
-    assert a._list_joined_rooms() == []
+    with pytest.raises(nc._RoomDiscoveryError, match="status 500"):
+        a._list_joined_rooms()
 
 
-def test_list_joined_rooms_handles_transport_error(monkeypatch):
+def test_list_joined_rooms_raises_on_transport_error(monkeypatch):
     a = _adapter()
 
     def boom(req, timeout=None):
         raise urllib.error.URLError("dns")
 
     monkeypatch.setattr(nc.urllib.request, "urlopen", boom)
-    assert a._list_joined_rooms() == []
+    with pytest.raises(nc._RoomDiscoveryError, match="transport error"):
+        a._list_joined_rooms()
+
+
+def test_discovery_rechecks_after_genuine_empty_room_list(monkeypatch):
+    a = _adapter()
+    results = iter([[], ["room1"]])
+    sleeps: list[float] = []
+    monkeypatch.setattr(a, "_list_joined_rooms", lambda: next(results))
+    monkeypatch.setattr(nc.time, "sleep", sleeps.append)
+
+    assert a._discover_rooms_until_available() == ["room1"]
+    assert sleeps == [nc.MAX_BACKOFF_SECS]
+
+
+def test_discovery_retries_transient_error_with_backoff(monkeypatch):
+    a = _adapter()
+    calls = 0
+    sleeps: list[float] = []
+
+    def discover():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise nc._RoomDiscoveryError("network unavailable")
+        return ["room1"]
+
+    monkeypatch.setattr(a, "_list_joined_rooms", discover)
+    monkeypatch.setattr(nc.time, "sleep", sleeps.append)
+    assert a._discover_rooms_until_available() == ["room1"]
+    assert sleeps == [1.0]
+
+
+def test_producer_uses_recovering_discovery_before_polling(monkeypatch):
+    a = _adapter()
+    polled: list[list[str]] = []
+
+    class _StopProducer(Exception):
+        pass
+
+    monkeypatch.setattr(a, "_verify_credentials", lambda: "bot")
+    monkeypatch.setattr(
+        a, "_discover_rooms_until_available", lambda: ["room1"],
+    )
+    monkeypatch.setattr(
+        a, "_poll_once", lambda _emit, rooms: polled.append(list(rooms)),
+    )
+    monkeypatch.setattr(
+        nc.time, "sleep", lambda _delay: (_ for _ in ()).throw(_StopProducer()),
+    )
+
+    with pytest.raises(_StopProducer):
+        a._producer_blocking(lambda _event: None)
+    assert polled == [["room1"]]
 
 
 # ---- _parse_message ----------------------------------------------
@@ -594,19 +648,34 @@ def test_verify_credentials_429_sleeps_retry_after_then_raises(monkeypatch):
     assert sleeps == [3.0]
 
 
-def test_list_joined_rooms_429_sleeps_then_returns_empty(monkeypatch):
-    """Room discovery is one-shot; the producer just retries on the
-    next pass, so a 429 here only needs to sleep — surfacing it as an
-    empty-list signal (same as transport error) is enough."""
+def test_list_joined_rooms_429_surfaces_retry_after(monkeypatch):
     a = _adapter()
     fake = _FakeUrlopen([
         (429, {"message": "Throttled"}, {"Retry-After": "4"}),
     ])
     monkeypatch.setattr(nc.urllib.request, "urlopen", fake)
-    sleeps: list = []
-    monkeypatch.setattr(nc.time, "sleep", lambda s: sleeps.append(s))
-    out = a._list_joined_rooms()
-    assert out == []
+    with pytest.raises(nc._RoomDiscoveryError) as error:
+        a._list_joined_rooms()
+    assert error.value.retry_after == 4.0
+
+
+def test_discovery_honours_429_retry_after(monkeypatch):
+    a = _adapter()
+    results = iter([
+        nc._RoomDiscoveryError("throttled", retry_after=4.0),
+        ["room1"],
+    ])
+    sleeps: list[float] = []
+
+    def discover():
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(a, "_list_joined_rooms", discover)
+    monkeypatch.setattr(nc.time, "sleep", sleeps.append)
+    assert a._discover_rooms_until_available() == ["room1"]
     assert sleeps == [4.0]
 
 


### PR DESCRIPTION
## Changes
- distinguish successful empty Nextcloud Talk room discovery from transport, throttling, HTTP, and response-shape failures
- preserve `Retry-After` on discovery 429s through a typed retry signal
- retry transient discovery failures with bounded exponential backoff
- periodically re-run successful-but-empty discovery so joining a room recovers without restarting the sidecar
- route the producer through the recovering discovery loop before polling

## Verification
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_nextcloud_adapter.py` (70 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2,000 passed)
- `python3 -m py_compile sdk/python/librefang/sidecar/adapters/nextcloud.py sdk/python/tests/test_nextcloud_adapter.py`
- `git diff --check`

## Out of scope
- changing configured `NEXTCLOUD_ROOMS` behavior
- dynamic removal of rooms after polling has started
- outbound message retry policy