### PR TITLE
fix(whatsapp): validate deduplication window

### DIFF
--- a/changelog.d/fixed/whatsapp-dedup-window.md
+++ b/changelog.d/fixed/whatsapp-dedup-window.md
@@ -1,0 +1,1 @@
+Reject invalid WhatsApp message-deduplication windows instead of silently disabling duplicate detection. (@xiaomo)

--- a/packages/whatsapp-gateway/lib/dedup-tracker.js
+++ b/packages/whatsapp-gateway/lib/dedup-tracker.js
@@ -21,6 +21,9 @@
  * WhatsApp's own retransmit window is a few seconds, so 60 s is generous.
  */
 function createDedupTracker({ windowMs = 60_000, now = () => Date.now() } = {}) {
+  if (typeof windowMs !== 'number' || !Number.isFinite(windowMs) || windowMs <= 0) {
+    throw new RangeError(`createDedupTracker: windowMs must be a positive number, got ${windowMs}`);
+  }
   const seen = new Map(); // id → timestamp
 
   function prune(nowMs = now()) {

--- a/packages/whatsapp-gateway/test/dedup-tracker.test.js
+++ b/packages/whatsapp-gateway/test/dedup-tracker.test.js
@@ -4,6 +4,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { createDedupTracker } = require('../lib/dedup-tracker');
 
+test('windowMs must be finite and positive', () => {
+  for (const windowMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, '100']) {
+    assert.throws(() => createDedupTracker({ windowMs }), RangeError);
+  }
+});
+
 test('wasProcessed is false on first sight and does NOT mark', () => {
   const t = createDedupTracker();
   assert.equal(t.wasProcessed('abc'), false);


### PR DESCRIPTION
## Changes
- reject zero, negative, non-numeric, NaN, and infinite deduplication windows
- preserve the existing positive default and two-phase decrypt-retry behavior
- add a focused constructor regression test

## Verification
- `cd packages/whatsapp-gateway && node --test test/dedup-tracker.test.js` (9 passed)
- `cd packages/whatsapp-gateway && node --check lib/dedup-tracker.js`
- `git diff --check`

## Out of scope
- changing the deliberate check-then-mark API used to admit decrypt retransmissions
- echo tracking, owned by #7183