### PR TITLE
fix(deploy): harden gcp config defaults

### DIFF
--- a/changelog.d/fixed/gcp-config-hygiene.md
+++ b/changelog.d/fixed/gcp-config-hygiene.md
@@ -1,0 +1,1 @@
+Pin the GCP template's default LibreFang release, validate project IDs early, and ignore local Terraform overrides, variable files, and common GCP credential files without excluding the provider lock file. (@xiaomo)

--- a/deploy/gcp/.gitignore
+++ b/deploy/gcp/.gitignore
@@ -1,5 +1,13 @@
 .terraform/
 *.tfstate
 *.tfstate.backup
-terraform.tfvars
-.terraform.lock.hcl
+*.tfvars
+*.tfvars.json
+!terraform.tfvars.example
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+service-account*.json
+credentials*.json
+*.key.json

--- a/deploy/gcp/terraform.tfvars.example
+++ b/deploy/gcp/terraform.tfvars.example
@@ -12,7 +12,7 @@ librefang_api_key = "replace-with-a-random-64-character-hex-key"
 # region           = "us-central1"
 # zone             = "us-central1-a"
 # ssh_pub_key_path = "~/.ssh/id_rsa.pub"
-# librefang_version = "latest"
+# librefang_version = "v2026.7.31"
 
 # At least one LLM API key is required
 groq_api_key      = ""

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -1,6 +1,11 @@
 variable "project_id" {
   description = "GCP project ID"
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid 6-30 character GCP project ID."
+  }
 }
 
 variable "region" {
@@ -45,9 +50,9 @@ variable "librefang_api_key" {
 }
 
 variable "librefang_version" {
-  description = "LibreFang release tag (e.g. v0.4.2-20260314), or 'latest'"
+  description = "LibreFang release tag (e.g. v2026.7.31), or 'latest' to opt into a floating release"
   type        = string
-  default     = "latest"
+  default     = "v2026.7.31"
 }
 
 variable "groq_api_key" {


### PR DESCRIPTION
## Changes
- pin the default GCP install to LibreFang v2026.7.31 while retaining explicit `latest` support
- validate GCP project IDs during Terraform evaluation
- ignore local tfvars, override files, and common GCP credential filenames
- stop ignoring `.terraform.lock.hcl` so provider resolution can be committed

## Verification
- used `git check-ignore --no-index` to verify tfvars and credential fixtures are ignored
- verified `terraform.tfvars.example` and `.terraform.lock.hcl` are not ignored
- verified the pinned default and project validation expression structurally
- `git diff --check`

## Out of scope
- provider API keys remain optional because LibreFang supports multiple providers
- moving provider keys from cloud-init metadata to Secret Manager requires an instance service account and input migration
- no generated provider lock file is included because Terraform is unavailable in this environment