### PR TITLE
fix(deploy): pin and probe fly template

### DIFF
--- a/changelog.d/fixed/fly-template-health.md
+++ b/changelog.d/fixed/fly-template-health.md
@@ -1,0 +1,1 @@
+Pin the Fly.io template to a concrete LibreFang release and add an authenticated-deployment-safe readiness check for reliable routing and restarts. (@xiaomo)

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -2,7 +2,7 @@ app = "librefang"
 primary_region = "nrt"
 
 [build]
-image = "ghcr.io/librefang/librefang:latest"
+image = "ghcr.io/librefang/librefang:v2026.7.31"
 
 [env]
   LIBREFANG_HOME = "/data"
@@ -16,6 +16,16 @@ image = "ghcr.io/librefang/librefang:latest"
   auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 1
+
+[[http_service.checks]]
+  grace_period = "30s"
+  interval = "30s"
+  method = "GET"
+  timeout = "5s"
+  path = "/api/ready"
+
+  [http_service.checks.headers]
+    X-Forwarded-Proto = "https"
 
 [mounts]
   source = "librefang_data"


### PR DESCRIPTION
## Changes
- pin the Fly image to LibreFang v2026.7.31
- add an HTTP readiness check on `/api/ready`
- supply the forwarded HTTPS header required alongside `force_https`
- allow a 30-second startup grace period

## Verification
- checked health-check fields and nested headers against Fly.io's current configuration reference
- verified the pinned image, readiness path, and forwarded-protocol header structurally
- `git diff --check`

## Out of scope
- the 256 MB VM size is unchanged because no workload measurement demonstrates an OOM condition
- always-on versus suspend policy remains unchanged
- `flyctl config validate` was unavailable locally