### PR TITLE
fix(test): isolate Discord adapter tests

### DIFF
--- a/changelog.d/fixed/python-discord-tests.md
+++ b/changelog.d/fixed/python-discord-tests.md
@@ -1,0 +1,1 @@
+(@xiaomo) Isolate Discord adapter test credentials and remove stale test dependencies.

--- a/sdk/python/tests/test_discord_adapter.py
+++ b/sdk/python/tests/test_discord_adapter.py
@@ -13,22 +13,32 @@ identify cycle. This sidecar runs proper periodic heartbeats so
 sessions survive long-running idle periods.
 """
 
-import io
 import json
 import os
-import urllib.error
-import urllib.parse
 
 import pytest
 
+from librefang.sidecar.adapters import discord as da
 
-os.environ.setdefault("DISCORD_BOT_TOKEN", "test-bot-token")
-from librefang.sidecar.adapters import discord as da  # noqa: E402
-
-from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+from _sidecar_fakes import _FakeUrlopen
 
 
 # ---- _FakeUrlopen scaffolding (shared shape with reddit tests) -----
+
+
+@pytest.fixture(autouse=True)
+def _isolated_discord_env(monkeypatch):
+    defaults = {
+        "DISCORD_BOT_TOKEN": "test-bot-token",
+        "DISCORD_ALLOWED_GUILDS": "",
+        "DISCORD_ALLOWED_USERS": "",
+        "DISCORD_INTENTS": "",
+        "DISCORD_IGNORE_BOTS": "",
+        "DISCORD_MENTION_PATTERNS": "",
+        "DISCORD_ACCOUNT_ID": "",
+    }
+    for key, value in defaults.items():
+        monkeypatch.setenv(key, value)
 
 
 def _adapter(**env):
@@ -61,12 +71,11 @@ def test_default_api_base_and_intents():
     assert a.account_id is None
 
 
-def test_missing_token_exits_2():
-    os.environ["DISCORD_BOT_TOKEN"] = ""
+def test_missing_token_exits_2(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "")
     with pytest.raises(SystemExit) as exc:
         da.DiscordAdapter()
     assert exc.value.code == 2
-    os.environ["DISCORD_BOT_TOKEN"] = "test-bot-token"
 
 
 def test_custom_intents_and_account_id():
@@ -869,7 +878,7 @@ async def test_on_send_drops_when_no_channel_id(monkeypatch):
 # ---- _run_session uses the heartbeat scheduling path --------------
 
 
-def test_run_session_sends_identify_when_no_session(monkeypatch):
+def test_run_session_sends_identify_when_no_session():
     """After HELLO, with no saved session, the adapter must send
     IDENTIFY (not RESUME). Captured via FakeWs.sent_text[0]."""
     a = _adapter()
@@ -898,7 +907,7 @@ def test_run_session_sends_identify_when_no_session(monkeypatch):
     assert first["d"]["properties"]["browser"] == "librefang"
 
 
-def test_run_session_sends_resume_when_session_known(monkeypatch):
+def test_run_session_sends_resume_when_session_known():
     a = _adapter()
     a.session_id = "sess-1"
     a.last_seq = 7
@@ -917,7 +926,7 @@ def test_run_session_sends_resume_when_session_known(monkeypatch):
     assert first["d"]["seq"] == 7
 
 
-def test_run_session_emits_message_create(monkeypatch):
+def test_run_session_emits_message_create():
     """End-to-end: HELLO + READY + MESSAGE_CREATE → one emit."""
     a = _adapter()
     a.session_id = None


### PR DESCRIPTION
## Changes

- install Discord test credentials and defaults through an autouse pytest fixture
- make the missing-token case use a fail-safe `monkeypatch` override
- remove import-time environment mutation
- remove dead stdlib and shared-fake imports
- remove unused monkeypatch parameters from the three session-loop tests

## Verification

- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests/test_discord_adapter.py` (69 passed)
- `PYTHONPATH=sdk/python /tmp/librefang-dingtalk-py314/bin/pytest -q sdk/python/tests` (1996 passed)
- `git diff --check`

## Out of scope

- production Discord adapter behavior is unchanged
- other adapter test modules have separate environment-isolation reports