### PR TITLE
fix(wecom): consume passive reply ids once

### DIFF
--- a/changelog.d/fixed/721-wecom-req-id-once.md
+++ b/changelog.d/fixed/721-wecom-req-id-once.md
@@ -1,0 +1,1 @@
+Track consumed WeCom passive-reply request IDs so restart-surviving reply hints cannot be reused after their one allowed send. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/wecom.py
+++ b/sdk/python/librefang/sidecar/adapters/wecom.py
@@ -374,6 +374,11 @@ class WeComAdapter(SidecarAdapter):
         # that user; subsequent sends fall back to aibot_send_msg.
         self._pending_req_ids: dict[str, str] = {}
         self._pending_lock = threading.Lock()
+        # A passive-reply req_id is one-shot, including a restart-surviving
+        # hint round-tripped through ChannelUser.librefang_user.
+        self._consumed_req_ids = _SeenSet(
+            max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT,
+        )
 
         # Inbound dedupe on req_id (improvement #1).
         self._seen = _SeenSet(
@@ -424,6 +429,8 @@ class WeComAdapter(SidecarAdapter):
         # between inbound and reply), try the round-tripped hint.
         if req_id is None and req_id_hint:
             req_id = req_id_hint
+        if req_id is not None and not self._consumed_req_ids.mark(req_id):
+            req_id = None
         first = chunks[0]
         if req_id:
             self._send_queue.put(_build_reply_frame(req_id, first))

--- a/sdk/python/tests/test_wecom_adapter.py
+++ b/sdk/python/tests/test_wecom_adapter.py
@@ -499,6 +499,41 @@ async def test_on_send_recovers_req_id_from_user_librefang_user_when_cache_cold(
 
 
 @pytest.mark.asyncio
+async def test_on_send_consumes_restart_req_id_hint_once():
+    a = _adapter()
+    cmd = _FakeSend(
+        channel_id="alice",
+        text="hi",
+        user={
+            "platform_id": "alice",
+            "librefang_user": "req-id-from-inbound-42",
+        },
+    )
+
+    await a.on_send(cmd)
+    await a.on_send(cmd)
+
+    first = json.loads(a._send_queue.get_nowait())
+    second = json.loads(a._send_queue.get_nowait())
+    assert first["cmd"] == "aibot_respond_msg"
+    assert second["cmd"] == "aibot_send_msg"
+
+
+def test_cached_req_id_cannot_be_reused_later_as_hint():
+    a = _adapter()
+    with a._pending_lock:
+        a._pending_req_ids["alice"] = "req-99"
+
+    a._enqueue_text("alice", "first")
+    a._enqueue_text("alice", "second", req_id_hint="req-99")
+
+    first = json.loads(a._send_queue.get_nowait())
+    second = json.loads(a._send_queue.get_nowait())
+    assert first["cmd"] == "aibot_respond_msg"
+    assert second["cmd"] == "aibot_send_msg"
+
+
+@pytest.mark.asyncio
 async def test_on_send_in_memory_cache_wins_over_librefang_user():
     """The in-memory cache holds the FRESHEST req_id (the latest
     inbound's id) — it should take precedence over librefang_user


### PR DESCRIPTION
## Changes

- track consumed WeCom passive-reply `req_id` values in a bounded thread-safe set
- consume restart-surviving `librefang_user` hints after their first passive reply
- prevent an ID first consumed from the live in-memory cache from later being reused as a stale hint
- fall back to proactive `aibot_send_msg` for later sends

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_wecom_adapter.py` (67 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1998 passed)
- `git diff --check`

## Out of scope

- Passive reply IDs remain process-local state, matching the existing restart-hint design.
- WeCom active-message quotas and WebSocket reconnect behavior are unchanged.