### PR TITLE
fix(examples): validate sidecar commands

### DIFF
--- a/changelog.d/fixed/sidecar-example-validation.md
+++ b/changelog.d/fixed/sidecar-example-validation.md
@@ -1,0 +1,1 @@
+Make every sidecar channel example reject malformed and unsupported commands, safely encode echoed data, and surface Go input and output failures. (@xiaomo)

--- a/examples/sidecar-channel-bash/adapter.sh
+++ b/examples/sidecar-channel-bash/adapter.sh
@@ -14,20 +14,35 @@
 # Signal readiness
 echo '{"method":"ready"}'
 
+send_error() {
+    jq -cn --arg message "$1" '{method:"error",params:{message:$message}}'
+}
+
 # Read commands from stdin
 while IFS= read -r line; do
     [ -z "$line" ] && continue
 
-    method=$(echo "$line" | jq -r '.method // empty')
+    if ! method=$(printf '%s\n' "$line" | jq -er 'select(type == "object" and (.method | type == "string")) | .method'); then
+        send_error "Invalid command: expected an object with a string method"
+        continue
+    fi
 
     case "$method" in
         send)
-            text=$(echo "$line" | jq -r '.params.text // ""')
-            channel_id=$(echo "$line" | jq -r '.params.channel_id // "default"')
-            echo "{\"method\":\"message\",\"params\":{\"user_id\":\"echo-user\",\"user_name\":\"Echo Bot (Bash)\",\"text\":\"Echo: ${text}\",\"channel_id\":\"${channel_id}\"}}"
+            if ! printf '%s\n' "$line" | jq -e '.params | type == "object"' >/dev/null; then
+                send_error "Invalid send params: expected an object"
+                continue
+            fi
+            text=$(printf '%s\n' "$line" | jq -r '.params.text // ""')
+            channel_id=$(printf '%s\n' "$line" | jq -r '.params.channel_id // "default"')
+            jq -cn --arg text "Echo: ${text}" --arg channel_id "$channel_id" \
+                '{method:"message",params:{user_id:"echo-user",user_name:"Echo Bot (Bash)",text:$text,channel_id:$channel_id}}'
             ;;
         shutdown)
             exit 0
+            ;;
+        *)
+            send_error "Unsupported command: ${method}"
             ;;
     esac
 done

--- a/examples/sidecar-channel-go/adapter.go
+++ b/examples/sidecar-channel-go/adapter.go
@@ -40,15 +40,17 @@ type MessageParams struct {
 	ChannelID string `json:"channel_id"`
 }
 
-func sendEvent(method string, params interface{}) {
+func sendEvent(method string, params interface{}) error {
 	evt := Event{Method: method, Params: params}
-	data, _ := json.Marshal(evt)
-	fmt.Println(string(data))
+	return json.NewEncoder(os.Stdout).Encode(evt)
 }
 
 func main() {
 	// Signal readiness
-	sendEvent("ready", nil)
+	if err := sendEvent("ready", nil); err != nil {
+		fmt.Fprintf(os.Stderr, "encode ready event: %v\n", err)
+		return
+	}
 
 	// Read commands from stdin
 	scanner := bufio.NewScanner(os.Stdin)
@@ -60,22 +62,33 @@ func main() {
 
 		var cmd Command
 		if err := json.Unmarshal([]byte(line), &cmd); err != nil {
-			sendEvent("error", map[string]string{"message": fmt.Sprintf("Invalid JSON: %v", err)})
+			_ = sendEvent("error", map[string]string{"message": fmt.Sprintf("Invalid JSON: %v", err)})
 			continue
 		}
 
 		switch cmd.Method {
 		case "send":
 			var params SendParams
-			json.Unmarshal(cmd.Params, &params)
-			sendEvent("message", MessageParams{
+			if err := json.Unmarshal(cmd.Params, &params); err != nil {
+				_ = sendEvent("error", map[string]string{"message": fmt.Sprintf("Invalid send params: %v", err)})
+				continue
+			}
+			if err := sendEvent("message", MessageParams{
 				UserID:    "echo-user",
 				UserName:  "Echo Bot (Go)",
 				Text:      fmt.Sprintf("Echo: %s", params.Text),
 				ChannelID: params.ChannelID,
-			})
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "encode message event: %v\n", err)
+				return
+			}
 		case "shutdown":
-			os.Exit(0)
+			return
+		default:
+			_ = sendEvent("error", map[string]string{"message": fmt.Sprintf("Unsupported command: %s", cmd.Method)})
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "read command: %v\n", err)
 	}
 }

--- a/examples/sidecar-channel-node/adapter.js
+++ b/examples/sidecar-channel-node/adapter.js
@@ -18,8 +18,17 @@ function sendEvent(method, params) {
 }
 
 function handleCommand(cmd) {
+  if (!cmd || typeof cmd !== "object" || Array.isArray(cmd) || typeof cmd.method !== "string") {
+    sendEvent("error", { message: "Invalid command: expected an object with a string method" });
+    return;
+  }
+
   switch (cmd.method) {
-    case "send":
+    case "send": {
+      if (!cmd.params || typeof cmd.params !== "object" || Array.isArray(cmd.params)) {
+        sendEvent("error", { message: "Invalid send params: expected an object" });
+        return;
+      }
       sendEvent("message", {
         user_id: "echo-user",
         user_name: "Echo Bot (Node)",
@@ -27,8 +36,12 @@ function handleCommand(cmd) {
         channel_id: cmd.params?.channel_id || "default",
       });
       break;
+    }
     case "shutdown":
       process.exit(0);
+      break;
+    default:
+      sendEvent("error", { message: `Unsupported command: ${cmd.method}` });
   }
 }
 

--- a/examples/sidecar-channel-python/adapter.py
+++ b/examples/sidecar-channel-python/adapter.py
@@ -31,9 +31,16 @@ def send_event(method, params=None):
 
 def handle_command(cmd):
     """Handle a command from LibreFang."""
+    if not isinstance(cmd, dict) or not isinstance(cmd.get("method"), str):
+        send_event("error", {"message": "Invalid command: expected an object with a string method"})
+        return
+
     method = cmd.get("method")
     if method == "send":
         params = cmd.get("params", {})
+        if not isinstance(params, dict):
+            send_event("error", {"message": "Invalid send params: expected an object"})
+            return
         # Echo: pretend we sent it and got a reply
         send_event("message", {
             "user_id": "echo-user",
@@ -43,6 +50,8 @@ def handle_command(cmd):
         })
     elif method == "shutdown":
         sys.exit(0)
+    else:
+        send_event("error", {"message": f"Unsupported command: {method}"})
 
 
 def main():

--- a/examples/test-sidecar-channel-adapters.sh
+++ b/examples/test-sidecar-channel-adapters.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+input='[]
+{"method":"unknown"}
+{"method":"send","params":{"text":"quote \" and slash \\","channel_id":"chat"}}'
+
+check_adapter() {
+    output=$(printf '%s\n' "$input" | "$@")
+    printf '%s\n' "$output" | jq -s -e '
+        length == 4 and
+        .[0].method == "ready" and
+        .[1].method == "error" and
+        .[2].method == "error" and
+        .[3].method == "message" and
+        .[3].params.channel_id == "chat" and
+        .[3].params.text == "Echo: quote \" and slash \\"
+    ' >/dev/null
+}
+
+check_adapter node examples/sidecar-channel-node/adapter.js
+check_adapter python3 examples/sidecar-channel-python/adapter.py
+check_adapter bash examples/sidecar-channel-bash/adapter.sh
+check_adapter go run examples/sidecar-channel-go/adapter.go


### PR DESCRIPTION
## Changes
- reject non-object commands, malformed send params, and unsupported methods in all four sidecar channel examples
- encode Bash events with jq instead of string interpolation
- surface Go scanner and event-encoding failures
- add one cross-language process smoke test with JSON metacharacters

## Verification
- `examples/test-sidecar-channel-adapters.sh`
- `go vet examples/sidecar-channel-go/adapter.go`
- `node --check examples/sidecar-channel-node/adapter.js`
- `python3 -m py_compile examples/sidecar-channel-python/adapter.py`
- `bash -n examples/sidecar-channel-bash/adapter.sh`
- `git diff --check`

## Out of scope
- production sidecar adapters and SDK runtimes are unchanged