### PR TITLE
ci: defer nextest failure output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
 [profile.default]
 # Show immediately which tests fail
 failure-output = "immediate"
+
+[profile.ci]
+# Aggregate concurrent failures at the end so CI logs remain readable.
+failure-output = "final"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,7 +890,7 @@ jobs:
         run: |
           if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Running workspace unit tests (lib+bin, full run)…"
-            cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
+            cargo nextest run --profile ci --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
           else
             if [ -z "$CRATES" ]; then
               echo "No crates affected — nothing to run."
@@ -899,7 +899,7 @@ jobs:
             echo "Running unit tests for: $CRATES"
             PFLAGS=""
             for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
-            cargo nextest run $PFLAGS -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
+            cargo nextest run --profile ci $PFLAGS -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
           fi
 
   # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────
@@ -992,7 +992,7 @@ jobs:
             # one of M shards by the hash of its name. Adding tests doesn't
             # reshuffle the others; deleting tests doesn't either. Stable
             # buckets are critical for cache hit rates across runs.
-            cargo nextest run --workspace --no-fail-fast \
+            cargo nextest run --profile ci --workspace --no-fail-fast \
               --partition hash:${{ matrix.shard }}/4
           else
             if [ -z "$CRATES" ]; then
@@ -1005,7 +1005,7 @@ jobs:
             # `--no-tests=pass` keeps PRs that only touch a crate without
             # tests from failing the selective lane — nextest defaults to
             # exit-4 when -p X resolves to zero tests.
-            cargo nextest run $PFLAGS --no-fail-fast --no-tests=pass
+            cargo nextest run --profile ci $PFLAGS --no-fail-fast --no-tests=pass
           fi
 
   # ── Windows tests: main-push only, 2-way shard ─────────────────────────────────
@@ -1065,7 +1065,7 @@ jobs:
           # Cargo's package-level `--exclude` is what keeps it out of the selected set entirely, and since nothing in the workspace depends on librefang-desktop (it is a leaf) it is then never built here.
           # Its 11 tests are platform-independent URL/scheme logic and still run on the Ubuntu shards, the unit-fast lane and macOS; the separate link-only step below keeps the Windows compile+link coverage.
           # Remove both once the missing DLL export is identified.
-          cargo nextest run --workspace --exclude librefang-desktop --no-fail-fast \
+          cargo nextest run --profile ci --workspace --exclude librefang-desktop --no-fail-fast \
             --partition hash:${{ matrix.shard }}/2
       # Restores the Windows compile+link coverage that `--exclude` above drops.
       # This is the only Windows build of librefang-desktop in CI (release-desktop.yml is workflow_dispatch-only, mobile-smoke.yml is ubuntu/macOS), so without this a Windows-only break in the crate would reach a release tag unseen.
@@ -1107,7 +1107,7 @@ jobs:
           # GitHub-hosted macOS runners resolve crates.io but consistently fail to resolve github.com for this clone ("Could not resolve host: github.com" -> "expected at least 15 hands, got 0"), so the set fails deterministically on macOS while passing on Linux/Windows where the clone succeeds.
           # The logic under test is platform-independent and fully covered by those lanes, so skip just this network-dependent module on macOS rather than red-flagging every main push (#6240).
           # The deeper fix — offline fixtures so the tests don't live-clone — is tracked as a follow-up.
-          cargo nextest run --workspace --no-fail-fast \
+          cargo nextest run --profile ci --workspace --no-fail-fast \
             -E 'not (package(librefang-hands) and test(/registry::tests::/))'
       # Mach-port abort guard — deliberately `cargo test`, not nextest.
       #

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Generate coverage (LCOV)
         env:
           RUST_TEST_THREADS: "1"
+          NEXTEST_PROFILE: ci
         run: |
           # pipefail: tee always exits 0, so without this the cargo failure
           # would be masked and the job would falsely succeed.

--- a/changelog.d/changed/nextest-ci-output.md
+++ b/changelog.d/changed/nextest-ci-output.md
@@ -1,0 +1,1 @@
+Use a dedicated nextest CI profile that aggregates concurrent failure output at the end of each run while preserving immediate feedback for local developers. (@xiaomo)


### PR DESCRIPTION
## Changes
- add a nextest `ci` profile with `failure-output = "final"`
- select it for every direct nextest run in the main CI workflow
- select it through `NEXTEST_PROFILE` for the cargo-llvm-cov wrapper
- preserve immediate failure output for local/default runs

## Verification
- checked `failure-output` values and profile selection against the current nextest repository config reference
- verified all six executable `cargo nextest run` commands in `ci.yml` select `--profile ci`
- parsed both modified workflows with Ruby YAML
- `git diff --check`

## Out of scope
- automatic retries are not enabled because they can hide deterministic failures
- per-test slow/leak timeout policy requires runtime baselines and remains unchanged
- the audit suggestion `failure-output = "deferred"` was not used because it is not a valid current nextest value