### PR TITLE
fix(sdk): repair Go client examples

### DIFF
--- a/changelog.d/fixed/go-sdk-examples.md
+++ b/changelog.d/fixed/go-sdk-examples.md
@@ -1,0 +1,1 @@
+(@xiaomo) Fix Go SDK examples to use current signatures, validate response IDs, and clean up created agents.

--- a/sdk/go/examples/basic.go
+++ b/sdk/go/examples/basic.go
@@ -10,40 +10,71 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() (err error) {
 	client := librefang.New("http://localhost:4545")
 
 	// Check server health
 	health, err := client.System.Health()
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("check server health: %w", err)
 	}
 	fmt.Println("Server:", health)
 
 	// List existing agents
-	raw, err := client.Agents.ListAgents()
+	raw, err := client.Agents.ListAgents(nil)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("list agents: %w", err)
 	}
-	agents := librefang.ToSlice(raw)
+	items, ok := librefang.ToMap(raw)["items"]
+	if !ok {
+		return fmt.Errorf("list agents response is missing items")
+	}
+	agents := librefang.ToSlice(items)
 	fmt.Println("Agents:", len(agents))
 
 	// Use existing agent or create a new one
 	var agentID string
-	var shouldDelete bool
 
 	if len(agents) > 0 {
-		agentID = agents[0]["id"].(string)
+		id, ok := agents[0]["id"].(string)
+		if !ok || id == "" {
+			return fmt.Errorf("existing agent entry is missing a valid id")
+		}
+		agentID = id
 		fmt.Println("Using existing agent:", agentID)
 	} else {
 		agent, err := client.Agents.SpawnAgent(map[string]interface{}{
 			"template": "assistant",
 		})
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("spawn agent: %w", err)
 		}
-		agentID = librefang.ToMap(agent)["id"].(string)
-		shouldDelete = true
+		id, ok := librefang.ToMap(agent)["agent_id"].(string)
+		if !ok || id == "" {
+			return fmt.Errorf("spawned agent response is missing a valid agent_id")
+		}
+		agentID = id
 		fmt.Println("Created agent:", agentID)
+		defer func() {
+			_, cleanupErr := client.Agents.KillAgent(
+				agentID,
+				map[string]string{"confirm": "true"},
+			)
+			if cleanupErr != nil {
+				if err == nil {
+					err = fmt.Errorf("delete created agent: %w", cleanupErr)
+				} else {
+					log.Printf("warning: failed to delete created agent: %v", cleanupErr)
+				}
+				return
+			}
+			fmt.Println("Agent deleted.")
+		}()
 	}
 
 	// Send a message
@@ -52,13 +83,9 @@ func main() {
 		"message": "Say hello in 5 words.",
 	})
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("send message: %w", err)
 	}
 	fmt.Println("Reply:", reply)
 
-	// Clean up only if we created it
-	if shouldDelete {
-		client.Agents.KillAgent(agentID)
-		fmt.Println("Agent deleted.")
-	}
+	return nil
 }

--- a/sdk/go/examples/streaming.go
+++ b/sdk/go/examples/streaming.go
@@ -10,19 +10,29 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() (err error) {
 	client := librefang.New("http://localhost:4545")
 
 	raw, err := client.Agents.ListAgents(nil)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("list agents: %w", err)
 	}
-	agents := librefang.ToSlice(raw)
+	items, ok := librefang.ToMap(raw)["items"]
+	if !ok {
+		return fmt.Errorf("list agents response is missing items")
+	}
+	agents := librefang.ToSlice(items)
 
 	var agentID string
 	if len(agents) > 0 {
 		id, ok := agents[0]["id"].(string)
 		if !ok || id == "" {
-			log.Fatal("existing agent entry is missing a valid id")
+			return fmt.Errorf("existing agent entry is missing a valid id")
 		}
 		agentID = id
 		fmt.Println("Using existing agent:", agentID)
@@ -31,14 +41,29 @@ func main() {
 			"template": "assistant",
 		})
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("spawn agent: %w", err)
 		}
 		id, ok := librefang.ToMap(agent)["agent_id"].(string)
 		if !ok || id == "" {
-			log.Fatal("spawned agent response is missing a valid agent_id")
+			return fmt.Errorf("spawned agent response is missing a valid agent_id")
 		}
 		agentID = id
 		fmt.Println("Created agent:", agentID)
+		defer func() {
+			_, cleanupErr := client.Agents.KillAgent(
+				agentID,
+				map[string]string{"confirm": "true"},
+			)
+			if cleanupErr != nil {
+				if err == nil {
+					err = fmt.Errorf("delete created agent: %w", cleanupErr)
+				} else {
+					log.Printf("warning: failed to delete created agent: %v", cleanupErr)
+				}
+				return
+			}
+			fmt.Println("Agent deleted.")
+		}()
 	}
 
 	fmt.Println("\n--- Streaming response ---")
@@ -47,7 +72,7 @@ func main() {
 		"message": "Say hello in 3 words.",
 	}) {
 		if errMessage, ok := event["error"].(string); ok {
-			log.Fatal("stream failed: ", errMessage)
+			return fmt.Errorf("stream failed: %s", errMessage)
 		}
 		if content, ok := event["content"].(string); ok {
 			fmt.Print(content)
@@ -58,6 +83,7 @@ func main() {
 		}
 	}
 	if !sawDone {
-		log.Fatal("stream ended before the done event")
+		return fmt.Errorf("stream ended before the done event")
 	}
+	return nil
 }

--- a/sdk/go/examples/test_apis.go
+++ b/sdk/go/examples/test_apis.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/librefang/librefang/sdk/go"
 )
@@ -11,12 +12,21 @@ import (
 func main() {
 	client := librefang.New("http://localhost:4545")
 
-	skills, _ := client.Skills.ListSkills()
-	fmt.Printf("Skills: %d\n", len(librefang.ToSlice(skills)))
+	if skills, err := client.Skills.ListSkills(); err != nil {
+		log.Printf("ListSkills failed: %v", err)
+	} else {
+		fmt.Printf("Skills: %d\n", len(librefang.ToSlice(skills)))
+	}
 
-	models, _ := client.Models.ListAllModels()
-	fmt.Printf("Models: %d\n", len(librefang.ToSlice(models)))
+	if models, err := client.Models.ListAllModels(); err != nil {
+		log.Printf("ListAllModels failed: %v", err)
+	} else {
+		fmt.Printf("Models: %d\n", len(librefang.ToSlice(models)))
+	}
 
-	providers, _ := client.Providers.ListProviders()
-	fmt.Printf("Providers: %d\n", len(librefang.ToSlice(providers)))
+	if providers, err := client.Models.ListProviders(); err != nil {
+		log.Printf("ListProviders failed: %v", err)
+	} else {
+		fmt.Printf("Providers: %d\n", len(librefang.ToSlice(providers)))
+	}
 }


### PR DESCRIPTION
## Changes

- call generated Go methods with their current query arguments and use the paginated `items` envelope
- validate existing-agent `id` and spawn-response `agent_id` fields without panic-prone assertions
- register confirmed agent deletion immediately after spawn and pass the required `confirm=true` query
- keep cleanup defers effective by returning errors from `run` instead of calling `log.Fatal` inside it
- surface stream errors and missing done events while still cleaning up a created agent
- handle ListSkills, ListAllModels, and ListProviders errors explicitly

## Verification

- `go test examples/basic.go`
- `go test examples/streaming.go`
- `go test examples/test_apis.go`
- `go test ./...`
- `git diff --check`

## Out of scope

- generated Go client implementation findings remain separate
- examples were compile-checked without contacting a live daemon or LLM