### PR TITLE
fix(email): honor TLS settings for SMTP

### DIFF
--- a/changelog.d/security/718-email-smtp-tls.md
+++ b/changelog.d/security/718-email-smtp-tls.md
@@ -1,0 +1,1 @@
+Reuse the configured email TLS context for SMTP so custom CA and certificate-validation settings apply consistently to inbound and outbound mail. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/email.py
+++ b/sdk/python/librefang/sidecar/adapters/email.py
@@ -472,9 +472,10 @@ class EmailAdapter(SidecarAdapter):
             # Always WARN, never just log on startup — operators forget
             # they enabled this (email.rs:336-337).
             log.warn(
-                "email IMAP TLS validation is DISABLED — "
-                "mailbox is exposed to MITM",
-                host=self.imap_host,
+                "email TLS validation is DISABLED — "
+                "mail traffic is exposed to MITM",
+                imap_host=self.imap_host,
+                smtp_host=self.smtp_host,
             )
             ctx = ssl._create_unverified_context()  # noqa: SLF001 — stdlib API
             return ctx
@@ -640,8 +641,8 @@ class EmailAdapter(SidecarAdapter):
             msg["References"] = in_reply_to
         msg.set_content(body)
 
+        ctx = self._build_ssl_context()
         if self.smtp_port == 465:
-            ctx = ssl.create_default_context()
             with smtplib.SMTP_SSL(
                 self.smtp_host, self.smtp_port,
                 context=ctx, timeout=self.net_timeout_secs,
@@ -661,7 +662,7 @@ class EmailAdapter(SidecarAdapter):
                         "credentials in plaintext. Use port 465 for "
                         "implicit TLS.",
                     )
-                smtp.starttls(context=ssl.create_default_context())
+                smtp.starttls(context=ctx)
                 smtp.ehlo()
                 self._smtp_login(smtp)
                 smtp.send_message(msg)

--- a/sdk/python/tests/test_email_adapter.py
+++ b/sdk/python/tests/test_email_adapter.py
@@ -843,6 +843,39 @@ async def test_on_send_smtp_ssl_465(monkeypatch):
     assert len(_FakeSMTP.sent) == 1
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("smtp_port", ["465", "587"])
+async def test_on_send_reuses_configured_tls_context(monkeypatch, smtp_port):
+    """Both SMTP TLS modes must honor the adapter's custom CA and
+    invalid-certificate settings through the shared context builder."""
+    expected_context = object()
+    captured: list[object] = []
+
+    class _ContextSMTP(_FakeSMTP):
+        def __init__(self, host, port, timeout=None, context=None):
+            if context is not None:
+                captured.append(context)
+            super().__init__(host, port, timeout=timeout, context=context)
+
+        def starttls(self, context=None):
+            captured.append(context)
+
+    monkeypatch.setattr(em.smtplib, "SMTP", _ContextSMTP)
+    monkeypatch.setattr(em.smtplib, "SMTP_SSL", _ContextSMTP)
+    a = _adapter(EMAIL_SMTP_PORT=smtp_port)
+    monkeypatch.setattr(a, "_build_ssl_context", lambda: expected_context)
+    from librefang.sidecar.protocol import Send
+    cmd = Send(
+        channel_id="alice@test", text="hi",
+        content={"Text": "hi"}, thread_id=None, user={},
+    )
+
+    await a.on_send(cmd)
+
+    assert captured == [expected_context]
+    assert len(_FakeSMTP.sent) == 1
+
+
 # ---- schema + capability ---------------------------------------------
 
 


### PR DESCRIPTION
## Changes

- reuse the Email adapter shared TLS context for implicit SMTP TLS and STARTTLS
- apply custom CA and invalid-certificate settings consistently to inbound and outbound mail
- broaden the insecure-TLS warning to identify both IMAP and SMTP exposure
- add regression coverage for ports 465 and 587

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_email_adapter.py` (70 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1998 passed)
- `git diff --check`

## Out of scope

- No changes to SMTP authentication or message construction.
- Other adapter audit findings remain in separate PRs.