### PR TITLE
fix(wechat): make recovery failures observable

### DIFF
--- a/changelog.d/fixed/723-wechat-recovery.md
+++ b/changelog.d/fixed/723-wechat-recovery.md
@@ -1,0 +1,1 @@
+Report interrupted WeChat multi-chunk sends, synchronize typing-ticket state, and isolate QR re-login retry delays from polling backoff. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/wechat.py
+++ b/sdk/python/librefang/sidecar/adapters/wechat.py
@@ -354,6 +354,7 @@ class WeChatAdapter(SidecarAdapter):
         self._token_lock = threading.Lock()
         self._cursor = ""
         self._typing_ticket: Optional[str] = None
+        self._ticket_lock = threading.Lock()
         self._context_lock = threading.Lock()
         self._user_context_tokens: dict[str, str] = {}
         self._seen = _SeenSet(
@@ -596,7 +597,8 @@ class WeChatAdapter(SidecarAdapter):
             return
         v = body.get("typing_ticket")
         if isinstance(v, str) and v:
-            self._typing_ticket = v
+            with self._ticket_lock:
+                self._typing_ticket = v
 
     # ---- long-poll ---------------------------------------------------
 
@@ -683,7 +685,10 @@ class WeChatAdapter(SidecarAdapter):
                     retry_after=wait,
                 )
                 if self._shutdown.wait(wait):
-                    return
+                    raise RuntimeError(
+                        "wechat send interrupted by shutdown during 429 "
+                        "backoff; message may be partially delivered",
+                    )
                 status, resp, raw, hdrs = self._post_json(
                     "/ilink/bot/sendmessage", body, token=token,
                 )
@@ -716,7 +721,8 @@ class WeChatAdapter(SidecarAdapter):
         token = self._get_token()
         if token is None:
             return  # not logged in yet
-        ticket = self._typing_ticket
+        with self._ticket_lock:
+            ticket = self._typing_ticket
         if not ticket:
             return  # no ticket primed yet (getconfig pending)
         body = {"to_user_id": to_user_id, "typing_ticket": ticket}
@@ -831,6 +837,7 @@ class WeChatAdapter(SidecarAdapter):
 
         log.info("wechat starting message polling loop")
         backoff = self.initial_backoff_secs
+        login_backoff = self.initial_backoff_secs
         while not self._shutdown.is_set():
             token = self._get_token()
             if token is None:
@@ -846,11 +853,15 @@ class WeChatAdapter(SidecarAdapter):
                     if self._shutdown.is_set():
                         return
                     log.error("wechat QR re-login failed", error=str(e))
-                    if self._shutdown.wait(backoff):
+                    if self._shutdown.wait(login_backoff):
                         return
-                    backoff = min(backoff * 2.0, self.max_backoff_secs)
+                    login_backoff = min(
+                        login_backoff * 2.0, self.max_backoff_secs,
+                    )
                     continue
                 self._set_token(token)
+                backoff = self.initial_backoff_secs
+                login_backoff = self.initial_backoff_secs
                 continue
             try:
                 data = self._poll_updates(token)
@@ -873,7 +884,8 @@ class WeChatAdapter(SidecarAdapter):
 
             ticket = data.get("typing_ticket")
             if isinstance(ticket, str) and ticket:
-                self._typing_ticket = ticket
+                with self._ticket_lock:
+                    self._typing_ticket = ticket
 
             msgs = data.get("msgs")
             if isinstance(msgs, list):

--- a/sdk/python/tests/test_wechat_adapter.py
+++ b/sdk/python/tests/test_wechat_adapter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 
 import pytest
 
@@ -335,6 +336,18 @@ def test_send_text_429_retries_once(monkeypatch):
     a = _adapter()
     a._send_text("alice@im.wechat", "ctx", "hi")
     assert len(calls) == 2  # one 429 + one success
+
+
+def test_send_text_429_shutdown_reports_partial_delivery(monkeypatch):
+    monkeypatch.setattr(
+        wc, "_http_request",
+        lambda url, **kw: (429, None, b"rate limited", {"retry-after": "30"}),
+    )
+    a = _adapter()
+    a._shutdown.set()
+
+    with pytest.raises(RuntimeError, match="partially delivered"):
+        a._send_text("alice@im.wechat", "ctx", "hi")
 
 
 def test_send_text_request_body_shape(monkeypatch):
@@ -735,6 +748,67 @@ def test_send_typing_basic(monkeypatch):
     assert "/ilink/bot/sendtyping" in sent[0][0]
     body = sent[0][1]
     assert body == {"to_user_id": "alice@im.wechat", "typing_ticket": "tk_typing"}
+
+
+def test_send_typing_reads_ticket_under_lock(monkeypatch):
+    called = threading.Event()
+    monkeypatch.setattr(
+        wc, "_http_request",
+        lambda url, **kw: (called.set(), (200, {}, b"", {}))[1],
+    )
+    a = _adapter()
+    a._typing_ticket = "tk"
+    a._ticket_lock.acquire()
+    thread = threading.Thread(
+        target=a._send_typing, args=("alice@im.wechat",), daemon=True,
+    )
+    thread.start()
+    assert not called.wait(0.05)
+
+    a._ticket_lock.release()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert called.is_set()
+
+
+def test_qr_relogin_uses_separate_backoff_and_resets_poll_delay(monkeypatch):
+    a = _adapter(WECHAT_INITIAL_BACKOFF_SECS="2", WECHAT_MAX_BACKOFF_SECS="60")
+    waits: list[float] = []
+    polls = 0
+
+    class _StopLoop(BaseException):
+        pass
+
+    monkeypatch.setattr(a, "_refresh_typing_ticket", lambda token: None)
+
+    def _poll(_token):
+        nonlocal polls
+        polls += 1
+        if polls == 2:
+            with a._token_lock:
+                a.bot_token = None
+        raise RuntimeError("poll unavailable")
+
+    monkeypatch.setattr(a, "_poll_updates", _poll)
+    monkeypatch.setattr(
+        a, "_qr_login", lambda **kwargs: (_ for _ in ()).throw(
+            RuntimeError("login unavailable"),
+        ),
+    )
+
+    def _wait(delay):
+        waits.append(delay)
+        if len(waits) == 4:
+            raise _StopLoop()
+        return False
+
+    monkeypatch.setattr(a._shutdown, "wait", _wait)
+
+    with pytest.raises(_StopLoop):
+        a._poll_loop(lambda _event: None)
+
+    assert waits == [2.0, 4.0, 2.0, 4.0]
 
 
 def test_send_typing_no_ticket_no_call(monkeypatch):


### PR DESCRIPTION
## Changes

- raise an explicit partial-delivery error when shutdown interrupts a 429 wait during a multi-chunk send
- synchronize typing-ticket reads and both update paths with a dedicated lock
- give QR re-login its own exponential backoff instead of inheriting an inflated polling delay
- reset polling and login backoff after successful re-authentication

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_wechat_adapter.py` (72 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1999 passed)
- `git diff --check`

## Out of scope

- Bot-token persistence and QR protocol payloads are unchanged.
- Typing remains best-effort and message retries remain daemon policy.