### PR TITLE
test: make JavaScript SDK tests hermetic

### DIFF
--- a/changelog.d/fixed/js-sdk-hermetic-tests.md
+++ b/changelog.d/fixed/js-sdk-hermetic-tests.md
@@ -1,0 +1,1 @@
+Replace the JavaScript SDK's live-server test command with hermetic Node tests that assert request construction and API error propagation. (@xiaomo)

--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librefang/sdk",
-  "version": "0.5.2-20260316",
+  "version": "2026.7.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librefang/sdk",
-      "version": "0.5.2-20260316",
+      "version": "2026.7.31",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -31,7 +31,7 @@
   },
   "type": "commonjs",
   "scripts": {
-    "test": "node examples/basic.js"
+    "test": "node --test"
   },
   "publishConfig": {
     "access": "public",

--- a/sdk/javascript/test/client.test.js
+++ b/sdk/javascript/test/client.test.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { afterEach, test } = require("node:test");
+
+const { LibreFang, LibreFangError } = require("../index.js");
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("resource methods send requests with headers, query parameters, and JSON bodies", async () => {
+  const requests = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    return new Response(JSON.stringify({ agent_id: "agent-1" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const client = new LibreFang("http://localhost:4545/", {
+    headers: { Authorization: "Bearer test-token" },
+  });
+
+  const result = await client.agents.spawnAgent({ name: "test-agent" });
+
+  assert.deepEqual(result, { agent_id: "agent-1" });
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "http://localhost:4545/api/agents");
+  assert.equal(requests[0].options.method, "POST");
+  assert.equal(requests[0].options.headers.Authorization, "Bearer test-token");
+  assert.equal(requests[0].options.headers["Content-Type"], "application/json");
+  assert.equal(requests[0].options.body, JSON.stringify({ name: "test-agent" }));
+
+  await client.agents.listAgents({ limit: 10, cursor: undefined });
+  assert.equal(requests[1].url, "http://localhost:4545/api/agents?limit=10");
+  assert.equal(requests[1].options.method, "GET");
+  assert.equal(requests[1].options.body, undefined);
+});
+
+test("HTTP failures reject with LibreFangError details", async () => {
+  globalThis.fetch = async () => new Response("service unavailable", { status: 503 });
+  const client = new LibreFang("http://localhost:4545");
+
+  await assert.rejects(
+    client.system.health(),
+    (error) => {
+      assert.ok(error instanceof LibreFangError);
+      assert.equal(error.status, 503);
+      assert.equal(error.body, "service unavailable");
+      assert.match(error.message, /HTTP 503/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Changes
- replace the JavaScript SDK test script that ran a live-server example with Node’s built-in test runner
- add hermetic request-construction and HTTP-error regression tests using a mocked `fetch`
- synchronize the stale root version in `package-lock.json` with `package.json`

## Verification
- `cd sdk/javascript && npm test`
- `cd sdk/javascript && npm pack --dry-run`
- `cd sdk/javascript && npm install --package-lock-only --ignore-scripts`
- `git diff --check`

## Out of scope
- a separate native ESM build; the SDK remains intentionally CommonJS-compatible
- adding dependencies or devDependencies; the runtime and tests use Node built-ins only