### PR TITLE
fix(npm): preserve CLI wrapper failures

### DIFF
--- a/changelog.d/fixed/cli-npm-wrapper-errors.md
+++ b/changelog.d/fixed/cli-npm-wrapper-errors.md
@@ -1,0 +1,1 @@
+Preserve signal-derived exit codes in the npm CLI wrapper and surface unexpected binary-resolution failures. (@xiaomo)

--- a/packages/cli-npm/bin/librefang.js
+++ b/packages/cli-npm/bin/librefang.js
@@ -3,6 +3,7 @@
 
 const { execFileSync } = require("child_process");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 const PLATFORM_MAP = {
@@ -15,6 +16,17 @@ const ARCH_MAP = {
   x64:   "x64",
   arm64: "arm64",
 };
+
+function resolveBinary(pkg, exe, resolver = require.resolve, exists = fs.existsSync) {
+  try {
+    const pkgDir = path.dirname(resolver(`${pkg}/package.json`));
+    const bin = path.join(pkgDir, "bin", exe);
+    return exists(bin) ? bin : null;
+  } catch (err) {
+    if (err && err.code === "MODULE_NOT_FOUND") return null;
+    throw err;
+  }
+}
 
 function getBinaryPath() {
   const platform = PLATFORM_MAP[process.platform];
@@ -34,11 +46,8 @@ function getBinaryPath() {
   const exe = process.platform === "win32" ? "librefang.exe" : "librefang";
 
   for (const pkg of candidates) {
-    try {
-      const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
-      const bin = path.join(pkgDir, "bin", exe);
-      if (fs.existsSync(bin)) return bin;
-    } catch {}
+    const bin = resolveBinary(pkg, exe);
+    if (bin) return bin;
   }
 
   console.error(
@@ -48,8 +57,23 @@ function getBinaryPath() {
   process.exit(1);
 }
 
-try {
-  execFileSync(getBinaryPath(), process.argv.slice(2), { stdio: "inherit" });
-} catch (err) {
-  process.exit(err.status ?? 1);
+function childExitCode(err) {
+  if (Number.isInteger(err && err.status)) return err.status;
+  const signalNumber = err && err.signal && os.constants.signals[err.signal];
+  return Number.isInteger(signalNumber) ? 128 + signalNumber : 1;
 }
+
+function main() {
+  const binary = getBinaryPath();
+  try {
+    execFileSync(binary, process.argv.slice(2), { stdio: "inherit" });
+  } catch (err) {
+    process.exit(childExitCode(err));
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { childExitCode, resolveBinary };

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/librefang/librefang"
+    "url": "https://github.com/librefang/librefang",
+    "directory": "packages/cli-npm"
   },
   "bin": {
     "librefang": "./bin/librefang.js"
@@ -15,6 +16,9 @@
   ],
   "engines": {
     "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test"
   },
   "optionalDependencies": {
     "@librefang/cli-linux-x64": "0.0.0",

--- a/packages/cli-npm/test/librefang.test.js
+++ b/packages/cli-npm/test/librefang.test.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { childExitCode, resolveBinary } = require("../bin/librefang.js");
+
+test("child exit status and signal deaths map to shell exit codes", () => {
+  assert.equal(childExitCode({ status: 23 }), 23);
+  assert.equal(
+    childExitCode({ status: null, signal: "SIGTERM" }),
+    128 + os.constants.signals.SIGTERM,
+  );
+  assert.equal(childExitCode({ status: null, signal: "UNKNOWN" }), 1);
+});
+
+test("binary resolution ignores only missing optional packages", () => {
+  const missing = new Error("missing package");
+  missing.code = "MODULE_NOT_FOUND";
+  assert.equal(
+    resolveBinary("@librefang/cli-test", "librefang", () => {
+      throw missing;
+    }),
+    null,
+  );
+
+  const denied = new Error("permission denied");
+  denied.code = "EACCES";
+  assert.throws(
+    () => resolveBinary("@librefang/cli-test", "librefang", () => {
+      throw denied;
+    }),
+    denied,
+  );
+});
+
+test("binary resolution checks the package bin directory", () => {
+  const packageJson = path.join("tmp", "package", "package.json");
+  const expected = path.join("tmp", "package", "bin", "librefang");
+  assert.equal(
+    resolveBinary("@librefang/cli-test", "librefang", () => packageJson, (candidate) => {
+      assert.equal(candidate, expected);
+      return true;
+    }),
+    expected,
+  );
+});


### PR DESCRIPTION
## Changes
- map child signal termination to conventional `128 + signal` exit codes
- ignore only `MODULE_NOT_FOUND` while probing optional binary packages and surface unexpected resolver failures
- add hermetic Node tests for resolver and exit-code behavior
- identify the package subdirectory in npm repository metadata

## Verification
- `cd packages/cli-npm && npm test`
- `cd packages/cli-npm && npm pack --dry-run`
- `cd packages/cli-npm && node --check bin/librefang.js`
- `git diff --check`

## Out of scope
- repository `0.0.0` version placeholders; `cargo xtask publish-npm-binaries` replaces the wrapper and optional-dependency versions in its publish staging directory
- native CLI implementation under `crates/librefang-cli`