### PR TITLE
fix(sdk): hide Python agent error details

### DIFF
--- a/changelog.d/security/python-sdk-agent-errors.md
+++ b/changelog.d/security/python-sdk-agent-errors.md
@@ -1,0 +1,1 @@
+(@xiaomo) Prevent Python agent exceptions and malformed kernel input from leaking details in responses.

--- a/sdk/python/librefang/librefang_sdk.py
+++ b/sdk/python/librefang/librefang_sdk.py
@@ -61,7 +61,10 @@ def read_input() -> Dict[str, Any]:
             "message": message,
             "context": {},
         }
-    return json.loads(line)
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError as e:
+        raise ValueError("Invalid JSON input from LibreFang kernel") from e
 
 
 def respond(text: str, metadata: Optional[Dict[str, Any]] = None) -> None:
@@ -122,25 +125,36 @@ class Agent:
 
         try:
             if self._setup:
-                self._setup()
+                try:
+                    self._setup()
+                except Exception as e:
+                    log(f"Agent setup error: {e}", "error")
+                    respond("An internal error occurred while processing your request.")
+                    sys.exit(1)
 
-            data = read_input()
+            try:
+                data = read_input()
+            except ValueError as e:
+                log(f"Invalid kernel input: {e}", "error")
+                respond("Invalid input received from the LibreFang kernel.")
+                sys.exit(1)
+
             message = data.get("message", "")
             context = data.get("context", {})
 
-            result = self._handler(message, context)
+            try:
+                result = self._handler(message, context)
 
-            if isinstance(result, str):
-                respond(result)
-            elif isinstance(result, dict):
-                respond(result.get("text", str(result)), result.get("metadata"))
-            else:
-                respond(str(result))
-
-        except Exception as e:
-            log(f"Agent error: {e}", "error")
-            respond(f"Error: {e}")
-            sys.exit(1)
+                if isinstance(result, str):
+                    respond(result)
+                elif isinstance(result, dict):
+                    respond(result.get("text", str(result)), result.get("metadata"))
+                else:
+                    respond(str(result))
+            except Exception as e:
+                log(f"Agent handler error: {e}", "error")
+                respond("An internal error occurred while processing your request.")
+                sys.exit(1)
         finally:
             if self._teardown:
                 try:

--- a/sdk/python/tests/test_librefang_sdk.py
+++ b/sdk/python/tests/test_librefang_sdk.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from librefang.librefang_sdk import Agent, read_input
+
+
+def _response(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+def test_read_input_wraps_malformed_json(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"secret":'))
+
+    with pytest.raises(ValueError, match="Invalid JSON input from LibreFang kernel") as error:
+        read_input()
+
+    assert isinstance(error.value.__cause__, json.JSONDecodeError)
+    assert "secret" not in str(error.value)
+
+
+def test_agent_reports_invalid_input_without_running_handler(monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO("not-json\n"))
+    agent = Agent()
+    calls = []
+    agent.on_message(lambda _message, _context: calls.append(True))
+
+    with pytest.raises(SystemExit) as error:
+        agent.run()
+
+    assert error.value.code == 1
+    assert calls == []
+    assert _response(capsys) == {
+        "type": "response",
+        "text": "Invalid input received from the LibreFang kernel.",
+    }
+
+
+def test_agent_does_not_expose_handler_exception(monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"message":"hello"}\n'))
+    agent = Agent()
+
+    @agent.on_message
+    def fail(_message, _context):
+        raise RuntimeError("credential=top-secret")
+
+    with pytest.raises(SystemExit) as error:
+        agent.run()
+
+    captured = capsys.readouterr()
+    assert error.value.code == 1
+    assert json.loads(captured.out) == {
+        "type": "response",
+        "text": "An internal error occurred while processing your request.",
+    }
+    assert "top-secret" not in captured.out
+    assert "Agent handler error" in captured.err
+    assert "credential=top-secret" in captured.err
+
+
+def test_agent_does_not_expose_setup_exception(monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"message":"hello"}\n'))
+    agent = Agent()
+    agent.on_message(lambda _message, _context: "unused")
+
+    @agent.on_setup
+    def fail_setup():
+        raise RuntimeError("internal-path=/private/agent")
+
+    with pytest.raises(SystemExit):
+        agent.run()
+
+    captured = capsys.readouterr()
+    assert "/private/agent" not in captured.out
+    assert json.loads(captured.out)["text"] == (
+        "An internal error occurred while processing your request."
+    )
+    assert "Agent setup error" in captured.err
+    assert "internal-path=/private/agent" in captured.err


### PR DESCRIPTION
## Changes

- wrap malformed kernel JSON in a stable public `ValueError` contract without embedding input contents
- classify invalid input separately and avoid calling the message handler
- return fixed non-revealing responses for setup and handler failures
- retain full exception details on stderr with distinct setup and handler labels
- add focused tests for parsing, control flow, response safety, and diagnostic logging

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_librefang_sdk.py` (4 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2000 passed)
- `git diff --check`

## Out of scope

- package import-path docstring corrections are tracked by a separate audit report
- Python SDK packaging metadata and examples are separate reports