### PR TITLE
fix(deploy): disable worker dev route

### DIFF
--- a/changelog.d/security/worker-custom-route-only.md
+++ b/changelog.d/security/worker-custom-route-only.md
@@ -1,0 +1,1 @@
+Disable the deploy Worker's public `workers.dev` hostname so provisioning is reachable only through the configured `deploy.librefang.ai` route. (@xiaomo)

--- a/deploy/worker/wrangler.toml
+++ b/deploy/worker/wrangler.toml
@@ -2,6 +2,7 @@
 name = "librefang-deploy"
 main = "src/index.js"
 compatibility_date = "2024-12-01"
+workers_dev = false
 
 routes = [
   { pattern = "deploy.librefang.ai/*", zone_name = "librefang.ai" }


### PR DESCRIPTION
## Changes
- set `workers_dev = false` for the production deploy Worker
- keep provisioning reachable only through `deploy.librefang.ai`
- rely on Cloudflare's documented behavior that preview URLs default to the `workers_dev` value

## Verification
- `cd deploy/worker && npx -y wrangler@4.121.0 deploy --dry-run --outdir /tmp/librefang-worker-route-dry-run`
- `cd deploy/worker && npm test`
- `git diff --check`

## Out of scope
- CI already fixes the account with `CLOUDFLARE_ACCOUNT_ID`; no public account ID is duplicated into this config
- compatibility behavior and observability policy are unchanged
- endpoint authentication/rate limiting still requires the separate product and infrastructure decision