### PR TITLE
fix(deploy): pin kubernetes image release

### DIFF
--- a/changelog.d/fixed/kubernetes-image-pin.md
+++ b/changelog.d/fixed/kubernetes-image-pin.md
@@ -1,0 +1,1 @@
+Pin the Kubernetes deployment base to a concrete LibreFang release so pod restarts cannot silently reuse or adopt a different `latest` image. (@xiaomo)

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -20,4 +20,4 @@ labels:
 #   kustomize edit set image ghcr.io/librefang/librefang=ghcr.io/librefang/librefang:vYYYY.M.D
 images:
   - name: ghcr.io/librefang/librefang
-    newTag: latest
+    newTag: v2026.7.31

--- a/deploy/kubernetes/base/statefulset.yaml
+++ b/deploy/kubernetes/base/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: librefang
-          image: ghcr.io/librefang/librefang:latest
+          image: ghcr.io/librefang/librefang:v2026.7.31
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Changes
- pin the Kubernetes base image to LibreFang v2026.7.31
- keep the StatefulSet default consistent with the Kustomize image override
- preserve `IfNotPresent` semantics for the immutable release tag

## Verification
- `kubectl kustomize deploy/kubernetes/base`
- verified rendered image is `ghcr.io/librefang/librefang:v2026.7.31`
- `git diff --check`

## Out of scope
- release automation for future image-pin bumps is unchanged