### PR TITLE
fix(sdk): modernize JavaScript examples

### DIFF
--- a/changelog.d/fixed/javascript-sdk-examples.md
+++ b/changelog.d/fixed/javascript-sdk-examples.md
@@ -1,0 +1,1 @@
+(@xiaomo) Update JavaScript SDK examples to current APIs and guarantee created-agent cleanup.

--- a/sdk/javascript/examples/basic.js
+++ b/sdk/javascript/examples/basic.js
@@ -1,52 +1,50 @@
-/**
- * Basic example — create an agent and chat with it.
- *
- * Usage:
- *   node basic.js
- */
+/** Create an isolated agent and chat with it through the LibreFang API. */
+
+"use strict";
 
 const { LibreFang } = require("../index");
 
 async function main() {
-  const client = new LibreFang("http://localhost:4545");
+  const baseUrl = process.env.LIBREFANG_URL || "http://localhost:4545";
+  const client = new LibreFang(baseUrl);
+  let agentId;
+  let activeError;
 
-  // Check server health
-  const health = await client.health();
-  console.log("Server:", health);
+  try {
+    console.log("Server:", await client.system.health());
 
-  // List existing agents
-  const agents = await client.agents.list();
-  console.log("Agents:", agents.length);
-
-  let agent;
-  let shouldDelete = false;
-
-  // Use existing agent or create a new one with unique name
-  if (agents.length > 0) {
-    // Use the first available agent
-    agent = agents[0];
-    console.log("Using existing agent:", agent.id);
-  } else {
-    // Create a new agent with a unique name to avoid conflicts
-    const timestamp = Date.now();
-    agent = await client.agents.create({
+    const agent = await client.agents.spawnAgent({
       template: "assistant",
-      name: `sdk-test-${timestamp}`
+      name: `sdk-test-${Date.now()}`,
     });
-    shouldDelete = true;
-    console.log("Created agent:", agent.id);
-  }
+    if (!agent || typeof agent.agent_id !== "string" || !agent.agent_id) {
+      throw new Error("spawn response is missing a valid agent_id");
+    }
+    agentId = agent.agent_id;
+    console.log("Created agent:", agentId);
 
-  // Send a message and get the full response
-  console.log("\n--- Sending message ---");
-  const reply = await client.agents.message(agent.id, "Say hello in 5 words.");
-  console.log("Reply:", reply);
-
-  // Clean up only if we created it
-  if (shouldDelete) {
-    await client.agents.delete(agent.id);
-    console.log("Agent deleted.");
+    console.log("\n--- Sending message ---");
+    const reply = await client.agents.sendMessage(agentId, {
+      message: "Say hello in 5 words.",
+    });
+    console.log("Reply:", reply);
+  } catch (error) {
+    activeError = error;
+    throw error;
+  } finally {
+    if (agentId) {
+      try {
+        await client.agents.killAgent(agentId, { confirm: true });
+        console.log("Agent deleted.");
+      } catch (cleanupError) {
+        if (!activeError) throw cleanupError;
+        console.error("[Warning] Failed to delete created agent:", cleanupError.message);
+      }
+    }
   }
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error("[Error] Basic example failed:", error.message);
+  process.exitCode = 1;
+});

--- a/sdk/javascript/examples/streaming.js
+++ b/sdk/javascript/examples/streaming.js
@@ -1,46 +1,71 @@
-/**
- * Streaming example — stream agent responses token by token.
- *
- * Usage:
- *   node streaming.js
- */
+/** Stream an isolated agent response through the LibreFang API. */
+
+"use strict";
 
 const { LibreFang } = require("../index");
 
 async function main() {
-  const client = new LibreFang("http://localhost:4545");
+  const baseUrl = process.env.LIBREFANG_URL || "http://localhost:4545";
+  const client = new LibreFang(baseUrl);
+  let agentId;
+  let activeError;
+  let interrupted = false;
 
-  // List existing agents
-  const agents = await client.agents.list();
+  const onSignal = (signal) => {
+    interrupted = true;
+    process.exitCode = signal === "SIGINT" ? 130 : 143;
+    console.error(`\n[Interrupted] Received ${signal}; cleaning up...`);
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
 
-  // Use existing agent or create a new one
-  let agent;
-  let shouldDelete = false;
-  if (agents.length > 0) {
-    agent = agents[0];
-    console.log("Using existing agent:", agent.id);
-  } else {
-    agent = await client.agents.create({ template: "assistant" });
-    console.log("Created agent:", agent.id);
-    shouldDelete = true;
-  }
-
-  // Stream the response
-  console.log("\n--- Streaming response ---");
-  for await (const event of client.agents.stream(agent.id, "Say hello in 3 words.")) {
-    if (event.type === "text_delta" && event.delta) {
-      process.stdout.write(event.delta);
-    } else if (event.type === "tool_call") {
-      console.log("\n[Tool call:", event.tool, "]");
-    } else if (event.type === "done") {
-      console.log("\n--- Done ---");
+  try {
+    const agent = await client.agents.spawnAgent({
+      template: "assistant",
+      name: `sdk-stream-${Date.now()}`,
+    });
+    if (!agent || typeof agent.agent_id !== "string" || !agent.agent_id) {
+      throw new Error("spawn response is missing a valid agent_id");
     }
-  }
+    agentId = agent.agent_id;
+    console.log("Created agent:", agentId);
 
-  // Clean up only if we created it
-  if (shouldDelete) {
-    await client.agents.delete(agent.id);
+    console.log("\n--- Streaming response ---");
+    const events = client.agents.sendMessageStream(agentId, {
+      message: "Say hello in 3 words.",
+    });
+    for await (const event of events) {
+      if (event.error) {
+        throw new Error(`stream failed: ${event.error}`);
+      }
+      if (event.content) {
+        process.stdout.write(event.content);
+      } else if (event.tool) {
+        console.log(`\n[Tool call: ${event.tool}]`);
+      } else if (event.done) {
+        console.log("\n--- Done ---");
+      }
+      if (interrupted) break;
+    }
+  } catch (error) {
+    activeError = error;
+    throw error;
+  } finally {
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+    if (agentId) {
+      try {
+        await client.agents.killAgent(agentId, { confirm: true });
+        console.log("Agent deleted.");
+      } catch (cleanupError) {
+        if (!activeError) throw cleanupError;
+        console.error("[Warning] Failed to delete created agent:", cleanupError.message);
+      }
+    }
   }
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error("[Error] Streaming example failed:", error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Changes

- migrate both examples from removed methods to the current generated camelCase API and response fields
- always create an isolated `sdk-test-*` agent instead of messaging an arbitrary existing agent
- read the daemon URL from `LIBREFANG_URL` with the existing localhost fallback
- delete every created agent in `finally` with required `confirm: true`, including request and stream failures
- surface stream error payloads and add SIGINT/SIGTERM interruption handling
- replace bare `console.error` catches with contextual error messages and nonzero exit status

## Verification

- `node --check examples/basic.js`
- `node --check examples/streaming.js`
- `npm pack --dry-run`
- `git diff --check`

## Out of scope

- `npm test` currently executes the networked basic example; that separate package.json audit finding is intentionally not invoked here
- generated JavaScript client and TypeScript declaration findings remain separate