### PR TITLE
fix(deploy): correct grafana dashboard links

### DIFF
--- a/changelog.d/fixed/grafana-dashboard-links.md
+++ b/changelog.d/fixed/grafana-dashboard-links.md
@@ -1,0 +1,1 @@
+Route Jaeger dashboard links through Grafana's proxied datasource and label global cost panels so remote operators are not sent to browser-local services or misled by filter controls. (@xiaomo)

--- a/deploy/grafana/dashboards/librefang-cost.json
+++ b/deploy/grafana/dashboards/librefang-cost.json
@@ -53,12 +53,12 @@
       "keepTime": true
     },
     {
-      "title": "Jaeger UI",
+      "title": "Search Traces (Jaeger)",
       "type": "link",
       "icon": "external link",
-      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
-      "url": "http://localhost:16686/search?service=librefang",
-      "targetBlank": true,
+      "tooltip": "Open Grafana Explore on the proxied Jaeger datasource",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-jaeger\",{}]",
+      "targetBlank": false,
       "tags": [],
       "asDropdown": false,
       "includeVars": false,
@@ -67,7 +67,8 @@
   ],
   "panels": [
     {
-      "title": "Cost Today (USD)",
+      "title": "Global Cost Today (USD)",
+      "description": "Global daily cost gauge; Agent, Provider, and Model filters do not apply.",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -230,7 +231,8 @@
       ]
     },
     {
-      "title": "Cost Trend",
+      "title": "Global Cost Trend",
+      "description": "Global daily cost gauge over time; Agent, Provider, and Model filters do not apply.",
       "description": "Today's estimated cost over time",
       "type": "timeseries",
       "gridPos": {

--- a/deploy/grafana/dashboards/librefang-http.json
+++ b/deploy/grafana/dashboards/librefang-http.json
@@ -53,12 +53,12 @@
       "keepTime": true
     },
     {
-      "title": "Jaeger UI",
+      "title": "Search Traces (Jaeger)",
       "type": "link",
       "icon": "external link",
-      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
-      "url": "http://localhost:16686/search?service=librefang",
-      "targetBlank": true,
+      "tooltip": "Open Grafana Explore on the proxied Jaeger datasource",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-jaeger\",{}]",
+      "targetBlank": false,
       "tags": [],
       "asDropdown": false,
       "includeVars": false,

--- a/deploy/grafana/dashboards/librefang-llm.json
+++ b/deploy/grafana/dashboards/librefang-llm.json
@@ -53,12 +53,12 @@
       "keepTime": true
     },
     {
-      "title": "Jaeger UI",
+      "title": "Search Traces (Jaeger)",
       "type": "link",
       "icon": "external link",
-      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
-      "url": "http://localhost:16686/search?service=librefang",
-      "targetBlank": true,
+      "tooltip": "Open Grafana Explore on the proxied Jaeger datasource",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-jaeger\",{}]",
+      "targetBlank": false,
       "tags": [],
       "asDropdown": false,
       "includeVars": false,

--- a/deploy/grafana/dashboards/librefang.json
+++ b/deploy/grafana/dashboards/librefang.json
@@ -53,12 +53,12 @@
       "keepTime": true
     },
     {
-      "title": "Jaeger UI",
+      "title": "Search Traces (Jaeger)",
       "type": "link",
       "icon": "external link",
-      "tooltip": "Open standalone Jaeger UI for waterfall / span-diff / service-deps views",
-      "url": "http://localhost:16686/search?service=librefang",
-      "targetBlank": true,
+      "tooltip": "Open Grafana Explore on the proxied Jaeger datasource",
+      "url": "/explore?left=[\"now-1h\",\"now\",\"librefang-jaeger\",{}]",
+      "targetBlank": false,
       "tags": [],
       "asDropdown": false,
       "includeVars": false,


### PR DESCRIPTION
## Changes
- route Jaeger links in all four dashboards through the provisioned Grafana proxy datasource
- remove browser-local `localhost:16686` links that fail for remote operators
- label the unlabeled daily-cost metric panels as global and document that template filters do not apply

## Verification
- `jq empty deploy/grafana/dashboards/*.json` (run for each file)
- verified no dashboard contains `http://localhost:16686`
- `git diff --check`

## Out of scope
- provisioned dashboards remain editable and persisted by documented design
- rolling one-hour gauge panel queries are unchanged because the API already exports rolling one-hour values