### PR TITLE
fix(sidecar): make logging failures visible

### DIFF
--- a/changelog.d/fixed/729-sidecar-logging.md
+++ b/changelog.d/fixed/729-sidecar-logging.md
@@ -1,0 +1,1 @@
+Add configurable Python sidecar log filtering and a raw stderr fallback when structured logging fails. (@xiaomo)

--- a/sdk/python/librefang/sidecar/logging.py
+++ b/sdk/python/librefang/sidecar/logging.py
@@ -9,13 +9,32 @@ never ``print()`` to stdout from an adapter.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from typing import Any
 
 
+_LEVEL_VALUES = {
+    "debug": 10,
+    "info": 20,
+    "warn": 30,
+    "warning": 30,
+    "error": 40,
+}
+_LOG_FAILURE = b"[sidecar log failure] could not write structured log\n"
+
+
+def _enabled(level: str) -> bool:
+    configured = os.environ.get("LIBREFANG_LOG_LEVEL", "debug").strip().lower()
+    minimum = _LEVEL_VALUES.get(configured, _LEVEL_VALUES["debug"])
+    return _LEVEL_VALUES.get(level.lower(), minimum) >= minimum
+
+
 def log(level: str, message: str, **fields: Any) -> None:
     """Write one structured JSON log line to stderr."""
+    if not _enabled(level):
+        return
     record = {
         "ts": time.time(),
         "level": level,
@@ -28,7 +47,10 @@ def log(level: str, message: str, **fields: Any) -> None:
         sys.stderr.flush()
     except Exception:
         # Logging must never take the adapter down.
-        pass
+        try:
+            os.write(2, _LOG_FAILURE)
+        except Exception:
+            pass
 
 
 def debug(message: str, **fields: Any) -> None:

--- a/sdk/python/tests/test_logging.py
+++ b/sdk/python/tests/test_logging.py
@@ -1,0 +1,65 @@
+"""Tests for the sidecar's stderr-only structured logger."""
+
+import json
+
+from librefang.sidecar import logging as sidecar_log
+
+
+def test_log_level_filters_debug_but_keeps_warning(monkeypatch, capsys):
+    monkeypatch.setenv("LIBREFANG_LOG_LEVEL", "info")
+
+    sidecar_log.debug("hidden")
+    sidecar_log.warn("visible")
+
+    lines = capsys.readouterr().err.splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    # `warn` is LibreFang's canonical configured level spelling.
+    assert record["level"] == "warn"
+    assert record["message"] == "visible"
+
+
+def test_unknown_log_level_configuration_preserves_debug_default(
+    monkeypatch, capsys,
+):
+    monkeypatch.setenv("LIBREFANG_LOG_LEVEL", "not-a-level")
+
+    sidecar_log.debug("still visible")
+
+    record = json.loads(capsys.readouterr().err)
+    assert record["level"] == "debug"
+
+
+def test_structured_write_failure_uses_raw_stderr_fallback(monkeypatch):
+    writes = []
+
+    class _BrokenStderr:
+        def write(self, _value):
+            raise BrokenPipeError("closed")
+
+        def flush(self):
+            raise AssertionError("write should fail first")
+
+    monkeypatch.setattr(sidecar_log.sys, "stderr", _BrokenStderr())
+    monkeypatch.setattr(
+        sidecar_log.os, "write",
+        lambda fd, data: writes.append((fd, data)) or len(data),
+    )
+
+    sidecar_log.error("cannot serialize to stream")
+
+    assert writes == [(2, sidecar_log._LOG_FAILURE)]
+
+
+def test_raw_fallback_failure_never_crashes_adapter(monkeypatch):
+    class _BrokenStderr:
+        def write(self, _value):
+            raise OSError("closed")
+
+    monkeypatch.setattr(sidecar_log.sys, "stderr", _BrokenStderr())
+    monkeypatch.setattr(
+        sidecar_log.os, "write",
+        lambda _fd, _data: (_ for _ in ()).throw(OSError("fd closed")),
+    )
+
+    sidecar_log.error("best effort")


### PR DESCRIPTION
## Changes

- emit a minimal raw file-descriptor fallback when structured stderr logging fails
- support `LIBREFANG_LOG_LEVEL` filtering with a compatibility-preserving `debug` default
- keep `warn` as the emitted level because LibreFang configuration canonically uses `trace/debug/info/warn/error`
- fall back to the current debug behavior for an unknown configured value

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_logging.py` (4 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2000 passed)
- `git diff --check`

## Out of scope

- Rust currently forwards every non-SDK sidecar stderr line at warn independently of the embedded JSON level.
- The audit suggestion to rename `warn` to `warning` is intentionally not applied because `warn` is LibreFang's configured level spelling.