### PR TITLE
fix(bluesky): serialize session refresh

### DIFF
--- a/changelog.d/fixed/720-bluesky-session-lock.md
+++ b/changelog.d/fixed/720-bluesky-session-lock.md
@@ -1,0 +1,1 @@
+Serialize Bluesky session refreshes across polling and sending, and prevent stale 401 responses from discarding a newly rotated JWT. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/bluesky.py
+++ b/sdk/python/librefang/sidecar/adapters/bluesky.py
@@ -188,6 +188,10 @@ class BlueskyAdapter(SidecarAdapter):
         self._refresh_jwt: str | None = None
         self._session_did: str | None = None
         self._session_created_at: float = 0.0
+        # Polling and outbound sends run on different executor threads.
+        # Keep each session check/refresh/update transaction indivisible;
+        # refreshSession rotates its refresh JWT.
+        self._session_lock = threading.Lock()
         # Discovered at startup via validate().
         self.own_did: str | None = None
         # Reply-thread cache: notification uri → {"root": {uri,cid},
@@ -295,6 +299,10 @@ class BlueskyAdapter(SidecarAdapter):
     def _create_session(self) -> str:
         """Mint a new session from identifier + app_password. Returns the
         DID of the authenticated account; stores session state on self."""
+        with self._session_lock:
+            return self._create_session_locked()
+
+    def _create_session_locked(self) -> str:
         url = f"{self.service_url}/xrpc/com.atproto.server.createSession"
         body = {"identifier": self.identifier, "password": self.app_password}
         status, resp, resp_hdrs = self._post_json(url, body)
@@ -332,8 +340,12 @@ class BlueskyAdapter(SidecarAdapter):
         """Refresh the access JWT. Falls back to createSession on failure
         — matches the Rust adapter's behaviour (transient refresh
         failures are recoverable by re-authing with the password)."""
+        with self._session_lock:
+            self._refresh_session_locked()
+
+    def _refresh_session_locked(self) -> None:
         if not self._refresh_jwt:
-            self._create_session()
+            self._create_session_locked()
             return
         url = f"{self.service_url}/xrpc/com.atproto.server.refreshSession"
         status, resp, resp_hdrs = self._post_json(
@@ -355,7 +367,7 @@ class BlueskyAdapter(SidecarAdapter):
                 "bluesky refreshSession failed; re-creating session",
                 status=status,
             )
-            self._create_session()
+            self._create_session_locked()
             return
         access = resp.get("accessJwt")
         new_refresh = resp.get("refreshJwt")
@@ -363,7 +375,7 @@ class BlueskyAdapter(SidecarAdapter):
         if not (isinstance(access, str) and access
                 and isinstance(new_refresh, str) and new_refresh
                 and isinstance(did, str) and did):
-            self._create_session()
+            self._create_session_locked()
             return
         self._access_jwt = access
         self._refresh_jwt = new_refresh
@@ -373,17 +385,29 @@ class BlueskyAdapter(SidecarAdapter):
     def _get_token(self) -> tuple[str, str]:
         """Return (access_jwt, did), refreshing if the session is close
         to expiry. Mirrors the Rust ``get_token`` logic."""
-        if (self._access_jwt is not None
-                and time.monotonic() - self._session_created_at
-                < (SESSION_LIFE_SECS - SESSION_REFRESH_BUFFER_SECS)):
-            assert self._session_did is not None
+        with self._session_lock:
+            if (self._access_jwt is not None
+                    and time.monotonic() - self._session_created_at
+                    < (SESSION_LIFE_SECS - SESSION_REFRESH_BUFFER_SECS)):
+                assert self._session_did is not None
+                return self._access_jwt, self._session_did
+            if self._access_jwt is not None:
+                self._refresh_session_locked()
+            else:
+                self._create_session_locked()
+            assert (self._access_jwt is not None
+                    and self._session_did is not None)
             return self._access_jwt, self._session_did
-        if self._access_jwt is not None:
-            self._refresh_session()
-        else:
-            self._create_session()
-        assert self._access_jwt is not None and self._session_did is not None
-        return self._access_jwt, self._session_did
+
+    def _invalidate_access_token(self, rejected_token: str) -> None:
+        """Invalidate only the token that actually received a 401.
+
+        A request can finish after another executor thread refreshed the
+        session.  Its late 401 must not discard that newer access token.
+        """
+        with self._session_lock:
+            if self._access_jwt == rejected_token:
+                self._access_jwt = None
 
     def _verify_credentials(self) -> str:
         """Validate at startup by creating a session and discovering the
@@ -498,7 +522,7 @@ class BlueskyAdapter(SidecarAdapter):
         status, body, resp_hdrs = self._get_json(url, bearer=token)
         if status == 401:
             # Mirror Rust: clear session so next poll re-auths.
-            self._access_jwt = None
+            self._invalidate_access_token(token)
             raise RuntimeError("bluesky 401 — session expired")
         if status == 429:
             # XRPC rate limit on listNotifications. Honour Retry-After
@@ -647,7 +671,7 @@ class BlueskyAdapter(SidecarAdapter):
                 "and retrying once",
                 uri=uri,
             )
-            self._access_jwt = None
+            self._invalidate_access_token(bearer)
             try:
                 bearer, _ = self._get_token()
             except Exception as e:  # noqa: BLE001
@@ -752,7 +776,7 @@ class BlueskyAdapter(SidecarAdapter):
             if status == 401:
                 # Token expired mid-batch: refresh once and retry this
                 # chunk. If it still fails we surface the error.
-                self._access_jwt = None
+                self._invalidate_access_token(token)
                 token, did = self._get_token()
                 body["repo"] = did
                 status, resp, resp_hdrs = self._post_json(

--- a/sdk/python/tests/test_bluesky_adapter.py
+++ b/sdk/python/tests/test_bluesky_adapter.py
@@ -378,7 +378,13 @@ def test_concurrent_token_reads_share_one_rotating_refresh(monkeypatch):
     a._access_jwt = "expired-access"
     a._refresh_jwt = "refresh-1"
     a._session_did = "did:plc:bot"
-    a._session_created_at = 0.0
+    # Age the session past the refresh threshold relative to the clock
+    # `_get_token` actually reads. A literal 0.0 only reads as expired
+    # once the host's monotonic clock has passed SESSION_LIFE_SECS, so
+    # it silently short-circuits to the "still fresh" branch on a
+    # freshly-booted CI runner.
+    a._session_created_at = (ba.time.monotonic()
+                             - ba.SESSION_LIFE_SECS)
     calls = 0
     calls_lock = threading.Lock()
 

--- a/sdk/python/tests/test_bluesky_adapter.py
+++ b/sdk/python/tests/test_bluesky_adapter.py
@@ -15,6 +15,7 @@ explicitly-acknowledged improvements:
 import io
 import json
 import os
+import threading
 import time
 
 import pytest
@@ -370,6 +371,58 @@ def test_refresh_session_falls_back_to_create_on_failure(monkeypatch):
     assert fake.calls[0]["url"].endswith("refreshSession")
     assert fake.calls[0]["headers"]["authorization"] == "Bearer stale-refresh"
     assert fake.calls[1]["url"].endswith("createSession")
+
+
+def test_concurrent_token_reads_share_one_rotating_refresh(monkeypatch):
+    a = _adapter()
+    a._access_jwt = "expired-access"
+    a._refresh_jwt = "refresh-1"
+    a._session_did = "did:plc:bot"
+    a._session_created_at = 0.0
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def _post_json(url, body, **kwargs):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        time.sleep(0.01)
+        assert kwargs["bearer"] == "refresh-1"
+        return (200, {
+            "accessJwt": "access-2",
+            "refreshJwt": "refresh-2",
+            "did": "did:plc:bot",
+        }, {})
+
+    monkeypatch.setattr(a, "_post_json", _post_json)
+    start = threading.Barrier(8)
+    results: list[tuple[str, str]] = []
+
+    def _reader():
+        start.wait()
+        results.append(a._get_token())
+
+    threads = [threading.Thread(target=_reader) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert calls == 1
+    assert results == [("access-2", "did:plc:bot")] * 8
+    assert a._refresh_jwt == "refresh-2"
+
+
+def test_stale_401_does_not_invalidate_new_access_token():
+    a = _adapter()
+    a._access_jwt = "access-2"
+
+    a._invalidate_access_token("access-1")
+
+    assert a._access_jwt == "access-2"
+    a._invalidate_access_token("access-2")
+    assert a._access_jwt is None
 
 
 # ---- _post_status: createRecord shape ----------------------------


### PR DESCRIPTION
## Changes

- serialize Bluesky session check, creation, and rotating refresh transactions across polling and outbound executor threads
- protect every session mutation, including direct startup validation
- invalidate an access token after 401 only when it is still the active token, preserving newer sessions from late responses
- add real eight-thread refresh and stale-401 regressions

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_bluesky_adapter.py` (55 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1998 passed)
- `git diff --check`

## Out of scope

- Session persistence across sidecar restarts is unchanged.
- Notification polling, post construction, and reply-thread caching behavior are unchanged.