### PR TITLE
fix(webex): reject empty outbound messages

### DIFF
--- a/changelog.d/fixed/726-webex-send.md
+++ b/changelog.d/fixed/726-webex-send.md
@@ -1,0 +1,1 @@
+Skip empty Webex messages, simplify outbound content routing, and use the shared Retry-After parser. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/webex.py
+++ b/sdk/python/librefang/sidecar/adapters/webex.py
@@ -115,9 +115,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import threading
 import time
-import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any, Callable, Optional
@@ -127,21 +125,13 @@ from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
     http_request as _http_request,
     MAX_BACKOFF_SECS,
-    parse_retry_after as _parse_retry_after_impl,
+    parse_retry_after as _parse_retry_after,
     RETRY_AFTER_DEFAULT_SECS,
     SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
-from librefang.sidecar.ws import (
-    MAX_FRAME_PAYLOAD,
-    OP_CLOSE as _OP_CLOSE,
-    OP_CONT as _OP_CONT,
-    OP_PING as _OP_PING,
-    OP_PONG as _OP_PONG,
-    OP_TEXT as _OP_TEXT,
-    WebSocketClient as _WebSocketClient,
-)
+from librefang.sidecar.ws import WebSocketClient as _WebSocketClient
 
 # Webex constants — mirror crate::webex defaults.
 DEFAULT_API_BASE = "https://webexapis.com/v1"
@@ -168,21 +158,6 @@ SEEN_MESSAGES_MAX = 10_000
 SEEN_MESSAGES_EVICT = 5_000
 
 READ_TICK_SECS = 30.0
-def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
-    """Webex's 429 response includes ``Retry-After`` (seconds).
-    Fall back to ``default_secs`` when missing/garbled. Floor 1 s,
-    capped at ``MAX_BACKOFF_SECS`` so a server bug can't pin the
-    loop for hours."""
-    raw = resp_hdrs.get("retry-after")
-    if not raw:
-        return default_secs
-    try:
-        v = float(raw)
-    except (TypeError, ValueError):
-        return default_secs
-    return min(max(v, 1.0), MAX_BACKOFF_SECS)
-
-
 def parse_webex_message(
     full_msg: dict,
     activity: dict,
@@ -667,29 +642,23 @@ class WebexAdapter(SidecarAdapter):
 
         content = cmd.content
         text = cmd.text or ""
-        loop = asyncio.get_event_loop()
         if isinstance(content, dict) and "Text" in content:
-            await loop.run_in_executor(
-                None,
-                lambda: self._post_message(
-                    room_id, text, parent_id=parent_id,
-                ),
-            )
-        elif content and not (isinstance(content, dict) and "Text" in content):
-            await loop.run_in_executor(
-                None,
-                lambda: self._post_message(
-                    room_id, "(Unsupported content type)",
-                    parent_id=parent_id,
-                ),
-            )
-        else:
-            await loop.run_in_executor(
-                None,
-                lambda: self._post_message(
-                    room_id, text, parent_id=parent_id,
-                ),
-            )
+            content_text = content.get("Text")
+            if isinstance(content_text, str):
+                text = content_text
+        elif content:
+            text = "(Unsupported content type)"
+        if not text:
+            log.debug("webex on_send: empty text, dropping", room_id=room_id)
+            return
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: self._post_message(
+                room_id, text, parent_id=parent_id,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_webex_adapter.py
+++ b/sdk/python/tests/test_webex_adapter.py
@@ -978,6 +978,31 @@ async def test_on_send_non_text_content_placeholder(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_on_send_text_content_is_authoritative(monkeypatch):
+    fake = _FakeUrlopen([(200, {"id": "REPLY_1"})])
+    monkeypatch.setattr(wa.urllib.request, "urlopen", fake)
+    a = _adapter()
+
+    await a.on_send(_SendCmd(
+        channel_id="ROOM_X", text="", content={"Text": "from content"},
+    ))
+
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert body["text"] == "from content"
+
+
+@pytest.mark.asyncio
+async def test_on_send_empty_text_drops(monkeypatch):
+    fake = _FakeUrlopen([])
+    monkeypatch.setattr(wa.urllib.request, "urlopen", fake)
+    a = _adapter()
+
+    await a.on_send(_SendCmd(channel_id="ROOM_X", text="", content=None))
+
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
 async def test_on_send_empty_room_id_drops(monkeypatch):
     """No channel_id and no user.platform_id → silent drop with a
     warn log (no urllib call)."""


### PR DESCRIPTION
## Changes

- skip outbound Webex sends when both text surfaces are empty
- use `content.Text` when present and collapse duplicate text-post branches into one call path
- preserve the unsupported-content placeholder for truthy non-text content
- replace the adapter-local Retry-After parser with the shared helper
- remove stale threading, urllib error, and WebSocket opcode imports

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_webex_adapter.py` (83 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1998 passed)
- `git diff --check`

## Out of scope

- Webex threading and Mercury reconnect behavior are unchanged.
- Non-text Webex content still degrades to the existing placeholder.