### PR TITLE
fix(sdk): correct Python package metadata

### DIFF
--- a/changelog.d/fixed/python-sdk-package-metadata.md
+++ b/changelog.d/fixed/python-sdk-package-metadata.md
@@ -1,0 +1,1 @@
+(@xiaomo) Correct the Python SDK minimum version and include nested sidecar template files in packages.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -17,14 +17,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]
@@ -48,7 +48,7 @@ exclude = ["examples*"]
 [tool.setuptools.package-data]
 # `sidecar/template/*` ships the adapter scaffold the sidecar docs tell
 # users to copy — without this it is absent from the installed wheel.
-librefang = ["sidecar/template/*"]
+librefang = ["sidecar/template/*", "sidecar/template/**/*"]
 
 # `python_files = ["*.py"]` made pytest import every example *script*
 # as a test module (they target the legacy flat `librefang_sdk`

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -18,8 +18,8 @@ setup(
     version=PROJECT_VERSION.group(1),
     description="Official Python client for the LibreFang Agent OS REST API",
     packages=find_packages(include=("librefang", "librefang.*")),
-    package_data={"librefang": ["sidecar/template/*"]},
-    python_requires=">=3.8",
+    package_data={"librefang": ["sidecar/template/*", "sidecar/template/**/*"]},
+    python_requires=">=3.10",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/sdk/python/tests/test_packaging.py
+++ b/sdk/python/tests/test_packaging.py
@@ -14,6 +14,9 @@ def test_legacy_setup_metadata_includes_real_package(tmp_path):
     for filename in ("setup.py", "pyproject.toml", "README.md", "LICENSE"):
         shutil.copy2(project / filename, checkout / filename)
     shutil.copytree(project / "librefang", checkout / "librefang")
+    nested_template = checkout / "librefang" / "sidecar" / "template" / "assets" / "config"
+    nested_template.mkdir(parents=True)
+    (nested_template / "example.toml").write_text("enabled = true\n", encoding="utf-8")
 
     fixture_version = "2099.1.2rc3"
     pyproject = checkout / "pyproject.toml"
@@ -45,11 +48,13 @@ def test_legacy_setup_metadata_includes_real_package(tmp_path):
 
     assert "Name: librefang-sdk" in metadata
     assert f"Version: {fixture_version}" in metadata
+    assert "Requires-Python: >=3.10" in metadata
     assert "librefang/__init__.py" in names
     assert "librefang/sidecar/adapters/discord.py" in names
     assert "librefang/sidecar/template/README.md" in names
     assert "librefang/sidecar/template/adapter.py.tmpl" in names
     assert "librefang/sidecar/template/requirements.txt" in names
+    assert "librefang/sidecar/template/assets/config/example.toml" in names
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(wheel)


### PR DESCRIPTION
## Changes

- raise the declared Python minimum from 3.8 to 3.10 to match PEP 604 syntax already used by shipped adapters
- remove unsupported 3.8/3.9 classifiers and add 3.13/3.14 compatibility classifiers
- include nested sidecar template files in both PEP 621 and legacy setuptools package-data configuration
- extend the real-wheel regression to assert `Requires-Python` and a nested scaffold asset

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_packaging.py` (1 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1996 passed)
- `git diff --check`

## Out of scope

- the legacy `setup.py` package/version findings are already fixed on current `main` by #6794
- package docstrings, examples, and license-year policy are separate reports