### PR TITLE
fix(whatsapp): harden gateway supervision

### DIFF
--- a/changelog.d/fixed/whatsapp-supervision-scripts.md
+++ b/changelog.d/fixed/whatsapp-supervision-scripts.md
@@ -1,0 +1,1 @@
+Serialize WhatsApp health checks, make their wake protocol explicit, harden HTTP/DNS/PM2 diagnostics, and give PM2 shutdown and deployment limits configurable supervision defaults. (@xiaomo)

--- a/packages/whatsapp-gateway/ecosystem.config.cjs
+++ b/packages/whatsapp-gateway/ecosystem.config.cjs
@@ -11,9 +11,16 @@
 // read by index.js from LIBREFANG_* env vars at runtime and should be set
 // in the deployment environment, not committed here.
 const path = require('node:path');
+const fs = require('node:fs');
 
 const cwd = process.env.WA_GATEWAY_CWD || __dirname;
 const logDir = process.env.WA_GATEWAY_LOG_DIR || path.join(cwd, 'logs');
+fs.mkdirSync(logDir, { recursive: true });
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 module.exports = {
   apps: [
@@ -23,11 +30,12 @@ module.exports = {
       cwd,
       watch: false,
       autorestart: true,
-      max_restarts: 5,
+      max_restarts: positiveInteger(process.env.WA_GATEWAY_MAX_RESTARTS, 5),
       min_uptime: '30s',
       restart_delay: 3000,
-      max_memory_restart: '256M',
+      max_memory_restart: process.env.WA_GATEWAY_MAX_MEMORY || '256M',
       exp_backoff_restart_delay: 1000,
+      kill_timeout: positiveInteger(process.env.WA_GATEWAY_KILL_TIMEOUT_MS, 5000),
       error_file: path.join(logDir, 'pm2-error.log'),
       out_file: path.join(logDir, 'pm2-out.log'),
       merge_logs: true,

--- a/packages/whatsapp-gateway/scripts/health-check.sh
+++ b/packages/whatsapp-gateway/scripts/health-check.sh
@@ -26,6 +26,9 @@
 #   5. Otherwise restart via PM2 once and re-check.
 #   6. After RECOVERY_GIVE_UP_FAILURES failures, write the flag file so the
 #      agent surfaces it to the operator on the next heartbeat.
+#
+# Stdout is a LibreFang pre-check gate: the last non-empty line is always
+# `{"wakeAgent": false}` for a skip or `{"wakeAgent": true}` for escalation.
 
 set -euo pipefail
 
@@ -89,10 +92,14 @@ clear_failure_state() {
 }
 
 check_health() {
-  local response http_code body
-  response=$(curl -s --max-time "$HEALTH_TIMEOUT" -o - -w '%{http_code}' "$HEALTH_URL" 2>/dev/null) || return 1
-  http_code="${response: -3}"
-  body="${response%???}"
+  local tmp_body http_code body
+  tmp_body=$(mktemp "${GATEWAY_DIR}/.health-body.XXXXXX") || return 1
+  if ! http_code=$(curl -s --max-time "$HEALTH_TIMEOUT" -o "$tmp_body" -w '%{http_code}' "$HEALTH_URL" 2>/dev/null); then
+    rm -f "$tmp_body"
+    return 1
+  fi
+  body=$(< "$tmp_body")
+  rm -f "$tmp_body"
 
   if [[ "$http_code" != "200" ]]; then
     log "[health] HTTP $http_code (expected 200)"
@@ -111,13 +118,17 @@ dns_ok() {
   # Returns 0 if web.whatsapp.com resolves. We try getent first (no extra deps),
   # then nslookup as a fallback. If neither is present we assume DNS is fine
   # rather than mis-diagnose.
+  local attempted=0
   if command -v getent >/dev/null 2>&1; then
-    getent hosts web.whatsapp.com >/dev/null 2>&1 && return 0 || return 1
+    attempted=1
+    if getent hosts web.whatsapp.com >/dev/null 2>&1; then return 0; fi
   fi
   if command -v nslookup >/dev/null 2>&1; then
-    nslookup -timeout=3 web.whatsapp.com >/dev/null 2>&1 && return 0 || return 1
+    attempted=1
+    if nslookup -timeout=3 web.whatsapp.com >/dev/null 2>&1; then return 0; fi
   fi
-  return 0
+  if (( attempted == 0 )); then return 0; fi
+  return 1
 }
 
 pm2_restart() {
@@ -130,15 +141,16 @@ pm2_restart() {
   # signal callers may eventually want is then a lie. With `pipefail`
   # already set at the top of the script, capture pm2's status via
   # PIPESTATUS so the function returns a faithful success/failure.
-  pm2 restart whatsapp-gateway 2>&1 | while read -r line; do log "[pm2] $line"; done
-  return "${PIPESTATUS[0]}"
+  local status=0
+  pm2 restart whatsapp-gateway 2>&1 | while read -r line; do log "[pm2] $line"; done || status=${PIPESTATUS[0]}
+  return "$status"
 }
 
 write_flag() {
   local kind=$1
   local pm2_status=""
   if command -v pm2 >/dev/null 2>&1; then
-    pm2_status=$(pm2 describe whatsapp-gateway 2>&1 | head -40 || true)
+    pm2_status=$(timeout 10s pm2 describe whatsapp-gateway 2>&1 | head -40 || true)
   fi
   cat > "$FLAG_FILE" <<EOF
 timestamp=$(date -Iseconds)
@@ -151,15 +163,26 @@ $pm2_status
 EOF
 }
 
+# Emit the LibreFang cron pre_check_script gate. Default to "skip the agent
+# turn" — flag paths explicitly emit the wake form.
+emit_skip() { echo '{"wakeAgent": false}'; }
+emit_wake() { echo '{"wakeAgent": true}'; }
+
+if [[ "${HEALTH_CHECK_LIB_ONLY:-0}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 # --- Main ---
+
+exec 9>"${GATEWAY_DIR}/health-check.lock"
+if ! flock -n 9; then
+  log "[health] Another health-check instance is running; skipping overlap"
+  emit_skip
+  exit 0
+fi
 
 date -Iseconds > "$HEARTBEAT_FILE"
 rotate_pm2_logs
-
-# Emit the LibreFang cron pre_check_script gate. Default to "skip the agent
-# turn" — we only wake the agent if a flag file gets written below, in which
-# case we print an empty (or different) line and let the agent fire.
-emit_skip() { echo '{"wakeAgent": false}'; }
 
 if check_health; then
   if [[ -f "$COUNTER_FILE" ]] || [[ -f "$FLAG_FILE" ]]; then
@@ -170,7 +193,8 @@ if check_health; then
   exit 0
 fi
 
-failures=$(($(read_counter) + 1))
+previous_failures=$(read_counter)
+failures=$((previous_failures + 1))
 write_counter "$failures"
 log "[health] Health check failed (consecutive=$failures)"
 
@@ -188,7 +212,7 @@ if ! dns_ok; then
   if (( failures >= RECOVERY_GIVE_UP_FAILURES )); then
     write_flag dns-blackout
     log "[health] Wrote flag file (kind=dns-blackout)"
-    # Wake the agent so the operator hears about it.
+    emit_wake
     exit 1
   fi
   emit_skip
@@ -209,7 +233,7 @@ fi
 if (( failures >= RECOVERY_GIVE_UP_FAILURES )); then
   write_flag restart-failed
   log "[health] Wrote flag file (kind=restart-failed)"
-  # Wake the agent.
+  emit_wake
   exit 1
 fi
 

--- a/packages/whatsapp-gateway/test/health-check.test.sh
+++ b/packages/whatsapp-gateway/test/health-check.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+HEALTH_SCRIPT="${SCRIPT_DIR}/../scripts/health-check.sh"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+MOCK_BIN="${TEST_DIR}/bin"
+mkdir -p "$MOCK_BIN" "${TEST_DIR}/gateway"
+
+cat > "${MOCK_BIN}/getent" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cat > "${MOCK_BIN}/nslookup" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "${MOCK_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+out=''
+while (($#)); do
+  if [[ "$1" == '-o' ]]; then out=$2; shift 2; else shift; fi
+done
+printf '{"connected":false,"suffix":"200"}' > "$out"
+printf '503'
+EOF
+cat > "${MOCK_BIN}/pm2" <<'EOF'
+#!/usr/bin/env bash
+echo 'restart failed'
+exit 7
+EOF
+cat > "${MOCK_BIN}/flock" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${MOCK_BIN}"/*
+
+PATH="${MOCK_BIN}:/usr/bin:/bin" GATEWAY_DIR="${TEST_DIR}/gateway" HEALTH_CHECK_LIB_ONLY=1 \
+  bash -c 'source "$1"; dns_ok; ! check_health; if pm2_restart; then exit 1; else [[ $? -eq 7 ]]; fi' _ "$HEALTH_SCRIPT"
+
+# A fourth DNS failure writes a flag and explicitly wakes the agent.
+printf '3\n' > "${TEST_DIR}/gateway/health-check.failures"
+cat > "${MOCK_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cat > "${MOCK_BIN}/nslookup" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "${MOCK_BIN}/curl" "${MOCK_BIN}/nslookup"
+set +e
+output=$(PATH="${MOCK_BIN}:/usr/bin:/bin" GATEWAY_DIR="${TEST_DIR}/gateway" bash "$HEALTH_SCRIPT")
+status=$?
+set -e
+[[ $status -eq 1 ]]
+[[ "$output" == '{"wakeAgent": true}' ]]
+grep -q '^kind=dns-blackout$' "${TEST_DIR}/gateway/health-check-failed.flag"

--- a/packages/whatsapp-gateway/test/supervision.test.js
+++ b/packages/whatsapp-gateway/test/supervision.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+test('PM2 config creates the log directory and accepts bounded overrides', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'librefang-pm2-'));
+  const logDir = path.join(root, 'nested', 'logs');
+  process.env.WA_GATEWAY_CWD = root;
+  process.env.WA_GATEWAY_LOG_DIR = logDir;
+  process.env.WA_GATEWAY_MAX_RESTARTS = '12';
+  process.env.WA_GATEWAY_MAX_MEMORY = '768M';
+  process.env.WA_GATEWAY_KILL_TIMEOUT_MS = '7000';
+  const config = require('../ecosystem.config.cjs');
+  const app = config.apps[0];
+  assert.equal(fs.statSync(logDir).isDirectory(), true);
+  assert.equal(app.max_restarts, 12);
+  assert.equal(app.max_memory_restart, '768M');
+  assert.equal(app.kill_timeout, 7000);
+});


### PR DESCRIPTION
## Changes
- serialize health-check runs with a nonblocking Linux `flock`
- separate curl response bodies from status codes using a temporary file
- fall through from failed `getent` resolution to `nslookup`
- preserve PM2 restart status under `errexit`/`pipefail` and bound `pm2 describe`
- emit explicit wake/skip JSON on every terminal health-check path
- create PM2 log directories, add a five-second shutdown grace, and expose memory/restart/shutdown limits through environment overrides
- add dependency-free shell and Node supervision tests

## Verification
- `cd packages/whatsapp-gateway && bash -n scripts/health-check.sh test/health-check.test.sh`
- `cd packages/whatsapp-gateway && bash test/health-check.test.sh`
- `cd packages/whatsapp-gateway && node --test test/supervision.test.js`
- `cd packages/whatsapp-gateway && node --check ecosystem.config.cjs`
- `git diff --check`

## Out of scope
- changing the default 256M memory ceiling or five-restart policy without production capacity evidence; both are now operator-configurable
- replacing the existing one-generation PM2 log rotation policy