### PR TITLE
fix(zulip): preserve queue retry backoff

### DIFF
--- a/changelog.d/fixed/722-zulip-reregister-backoff.md
+++ b/changelog.d/fixed/722-zulip-reregister-backoff.md
@@ -1,0 +1,1 @@
+Preserve Zulip's exponential retry delay when an expired event queue cannot be re-registered. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/zulip.py
+++ b/sdk/python/librefang/sidecar/adapters/zulip.py
@@ -119,11 +119,8 @@ import asyncio
 import base64
 import json
 import os
-import threading
 import time
-import urllib.error
 import urllib.parse
-import urllib.request
 from typing import Any, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
@@ -131,7 +128,6 @@ from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
     http_request as _http_request,
     MAX_BACKOFF_SECS,
-    parse_retry_after as _parse_retry_after_impl,
     RETRY_AFTER_DEFAULT_SECS,
     SeenSet as _SeenSet,
     split_csv as _split_csv,
@@ -640,7 +636,6 @@ class ZulipAdapter(SidecarAdapter):
                 last_event_id, signal = self._poll_once(
                     emit, queue_id, last_event_id,
                 )
-                backoff = INITIAL_BACKOFF_SECS
                 if signal == "reregister":
                     # Re-register inline so the next poll uses the new
                     # queue id. If re-register itself fails the outer
@@ -651,6 +646,7 @@ class ZulipAdapter(SidecarAdapter):
                         queue_id=queue_id,
                         last_event_id=last_event_id,
                     )
+                backoff = INITIAL_BACKOFF_SECS
             except Exception as e:  # noqa: BLE001
                 log.warn(
                     "zulip poll error; backing off",

--- a/sdk/python/tests/test_zulip_adapter.py
+++ b/sdk/python/tests/test_zulip_adapter.py
@@ -622,6 +622,42 @@ def test_poll_once_bad_event_queue_id_signals_reregister(monkeypatch):
     assert new_last == 9  # Watermark unchanged.
 
 
+def test_reregister_failures_keep_exponential_backoff(monkeypatch):
+    a = _adapter()
+    register_calls = 0
+    sleeps: list[float] = []
+
+    class _StopProducer(BaseException):
+        pass
+
+    monkeypatch.setattr(a, "_validate", lambda: (1, "Bot"))
+
+    def _register():
+        nonlocal register_calls
+        register_calls += 1
+        if register_calls == 1:
+            return "expired-queue", 0
+        raise RuntimeError("register unavailable")
+
+    monkeypatch.setattr(a, "_register_queue", _register)
+    monkeypatch.setattr(
+        a, "_poll_once",
+        lambda emit, queue_id, last_event_id: (last_event_id, "reregister"),
+    )
+
+    def _sleep(delay):
+        sleeps.append(delay)
+        if len(sleeps) == 3:
+            raise _StopProducer()
+
+    monkeypatch.setattr(zu.time, "sleep", _sleep)
+
+    with pytest.raises(_StopProducer):
+        a._producer_blocking(lambda _event: None)
+
+    assert sleeps == [1.0, 2.0, 4.0]
+
+
 def test_poll_once_other_400_raises(monkeypatch):
     """A 400 with a different code is a real error → raise so the
     producer backs off (e.g. malformed query)."""


### PR DESCRIPTION
## Changes

- reset Zulip polling backoff only after expired-queue re-registration succeeds
- retain exponential delays across persistent `/register` failures instead of hammering `/events` and `/register` every second
- remove the three unused urllib/threading imports and unused shared retry parser alias identified by the audit
- add a producer-level regression proving 1, 2, 4 second escalation

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_zulip_adapter.py` (75 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1997 passed)
- `git diff --check`

## Out of scope

- Zulip queue persistence across restarts is unchanged.
- Retry-After parsing and outbound message behavior are unchanged.