### PR TITLE
fix(examples): align custom agent capabilities

### DIFF
--- a/changelog.d/fixed/custom-agent-capabilities.md
+++ b/changelog.d/fixed/custom-agent-capabilities.md
@@ -1,0 +1,1 @@
+Make the custom agent example's web and memory tools usable by granting their matching network and memory capabilities, and add a conservative hourly cost ceiling. (@xiaomo)

--- a/crates/librefang-kernel/src/kernel/manifest_helpers.rs
+++ b/crates/librefang-kernel/src/kernel/manifest_helpers.rs
@@ -771,6 +771,21 @@ mod context_window_tests {
 mod tests {
     use super::*;
 
+    #[test]
+    fn custom_agent_example_grants_tools_matching_its_scopes() {
+        let source = include_str!("../../../../examples/custom-agent/agent.toml");
+        let manifest: AgentManifest = toml::from_str(source).unwrap();
+        let caps = manifest_to_capabilities(&manifest);
+
+        assert!(caps.contains(&Capability::ToolInvoke("web_fetch".into())));
+        assert!(caps.contains(&Capability::NetConnect("*".into())));
+        assert!(caps.contains(&Capability::ToolInvoke("memory_store".into())));
+        assert!(caps.contains(&Capability::ToolInvoke("memory_recall".into())));
+        assert!(caps.contains(&Capability::MemoryRead("self.*".into())));
+        assert!(caps.contains(&Capability::MemoryWrite("self.*".into())));
+        assert_eq!(manifest.resources.max_cost_per_hour_usd, 1.0);
+    }
+
     const HAND_TOML: &str = r#"
 id = "jarvis"
 version = "1.0.0"

--- a/examples/custom-agent/agent.toml
+++ b/examples/custom-agent/agent.toml
@@ -24,9 +24,11 @@ When you don't know something, you say so honestly.
 
 [resources]
 max_llm_tokens_per_hour = 50000
+max_cost_per_hour_usd = 1.0
 
 [capabilities]
-tools = ["web_fetch", "file_read", "file_list"]
+tools = ["web_fetch", "file_read", "file_list", "memory_store", "memory_recall", "memory_list"]
+network = ["*"]
 memory_read = ["self.*"]
 memory_write = ["self.*"]
 agent_spawn = false

--- a/xtask/baselines/agent.sha256
+++ b/xtask/baselines/agent.sha256
@@ -1,1 +1,1 @@
-92a513f1b70915a194d56c4e49feb03cfd30fd459e3e9a9425ffc3823f67f1d6  examples/custom-agent/agent.toml
+5f5b986737bc466213485f4b104e294e7d718e18d612a18d36fc39427262cfa4  examples/custom-agent/agent.toml


### PR DESCRIPTION
## Changes
- add the three memory tools corresponding to the example's read/write memory scopes
- grant the network capability required by `web_fetch` when tools are explicitly listed
- add a conservative $1 hourly cost ceiling alongside the token limit
- parse the checked-in example and assert its effective capabilities in a regression test

## Verification
- `cargo test -p librefang-kernel custom_agent_example_grants_tools_matching_its_scopes`
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- provider/model inheritance remains intentional and is documented inline
- operators copying the template can tune its example quota values