### PR TITLE
fix(whatsapp): scope and expire echo tracking

### DIFF
--- a/changelog.d/fixed/whatsapp-tracker-correctness.md
+++ b/changelog.d/fixed/whatsapp-tracker-correctness.md
@@ -1,0 +1,1 @@
+Scope WhatsApp echo detection by chat, expire stale echo entries, and reject invalid message-deduplication windows. (@xiaomo)

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -1417,7 +1417,7 @@ async function executeRelay(relay) {
 
   try {
     const sentRelay = await sock.sendMessage(jid, { text: markdownToWhatsApp(message) });
-    if (ECHO_TRACKER_ENABLED) echoTracker.track(message);
+    if (ECHO_TRACKER_ENABLED) echoTracker.track(message, jid);
 
     // F4: Audit log
     console.log(`[gateway] RELAY SENT | to: ${convo.pushName} (${convo.phone}) [${jid}] | message: "${message.substring(0, 100)}" | timestamp: ${new Date().toISOString()}`);
@@ -2056,7 +2056,7 @@ async function startConnection() {
       // (self-loop prevention when WhatsApp reflects our own message back
       // via sync/cross-device mirror). Flag `LIBREFANG_ECHO_TRACKER=off`
       // disables this gate. Only checks text bodies (never attachments).
-      if (ECHO_TRACKER_ENABLED && messageText && echoTracker.isEcho(messageText)) {
+      if (ECHO_TRACKER_ENABLED && messageText && echoTracker.isEcho(messageText, sender)) {
         console.log(JSON.stringify({
           event: 'echo_drop',
           body_excerpt: EchoTracker.normalize(messageText).slice(0, 80),
@@ -2272,7 +2272,7 @@ async function startConnection() {
               await localSock.sendMessage(sender, { text: formatted, edit: streamMsgKey });
             }
             streamEditFailures = 0;
-            if (ECHO_TRACKER_ENABLED) echoTracker.track(cleaned);
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(cleaned, sender);
           } catch (err) {
             streamEditFailures += 1;
             console.warn(JSON.stringify({
@@ -2362,7 +2362,7 @@ async function startConnection() {
             // accept the last visible chunk as final instead.
             try {
               await s.sendMessage(jid, { text: finalText, edit: streamMsgKey });
-              if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+              if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText, jid);
               console.log(JSON.stringify({
                 event: 'send_message_outbound',
                 kind: 'edit_final',
@@ -2394,7 +2394,7 @@ async function startConnection() {
           // already handles when sendOrEdit's entry-snapshot was null).
           try {
             const sent = await s.sendMessage(jid, { text: finalText });
-            if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText, jid);
             console.log(JSON.stringify({
               event: 'send_message_outbound',
               kind: 'new_message',
@@ -2449,7 +2449,7 @@ async function startConnection() {
 
               // Send notification to primary owner
               await sock.sendMessage(OWNER_JID, { text: ownerNotif });
-              if (ECHO_TRACKER_ENABLED) echoTracker.track(ownerNotif);
+              if (ECHO_TRACKER_ENABLED) echoTracker.track(ownerNotif, OWNER_JID);
               console.log(`[gateway] NOTIFY_OWNER sent for ${pushName}: ${notif.reason}`);
             }
 
@@ -3404,7 +3404,7 @@ async function runCatchUpSweep() {
         try {
           const formatted = markdownToWhatsApp(response);
           await sock.sendMessage(msg.jid, { text: formatted });
-          if (ECHO_TRACKER_ENABLED) echoTracker.track(response);
+          if (ECHO_TRACKER_ENABLED) echoTracker.track(response, msg.jid);
           dbSaveMessage({ id: randomUUID(), jid: msg.jid, senderJid: ownJid, pushName: null, phone: msg.phone, text: response, direction: 'outbound', timestamp: Date.now(), processed: 1, rawType: 'text' });
         } catch (sendErr) {
           console.warn(`[gateway][catchup] Could not send catch-up reply to ${msg.jid}: ${sendErr.message}`);
@@ -3464,7 +3464,7 @@ async function sendMessage(to, text) {
 
   const formatted = markdownToWhatsApp(text);
   const sent = await sock.sendMessage(jid, { text: formatted });
-  if (ECHO_TRACKER_ENABLED) echoTracker.track(text);
+  if (ECHO_TRACKER_ENABLED) echoTracker.track(text, jid);
   // Save outbound message to DB (store formatted text to match what was delivered)
   dbSaveMessage({
     id: sent?.key?.id || randomUUID(),

--- a/packages/whatsapp-gateway/lib/dedup-tracker.js
+++ b/packages/whatsapp-gateway/lib/dedup-tracker.js
@@ -21,6 +21,9 @@
  * WhatsApp's own retransmit window is a few seconds, so 60 s is generous.
  */
 function createDedupTracker({ windowMs = 60_000, now = () => Date.now() } = {}) {
+  if (typeof windowMs !== 'number' || !Number.isFinite(windowMs) || windowMs <= 0) {
+    throw new RangeError(`createDedupTracker: windowMs must be a positive number, got ${windowMs}`);
+  }
   const seen = new Map(); // id → timestamp
 
   function prune(nowMs = now()) {

--- a/packages/whatsapp-gateway/lib/echo-tracker.js
+++ b/packages/whatsapp-gateway/lib/echo-tracker.js
@@ -3,20 +3,28 @@
 /**
  * EchoTracker — process-local LRU for self-loop prevention (EB-01, Phase 3 §A).
  *
- * Records the normalized body of every outbound text the gateway sends via
+ * Records the chat-scoped normalized body of every outbound text the gateway sends via
  * `sock.sendMessage({ text })`. Before forwarding an inbound message to
  * librefang, callers consult `isEcho(body)` to detect and drop the
  * WhatsApp-reflected copy of our own outgoing text (sync/cross-device mirror).
  *
  * Decisions (see .planning/phases/03-chat-isolation-layer/03-CONTEXT.md §A):
  * - In-memory only, no persistence (Q6 locked).
+ * - Process-local: run one gateway process per account. Multi-process echo
+ *   detection would require a shared tracker.
  * - maxSize=100 default, LRU eviction on insertion-order.
+ * - ttlMs=5 minutes default, with lazy expiry on access.
  * - Normalization: lowercase + emoji strip + whitespace collapse + trailing
  *   punctuation strip so minor echo rewrites still match.
  */
 class EchoTracker {
-  constructor(maxSize = 100) {
+  constructor(maxSize = 100, { ttlMs = 300_000, now = () => Date.now() } = {}) {
     this.max = Math.max(1, Number(maxSize) || 100);
+    if (typeof ttlMs !== 'number' || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+      throw new RangeError(`EchoTracker: ttlMs must be a positive number, got ${ttlMs}`);
+    }
+    this.ttlMs = ttlMs;
+    this.now = now;
     this.map = new Map();
     this.lastSentAt = 0;
   }
@@ -31,31 +39,46 @@ class EchoTracker {
       .replace(/[.!?]+$/, '');
   }
 
-  track(body) {
-    const key = EchoTracker.normalize(body);
+  key(body, scope = '') {
+    const normalized = EchoTracker.normalize(body);
+    return normalized ? `${String(scope)}\0${normalized}` : '';
+  }
+
+  prune(now = this.now()) {
+    for (const [key, timestamp] of this.map) {
+      if (now - timestamp > this.ttlMs) this.map.delete(key);
+    }
+  }
+
+  track(body, scope = '') {
+    const key = this.key(body, scope);
     if (!key) return;
+    const now = this.now();
+    this.prune(now);
     // Refresh insertion order on re-track.
     if (this.map.has(key)) this.map.delete(key);
-    this.map.set(key, Date.now());
-    this.lastSentAt = Date.now();
+    this.map.set(key, now);
+    this.lastSentAt = now;
     while (this.map.size > this.max) {
       const oldest = this.map.keys().next().value;
       this.map.delete(oldest);
     }
   }
 
-  isEcho(body) {
-    const key = EchoTracker.normalize(body);
+  isEcho(body, scope = '') {
+    const key = this.key(body, scope);
     if (!key) return false;
+    this.prune();
     return this.map.has(key);
   }
 
   size() {
+    this.prune();
     return this.map.size;
   }
 
   elapsedSinceLastSent() {
-    return this.lastSentAt ? Date.now() - this.lastSentAt : -1;
+    return this.lastSentAt ? this.now() - this.lastSentAt : -1;
   }
 
   reset() {

--- a/packages/whatsapp-gateway/test/dedup-tracker.test.js
+++ b/packages/whatsapp-gateway/test/dedup-tracker.test.js
@@ -4,6 +4,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { createDedupTracker } = require('../lib/dedup-tracker');
 
+test('windowMs must be finite and positive', () => {
+  for (const windowMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, '100']) {
+    assert.throws(() => createDedupTracker({ windowMs }), RangeError);
+  }
+});
+
 test('wasProcessed is false on first sight and does NOT mark', () => {
   const t = createDedupTracker();
   assert.equal(t.wasProcessed('abc'), false);

--- a/packages/whatsapp-gateway/test/echo-tracker.test.js
+++ b/packages/whatsapp-gateway/test/echo-tracker.test.js
@@ -54,6 +54,31 @@ describe('EchoTracker.track / isEcho', () => {
     assert.equal(t.isEcho('never-sent'), false);
   });
 
+  it('scopes identical text to its destination chat', () => {
+    const t = new EchoTracker();
+    t.track('ok', 'alice@s.whatsapp.net');
+    assert.equal(t.isEcho('OK!', 'alice@s.whatsapp.net'), true);
+    assert.equal(t.isEcho('ok', 'bob@s.whatsapp.net'), false);
+  });
+
+  it('expires tracked text after the TTL', () => {
+    let clock = 1_000;
+    const t = new EchoTracker(100, { ttlMs: 50, now: () => clock });
+    t.track('hello', 'alice@s.whatsapp.net');
+    clock += 50;
+    assert.equal(t.isEcho('hello', 'alice@s.whatsapp.net'), true);
+    clock += 1;
+    assert.equal(t.isEcho('hello', 'alice@s.whatsapp.net'), false);
+    assert.equal(t.size(), 0);
+  });
+
+  it('uses one clock reading when tracking', () => {
+    let clock = 0;
+    const t = new EchoTracker(100, { now: () => ++clock });
+    t.track('hello');
+    assert.equal(t.lastSentAt, 1);
+  });
+
   it('track(null), track(""), track(undefined) are no-ops', () => {
     const t = new EchoTracker();
     t.track(null);


### PR DESCRIPTION
## Changes
- scope echo-tracker keys by destination chat so identical messages in unrelated conversations do not collide
- expire echo entries after five minutes while preserving the existing LRU capacity bound
- pass stable JID scopes at every inbound and outbound production call site
- reject non-finite and non-positive deduplication windows at construction
- document the tracker’s single-process deployment assumption

## Verification
- `cd packages/whatsapp-gateway && node --test test/dedup-tracker.test.js test/echo-tracker.test.js` (27 passed)
- `cd packages/whatsapp-gateway && node --check index.js`
- `cd packages/whatsapp-gateway && node --check lib/echo-tracker.js`
- structural search confirms all eight production `echoTracker.track` / `isEcho` calls pass a chat scope
- `git diff --check`

## Out of scope
- distributed echo tracking across multiple gateway processes
- changing the deliberate two-phase message deduplication flow used for decrypt retries