### PR TITLE
fix(deploy): roll back incomplete worker apps

### DIFF
--- a/changelog.d/fixed/worker-deploy-rollback.md
+++ b/changelog.d/fixed/worker-deploy-rollback.md
@@ -1,0 +1,1 @@
+Validate Fly IP allocation responses and remove partially created apps when one-click deployment cannot finish provisioning resources. (@xiaomo)

--- a/deploy/worker/src/index.js
+++ b/deploy/worker/src/index.js
@@ -55,92 +55,110 @@ async function handleDeploy(request, fetchImpl) {
       return json({ error: `Failed to create app: ${err}` }, 500);
     }
 
-    // 3. Allocate shared IPv4 + IPv6 (needed for public HTTPS)
-    const flyGraphQL = 'https://api.fly.io/graphql';
-    const gqlHeaders = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+    try {
+      // 3. Allocate shared IPv4 + IPv6 (needed for public HTTPS)
+      await allocateIpAddress(fetchImpl, token, appName, 'shared_v4');
+      await allocateIpAddress(fetchImpl, token, appName, 'v6');
 
-    await fetchImpl(flyGraphQL, {
-      method: 'POST',
-      headers: gqlHeaders,
-      body: JSON.stringify({
-        query: `mutation { allocateIPAddress(input: { appId: "${appName}", type: shared_v4 }) { ipAddress { address type } } }`,
-      }),
-    });
-    await fetchImpl(flyGraphQL, {
-      method: 'POST',
-      headers: gqlHeaders,
-      body: JSON.stringify({
-        query: `mutation { allocateIPAddress(input: { appId: "${appName}", type: v6 }) { ipAddress { address type } } }`,
-      }),
-    });
+      // 4. Create volume
+      const volRes = await fetchImpl(`${FLY_API}/apps/${appName}/volumes`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ name: 'librefang_data', region: REGION, size_gb: 1 }),
+      });
+      if (!volRes.ok) {
+        throw new Error('Failed to create volume. Check your Fly configuration and try again.');
+      }
 
-    // 4. Create volume
-    const volRes = await fetchImpl(`${FLY_API}/apps/${appName}/volumes`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ name: 'librefang_data', region: REGION, size_gb: 1 }),
-    });
-    if (!volRes.ok) {
-      const err = await volRes.text();
-      return json({ error: `Failed to create volume: ${err}` }, 500);
-    }
+      // 5. Build env exclusively from credentials supplied by this deployer.
+      // Never copy a Worker-level provider key into user-owned infrastructure.
+      const env_vars = {
+        LIBREFANG_HOME: '/data',
+        OPENROUTER_API_KEY: openrouterApiKey.trim(),
+      };
 
-    // 5. Build env exclusively from credentials supplied by this deployer.
-    // Never copy a Worker-level provider key into user-owned infrastructure.
-    const env_vars = {
-      LIBREFANG_HOME: '/data',
-      OPENROUTER_API_KEY: openrouterApiKey.trim(),
-    };
+      // 6. Create machine
+      const machineRes = await fetchImpl(`${FLY_API}/apps/${appName}/machines`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          region: REGION,
+          config: {
+            image: DOCKER_IMAGE,
+            env: env_vars,
+            guest: { cpu_kind: 'shared', cpus: 1, memory_mb: 256 },
+            services: [
+              {
+                ports: [
+                  { port: 443, handlers: ['tls', 'http'] },
+                  { port: 80, handlers: ['http'] },
+                ],
+                protocol: 'tcp',
+                internal_port: 4545,
+                force_instance_key: null,
+              },
+            ],
+            mounts: [{ volume: 'librefang_data', path: '/data' }],
+            auto_destroy: false,
+          },
+        }),
+      });
 
-    // 6. Create machine
-    const machineRes = await fetchImpl(`${FLY_API}/apps/${appName}/machines`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
+      if (!machineRes.ok) {
+        // This request contains the caller's provider key.
+        // Never reflect Fly's raw validation body because it may echo the submitted machine config.
+        throw new Error('Failed to create machine. Check your Fly configuration and try again.');
+      }
+
+      const machine = await machineRes.json();
+      const appUrl = `https://${appName}.fly.dev`;
+
+      return json({
+        success: true,
+        appName,
+        url: appUrl,
+        dashboardUrl: `https://fly.io/apps/${appName}`,
+        machineId: machine.id,
         region: REGION,
-        config: {
-          image: DOCKER_IMAGE,
-          env: env_vars,
-          guest: { cpu_kind: 'shared', cpus: 1, memory_mb: 256 },
-          services: [
-            {
-              ports: [
-                { port: 443, handlers: ['tls', 'http'] },
-                { port: 80, handlers: ['http'] },
-              ],
-              protocol: 'tcp',
-              internal_port: 4545,
-              force_instance_key: null,
-            },
-          ],
-          mounts: [{ volume: 'librefang_data', path: '/data' }],
-          auto_destroy: false,
-        },
-      }),
-    });
-
-    if (!machineRes.ok) {
-      // This request contains the caller's provider key.
-      // Never reflect Fly's raw validation body because it may echo the submitted machine config.
-      return json(
-        { error: 'Failed to create machine. Check your Fly configuration and try again.' },
-        500,
-      );
+      });
+    } catch (err) {
+      await deleteApp(fetchImpl, headers, appName);
+      return json({ error: err.message || 'Deployment failed' }, 500);
     }
-
-    const machine = await machineRes.json();
-    const appUrl = `https://${appName}.fly.dev`;
-
-    return json({
-      success: true,
-      appName,
-      url: appUrl,
-      dashboardUrl: `https://fly.io/apps/${appName}`,
-      machineId: machine.id,
-      region: REGION,
-    });
   } catch (err) {
     return json({ error: err.message || 'Unexpected error' }, 500);
+  }
+}
+
+async function allocateIpAddress(fetchImpl, token, appName, type) {
+  const response = await fetchImpl('https://api.fly.io/graphql', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: `mutation { allocateIPAddress(input: { appId: "${appName}", type: ${type} }) { ipAddress { address type } } }`,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to allocate ${type} address.`);
+  }
+
+  let result;
+  try {
+    result = await response.json();
+  } catch {
+    throw new Error(`Failed to allocate ${type} address.`);
+  }
+  if (result.errors?.length || !result.data?.allocateIPAddress?.ipAddress?.address) {
+    throw new Error(`Failed to allocate ${type} address.`);
+  }
+}
+
+async function deleteApp(fetchImpl, headers, appName) {
+  try {
+    await fetchImpl(`${FLY_API}/apps/${appName}`, { method: 'DELETE', headers });
+  } catch {
+    // Cleanup is best effort. Preserve the original deployment error.
   }
 }
 

--- a/deploy/worker/src/index.test.js
+++ b/deploy/worker/src/index.test.js
@@ -5,6 +5,11 @@ import worker, { createWorker } from './index.js';
 
 function successfulFlyFetches(onMachineRequest = () => {}) {
   return async (url, options = {}) => {
+    if (String(url) === 'https://api.fly.io/graphql') {
+      return Response.json({
+        data: { allocateIPAddress: { ipAddress: { address: '203.0.113.1' } } },
+      });
+    }
     if (String(url).endsWith('/machines')) {
       onMachineRequest(JSON.parse(options.body));
       return new Response(JSON.stringify({ id: 'machine-1' }), { status: 200 });
@@ -71,6 +76,11 @@ test('deploy rejects a missing caller OpenRouter key before contacting Fly', asy
 test('machine creation errors never reflect the caller OpenRouter key', async () => {
   const callerKey = 'user-openrouter-key-must-not-return';
   const testWorker = createWorker(async (url) => {
+    if (String(url) === 'https://api.fly.io/graphql') {
+      return Response.json({
+        data: { allocateIPAddress: { ipAddress: { address: '203.0.113.1' } } },
+      });
+    }
     if (String(url).endsWith('/machines')) {
       return new Response(`invalid env OPENROUTER_API_KEY=${callerKey}`, {
         status: 400,
@@ -91,3 +101,53 @@ test('machine creation errors never reflect the caller OpenRouter key', async ()
   assert.ok(!responseText.includes(callerKey));
   assert.ok(!responseText.includes('OPENROUTER_API_KEY='));
 });
+
+test('GraphQL allocation errors delete the partially created app', async () => {
+  const requests = [];
+  const testWorker = createWorker(async (url, options = {}) => {
+    requests.push([String(url), options.method || 'GET', options]);
+    if (String(url) === 'https://api.fly.io/graphql') {
+      return Response.json({ errors: [{ message: 'allocation failed' }] });
+    }
+    return new Response('{}', { status: 200 });
+  });
+
+  const response = await deploy(testWorker);
+  const appCreate = requests.find(([url, method]) => url.endsWith('/apps') && method === 'POST');
+  const appName = JSON.parse(appCreate[2].body).app_name;
+
+  assert.equal(response.status, 500);
+  assert.ok(requests.some(([url, method]) => url.endsWith(`/apps/${appName}`) && method === 'DELETE'));
+  assert.ok(!requests.some(([url]) => url.endsWith('/volumes')));
+});
+
+test('machine creation failure deletes the partially created app', async () => {
+  const requests = [];
+  const testWorker = createWorker(async (url, options = {}) => {
+    requests.push([String(url), options.method || 'GET', options]);
+    if (String(url) === 'https://api.fly.io/graphql') {
+      return Response.json({
+        data: { allocateIPAddress: { ipAddress: { address: '203.0.113.1' } } },
+      });
+    }
+    if (String(url).endsWith('/machines')) {
+      return new Response('machine failed', { status: 500 });
+    }
+    return new Response('{}', { status: 200 });
+  });
+
+  const response = await deploy(testWorker);
+  const appRequest = requests.find(([url, method]) => url.endsWith('/apps') && method === 'POST');
+  const appName = JSON.parse(appRequest[2].body).app_name;
+
+  assert.equal(response.status, 500);
+  assert.ok(requests.some(([url, method]) => url.endsWith(`/apps/${appName}`) && method === 'DELETE'));
+});
+
+function deploy(testWorker) {
+  return testWorker.fetch(new Request('https://deploy.librefang.ai/api/deploy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: 'fly-user-token', openrouterApiKey: 'openrouter-key' }),
+  }));
+}


### PR DESCRIPTION
## Changes
- validate Fly GraphQL HTTP responses, payloads, and allocated addresses
- delete partially created Fly apps when IP, volume, or machine provisioning fails
- keep deployment failures generic instead of reflecting provider response bodies
- add regression coverage for allocation and machine failure rollback

## Verification
- `cd deploy/worker && npm test`
- `git diff --check`

## Out of scope
- public endpoint authentication and rate limiting require an explicit product/infrastructure policy
- Worker route and `workers_dev` policy are unchanged