### PR TITLE
fix(whatsapp): validate postinstall patch shapes

### DIFF
--- a/changelog.d/fixed/whatsapp-postinstall-validation.md
+++ b/changelog.d/fixed/whatsapp-postinstall-validation.md
@@ -1,0 +1,1 @@
+Fail WhatsApp gateway installation when pinned Baileys or Termux patch shapes drift, verify every Baileys rejection handler, and load the intended local SQLite addon. (@xiaomo)

--- a/packages/whatsapp-gateway/scripts/postinstall.js
+++ b/packages/whatsapp-gateway/scripts/postinstall.js
@@ -19,7 +19,7 @@ const { execSync } = require('child_process');
 // ---------------------------------------------------------------------------
 // Baileys `fetchProps` non-blocking patch
 // ---------------------------------------------------------------------------
-// Baileys 6.7.21 (pinned exactly in package.json) issues
+// Baileys 6.7.22 (pinned exactly in package.json) issues
 // `Promise.all([fetchProps, fetchBlocklist, fetchPrivacySettings])` during
 // the initial post-auth handshake (`executeInitQueries` in
 // `node_modules/@whiskeysockets/baileys/lib/Socket/chats.js`, ~line 762 —
@@ -85,22 +85,44 @@ const BAILEYS_INIT_QUERIES_REPLACEMENT =
   "        fetchBlocklist().catch((err) => { try { logger && logger.warn ? logger.warn({ err }, '[librefang-baileys-patch] fetchBlocklist rejected') : console.warn('[librefang-baileys-patch] fetchBlocklist rejected:', err && err.message ? err.message : err); } catch (_) {} }),\n" +
   "        fetchPrivacySettings().catch((err) => { try { logger && logger.warn ? logger.warn({ err }, '[librefang-baileys-patch] fetchPrivacySettings rejected') : console.warn('[librefang-baileys-patch] fetchPrivacySettings rejected:', err && err.message ? err.message : err); } catch (_) {} }),\n" +
   "    ])";
+const BAILEYS_PATCH_MARKERS = [
+  'Promise.allSettled',
+  '[librefang-baileys-patch] fetchProps rejected',
+  '[librefang-baileys-patch] fetchBlocklist rejected',
+  '[librefang-baileys-patch] fetchPrivacySettings rejected',
+];
+
+function hasCompleteBaileysPatch(source) {
+  return BAILEYS_PATCH_MARKERS.every((marker) => source.includes(marker));
+}
 
 function patchBaileysInitQueries() {
-  const chatsJs = path.join(
+  const baileysDir = path.join(
     __dirname,
     '..',
     'node_modules',
     '@whiskeysockets',
     'baileys',
+  );
+  const chatsJs = path.join(
+    baileysDir,
     'lib',
     'Socket',
     'chats.js',
   );
-  if (!fs.existsSync(chatsJs)) {
-    // Baileys not installed (dev `--no-save` install) or 7.x path layout —
-    // nothing to patch.
+  const packageJson = path.join(baileysDir, 'package.json');
+  if (!fs.existsSync(packageJson)) {
+    // Dependency installation itself will report a missing required package.
     return;
+  }
+  const installedVersion = JSON.parse(fs.readFileSync(packageJson, 'utf8')).version;
+  const installedMajor = Number.parseInt(String(installedVersion).split('.')[0], 10);
+  if (!fs.existsSync(chatsJs)) {
+    if (installedMajor >= 7) return;
+    throw new Error(
+      `[librefang-baileys-patch] Baileys ${installedVersion} is missing ${chatsJs}; ` +
+        'refresh the postinstall patch for the installed source layout.',
+    );
   }
   const src = fs.readFileSync(chatsJs, 'utf8');
   // Already patched: the file contains an `allSettled` form referencing all
@@ -119,7 +141,11 @@ function patchBaileysInitQueries() {
   } else if (src.includes(BAILEYS_INIT_QUERIES_NEEDLE)) {
     patched = src.replace(BAILEYS_INIT_QUERIES_NEEDLE, BAILEYS_INIT_QUERIES_REPLACEMENT);
   } else {
-    return; // Baileys version doesn't expose this call shape (e.g. 7.x)
+    if (installedMajor >= 7) return;
+    throw new Error(
+      `[librefang-baileys-patch] unrecognized executeInitQueries shape in Baileys ${installedVersion}; ` +
+        'refresh BAILEYS_INIT_QUERIES_NEEDLE / BAILEYS_INIT_QUERIES_REPLACEMENT.',
+    );
   }
   fs.writeFileSync(chatsJs, patched, 'utf8');
 
@@ -127,10 +153,10 @@ function patchBaileysInitQueries() {
   // match no-op'd, fail loudly at install time so operators know to refresh
   // the patch rather than discovering a regressed gateway in production.
   const verify = fs.readFileSync(chatsJs, 'utf8');
-  if (!verify.includes('Promise.allSettled') || !verify.includes('[librefang-baileys-patch]')) {
+  if (!hasCompleteBaileysPatch(verify)) {
     throw new Error(
       '[librefang-baileys-patch] post-write verification failed: ' +
-        'expected `Promise.allSettled` and `[librefang-baileys-patch]` markers in ' +
+        'expected the allSettled call and all three per-query rejection markers in ' +
         chatsJs +
         '. The Baileys source likely changed shape; refresh the patch in ' +
         'scripts/postinstall.js (BAILEYS_INIT_QUERIES_NEEDLE / REPLACEMENT).',
@@ -150,6 +176,20 @@ function isTermux() {
   return false;
 }
 
+function patchAndroidNdkCflags(content) {
+  if (!content.includes('android_ndk_path')) return content;
+  const patched = content.replace(
+    /('cflags':\s*\[\s*'-fPIC'),\s*'-I<\(android_ndk_path\)[^']*'\s*(\])/,
+    '$1 $2',
+  );
+  if (patched === content) {
+    throw new Error(
+      '[postinstall] common.gypi contains android_ndk_path but its cflags shape is unrecognized',
+    );
+  }
+  return patched;
+}
+
 function rebuildBetterSqlite3OnTermux() {
   if (!isTermux()) {
     return;
@@ -163,7 +203,7 @@ function rebuildBetterSqlite3OnTermux() {
   }
 
   try {
-    require('better-sqlite3');
+    require(betterSqlite3Dir);
     // Native addon loads fine — no patching needed
     return;
   } catch (_) {
@@ -205,10 +245,7 @@ function rebuildBetterSqlite3OnTermux() {
     //   'cflags': [ '-fPIC', '-I<(android_ndk_path)/sources/android/cpufeatures' ],
     // Replace with:
     //   'cflags': [ '-fPIC' ],
-    gypiContent = gypiContent.replace(
-      /('cflags':\s*\[\s*'-fPIC'\s*),\s*'-I<\(android_ndk_path\)[^']*'\s*(\])/,
-      '$1 $2'
-    );
+    gypiContent = patchAndroidNdkCflags(gypiContent);
     fs.writeFileSync(gypiPath, gypiContent, 'utf8');
     console.log('[postinstall] Patched common.gypi — removed android_ndk_path reference');
   } else {
@@ -240,10 +277,12 @@ module.exports = {
   patchBaileysInitQueries,
   isTermux,
   rebuildBetterSqlite3OnTermux,
+  patchAndroidNdkCflags,
   // Exposed for fixture-based tests: the literal needle/replacement strings
   // used by the patcher.
   BAILEYS_INIT_QUERIES_NEEDLE,
   BAILEYS_INIT_QUERIES_REPLACEMENT,
+  hasCompleteBaileysPatch,
 };
 
 if (require.main === module) {

--- a/packages/whatsapp-gateway/test/postinstall-baileys-patch.test.js
+++ b/packages/whatsapp-gateway/test/postinstall-baileys-patch.test.js
@@ -14,7 +14,7 @@ const { execFileSync } = require('node:child_process');
 
 const SCRIPT = path.join(__dirname, '..', 'scripts', 'postinstall.js');
 
-function mkFixture(chatsJsContents) {
+function mkFixture(chatsJsContents, version = '6.7.22') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'librefang-postinstall-'));
   // Mirror the layout the patcher expects:
   //   <fixture>/scripts/postinstall.js     (copy of the real script — copy,
@@ -36,6 +36,11 @@ function mkFixture(chatsJsContents) {
   fs.mkdirSync(chatsDir, { recursive: true });
   const chatsJs = path.join(chatsDir, 'chats.js');
   fs.writeFileSync(chatsJs, chatsJsContents, 'utf8');
+  fs.writeFileSync(
+    path.join(root, 'node_modules', '@whiskeysockets', 'baileys', 'package.json'),
+    JSON.stringify({ name: '@whiskeysockets/baileys', version }),
+    'utf8',
+  );
   return { root, chatsJs };
 }
 
@@ -109,7 +114,7 @@ test('no-op on Baileys 7.x (call site shape gone) — exits cleanly without modi
         ]);
     };
   `;
-  const { root, chatsJs } = mkFixture(BAILEYS_7X);
+  const { root, chatsJs } = mkFixture(BAILEYS_7X, '7.0.0');
   const before = fs.readFileSync(chatsJs, 'utf8');
   runPostinstall(root);
   const after = fs.readFileSync(chatsJs, 'utf8');
@@ -117,10 +122,6 @@ test('no-op on Baileys 7.x (call site shape gone) — exits cleanly without modi
 });
 
 test('fails loudly when Baileys is missing the expected call site (e.g. major rewrite)', () => {
-  // No `Promise.all(...fetchProps()...)` and no `Promise.allSettled(...
-  // fetchProps()...)` — the patcher cannot find the line, so it should
-  // skip silently (file untouched). This is the "Baileys version doesn't
-  // expose this call shape" path. Verified via no-write.
   const REWRITTEN = `
     const executeInitQueries = async () => {
         // entirely refactored
@@ -129,38 +130,48 @@ test('fails loudly when Baileys is missing the expected call site (e.g. major re
   `;
   const { root, chatsJs } = mkFixture(REWRITTEN);
   const before = fs.readFileSync(chatsJs, 'utf8');
-  runPostinstall(root);
+  assert.throws(
+    () => runPostinstall(root),
+    (error) => {
+      assert.match(error.stderr, /unrecognized executeInitQueries shape in Baileys 6\.7\.22/);
+      return true;
+    },
+  );
   const after = fs.readFileSync(chatsJs, 'utf8');
-  assert.equal(before, after, 'unrecognized Baileys shape: file unchanged, no throw');
+  assert.equal(before, after, 'unrecognized Baileys shape is not modified');
 });
 
-test('post-write verification: throws if the writeFileSync somehow produced an unmarked file', () => {
-  // Direct unit test of the patcher: monkeypatch fs.writeFileSync to drop
-  // the [librefang-baileys-patch] marker, then assert the verification
-  // step catches it.
-  const fixturesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'librefang-postinstall-verify-'));
-  const chatsDir = path.join(
-    fixturesDir,
-    'node_modules',
-    '@whiskeysockets',
-    'baileys',
-    'lib',
-    'Socket',
-  );
-  fs.mkdirSync(chatsDir, { recursive: true });
-  const chatsJs = path.join(chatsDir, 'chats.js');
-  fs.writeFileSync(chatsJs, VANILLA_INIT_QUERIES, 'utf8');
-  // Require the script as a library (no side-effects thanks to
-  // require.main === module guard).
+test('post-write verification requires every per-query marker', () => {
   const script = require('../scripts/postinstall.js');
-  // Re-route __dirname expectation: the script joins __dirname/..
-  // /node_modules. Use a local helper that monkeypatches by writing the
-  // fixture inside the package itself? We instead duplicate the small
-  // path-resolution: simpler to assert that the exported helpers exist
-  // and the needle/replacement constants are well-formed.
   assert.equal(typeof script.patchBaileysInitQueries, 'function');
   assert.equal(typeof script.isTermux, 'function');
   assert.ok(script.BAILEYS_INIT_QUERIES_NEEDLE.includes('Promise.all(['));
   assert.ok(script.BAILEYS_INIT_QUERIES_REPLACEMENT.includes('Promise.allSettled'));
   assert.ok(script.BAILEYS_INIT_QUERIES_REPLACEMENT.includes('[librefang-baileys-patch]'));
+  assert.equal(script.hasCompleteBaileysPatch(script.BAILEYS_INIT_QUERIES_REPLACEMENT), true);
+  for (const marker of [
+    'fetchProps rejected',
+    'fetchBlocklist rejected',
+    'fetchPrivacySettings rejected',
+  ]) {
+    assert.equal(
+      script.hasCompleteBaileysPatch(script.BAILEYS_INIT_QUERIES_REPLACEMENT.replaceAll(marker, 'missing')),
+      false,
+      marker,
+    );
+  }
+});
+
+test('patchAndroidNdkCflags removes only the Termux NDK include', () => {
+  const { patchAndroidNdkCflags } = require('../scripts/postinstall.js');
+  const input = "'cflags': [ '-fPIC', '-I<(android_ndk_path)/sources/android/cpufeatures' ],";
+  assert.equal(patchAndroidNdkCflags(input), "'cflags': [ '-fPIC' ],");
+});
+
+test('patchAndroidNdkCflags rejects unknown NDK cflags shapes', () => {
+  const { patchAndroidNdkCflags } = require('../scripts/postinstall.js');
+  assert.throws(
+    () => patchAndroidNdkCflags("'cflags': [ '-Wall', '-I<(android_ndk_path)/include' ]"),
+    /cflags shape is unrecognized/,
+  );
 });


### PR DESCRIPTION
## Changes
- read the installed Baileys version and fail on unknown 6.x source layouts while allowing the 7.x migration layout
- verify all three per-query rejection handlers after patching
- resolve `better-sqlite3` from the exact local directory that would be rebuilt
- extract and validate the Termux NDK cflags rewrite before attempting a doomed rebuild
- update fixture tests to distinguish supported 7.x skips from 6.x drift

## Verification
- `cd packages/whatsapp-gateway && node --test test/postinstall-baileys-patch.test.js` (8 passed)
- `cd packages/whatsapp-gateway && node --check scripts/postinstall.js`
- `git diff --check`

## Out of scope
- migrating the gateway to Baileys 7.x
- changing native-addon build policy outside Termux/Android