### PR TITLE
fix(teams): bound shared adapter state

### DIFF
--- a/changelog.d/fixed/teams-token-and-service-url-state.md
+++ b/changelog.d/fixed/teams-token-and-service-url-state.md
@@ -1,0 +1,1 @@
+Serialize Teams OAuth refreshes and bound the per-conversation service URL cache. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/teams.py
+++ b/sdk/python/librefang/sidecar/adapters/teams.py
@@ -103,6 +103,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+from collections import OrderedDict
 import hashlib
 import hmac
 import http.server
@@ -146,6 +147,8 @@ DEFAULT_BIND_HOST = "0.0.0.0"
 SEND_TIMEOUT_SECS = 30.0
 SEEN_MESSAGES_MAX = 10_000
 SEEN_MESSAGES_EVICT = 5_000
+SERVICE_URLS_MAX = 10_000
+SERVICE_URLS_EVICT = 5_000
 
 
 # ---------------------------------------------------------------------------
@@ -396,11 +399,12 @@ class TeamsAdapter(SidecarAdapter):
         )
 
         self._token_lock = threading.Lock()
+        self._token_refresh_lock = threading.Lock()
         self._cached_token: Optional[tuple[str, float]] = None  # (token, expiry_monotonic)
 
         # Per-conversation serviceUrl cache (Improvement #1).
         self._service_url_lock = threading.Lock()
-        self._service_urls: dict[str, str] = {}
+        self._service_urls: OrderedDict[str, str] = OrderedDict()
 
         self._seen = _SeenSet(
             max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT,
@@ -419,43 +423,54 @@ class TeamsAdapter(SidecarAdapter):
                 token, expiry = self._cached_token
                 if time.monotonic() < expiry:
                     return token
-        body = urllib.parse.urlencode({
-            "grant_type": "client_credentials",
-            "client_id": self.app_id,
-            "client_secret": self.app_password,
-            "scope": "https://api.botframework.com/.default",
-        }).encode("ascii")
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent": "librefang-teams-sidecar/1 (https://librefang.org)",
-        }
-        status, resp, raw, _hdrs = _http_request(
-            self.oauth_token_url, method="POST", body=body, headers=headers,
-            timeout=SEND_TIMEOUT_SECS,
-        )
-        if status < 200 or status >= 300 or not isinstance(resp, dict):
-            snippet = raw[:200].decode("utf-8", "replace") if raw else ""
-            raise RuntimeError(
-                f"teams OAuth2 token error (status={status}): {snippet}",
+        # Serialize only refreshes. Ordinary cache hits never wait on the
+        # blocking OAuth request, while concurrent misses re-check after the
+        # first refresher publishes its token.
+        with self._token_refresh_lock:
+            with self._token_lock:
+                if self._cached_token is not None:
+                    token, expiry = self._cached_token
+                    if time.monotonic() < expiry:
+                        return token
+            body = urllib.parse.urlencode({
+                "grant_type": "client_credentials",
+                "client_id": self.app_id,
+                "client_secret": self.app_password,
+                "scope": "https://api.botframework.com/.default",
+            }).encode("ascii")
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": "librefang-teams-sidecar/1 (https://librefang.org)",
+            }
+            status, resp, raw, _hdrs = _http_request(
+                self.oauth_token_url, method="POST", body=body, headers=headers,
+                timeout=SEND_TIMEOUT_SECS,
             )
-        token = resp.get("access_token")
-        if not isinstance(token, str) or not token:
-            raise RuntimeError("teams OAuth2 response missing access_token")
-        try:
-            expires_in = int(resp.get("expires_in") or 3600)
-        except (TypeError, ValueError):
-            expires_in = 3600
-        # Refresh 5 minutes before actual expiry.
-        ttl = max(60, expires_in - int(TOKEN_REFRESH_BUFFER_SECS))
-        with self._token_lock:
-            self._cached_token = (token, time.monotonic() + ttl)
-        return token
+            if status < 200 or status >= 300 or not isinstance(resp, dict):
+                snippet = raw[:200].decode("utf-8", "replace") if raw else ""
+                raise RuntimeError(
+                    f"teams OAuth2 token error (status={status}): {snippet}",
+                )
+            token = resp.get("access_token")
+            if not isinstance(token, str) or not token:
+                raise RuntimeError("teams OAuth2 response missing access_token")
+            try:
+                expires_in = int(resp.get("expires_in") or 3600)
+            except (TypeError, ValueError):
+                expires_in = 3600
+            # Refresh 5 minutes before actual expiry.
+            ttl = max(60, expires_in - int(TOKEN_REFRESH_BUFFER_SECS))
+            with self._token_lock:
+                self._cached_token = (token, time.monotonic() + ttl)
+            return token
 
     # ---- service_url cache ------------------------------------------
 
     def _service_url_for(self, conversation_id: str) -> str:
         with self._service_url_lock:
             url = self._service_urls.get(conversation_id)
+            if url is not None:
+                self._service_urls.move_to_end(conversation_id)
         return url or self.default_service_url
 
     def _stash_service_url(self, conversation_id: str, url: str) -> None:
@@ -463,6 +478,12 @@ class TeamsAdapter(SidecarAdapter):
             return
         with self._service_url_lock:
             self._service_urls[conversation_id] = url
+            self._service_urls.move_to_end(conversation_id)
+            if len(self._service_urls) > SERVICE_URLS_MAX:
+                for _ in range(SERVICE_URLS_EVICT):
+                    if not self._service_urls:
+                        break
+                    self._service_urls.popitem(last=False)
 
     # ---- outbound REST ----------------------------------------------
 

--- a/sdk/python/tests/test_teams_adapter.py
+++ b/sdk/python/tests/test_teams_adapter.py
@@ -9,6 +9,8 @@ import hashlib
 import hmac
 import json
 import os
+import threading
+import time
 
 import pytest
 
@@ -443,6 +445,19 @@ def test_webhook_body_unknown_conversation_falls_back_to_default():
     assert a._service_url_for("never-seen") == tm.DEFAULT_SERVICE_URL
 
 
+def test_service_url_cache_evicts_oldest_entries(monkeypatch):
+    monkeypatch.setattr(tm, "SERVICE_URLS_MAX", 3)
+    monkeypatch.setattr(tm, "SERVICE_URLS_EVICT", 1)
+    a = _adapter()
+    for i in range(3):
+        a._stash_service_url(f"conv-{i}", f"https://service-{i}.test")
+    # A read refreshes conv-0, so conv-1 is now the least recently used.
+    assert a._service_url_for("conv-0") == "https://service-0.test"
+    a._stash_service_url("conv-3", "https://service-3.test")
+    assert list(a._service_urls) == ["conv-2", "conv-0", "conv-3"]
+    assert a._service_url_for("conv-1") == tm.DEFAULT_SERVICE_URL
+
+
 # ---- _send_text via mocked http_request ----------------------------
 
 
@@ -561,6 +576,35 @@ def test_get_token_caches(monkeypatch):
     t2 = a._get_token()
     assert t1 == t2 == "fresh-tok"
     assert len(calls) == 1  # second call hit the cache
+
+
+def test_get_token_concurrent_misses_single_flight(monkeypatch):
+    calls: list[str] = []
+    barrier = threading.Barrier(8)
+
+    def _fake_http(url, **kw):
+        calls.append(url)
+        time.sleep(0.05)
+        return (200, {"access_token": "fresh-tok", "expires_in": 3600}, b"", {})
+
+    monkeypatch.setattr(tm, "_http_request", _fake_http)
+    a = _adapter()
+    a._cached_token = None
+    results: list[str] = []
+
+    def worker():
+        barrier.wait()
+        results.append(a._get_token())
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2.0)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert results == ["fresh-tok"] * 8
+    assert len(calls) == 1
 
 
 def test_get_token_raises_on_non_2xx(monkeypatch):


### PR DESCRIPTION
## Changes
- add a dedicated Teams OAuth refresh lock with a second cache check so concurrent expired-token callers share one exchange
- leave ordinary valid-token cache hits outside the blocking refresh lock
- convert the per-conversation service URL map to access-order LRU state
- cap service URL state at 10,000 entries and evict the oldest 5,000 on overflow
- add real eight-thread single-flight and LRU refresh/eviction regressions

## Verification
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_teams_adapter.py` (68 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1,998 passed)
- `python3 -m py_compile sdk/python/librefang/sidecar/adapters/teams.py sdk/python/tests/test_teams_adapter.py`
- `git diff --check`

## Out of scope
- cross-process OAuth refresh coordination
- persistence of per-conversation service URLs
- webhook authentication policy