### PR TITLE
fix(whatsapp): harden Cloud webhook handling

### DIFF
--- a/changelog.d/security/719-whatsapp-cloud-webhook.md
+++ b/changelog.d/security/719-whatsapp-cloud-webhook.md
@@ -1,0 +1,1 @@
+Fail closed when WhatsApp Cloud webhook authentication is unconfigured, marshal inbound events onto the asyncio loop, and reject incomplete outbound locations. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/whatsapp.py
+++ b/sdk/python/librefang/sidecar/adapters/whatsapp.py
@@ -458,10 +458,9 @@ class WhatsAppAdapter(SidecarAdapter):
                 )
                 raise SystemExit(2)
             if not self.app_secret:
-                log.warn(
-                    "whatsapp WHATSAPP_APP_SECRET unset — X-Hub-Signature-256 "
-                    "verification on inbound webhook is DISABLED. Production "
-                    "deployments should always set this.",
+                log.error(
+                    "whatsapp WHATSAPP_APP_SECRET unset — inbound webhook "
+                    "requests will be rejected",
                 )
             if not self.verify_token:
                 # Without this, _handle_get_verify short-circuits on
@@ -560,7 +559,7 @@ class WhatsAppAdapter(SidecarAdapter):
                 retry_after=wait,
             )
             if self._shutdown.wait(wait):
-                return status, resp, raw, hdrs
+                raise asyncio.CancelledError()
             status, resp, raw, hdrs = _http_request(
                 url, method="POST", body=body,
                 headers=self._cloud_headers(),
@@ -703,7 +702,9 @@ class WhatsAppAdapter(SidecarAdapter):
         if (
             mode == "subscribe"
             and self.verify_token
-            and hmac.compare_digest(token, self.verify_token)
+            and hmac.compare_digest(
+                token.encode("utf-8"), self.verify_token.encode("utf-8"),
+            )
         ):
             return 200, challenge.encode("utf-8")
         return 403, b""
@@ -714,20 +715,25 @@ class WhatsAppAdapter(SidecarAdapter):
         signature: Optional[str],
         emit: Callable[[dict], None],
     ) -> int:
-        """Verify X-Hub-Signature-256 (if app_secret configured) +
+        """Verify X-Hub-Signature-256 +
         parse Cloud API webhook body + emit text events."""
-        if self.app_secret:
-            if not signature:
-                # Missing header (Meta omits it, or the upstream
-                # proxy stripped it) — 400 not 401, since 401
-                # implies credentials were presented and rejected.
-                log.warn("whatsapp: missing X-Hub-Signature-256 header")
-                return 400
-            if not verify_xhub_signature(
-                self.app_secret.encode("utf-8"), body, signature,
-            ):
-                log.warn("whatsapp: invalid X-Hub-Signature-256")
-                return 401
+        if not self.app_secret:
+            log.error(
+                "whatsapp: refusing webhook because WHATSAPP_APP_SECRET "
+                "is unset",
+            )
+            return 500
+        if not signature:
+            # Missing header (Meta omits it, or the upstream
+            # proxy stripped it) — 400 not 401, since 401
+            # implies credentials were presented and rejected.
+            log.warn("whatsapp: missing X-Hub-Signature-256 header")
+            return 400
+        if not verify_xhub_signature(
+            self.app_secret.encode("utf-8"), body, signature,
+        ):
+            log.warn("whatsapp: invalid X-Hub-Signature-256")
+            return 401
         try:
             payload = json.loads(body.decode("utf-8"))
         except (ValueError, UnicodeDecodeError):
@@ -872,10 +878,15 @@ class WhatsAppAdapter(SidecarAdapter):
             return
 
         # Cloud API mode: spin up our own webhook server.
+        loop = asyncio.get_running_loop()
+
+        def emit_on_loop(event: dict) -> None:
+            loop.call_soon_threadsafe(emit, event)
+
         ready = threading.Event()
         t = threading.Thread(
             target=self._serve_forever,
-            args=(emit, ready),
+            args=(emit_on_loop, ready),
             name="whatsapp-webhook",
             daemon=True,
         )
@@ -1019,9 +1030,13 @@ class WhatsAppAdapter(SidecarAdapter):
                 loc = content.get("Location") or {}
                 lat = loc.get("lat") if isinstance(loc, dict) else None
                 lon = loc.get("lon") if isinstance(loc, dict) else None
+                if lat is None or lon is None:
+                    log.warn("whatsapp location: missing lat/lon",
+                             lat=lat, lon=lon)
+                    return
                 try:
-                    lat_f = float(lat) if lat is not None else 0.0
-                    lon_f = float(lon) if lon is not None else 0.0
+                    lat_f = float(lat)
+                    lon_f = float(lon)
                 except (TypeError, ValueError):
                     log.warn("whatsapp location: invalid lat/lon",
                              lat=lat, lon=lon)

--- a/sdk/python/tests/test_whatsapp_adapter.py
+++ b/sdk/python/tests/test_whatsapp_adapter.py
@@ -4,10 +4,12 @@ Deterministic, no network — urllib monkeypatched via _http_request.
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import json
 import os
+import threading
 
 import pytest
 
@@ -118,6 +120,38 @@ def test_dm_policy_lowercased():
 def test_group_policy_lowercased():
     a = _cloud_adapter(WHATSAPP_GROUP_POLICY="Mention_Only")
     assert a.group_policy == "mention_only"
+
+
+@pytest.mark.asyncio
+async def test_produce_marshals_webhook_emit_to_event_loop(monkeypatch):
+    a = _cloud_adapter(WHATSAPP_APP_SECRET="appsecret")
+    event = {"method": "inbound", "params": {"text": "hello"}}
+    seen = asyncio.Event()
+    emit_threads: list[int] = []
+    loop_thread = threading.get_ident()
+
+    class _Server:
+        def shutdown(self):
+            pass
+
+    def _serve(emit, ready):
+        a._httpd = _Server()
+        emit(event)
+        ready.set()
+
+    def _emit(received):
+        emit_threads.append(threading.get_ident())
+        assert received is event
+        seen.set()
+
+    monkeypatch.setattr(a, "_serve_forever", _serve)
+    task = asyncio.create_task(a.produce(_emit))
+    await asyncio.wait_for(seen.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert emit_threads == [loop_thread]
 
 
 # ---- X-Hub-Signature-256 verification ------------------------------
@@ -466,15 +500,13 @@ def test_get_verify_empty_self_token_rejects(monkeypatch):
     assert status == 403
 
 
-def test_post_webhook_signature_disabled_accepts_any():
-    """When WHATSAPP_APP_SECRET is empty, signature is skipped —
-    operator was warned at startup."""
+def test_post_webhook_without_app_secret_fails_closed():
     a = _cloud_adapter()  # app_secret = ""
     body = json.dumps(_wh_payload()).encode("utf-8")
     emitted: list = []
     status = a._handle_post_webhook(body, None, lambda ev: emitted.append(ev))
-    assert status == 200
-    assert len(emitted) == 1
+    assert status == 500
+    assert emitted == []
 
 
 def test_post_webhook_valid_signature_emits():
@@ -485,6 +517,14 @@ def test_post_webhook_valid_signature_emits():
     status = a._handle_post_webhook(body, sig, lambda ev: emitted.append(ev))
     assert status == 200
     assert len(emitted) == 1
+
+
+def test_verify_token_non_ascii_input_returns_403():
+    a = _cloud_adapter(WHATSAPP_VERIFY_TOKEN="expected")
+    status, _body = a._handle_get_verify(
+        "hub.mode=subscribe&hub.verify_token=%C3%A9&hub.challenge=ECHO",
+    )
+    assert status == 403
 
 
 def test_post_webhook_missing_signature_returns_400():
@@ -524,31 +564,37 @@ def test_post_webhook_invalid_signature_rejected():
 
 
 def test_post_webhook_malformed_json_400():
-    a = _cloud_adapter()
-    status = a._handle_post_webhook(b"{not json", None, lambda _: None)
+    a = _cloud_adapter(WHATSAPP_APP_SECRET="appsecret")
+    body = b"{not json"
+    status = a._handle_post_webhook(
+        body, _xhub(b"appsecret", body), lambda _: None,
+    )
     assert status == 400
 
 
 def test_post_webhook_dedupes_message_id():
     """Meta retries on non-200 — sidecar's SeenSet keeps the second
     delivery from double-emitting."""
-    a = _cloud_adapter()
+    a = _cloud_adapter(WHATSAPP_APP_SECRET="appsecret")
     body = json.dumps(_wh_payload(msg_id="dup-1")).encode("utf-8")
+    sig = _xhub(b"appsecret", body)
     emitted: list = []
-    s1 = a._handle_post_webhook(body, None, lambda ev: emitted.append(ev))
-    s2 = a._handle_post_webhook(body, None, lambda ev: emitted.append(ev))
+    s1 = a._handle_post_webhook(body, sig, lambda ev: emitted.append(ev))
+    s2 = a._handle_post_webhook(body, sig, lambda ev: emitted.append(ev))
     assert s1 == 200 and s2 == 200
     assert len(emitted) == 1
 
 
 def test_post_webhook_applies_dm_policy():
     a = _cloud_adapter(
+        WHATSAPP_APP_SECRET="appsecret",
         WHATSAPP_DM_POLICY="allowed_only",
         WHATSAPP_ALLOWED_USERS="+19990",
     )
     body = json.dumps(_wh_payload(from_phone="15551234567")).encode("utf-8")
+    sig = _xhub(b"appsecret", body)
     emitted: list = []
-    status = a._handle_post_webhook(body, None, lambda ev: emitted.append(ev))
+    status = a._handle_post_webhook(body, sig, lambda ev: emitted.append(ev))
     assert status == 200
     assert emitted == []
 
@@ -604,6 +650,18 @@ def test_cloud_send_text_429_retries_once(monkeypatch):
     monkeypatch.setattr(wa, "_parse_retry_after", lambda h, **kw: 0.0)
     a = _cloud_adapter()
     a._cloud_send_text("+1", "hi")
+
+
+def test_cloud_send_429_shutdown_raises_cancelled(monkeypatch):
+    monkeypatch.setattr(
+        wa, "_http_request",
+        lambda url, **kw: (429, None, b"slow", {"retry-after": "30"}),
+    )
+    a = _cloud_adapter()
+    a._shutdown.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        a._cloud_send_text("+1", "hi")
 
 
 def test_cloud_send_text_non_2xx_raises(monkeypatch):
@@ -860,6 +918,23 @@ async def test_on_send_cloud_mode_location(monkeypatch):
     }))
     assert sent[0]["type"] == "location"
     assert sent[0]["location"]["latitude"] == 37.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("location", [{"lat": 37.5}, {"lon": -122.0}, {}])
+async def test_on_send_cloud_mode_rejects_incomplete_location(
+    monkeypatch, location,
+):
+    sent: list = []
+    monkeypatch.setattr(
+        wa, "_http_request",
+        lambda url, **kw: (sent.append(kw), (200, {}, b"", {}))[1],
+    )
+    a = _cloud_adapter()
+
+    await a.on_send(_send_cmd(content={"Location": location}))
+
+    assert sent == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes

- fail closed with HTTP 500 when `WHATSAPP_APP_SECRET` is unset instead of accepting unsigned inbound events
- marshal webhook-thread emissions onto the owning asyncio event loop
- reject locations missing either coordinate rather than substituting `0.0`
- surface shutdown during a 429 backoff as cancellation instead of returning the stale 429
- compare verification tokens as UTF-8 bytes so non-ASCII input cannot raise `TypeError`

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_whatsapp_adapter.py` (85 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2002 passed)
- `git diff --check`

## Out of scope

- WhatsApp Baileys gateway identity and echo tracking are handled by #7181 and #7183.
- Cloud API credential provisioning and proxy/TLS deployment policy are unchanged.