### PR TITLE
fix(whatsapp): support Unicode relay intents

### DIFF
--- a/changelog.d/fixed/whatsapp-unicode-relay-intents.md
+++ b/changelog.d/fixed/whatsapp-unicode-relay-intents.md
@@ -1,0 +1,1 @@
+Recognize Unicode relay commands and recipient names in the WhatsApp gateway while avoiding declarative-text false positives and warning on unknown language configuration. (@xiaomo)

--- a/packages/whatsapp-gateway/lib/intent_patterns.js
+++ b/packages/whatsapp-gateway/lib/intent_patterns.js
@@ -66,8 +66,8 @@ const DE_RELAY = [
   'leite\\s+an\\s+\\w+\\s+weiter',
   // Exclude "Sag mir" / "Sage uns" (owner→bot self-directed) — same
   // negative-lookahead pattern used by the English "tell" entry.
-  'sag\\s+(?!mir\\b|uns\\b)\\w+',
-  'sage\\s+(?!mir\\b|uns\\b)\\w+',
+  'sag\\s+(?!mir\\b|uns\\b|euch\\b|dir\\b|dich\\b)\\w+',
+  'sage\\s+(?!mir\\b|uns\\b|euch\\b|dir\\b|dich\\b)\\w+',
   'grüße\\s+\\w+',
   'grusse\\s+\\w+',
 ];
@@ -110,8 +110,9 @@ const IT_RELAY = [
 /**
  * Compile a union regex from the requested language packs.
  *
- * `languages` is a list of two-letter codes (`["en", "it"]`). Unknown
- * codes are silently skipped so a config-side typo can't crash boot.
+ * `languages` is a list of two-letter codes (`["en", "it"]`) or locale
+ * identifiers (`["en-US", "it-IT"]`). Unknown codes are skipped with a
+ * warning so a typo cannot silently disable relay detection.
  */
 function compileIntentRegex(languages = ['en']) {
   const packs = {
@@ -123,15 +124,22 @@ function compileIntentRegex(languages = ['en']) {
     pt: PT_RELAY,
   };
   const patterns = [];
-  for (const code of languages) {
-    const pack = packs[code.toLowerCase()];
-    if (pack) patterns.push(...pack);
+  for (const configuredCode of languages) {
+    const code = String(configuredCode).trim().toLowerCase().split(/[-_]/, 1)[0];
+    const pack = packs[code];
+    if (pack) {
+      patterns.push(...pack);
+    } else {
+      console.warn(`[gateway] unknown relay intent language ignored: ${JSON.stringify(configuredCode)}`);
+    }
   }
   if (patterns.length === 0) {
     // Empty config → never match; safer than always-match.
     return /(?!.*)/;
   }
-  return new RegExp('\\b(?:' + patterns.join('|') + ')\\b', 'i');
+  const unicodeWord = '[\\p{L}\\p{N}_]+';
+  const unicodePatterns = patterns.map((pattern) => pattern.replaceAll('\\w+', unicodeWord));
+  return new RegExp('^\\s*(?:' + unicodePatterns.join('|') + ')(?![\\p{L}\\p{N}_])', 'iu');
 }
 
 module.exports = {

--- a/packages/whatsapp-gateway/test/intent-patterns.test.js
+++ b/packages/whatsapp-gateway/test/intent-patterns.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+
+const { compileIntentRegex } = require('../lib/intent_patterns');
+
+describe('compileIntentRegex', () => {
+  it('matches accented verbs and Unicode recipient names', () => {
+    const re = compileIntentRegex(['fr', 'es', 'de']);
+    for (const message of [
+      'Écris à Élodie demain',
+      'Réponds à Łukasz maintenant',
+      'Envía a Özlem el informe',
+      'Grüße Åsa von mir',
+    ]) {
+      assert.equal(re.test(message), true, message);
+    }
+  });
+
+  it('accepts locale identifiers and trims configuration', () => {
+    assert.equal(compileIntentRegex([' fr-FR ']).test('Écris à Marie'), true);
+    assert.equal(compileIntentRegex(['de_DE']).test('Schreib an Petra'), true);
+  });
+
+  it('warns for unknown languages and returns a never-match regex', () => {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+    try {
+      const re = compileIntentRegex(['Klingon']);
+      assert.equal(re.test('tell Alice hello'), false);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.deepEqual(warnings, ['[gateway] unknown relay intent language ignored: "Klingon"']);
+  });
+
+  it('requires the relay imperative at the start of the message', () => {
+    const re = compileIntentRegex(['en']);
+    assert.equal(re.test('tell Alice I am busy'), true);
+    assert.equal(re.test('  write to Bob about this'), true);
+    assert.equal(re.test("I can't reply to Marta right now"), false);
+    assert.equal(re.test('She said: write to the customer'), false);
+    assert.equal(re.test('I will tell Sarah myself later'), false);
+  });
+
+  it('rejects German owner-directed pronouns', () => {
+    const re = compileIntentRegex(['de']);
+    for (const message of ['Sag mir etwas', 'Sag uns etwas', 'Sag euch etwas', 'Sag dir etwas', 'Sag dich an']) {
+      assert.equal(re.test(message), false, message);
+    }
+    assert.equal(re.test('Sag Klaus ich komme später'), true);
+  });
+});


### PR DESCRIPTION
## Changes
- use Unicode-aware recipient matching so accented and non-ASCII names are recognized
- anchor natural-language relay imperatives at message start to avoid declarative-text false positives
- accept locale identifiers such as `fr-FR` and warn when configured languages are unknown
- exclude additional German owner-directed pronouns
- add focused dependency-free Node regressions

## Verification
- `cd packages/whatsapp-gateway && node --test test/intent-patterns.test.js` (5 passed)
- `cd packages/whatsapp-gateway && node --check lib/intent_patterns.js`
- `git diff --check`

## Out of scope
- explicit `/relay`, `/reply`, and `@mention` detection, which remains handled before the natural-language pattern matcher
- machine translation or adding new language packs