### PR TITLE
fix(reddit): serialize token refresh

### DIFF
--- a/changelog.d/fixed/727-reddit-concurrency.md
+++ b/changelog.d/fixed/727-reddit-concurrency.md
@@ -1,0 +1,1 @@
+Serialize Reddit OAuth token refresh, validate every reply fullname, and mark inbound comments seen only after successful delivery. (@xiaomo)

--- a/sdk/python/librefang/sidecar/adapters/reddit.py
+++ b/sdk/python/librefang/sidecar/adapters/reddit.py
@@ -111,6 +111,7 @@ import asyncio
 import base64
 import json
 import os
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -171,6 +172,15 @@ PLACEHOLDER_UA_FRAGMENTS = ("librefang-bot", "/u/your", "/u/example")
 # reset so we don't burn through the budget and trip a 429. Capped at
 # MAX_BACKOFF_SECS so we never block the poller for more than a minute.
 RATELIMIT_REMAINING_FLOOR = 10.0
+
+
+def _is_reddit_fullname(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith(("t1_", "t3_", "t4_", "t5_"))
+        and " " not in value
+        and "/" not in value
+    )
 # Default Retry-After when Reddit 429s without the header (rare but
 # documented). 60 s matches Reddit's API guideline minimum back-off.
 RETRY_AFTER_DEFAULT_SECS = 60.0
@@ -373,6 +383,7 @@ class RedditAdapter(SidecarAdapter):
 
         # OAuth2 token cache: (access_token, monotonic_expiry_seconds).
         self._cached_token: tuple[str, float] | None = None
+        self._token_lock = threading.Lock()
         # Discovered at startup via _verify_credentials().
         self.own_username: str = ""
         # Dedupe set for already-seen comment IDs. Capped by
@@ -518,13 +529,20 @@ class RedditAdapter(SidecarAdapter):
 
     def _get_token(self) -> str:
         """Return a valid bearer token, fetching / refreshing as needed."""
-        if self._cached_token is not None:
-            token, expiry = self._cached_token
-            if time.monotonic() < expiry:
-                return token
-        token, expiry = self._fetch_token()
-        self._cached_token = (token, expiry)
-        return token
+        with self._token_lock:
+            if self._cached_token is not None:
+                token, expiry = self._cached_token
+                if time.monotonic() < expiry:
+                    return token
+            token, expiry = self._fetch_token()
+            self._cached_token = (token, expiry)
+            return token
+
+    def _invalidate_token(self, rejected_token: str) -> None:
+        with self._token_lock:
+            if (self._cached_token is not None
+                    and self._cached_token[0] == rejected_token):
+                self._cached_token = None
 
     def _verify_credentials(self) -> str:
         """Call ``GET /api/v1/me`` to validate the token and discover the
@@ -546,7 +564,7 @@ class RedditAdapter(SidecarAdapter):
 
     # ---- inbound: poll new comments per subreddit --------------------
 
-    def _mark_seen(self, comment_id: str) -> None:
+    def _mark_seen(self, comment_id: str) -> bool:
         """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
         return self._seen.mark(comment_id)
 
@@ -577,7 +595,7 @@ class RedditAdapter(SidecarAdapter):
                 continue
             if status == 401:
                 # Clear the cached token; caller backs off and retries.
-                self._cached_token = None
+                self._invalidate_token(token)
                 raise RuntimeError("reddit 401 — token expired")
             if status == 429:
                 # Rate-limited mid-poll. Honour Retry-After (or our
@@ -637,11 +655,11 @@ class RedditAdapter(SidecarAdapter):
                     # the redundant-parse case).
                     self._mark_seen(comment_id)
                     continue
-                self._mark_seen(comment_id)
                 if self.account_id is not None:
                     meta = ev["params"].setdefault("metadata", {})
                     meta["account_id"] = self.account_id
                 emit(ev)
+                self._mark_seen(comment_id)
 
     def _producer_blocking(self, emit) -> None:
         """Verify credentials then poll forever in this worker thread.
@@ -711,7 +729,7 @@ class RedditAdapter(SidecarAdapter):
         )
         if status == 401:
             # Token expired mid-send: refresh once and retry.
-            self._cached_token = None
+            self._invalidate_token(token)
             token = self._get_token()
             headers["Authorization"] = f"Bearer {token}"
             status, resp, raw, resp_hdrs = self._http(
@@ -774,16 +792,14 @@ class RedditAdapter(SidecarAdapter):
         user = getattr(cmd, "user", None) or {}
         if isinstance(user, dict):
             candidate = user.get("librefang_user")
-            if (isinstance(candidate, str)
-                    and candidate.startswith(("t1_", "t3_", "t4_", "t5_"))
-                    and " " not in candidate
-                    and "/" not in candidate):
+            if _is_reddit_fullname(candidate):
                 parent_fullname = candidate
         if parent_fullname is None:
             thread_id = getattr(cmd, "thread_id", None)
             if thread_id is not None and not isinstance(thread_id, str):
                 thread_id = str(thread_id) if thread_id else None
-            parent_fullname = thread_id
+            if _is_reddit_fullname(thread_id):
+                parent_fullname = thread_id
 
         await asyncio.get_event_loop().run_in_executor(
             None, self._post_comment, parent_fullname or "", text,

--- a/sdk/python/tests/test_reddit_adapter.py
+++ b/sdk/python/tests/test_reddit_adapter.py
@@ -18,6 +18,7 @@ explicitly-acknowledged improvements:
 import io
 import json
 import os
+import threading
 import urllib.error
 import urllib.parse
 
@@ -359,6 +360,47 @@ def test_token_refresh_buffer_subtracted(monkeypatch):
     assert 250 < delta < 350
 
 
+def test_concurrent_token_reads_share_one_fetch(monkeypatch):
+    a = _adapter()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def _fetch():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        ra.time.sleep(0.01)
+        return "shared", ra.time.monotonic() + 600
+
+    monkeypatch.setattr(a, "_fetch_token", _fetch)
+    start = threading.Barrier(8)
+    results = []
+
+    def _read():
+        start.wait()
+        results.append(a._get_token())
+
+    threads = [threading.Thread(target=_read) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert calls == 1
+    assert results == ["shared"] * 8
+
+
+def test_stale_401_does_not_clear_new_token():
+    a = _adapter()
+    a._cached_token = ("new", ra.time.monotonic() + 600)
+
+    a._invalidate_token("old")
+
+    assert a._cached_token is not None
+    assert a._cached_token[0] == "new"
+
+
 # ---- verify_credentials -------------------------------------------
 
 
@@ -565,6 +607,28 @@ def test_poll_once_dedupes_seen_comments(monkeypatch):
     emitted = []
     a._poll_once(emitted.append)
     assert emitted == []
+
+
+def test_poll_once_marks_seen_only_after_emit_succeeds(monkeypatch):
+    a = _adapter()
+    a.own_username = "bot"
+    a._cached_token = ("tok", ra.time.monotonic() + 600)
+    response = (200, _children(_comment(cid="retry-me", body="hello")))
+    fake = _FakeUrlopen([response, response])
+    monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
+
+    with pytest.raises(RuntimeError, match="emit unavailable"):
+        a._poll_once(
+            lambda _event: (_ for _ in ()).throw(
+                RuntimeError("emit unavailable"),
+            ),
+        )
+    assert "retry-me" not in a._seen.ids
+
+    emitted = []
+    a._poll_once(emitted.append)
+    assert len(emitted) == 1
+    assert "retry-me" in a._seen.ids
 
 
 def test_poll_once_401_clears_token_and_raises(monkeypatch):
@@ -851,3 +915,15 @@ def test_on_send_rejects_non_reddit_fullname_in_librefang_user(monkeypatch):
     form = _form(fake.calls[0]["body_raw"])
     # URL-shaped librefang_user rejected → falls back to thread_id.
     assert form["thing_id"] == "t1_fallback"
+
+
+@pytest.mark.parametrize(
+    "thread_id",
+    ["https://reddit.com/r/test", "foreign-id", "t1_bad value", "t1_bad/path"],
+)
+def test_on_send_rejects_invalid_thread_id_fallback(thread_id):
+    a = _adapter()
+    import asyncio as _asyncio
+
+    with pytest.raises(RuntimeError, match="missing parent fullname"):
+        _asyncio.run(a.on_send(_StubCmd(text="hi", thread_id=thread_id)))


### PR DESCRIPTION
## Changes

- serialize Reddit OAuth cache checks and refreshes across polling and outbound executor threads
- invalidate a token after 401 only if it is still the active cached token
- validate both `librefang_user` and fallback `thread_id` through one Reddit-fullname guard
- mark parsed comments seen only after `emit` succeeds
- correct `_mark_seen` to return `bool` in its annotation

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_reddit_adapter.py` (63 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2003 passed)
- `git diff --check`

## Out of scope

- OAuth tokens and inbound dedupe remain process-local.
- Reddit rate-limit and content-trigger policies are unchanged.