### PR TITLE
fix(sdk): modernize Python examples

### DIFF
--- a/changelog.d/fixed/python-sdk-examples.md
+++ b/changelog.d/fixed/python-sdk-examples.md
@@ -1,0 +1,1 @@
+(@xiaomo) Update Python SDK examples to the current API and guarantee created-agent cleanup on failures.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,14 +5,14 @@ Official Python client and SDK for the LibreFang Agent OS.
 ## Installation
 
 ```bash
-pip install librefang
+pip install librefang-sdk
 ```
 
-## Two Packages
+## Public APIs
 
 This package provides two different interfaces:
 
-### 1. REST API Client (`librefang.client`)
+### 1. REST API Client
 
 Control LibreFang remotely via its REST API.
 
@@ -22,20 +22,21 @@ from librefang import Client
 client = Client("http://localhost:4545")
 
 # Create an agent
-agent = client.agents.create(template="assistant")
-print(f"Agent created: {agent['id']}")
+agent = client.agents.spawn_agent(template="assistant")
+agent_id = agent["agent_id"]
+print(f"Agent created: {agent_id}")
 
 # Send a message
-reply = client.agents.message(agent["id"], "Hello!")
+reply = client.agents.send_message(agent_id, message="Hello!")
 print(reply)
 
 # Stream a response
-for event in client.agents.stream(agent["id"], "Tell me a story"):
-    if event.get("type") == "text_delta":
-        print(event["delta"], end="", flush=True)
+for event in client.agents.send_message_stream(agent_id, message="Tell me a story"):
+    if event.get("content"):
+        print(event["content"], end="", flush=True)
 ```
 
-### 2. Agent SDK (`librefang.sdk`)
+### 2. Agent SDK
 
 Write Python agents that run inside LibreFang.
 
@@ -74,7 +75,7 @@ See the `examples/` directory for more examples:
 
 ## Requirements
 
-- Python 3.8+
+- Python 3.10+
 
 ## License
 

--- a/sdk/python/examples/client_basic.py
+++ b/sdk/python/examples/client_basic.py
@@ -1,45 +1,59 @@
 #!/usr/bin/env python3
-"""
-Basic example — create an agent and chat with it via the REST API.
-
-Usage:
-    python client_basic.py
-"""
+"""Create an agent and chat with it through the LibreFang REST API."""
 
 import sys
-import os
 import time
+from typing import Any, Optional
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from librefang import Client as LibreFang
+from librefang import Client
+from librefang.librefang_client import LibreFangError
 
-client = LibreFang("http://localhost:4545")
 
-# Check server health
-health = client.health()
-print("Server:", health)
+def main(client: Optional[Any] = None) -> int:
+    client = client or Client("http://localhost:4545")
+    created_agent_id = None
+    failed = False
 
-# List existing agents
-agents = client.agents.list()
-print(f"Agents: {len(agents)}")
+    try:
+        print("Server:", client.system.health())
 
-# Use existing agent or create a new one with unique name
-if agents:
-    agent = agents[0]
-    print(f"Using existing agent: {agent['id']}")
-    should_delete = False
-else:
-    timestamp = int(time.time())
-    agent = client.agents.create(template="assistant", name=f"sdk-test-{timestamp}")
-    print(f"Created agent: {agent['id']}")
-    should_delete = True
+        page = client.agents.list_agents()
+        agents = page.get("items", [])
+        print(f"Agents: {page.get('total', len(agents))}")
 
-# Send a message and get the full response
-print("\n--- Sending message ---")
-reply = client.agents.message(agent["id"], "Say hello in 5 words.")
-print(f"Reply: {reply}")
+        if agents:
+            agent_id = agents[0]["id"]
+            print(f"Using existing agent: {agent_id}")
+        else:
+            timestamp = int(time.time())
+            agent = client.agents.spawn_agent(
+                template="assistant",
+                name=f"sdk-test-{timestamp}",
+            )
+            agent_id = agent["agent_id"]
+            created_agent_id = agent_id
+            print(f"Created agent: {agent_id}")
 
-# Clean up only if we created it
-if should_delete:
-    client.agents.delete(agent["id"])
-    print("Agent deleted.")
+        print("\n--- Sending message ---")
+        reply = client.agents.send_message(
+            agent_id,
+            message="Say hello in 5 words.",
+        )
+        print(f"Reply: {reply}")
+    except LibreFangError as error:
+        print(f"LibreFang request failed: {error}", file=sys.stderr)
+        failed = True
+    finally:
+        if created_agent_id is not None:
+            try:
+                client.agents.kill_agent(created_agent_id, confirm=True)
+                print("Agent deleted.")
+            except LibreFangError as error:
+                print(f"Agent cleanup failed: {error}", file=sys.stderr)
+                failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/examples/client_streaming.py
+++ b/sdk/python/examples/client_streaming.py
@@ -1,33 +1,52 @@
 #!/usr/bin/env python3
-"""
-Streaming example — stream agent responses token by token.
-
-Usage:
-    python client_streaming.py
-"""
+"""Stream an agent response through the LibreFang REST API."""
 
 import sys
-import os
+from typing import Any, Optional
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from librefang_client import LibreFang
+from librefang import Client
+from librefang.librefang_client import LibreFangError
 
-client = LibreFang("http://localhost:4545")
 
-# Create an agent
-agent = client.agents.create(template="assistant")
-print(f"Agent: {agent['id']}")
+def main(client: Optional[Any] = None) -> int:
+    client = client or Client("http://localhost:4545")
+    agent_id = None
+    failed = False
 
-# Stream the response
-print("\n--- Streaming response ---")
-for event in client.agents.stream(agent["id"], "Tell me a short story about a robot."):
-    event_type = event.get("type", "")
-    if event_type == "text_delta" and event.get("delta"):
-        print(event["delta"], end="", flush=True)
-    elif event_type == "tool_call":
-        print(f"\n[Tool call: {event.get('tool')}]")
-    elif event_type == "done":
-        print("\n--- Done ---")
+    try:
+        agent = client.agents.spawn_agent(template="assistant")
+        agent_id = agent["agent_id"]
+        print(f"Agent: {agent_id}")
 
-# Clean up
-client.agents.delete(agent["id"])
+        print("\n--- Streaming response ---")
+        events = client.agents.send_message_stream(
+            agent_id,
+            message="Tell me a short story about a robot.",
+        )
+        for event in events:
+            if "error" in event or event.get("raw") == "error":
+                detail = event.get("error", event.get("raw"))
+                raise LibreFangError(f"Stream error: {detail}")
+            if event.get("content"):
+                print(event["content"], end="", flush=True)
+            elif event.get("tool"):
+                print(f"\n[Tool call: {event['tool']}]")
+            elif event.get("done"):
+                print("\n--- Done ---")
+    except LibreFangError as error:
+        print(f"LibreFang request failed: {error}", file=sys.stderr)
+        failed = True
+    finally:
+        if agent_id is not None:
+            try:
+                client.agents.kill_agent(agent_id, confirm=True)
+                print("Agent deleted.")
+            except LibreFangError as error:
+                print(f"Agent cleanup failed: {error}", file=sys.stderr)
+                failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/examples/echo_agent.py
+++ b/sdk/python/examples/echo_agent.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 """Example LibreFang agent: echoes back messages with a friendly greeting."""
 
-import sys
 import os
 
-# Add parent directory to path for librefang_sdk import
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from librefang_sdk import Agent
+from librefang import Agent
 
 agent = Agent()
 
@@ -17,4 +14,5 @@ def handle(message: str, context: dict) -> str:
     return f"Hello from Python agent {agent_id}! You said: {message}"
 
 
-agent.run()
+if __name__ == "__main__":
+    agent.run()

--- a/sdk/python/librefang/__init__.py
+++ b/sdk/python/librefang/__init__.py
@@ -1,10 +1,13 @@
 """
 LibreFang Python SDK and Client.
 
-Three packages:
-- librefang.client: REST API client for controlling LibreFang remotely
-- librefang.sdk: Helper library for writing Python agents that run inside LibreFang
-- librefang.sidecar: Framework for writing out-of-process channel adapters
+Public APIs:
+- ``from librefang import Client`` controls LibreFang through its REST API.
+- ``from librefang import Agent`` writes Python agents that run inside LibreFang.
+- ``librefang.sidecar`` provides the out-of-process channel adapter framework.
+
+The implementation modules are ``librefang.librefang_client`` and
+``librefang.librefang_sdk``; applications should prefer the root re-exports.
 """
 
 import re

--- a/sdk/python/tests/test_examples.py
+++ b/sdk/python/tests/test_examples.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib
+
+from librefang.librefang_client import LibreFangError
+
+
+class _BasicAgents:
+    def __init__(self):
+        self.deleted = []
+
+    def list_agents(self):
+        return {"items": [], "total": 0}
+
+    def spawn_agent(self, **_data):
+        return {"agent_id": "created-id"}
+
+    def send_message(self, _agent_id, **_data):
+        raise LibreFangError("connection lost")
+
+    def kill_agent(self, agent_id, **query):
+        self.deleted.append((agent_id, query))
+
+
+class _StreamingAgents:
+    def __init__(self):
+        self.deleted = []
+
+    def spawn_agent(self, **_data):
+        return {"agent_id": "stream-id"}
+
+    def send_message_stream(self, _agent_id, **_data):
+        yield {"content": "hello"}
+        yield {"error": "provider failed"}
+
+    def kill_agent(self, agent_id, **query):
+        self.deleted.append((agent_id, query))
+
+
+class _Client:
+    def __init__(self, agents):
+        self.agents = agents
+        self.system = self
+
+    def health(self):
+        return {"status": "ok"}
+
+
+def test_basic_example_cleans_up_created_agent_after_request_failure(capsys):
+    module = importlib.import_module("examples.client_basic")
+    agents = _BasicAgents()
+
+    assert module.main(_Client(agents)) == 1
+
+    assert agents.deleted == [("created-id", {"confirm": True})]
+    assert "LibreFang request failed: connection lost" in capsys.readouterr().err
+
+
+def test_streaming_example_surfaces_error_event_and_cleans_up(capsys):
+    module = importlib.import_module("examples.client_streaming")
+    agents = _StreamingAgents()
+
+    assert module.main(_Client(agents)) == 1
+
+    assert agents.deleted == [("stream-id", {"confirm": True})]
+    assert "Stream error: provider failed" in capsys.readouterr().err
+
+
+def test_importing_echo_example_does_not_run_agent(monkeypatch):
+    calls = []
+    monkeypatch.setattr("librefang.Agent.run", lambda _self: calls.append(True))
+
+    importlib.import_module("examples.echo_agent")
+
+    assert calls == []


### PR DESCRIPTION
## Changes

- migrate client examples from removed flat imports and obsolete methods to the current root exports and generated API
- guarantee newly created agents are deleted in `finally`, including request and stream failures
- catch `LibreFangError` with concise diagnostics and fail explicitly on streamed error payloads
- make all examples import-safe and remove import-time `sys.path` mutation
- correct the package docstring, install command, current API snippets, and Python requirement in the SDK README
- add hermetic fake-client regressions for cleanup, stream errors, and echo-agent imports

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_examples.py` (3 passed)
- `python3 -m py_compile sdk/python/examples/client_basic.py sdk/python/examples/client_streaming.py sdk/python/examples/echo_agent.py`
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1999 passed)
- `git diff --check`

## Out of scope

- package metadata is handled separately by #7205
- license-year policy is a separate report
- this does not launch a live daemon or invoke an LLM