### PR TITLE
fix(sdk): parse multiline SSE events

### DIFF
--- a/changelog.d/fixed/python-sdk-multiline-sse.md
+++ b/changelog.d/fixed/python-sdk-multiline-sse.md
@@ -1,0 +1,1 @@
+(@xiaomo) Fix the generated Python SDK splitting multi-line SSE events into separate payloads.

--- a/scripts/codegen-sdks.py
+++ b/scripts/codegen-sdks.py
@@ -223,6 +223,7 @@ class LibreFang:
 
         try:
             buffer = b""
+            data_lines = []
             while True:
                 chunk = resp.read(4096)
                 if not chunk:
@@ -230,27 +231,40 @@ class LibreFang:
                 buffer += chunk
                 lines = buffer.split(b"\\n")
                 buffer = lines.pop()
-                for line in lines:
-                    line = line.decode().strip()
-                    if line.startswith("data: "):
-                        data_str = line[6:]
+                for raw_line in lines:
+                    line = raw_line.decode().removesuffix("\\r")
+                    if not line:
+                        if not data_lines:
+                            continue
+                        data_str = "\\n".join(data_lines)
+                        data_lines.clear()
                         if data_str == "[DONE]":
                             return
                         try:
                             yield json.loads(data_str)
                         except json.JSONDecodeError:
                             yield {"raw": data_str}
+                    elif line.startswith("data:"):
+                        value = line[5:]
+                        if value.startswith(" "):
+                            value = value[1:]
+                        data_lines.append(value)
             # A clean EOF can arrive without a trailing newline, leaving the last event in the buffer.
             # Parse it here rather than dropping it; the loop above only fires on a newline.
             if buffer:
-                line = buffer.decode().strip()
-                if line.startswith("data: "):
-                    data_str = line[6:]
-                    if data_str != "[DONE]":
-                        try:
-                            yield json.loads(data_str)
-                        except json.JSONDecodeError:
-                            yield {"raw": data_str}
+                line = buffer.decode().removesuffix("\\r")
+                if line.startswith("data:"):
+                    value = line[5:]
+                    if value.startswith(" "):
+                        value = value[1:]
+                    data_lines.append(value)
+            if data_lines:
+                data_str = "\\n".join(data_lines)
+                if data_str != "[DONE]":
+                    try:
+                        yield json.loads(data_str)
+                    except json.JSONDecodeError:
+                        yield {"raw": data_str}
         except socket.timeout as e:
             raise LibreFangError(f"Request timed out after {self.timeout}s") from e
         finally:

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -118,6 +118,7 @@ class LibreFang:
 
         try:
             buffer = b""
+            data_lines = []
             while True:
                 chunk = resp.read(4096)
                 if not chunk:
@@ -125,27 +126,40 @@ class LibreFang:
                 buffer += chunk
                 lines = buffer.split(b"\n")
                 buffer = lines.pop()
-                for line in lines:
-                    line = line.decode().strip()
-                    if line.startswith("data: "):
-                        data_str = line[6:]
+                for raw_line in lines:
+                    line = raw_line.decode().removesuffix("\r")
+                    if not line:
+                        if not data_lines:
+                            continue
+                        data_str = "\n".join(data_lines)
+                        data_lines.clear()
                         if data_str == "[DONE]":
                             return
                         try:
                             yield json.loads(data_str)
                         except json.JSONDecodeError:
                             yield {"raw": data_str}
+                    elif line.startswith("data:"):
+                        value = line[5:]
+                        if value.startswith(" "):
+                            value = value[1:]
+                        data_lines.append(value)
             # A clean EOF can arrive without a trailing newline, leaving the last event in the buffer.
             # Parse it here rather than dropping it; the loop above only fires on a newline.
             if buffer:
-                line = buffer.decode().strip()
-                if line.startswith("data: "):
-                    data_str = line[6:]
-                    if data_str != "[DONE]":
-                        try:
-                            yield json.loads(data_str)
-                        except json.JSONDecodeError:
-                            yield {"raw": data_str}
+                line = buffer.decode().removesuffix("\r")
+                if line.startswith("data:"):
+                    value = line[5:]
+                    if value.startswith(" "):
+                        value = value[1:]
+                    data_lines.append(value)
+            if data_lines:
+                data_str = "\n".join(data_lines)
+                if data_str != "[DONE]":
+                    try:
+                        yield json.loads(data_str)
+                    except json.JSONDecodeError:
+                        yield {"raw": data_str}
         except socket.timeout as e:
             raise LibreFangError(f"Request timed out after {self.timeout}s") from e
         finally:

--- a/sdk/python/tests/test_generated_client_stream.py
+++ b/sdk/python/tests/test_generated_client_stream.py
@@ -36,6 +36,28 @@ def test_stream_closes_response_when_done_marker_returns(monkeypatch):
     assert response.closed
 
 
+def test_stream_joins_multiline_data_fields_at_event_boundary(monkeypatch):
+    response = FakeStreamResponse([
+        b'data: {"content":\ndata:"hello"}\n\ndata: {"next":true}\n\n',
+        b"",
+    ])
+    monkeypatch.setattr(client_module, "urlopen", lambda _request, **_kwargs: response)
+
+    events = list(LibreFang("http://example.test")._stream("GET", "/events"))
+
+    assert events == [{"content": "hello"}, {"next": True}]
+    assert response.closed
+
+
+def test_stream_preserves_newlines_in_non_json_multiline_data(monkeypatch):
+    response = FakeStreamResponse([b"data: first\ndata: second\n\n", b""])
+    monkeypatch.setattr(client_module, "urlopen", lambda _request, **_kwargs: response)
+
+    events = list(LibreFang("http://example.test")._stream("GET", "/events"))
+
+    assert events == [{"raw": "first\nsecond"}]
+
+
 def test_stream_closes_response_when_consumer_stops_early(monkeypatch):
     response = FakeStreamResponse([
         b'data: {"content":"first"}\n\ndata: {"content":"second"}\n\n',


### PR DESCRIPTION
## Changes

- accumulate consecutive Python SDK SSE `data:` fields until the event boundary
- join multi-line payloads with newlines before JSON parsing
- accept valid `data:` fields without a space and preserve CRLF handling
- update the generator template and regenerated Python client together
- add JSON and raw multi-line event regression coverage

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_generated_client_stream.py sdk/python/tests/test_generated_client_stream_utf8.py sdk/python/tests/test_generated_client_trailing_sse.py sdk/python/tests/test_generated_client_timeout.py scripts/tests/test_codegen_sdks.py` (17 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1998 passed)
- `python3 -m py_compile sdk/python/librefang/librefang_client.py`
- `python3 scripts/codegen-sdks.py`
- `git diff --check`

## Out of scope

- `librefang_sdk.py` input/error reporting findings are separate audit work
- package docstring and example documentation findings are separate reports