### PR TITLE
fix(test): align sidecar HTTP fakes with responses

### DIFF
--- a/changelog.d/fixed/python-sidecar-test-fakes.md
+++ b/changelog.d/fixed/python-sidecar-test-fakes.md
@@ -1,0 +1,1 @@
+(@xiaomo) Make shared Python sidecar HTTP test fakes consume response bodies like real responses.

--- a/sdk/python/tests/_sidecar_fakes.py
+++ b/sdk/python/tests/_sidecar_fakes.py
@@ -87,17 +87,30 @@ class FakeResp:
     ) -> None:
         self.status = status
         self._body = body
+        self._pos = 0
+        self.closed = False
         self.headers = headers if headers is not None else HdrShim({})
 
     def read(self, size: Optional[int] = None) -> bytes:
+        if self.closed:
+            raise ValueError("read of closed response")
         if size is None or size < 0:
-            return self._body
-        return self._body[:size]
+            chunk = self._body[self._pos:]
+            self._pos = len(self._body)
+            return chunk
+        end = min(self._pos + size, len(self._body))
+        chunk = self._body[self._pos:end]
+        self._pos = end
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
 
     def __enter__(self) -> "FakeResp":
         return self
 
     def __exit__(self, *_exc) -> bool:
+        self.close()
         return False
 
 
@@ -125,7 +138,7 @@ class FakeUrlopen:
         # str-decoded body (most common shape)
         try:
             body_raw: Optional[str] = (
-                body_bytes.decode("utf-8") if body_bytes else None
+                body_bytes.decode("utf-8") if body_bytes is not None else None
             )
         except Exception:  # noqa: BLE001
             body_raw = None
@@ -161,9 +174,14 @@ class FakeUrlopen:
         entry = self.script.pop(0)
         if len(entry) == 3:
             status, body, resp_hdrs = entry
-        else:
+        elif len(entry) == 2:
             status, body = entry
             resp_hdrs = {}
+        else:
+            raise AssertionError(
+                "urlopen script entries must be (status, body) or "
+                f"(status, body, headers), got {len(entry)} values"
+            )
         if status >= 400:
             raise urllib.error.HTTPError(
                 req.full_url, status, "Error", HdrShim(resp_hdrs),

--- a/sdk/python/tests/test_sidecar_fakes.py
+++ b/sdk/python/tests/test_sidecar_fakes.py
@@ -41,6 +41,18 @@ def test_fakeresp_is_context_manager():
     with fr as resp:
         assert resp.status == 200
         assert resp.read() == b"hello"
+        assert resp.read() == b""
+    assert fr.closed
+    with pytest.raises(ValueError, match="closed response"):
+        fr.read()
+
+
+def test_fakeresp_bounded_reads_advance_cursor():
+    fr = FakeResp(200, b"abcdef")
+    assert fr.read(2) == b"ab"
+    assert fr.read(3) == b"cde"
+    assert fr.read(3) == b"f"
+    assert fr.read(1) == b""
 
 
 def test_fakeresp_default_headers_empty():
@@ -115,6 +127,14 @@ def test_fakeurlopen_3_tuple_with_headers():
     assert exc.value.headers.items() == [("Retry-After", "5")]
 
 
+def test_fakeurlopen_success_response_preserves_headers():
+    fake = FakeUrlopen([(200, b"ok", {"Link": "</next>; rel=next"})])
+
+    resp = fake(_make_req())
+
+    assert resp.headers.items() == [("Link", "</next>; rel=next")]
+
+
 def test_fakeurlopen_4xx_raises_httperror():
     fake = FakeUrlopen([(404, {"err": "not found"})])
     with pytest.raises(urllib.error.HTTPError) as exc:
@@ -148,6 +168,34 @@ def test_fakeurlopen_bytes_body_passthrough():
     fake = FakeUrlopen([(200, b"plain text response")])
     resp = fake(_make_req())
     assert resp.read() == b"plain text response"
+
+
+def test_fakeurlopen_distinguishes_empty_body_from_no_body():
+    fake = FakeUrlopen([(200, {}), (200, {})])
+
+    fake(_make_req(method="POST", body=b""))
+    fake(_make_req(method="POST", body=None))
+
+    assert fake.calls[0]["body_raw"] == ""
+    assert fake.calls[1]["body_raw"] is None
+
+
+def test_fakeurlopen_invalid_body_degrades_parse_fields():
+    fake = FakeUrlopen([(200, {})])
+
+    fake(_make_req(method="POST", body=b"\xff"))
+
+    assert fake.calls[0]["body_raw"] is None
+    assert fake.calls[0]["body"] is None
+    assert fake.calls[0]["params"] == {}
+
+
+@pytest.mark.parametrize("entry", [(200,), (200, {}, {}, "extra")])
+def test_fakeurlopen_rejects_invalid_script_tuple_length(entry):
+    fake = FakeUrlopen([entry])
+
+    with pytest.raises(AssertionError, match="script entries must be"):
+        fake(_make_req())
 
 
 def test_fakeurlopen_backcompat_underscore_aliases():


### PR DESCRIPTION
## Changes

- make shared fake HTTP responses consume bounded and unbounded reads through a cursor
- close responses on context-manager exit and reject reads after close
- distinguish an explicit empty request body from no request body
- reject malformed scripted response tuple lengths with an actionable assertion
- cover 2xx scripted headers, malformed-body fallback, cursor behavior, close behavior, and both invalid tuple shapes

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_sidecar_fakes.py` (21 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (2002 passed)
- `git diff --check`

## Out of scope

- adapter-specific environment isolation and timing findings remain separate reports
- production sidecar HTTP behavior is unchanged