### PR TITLE
fix(telegram): preserve streamed message state

### DIFF
--- a/changelog.d/fixed/724-telegram-streaming.md
+++ b/changelog.d/fixed/724-telegram-streaming.md
@@ -1,0 +1,1 @@
+Keep Telegram Markdown links, interactive formatting, media groups, and multi-message streaming output consistent across sends and edits. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/telegram.py
+++ b/sdk/python/librefang/sidecar/adapters/telegram.py
@@ -51,6 +51,7 @@ Configure via ``[[sidecar_channels]]``:
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import os
 import socket
@@ -283,7 +284,9 @@ def _render_inline_markdown(text: str) -> str:
             break
         pe = be + 2 + pe_rel
         link_text = result[bs + 1:be]
-        url = result[be + 2:pe]
+        # The source string was escaped before parsing. Restore the URL;
+        # the sanitizer performs the single canonical attribute escape.
+        url = html.unescape(result[be + 2:pe])
         result = (
             result[:bs] + f'<a href="{url}">{link_text}</a>' + result[pe + 1:]
         )
@@ -898,29 +901,42 @@ class TelegramAdapter(SidecarAdapter):
     # ---- outbound text (formatter + sanitize + chunk + HTML) ---------
 
     def _send_text(self, chat_id, text: str, thread_id=None) -> dict:
+        responses = self._send_text_chunks(chat_id, text, thread_id)
+        return responses[0] if responses else {}
+
+    def _send_text_chunks(self, chat_id, text: str, thread_id=None) -> list:
         sanitized = _format_and_sanitize(text)
-        last: dict = {}
+        responses = []
         for chunk in _split_to_utf16_chunks(sanitized, TELEGRAM_MSG_LIMIT):
-            payload = {
-                "chat_id": chat_id,
-                "text": chunk,
-                "parse_mode": PARSE_MODE_HTML,
-            }
+            responses.append(
+                self._send_formatted_chunk(chat_id, chunk, thread_id),
+            )
+        return responses
+
+    def _send_formatted_chunk(self, chat_id, chunk: str, thread_id=None) -> dict:
+        payload = {
+            "chat_id": chat_id,
+            "text": chunk,
+            "parse_mode": PARSE_MODE_HTML,
+        }
+        if thread_id:
+            payload["message_thread_id"] = thread_id
+        resp = self._call_retrying("sendMessage", payload)
+        if (resp.get("_http") == 400
+                and "can't parse entities" in str(resp.get("description", ""))):
+            plain = {"chat_id": chat_id, "text": chunk}
             if thread_id:
-                payload["message_thread_id"] = thread_id
-            resp = self._call_retrying("sendMessage", payload)
-            if (resp.get("_http") == 400
-                    and "can't parse entities" in str(resp.get("description",
-                                                               ""))):
-                plain = {"chat_id": chat_id, "text": chunk}
-                if thread_id:
-                    plain["message_thread_id"] = thread_id
-                resp = self._call("sendMessage", plain)
-            last = resp
-        return last
+                plain["message_thread_id"] = thread_id
+            resp = self._call("sendMessage", plain)
+        return resp
 
     def _edit_text(self, chat_id, message_id, text: str) -> None:
         sanitized = _format_and_sanitize(text)
+        self._edit_formatted_chunk(chat_id, message_id, sanitized, text)
+
+    def _edit_formatted_chunk(
+        self, chat_id, message_id, sanitized: str, plain_fallback: str,
+    ) -> None:
         resp = self._call("editMessageText", {
             "chat_id": chat_id,
             "message_id": message_id,
@@ -932,7 +948,7 @@ class TelegramAdapter(SidecarAdapter):
             if resp.get("_http") == 400 and "can't parse entities" in desc:
                 self._call("editMessageText", {
                     "chat_id": chat_id, "message_id": message_id,
-                    "text": text,
+                    "text": plain_fallback,
                 })
 
     def _send_media_request(self, endpoint: str, chat_id, body: dict,
@@ -1069,20 +1085,39 @@ class TelegramAdapter(SidecarAdapter):
                 f"{len(items)}")
         media = []
         for it in items:
+            if not isinstance(it, dict):
+                log.warn(
+                    "telegram media group skipping non-object item",
+                    item_type=type(it).__name__,
+                )
+                continue
             if "Photo" in it:
                 p = it["Photo"]
                 v = {"type": "photo", "media": p.get("url")}
                 if p.get("caption"):
                     v["caption"] = p["caption"]
                     v["parse_mode"] = PARSE_MODE_HTML
-            else:
+            elif "Video" in it:
                 p = it["Video"]
                 v = {"type": "video", "media": p.get("url"),
                      "duration": p.get("duration_seconds", 0)}
                 if p.get("caption"):
                     v["caption"] = p["caption"]
                     v["parse_mode"] = PARSE_MODE_HTML
+            else:
+                log.warn(
+                    "telegram media group skipping unsupported item",
+                    kinds=list(it) if isinstance(it, dict) else [],
+                )
+                continue
             media.append(v)
+        if len(media) < 2:
+            log.warn(
+                "telegram media group has fewer than two supported items; "
+                "not sending",
+                supported_items=len(media),
+            )
+            return {}
         body = {"chat_id": chat_id, "media": media}
         if thread_id:
             body["message_thread_id"] = thread_id
@@ -1125,7 +1160,7 @@ class TelegramAdapter(SidecarAdapter):
     def _send_interactive(self, chat_id, text, buttons, thread_id):
         body = {
             "chat_id": chat_id,
-            "text": sanitize_telegram_html(text),
+            "text": _format_and_sanitize(text),
             "parse_mode": PARSE_MODE_HTML,
             "reply_markup": self._inline_keyboard(buttons),
         }
@@ -1137,7 +1172,7 @@ class TelegramAdapter(SidecarAdapter):
         kb = self._inline_keyboard(buttons)
         resp = self._call("editMessageText", {
             "chat_id": chat_id, "message_id": int(message_id),
-            "text": sanitize_telegram_html(text),
+            "text": _format_and_sanitize(text),
             "parse_mode": PARSE_MODE_HTML,
             "reply_markup": kb,
         })
@@ -1625,21 +1660,46 @@ class TelegramAdapter(SidecarAdapter):
         if st is None:
             return
         st["text"] += chunk
-        if st["msg_id"] is None:
-            resp = self._send_text(st["chat_id"], st["text"], st["thread_id"])
-            st["msg_id"] = (resp.get("result") or {}).get("message_id")
+        if not st["initial_attempted"]:
+            st["initial_attempted"] = True
+            self._sync_stream_messages(st)
             st["last_edit"] = time.monotonic()
-        elif time.monotonic() - st["last_edit"] >= STREAM_EDIT_INTERVAL:
-            self._edit_text(st["chat_id"], st["msg_id"], st["text"])
+        elif (st["message_ids"]
+              and time.monotonic() - st["last_edit"] >= STREAM_EDIT_INTERVAL):
+            self._sync_stream_messages(st)
             st["last_edit"] = time.monotonic()
+
+    def _sync_stream_messages(self, st: dict) -> None:
+        sanitized = _format_and_sanitize(st["text"])
+        chunks = _split_to_utf16_chunks(sanitized, TELEGRAM_MSG_LIMIT)
+        for index, formatted_chunk in enumerate(chunks):
+            if index < len(st["message_ids"]):
+                self._edit_formatted_chunk(
+                    st["chat_id"], st["message_ids"][index],
+                    formatted_chunk, formatted_chunk,
+                )
+                continue
+            resp = self._send_formatted_chunk(
+                st["chat_id"], formatted_chunk, st["thread_id"],
+            )
+            message_id = (resp.get("result") or {}).get("message_id")
+            if message_id is None:
+                break
+            st["message_ids"].append(message_id)
+        if len(st["message_ids"]) > len(chunks):
+            for obsolete_id in st["message_ids"][len(chunks):]:
+                self._delete_message(st["chat_id"], obsolete_id)
+            del st["message_ids"][len(chunks):]
 
     def _stream_end(self, sid: str) -> None:
         st = self._streams.pop(sid, None)
         if st is None or not st["text"]:
             return
-        if st["msg_id"] is not None:
-            self._edit_text(st["chat_id"], st["msg_id"], st["text"])
+        if st["message_ids"]:
+            self._sync_stream_messages(st)
         else:
+            # Retry a failed initial send once at the terminal event, not on
+            # every accumulated delta.
             self._send_text(st["chat_id"], st["text"], st["thread_id"])
 
     # ---- command dispatch -------------------------------------------
@@ -1672,7 +1732,8 @@ class TelegramAdapter(SidecarAdapter):
             self._streams[cmd.stream_id] = {
                 "chat_id": cmd.channel_id,
                 "thread_id": getattr(cmd, "thread_id", None),
-                "text": "", "msg_id": None, "last_edit": 0.0,
+                "text": "", "message_ids": [], "initial_attempted": False,
+                "last_edit": 0.0,
             }
         elif isinstance(cmd, protocol.StreamDelta):
             await loop.run_in_executor(

--- a/sdk/python/tests/test_telegram_adapter.py
+++ b/sdk/python/tests/test_telegram_adapter.py
@@ -59,6 +59,12 @@ def test_markdown_to_telegram_html_matches_rust_oracle():
     assert m("a < b & c > d") == "a &lt; b &amp; c &gt; d"
 
 
+def test_markdown_link_query_ampersand_is_escaped_once():
+    assert tg._format_and_sanitize(
+        "[results](https://example.com/search?a=1&b=2)",
+    ) == '<a href="https://example.com/search?a=1&amp;b=2">results</a>'
+
+
 # ---- sanitizer: vs telegram.rs sanitize_telegram_html tests --------
 
 
@@ -615,6 +621,53 @@ async def test_send_text_plain_fallback_on_parse_error(monkeypatch):
     assert "parse_mode" not in calls[1][1]
 
 
+def test_send_text_returns_first_chunk_response(monkeypatch):
+    monkeypatch.setattr(tg, "TELEGRAM_MSG_LIMIT", 4)
+    ids = iter((101, 102, 103))
+    monkeypatch.setattr(
+        tg.TelegramAdapter, "_call",
+        lambda self, method, payload: {
+            "ok": True, "result": {"message_id": next(ids)},
+        },
+    )
+    a = _adapter()
+
+    response = a._send_text("c1", "abcdefghij")
+
+    assert response["result"]["message_id"] == 101
+
+
+def test_interactive_send_and_edit_format_markdown(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        tg.TelegramAdapter, "_call",
+        lambda self, method, payload: calls.append((method, payload)) or {},
+    )
+    a = _adapter()
+
+    a._send_interactive("c1", "**pick**", [], None)
+    a._edit_interactive("c1", 7, "`updated`", [])
+
+    assert calls[0][1]["text"] == "<b>pick</b>"
+    assert calls[1][1]["text"] == "<code>updated</code>"
+
+
+def test_media_group_skips_unknown_item_without_invalid_request(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        tg.TelegramAdapter, "_call",
+        lambda self, method, payload: calls.append((method, payload)) or {},
+    )
+    a = _adapter()
+
+    result = a._send_media_group(
+        "c1", [{"Photo": {"url": "p"}}, {"Audio": {"url": "a"}}], None,
+    )
+
+    assert result == {}
+    assert calls == []
+
+
 @pytest.mark.asyncio
 async def test_streaming_initial_then_throttled_edit(monkeypatch):
     calls = []
@@ -635,6 +688,55 @@ async def test_streaming_initial_then_throttled_edit(monkeypatch):
     final = [p for m, p in calls if m == "editMessageText"][-1]
     assert final["message_id"] == 4242 and final["text"] == "Hello"
     assert "s1" not in a._streams
+
+
+@pytest.mark.asyncio
+async def test_streaming_tracks_and_edits_every_message_chunk(monkeypatch):
+    monkeypatch.setattr(tg, "TELEGRAM_MSG_LIMIT", 4)
+    monkeypatch.setattr(tg, "STREAM_EDIT_INTERVAL", 0.0)
+    calls = []
+    next_id = 100
+
+    def fake_call(self, method, payload):
+        nonlocal next_id
+        calls.append((method, payload))
+        if method == "sendMessage":
+            next_id += 1
+            return {"ok": True, "result": {"message_id": next_id}}
+        return {"ok": True}
+
+    monkeypatch.setattr(tg.TelegramAdapter, "_call", fake_call)
+    a = _adapter()
+    await a.on_command(tg.protocol.StreamStart("c1", "multi"))
+    await a.on_command(tg.protocol.StreamDelta("multi", "abcdefghij"))
+    await a.on_command(tg.protocol.StreamDelta("multi", "kl"))
+    await a.on_command(tg.protocol.StreamEnd("multi"))
+
+    sends = [p for method, p in calls if method == "sendMessage"]
+    edits = [p for method, p in calls if method == "editMessageText"]
+    assert [p["message_id"] for p in edits[-3:]] == [101, 102, 103]
+    assert len(sends) == 3
+    assert all(tg._utf16_len(p["text"]) <= 4 for p in sends + edits)
+
+
+@pytest.mark.asyncio
+async def test_failed_initial_stream_send_is_not_retried_per_delta(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        tg.TelegramAdapter, "_call",
+        lambda self, method, payload: calls.append((method, payload)) or {
+            "_http": 503,
+        },
+    )
+    a = _adapter()
+    await a.on_command(tg.protocol.StreamStart("c1", "failed"))
+    await a.on_command(tg.protocol.StreamDelta("failed", "a"))
+    await a.on_command(tg.protocol.StreamDelta("failed", "b"))
+    await a.on_command(tg.protocol.StreamDelta("failed", "c"))
+
+    assert [m for m, _ in calls] == ["sendMessage"]
+    await a.on_command(tg.protocol.StreamEnd("failed"))
+    assert [m for m, _ in calls] == ["sendMessage", "sendMessage"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes

- prevent Markdown link query strings from being HTML-escaped twice
- format interactive send/edit text through the same Markdown-to-Telegram pipeline as ordinary messages
- skip unsupported media-group variants and avoid issuing invalid one-item group requests
- track every Telegram message created by a long stream, editing each bounded chunk and removing obsolete chunks
- record the initial streaming attempt so a transient failure is not retried with the full accumulated text on every delta; StreamEnd performs one controlled final retry

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_telegram_adapter.py` (37 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2002 passed)
- `git diff --check`

## Out of scope

- Stream state remains process-local.
- Telegram flood-wait policy and media upload limits are unchanged.