### PR TITLE
fix(deploy): harden Fly helper scripts

### DIFF
--- a/changelog.d/security/fly-script-secret-handling.md
+++ b/changelog.d/security/fly-script-secret-handling.md
@@ -1,0 +1,1 @@
+Keep Fly provider keys out of terminal echo and process arguments, remove the unverified installer pipeline, clean up terminal/temp state, and make uninstall discovery and partial failures fail closed. (@xiaomo)

--- a/deploy/fly/deploy.sh
+++ b/deploy/fly/deploy.sh
@@ -12,11 +12,21 @@ ok()    { printf "\033[1;32m✓\033[0m %s\n" "$1"; }
 warn()  { printf "\033[1;33m⚠\033[0m %s\n" "$1"; }
 err()   { printf "\033[1;31m✗\033[0m %s\n" "$1" >&2; exit 1; }
 
+WORK_DIR=""
+CURSOR_HIDDEN=0
+cleanup() {
+  if [ "$CURSOR_HIDDEN" -eq 1 ]; then
+    printf "\033[?25h" > /dev/tty 2>/dev/null || true
+  fi
+  if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf -- "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
 # --- 1. Check / Install flyctl ---
 if ! command -v flyctl &>/dev/null; then
-  info "Installing flyctl..."
-  curl -sL https://fly.io/install.sh | sh
-  export PATH="$HOME/.fly/bin:$PATH"
+  err "flyctl not found. Install it from https://fly.io/docs/flyctl/install/ and rerun this script."
 fi
 ok "flyctl $(flyctl version 2>&1 | head -1 || echo 'installed')"
 
@@ -28,10 +38,10 @@ fi
 ok "Logged in as $(flyctl auth whoami)"
 
 # --- 3. Clone repo ---
-TMPDIR=$(mktemp -d)
+WORK_DIR=$(mktemp -d)
 info "Cloning LibreFang..."
-git clone --depth 1 "$REPO" "$TMPDIR/librefang"
-cd "$TMPDIR/librefang"
+git clone --depth 1 "$REPO" "$WORK_DIR/librefang"
+cd "$WORK_DIR/librefang"
 
 # --- 4. Name & create app ---
 while true; do
@@ -48,11 +58,13 @@ while true; do
   fi
 
   info "Creating Fly app: $APP_NAME (region: $REGION)..."
-  if flyctl apps create "$APP_NAME" --machines 2>/dev/null; then
+  if create_output=$(flyctl apps create "$APP_NAME" --machines 2>&1); then
     ok "App created: $APP_NAME"
     break
   else
-    warn "Name '$APP_NAME' is already taken. Please choose another name."
+    warn "Could not create app '$APP_NAME':"
+    printf '%s\n' "$create_output" >&2
+    warn "Choose another name or fix the Fly error and retry."
   fi
 done
 
@@ -102,7 +114,7 @@ tui_multiselect() {
 
   # Hide cursor
   printf "\033[?25l" > /dev/tty
-  trap 'printf "\033[?25h" > /dev/tty' RETURN
+  CURSOR_HIDDEN=1
 
   draw_menu() {
     for ((i = 0; i < count; i++)); do
@@ -166,6 +178,8 @@ tui_multiselect() {
     draw_menu
   done
   echo "" > /dev/tty
+  printf "\033[?25h" > /dev/tty
+  CURSOR_HIDDEN=0
 
   SELECTED_INDICES=()
   for ((i = 0; i < count; i++)); do
@@ -180,9 +194,11 @@ tui_multiselect
 for idx in "${SELECTED_INDICES[@]}"; do
   name="${PROVIDER_NAMES[$idx]}"
   env_var="${PROVIDER_KEYS[$idx]}"
-  read -rp "  $name ($env_var): " KEY_VAL < /dev/tty
+  read -rsp "  $name ($env_var): " KEY_VAL < /dev/tty
+  echo "" > /dev/tty
   if [ -n "$KEY_VAL" ]; then
-    flyctl secrets set "$env_var=$KEY_VAL" --app "$APP_NAME"
+    printf '%s=%s\n' "$env_var" "$KEY_VAL" | flyctl secrets import --app "$APP_NAME"
+    KEY_VAL=""
   fi
 done
 
@@ -206,6 +222,3 @@ echo ""
 echo "  To add or change API keys later:"
 echo "    flyctl secrets set <PROVIDER>_API_KEY=your-key --app $APP_NAME"
 echo ""
-
-# Cleanup
-rm -rf "$TMPDIR"

--- a/deploy/fly/uninstall.sh
+++ b/deploy/fly/uninstall.sh
@@ -9,8 +9,17 @@ ok()    { printf "\033[1;32m✓\033[0m %s\n" "$1"; }
 warn()  { printf "\033[1;33m⚠\033[0m %s\n" "$1"; }
 err()   { printf "\033[1;31m✗\033[0m %s\n" "$1" >&2; exit 1; }
 
+CURSOR_HIDDEN=0
+cleanup() {
+  if [ "$CURSOR_HIDDEN" -eq 1 ]; then
+    printf "\033[?25h" > /dev/tty 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
 # --- 1. Check flyctl ---
-command -v flyctl &>/dev/null || err "flyctl not found. Install it first: curl -sL https://fly.io/install.sh | sh"
+command -v flyctl &>/dev/null || err "flyctl not found. Install it from https://fly.io/docs/flyctl/install/ first."
+command -v python3 &>/dev/null || err "python3 not found. Install Python 3 before running uninstall."
 
 # --- 2. Auth ---
 if ! flyctl auth whoami &>/dev/null; then
@@ -21,17 +30,23 @@ ok "Logged in as $(flyctl auth whoami)"
 
 # --- 3. Fetch LibreFang apps ---
 info "Fetching your LibreFang apps..."
-APPS=()
-while IFS= read -r line; do
-  [[ -n "$line" ]] && APPS+=("$line")
-done < <(flyctl apps list --json 2>/dev/null | python3 -c "
+if ! apps_json=$(flyctl apps list --json 2>&1); then
+  err "Could not list Fly apps: $apps_json"
+fi
+if ! parsed_apps=$(printf '%s' "$apps_json" | python3 -c "
 import sys, json
 apps = json.load(sys.stdin)
 for a in apps:
     name = a.get('Name', a.get('name', ''))
-    if name.startswith('librefang'):
+    if name == 'librefang' or name.startswith('librefang-'):
         print(name)
-" 2>/dev/null || true)
+" 2>&1); then
+  err "Could not parse Fly app list: $parsed_apps"
+fi
+APPS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && APPS+=("$line")
+done <<< "$parsed_apps"
 
 if [ ${#APPS[@]} -eq 0 ]; then
   ok "No LibreFang apps found on your account."
@@ -51,7 +66,7 @@ tui_multiselect() {
   for ((i = 0; i < count; i++)); do selected+=(0); done
 
   printf "\033[?25l" > /dev/tty
-  trap 'printf "\033[?25h" > /dev/tty' RETURN
+  CURSOR_HIDDEN=1
 
   draw_menu() {
     for ((i = 0; i < count; i++)); do
@@ -115,6 +130,8 @@ tui_multiselect() {
     draw_menu
   done
   echo "" > /dev/tty
+  printf "\033[?25h" > /dev/tty
+  CURSOR_HIDDEN=0
 
   SELECTED_INDICES=()
   for ((i = 0; i < count; i++)); do
@@ -149,15 +166,20 @@ fi
 
 # --- 6. Destroy selected apps ---
 echo ""
+destroy_failures=0
 for idx in "${SELECTED_INDICES[@]}"; do
   app="${TUI_ITEMS[$idx]}"
   info "Destroying $app..."
-  if flyctl apps destroy "$app" --yes 2>/dev/null; then
+  if destroy_output=$(flyctl apps destroy "$app" --yes 2>&1); then
     ok "Destroyed $app"
   else
-    warn "Failed to destroy $app (may already be deleted)"
+    warn "Failed to destroy $app: $destroy_output"
+    destroy_failures=$((destroy_failures + 1))
   fi
 done
 
 echo ""
+if (( destroy_failures > 0 )); then
+  err "$destroy_failures selected app(s) could not be destroyed. Review the errors above."
+fi
 ok "Done! All selected apps have been destroyed."

--- a/deploy/tests/fly-scripts.test.sh
+++ b/deploy/tests/fly-scripts.test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+DEPLOY_SCRIPT="${ROOT}/deploy/fly/deploy.sh"
+UNINSTALL_SCRIPT="${ROOT}/deploy/fly/uninstall.sh"
+
+bash -n "$DEPLOY_SCRIPT" "$UNINSTALL_SCRIPT"
+
+! grep -Eq 'curl[^|]*\|[[:space:]]*sh' "$DEPLOY_SCRIPT"
+! grep -Eq 'flyctl secrets set.*KEY_VAL' "$DEPLOY_SCRIPT"
+grep -Fq 'flyctl secrets import --app "$APP_NAME"' "$DEPLOY_SCRIPT"
+grep -Fq 'read -rsp' "$DEPLOY_SCRIPT"
+grep -Fq 'trap cleanup EXIT' "$DEPLOY_SCRIPT"
+grep -Fq 'trap cleanup EXIT' "$UNINSTALL_SCRIPT"
+grep -Fq "name == 'librefang' or name.startswith('librefang-')" "$UNINSTALL_SCRIPT"
+grep -Fq 'destroy_failures=$((destroy_failures + 1))' "$UNINSTALL_SCRIPT"


### PR DESCRIPTION
## Changes
- read provider credentials without terminal echo and import them over stdin instead of process arguments
- require an operator-installed flyctl rather than executing a remote installer pipeline
- clean temporary clones and restore the terminal cursor through an EXIT trap
- surface app-creation errors instead of assuming every failure is a name collision
- make uninstall verify Python, app-list transport, and JSON parsing before presenting destructive choices
- restrict auto-discovered apps to `librefang` / `librefang-*`, preserve destroy diagnostics, and fail on partial deletion

## Verification
- `bash deploy/tests/fly-scripts.test.sh`
- `bash -n deploy/fly/deploy.sh deploy/fly/uninstall.sh` (included by the test)
- `git diff --check`

## Out of scope
- Fly image/VM sizing policy
- changing the one-time generated LibreFang API key display; the operator must save that generated credential because Fly secrets cannot be read back