### PR TITLE
fix(ntfy): avoid stacked reconnect delays

### DIFF
--- a/changelog.d/fixed/725-ntfy-backoff.md
+++ b/changelog.d/fixed/725-ntfy-backoff.md
@@ -1,0 +1,1 @@
+Normalize ntfy sender titles and avoid stacking reconnect backoff after an SSE rate-limit delay has already been observed. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/ntfy.py
+++ b/sdk/python/librefang/sidecar/adapters/ntfy.py
@@ -48,6 +48,12 @@ MAX_MESSAGE_LEN = 4096
 DEFAULT_SERVER_URL = "https://ntfy.sh"
 # Reconnect/post backoff ceilings, kept separate so the publish-side
 # raise can be capped distinctly from the SSE reconnect curve.
+
+
+class _RateLimited(RuntimeError):
+    """The server-requested delay was already observed synchronously."""
+
+
 class NtfyAdapter(SidecarAdapter):
     # ntfy has no typing/reaction/interactive/thread/streaming concept
     # — declare nothing, so LibreFang routes plain text only.
@@ -134,7 +140,7 @@ class NtfyAdapter(SidecarAdapter):
             str(mid),
             str(msg),
             str(val.get("topic", "")),
-            val.get("title"),
+            str(val.get("title")) if val.get("title") is not None else None,
         )
 
     def _to_event(self, mid, message, topic, title) -> dict:
@@ -171,7 +177,7 @@ class NtfyAdapter(SidecarAdapter):
                     topic=self.topic, retry_after_secs=wait,
                 )
                 time.sleep(wait)
-                raise RuntimeError("ntfy 429 — rate-limited") from e
+                raise _RateLimited("ntfy 429 — rate-limited") from e
             raise
         with resp_cm as resp:
             if getattr(resp, "status", 200) != 200:
@@ -197,6 +203,14 @@ class NtfyAdapter(SidecarAdapter):
                 backoff = 1.0  # clean stream end → reconnect promptly
             except asyncio.CancelledError:
                 raise
+            except _RateLimited as e:
+                # `_sse_loop` already honored Retry-After. Reconnect without
+                # stacking the generic transport backoff on top.
+                log.warn(
+                    "ntfy SSE rate limit wait completed; reconnecting",
+                    error=str(e),
+                )
+                backoff = 1.0
             except Exception as e:  # noqa: BLE001 - transport errors vary
                 log.warn(
                     "ntfy SSE error; backing off",
@@ -204,7 +218,7 @@ class NtfyAdapter(SidecarAdapter):
                     delay=backoff,
                 )
                 await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 120.0)
+                backoff = min(backoff * 2, MAX_BACKOFF_SECS)
 
     # ---- outbound: publish -------------------------------------------
 

--- a/sdk/python/tests/test_ntfy_adapter.py
+++ b/sdk/python/tests/test_ntfy_adapter.py
@@ -53,6 +53,9 @@ def test_parse_event_message_and_skips():
     ) is None
     assert a._parse_event('{"event":"message","message":"x"}') is None
     assert a._parse_event("not json") is None
+    assert a._parse_event(
+        '{"id":"n","event":"message","message":"hi","title":42}',
+    ) == ("n", "hi", "", "42")
 
 
 def test_to_event_text_command_sender_group_metadata():
@@ -215,6 +218,60 @@ def test_sse_loop_429_without_header_uses_default(monkeypatch):
     with pytest.raises(RuntimeError, match="429"):
         a._sse_loop(lambda _: None)
     assert sleeps == [na.RETRY_AFTER_DEFAULT_SECS]
+
+
+@pytest.mark.asyncio
+async def test_produce_does_not_stack_backoff_after_rate_limit(monkeypatch):
+    a = _adapter()
+    calls = 0
+    async_sleeps: list[float] = []
+
+    class _StopProducer(BaseException):
+        pass
+
+    def _sse(_emit):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise na._RateLimited("wait already completed")
+        raise _StopProducer()
+
+    monkeypatch.setattr(a, "_sse_loop", _sse)
+    async def _sleep(delay):
+        async_sleeps.append(delay)
+
+    monkeypatch.setattr(na.asyncio, "sleep", _sleep)
+
+    with pytest.raises(_StopProducer):
+        await a.produce(lambda _event: None)
+
+    assert async_sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_produce_transport_backoff_uses_shared_cap(monkeypatch):
+    a = _adapter()
+    sleeps: list[float] = []
+
+    class _StopProducer(BaseException):
+        pass
+
+    monkeypatch.setattr(
+        a, "_sse_loop",
+        lambda _emit: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    async def _sleep(delay):
+        sleeps.append(delay)
+        if len(sleeps) == 8:
+            raise _StopProducer()
+
+    monkeypatch.setattr(na.asyncio, "sleep", _sleep)
+
+    with pytest.raises(_StopProducer):
+        await a.produce(lambda _event: None)
+
+    assert sleeps == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 60.0, 60.0]
 
 
 def test_publish_429_sleeps_retry_after_then_raises(monkeypatch):


### PR DESCRIPTION
## Changes

- normalize non-string ntfy titles before using them as sender identity
- distinguish SSE 429 responses whose `Retry-After` delay was already observed
- reconnect immediately after that server-requested wait instead of stacking generic exponential backoff
- cap ordinary reconnect backoff with the shared 60-second constant instead of a 120-second literal

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_ntfy_adapter.py` (12 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1998 passed)
- `git diff --check`

## Out of scope

- Retry-After HTTP-date parsing is unchanged.
- SSE cursor persistence and outbound publish retry policy are unchanged.