### PR TITLE
fix(packaging): harden AUR runtime secrets

### DIFF
--- a/changelog.d/security/aur-runtime-secrets.md
+++ b/changelog.d/security/aur-runtime-secrets.md
@@ -1,0 +1,1 @@
+Restrict AUR service environment files, keep Docker secrets out of command-line arguments, refuse to replace unrelated containers, and update the packaged Docker image to the current stable release. (@xiaomo)

--- a/packaging/aur/.gitignore
+++ b/packaging/aur/.gitignore
@@ -1,6 +1,5 @@
-*/LICENSE
-*/src/
-*/pkg/
-*/*.pkg.tar.*
-*/*.tar.gz
-*/*.deb
+LICENSE
+src/
+pkg/
+*.pkg.tar.*
+*.tar.*

--- a/packaging/aur/librefang-bin/.SRCINFO
+++ b/packaging/aur/librefang-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = librefang-bin
 	pkgdesc = Community-maintained Agent Operating System written in Rust
 	pkgver = 2026.6.24_beta.23
-	pkgrel = 1
+	pkgrel = 2
 	url = https://librefang.ai
 	install = librefang-bin.install
 	arch = x86_64
@@ -25,7 +25,7 @@ pkgbase = librefang-bin
 	sha256sums = d4330a3004bd990da1830124b1ccccb51129ebb8b5a70a0b79d5626b7c1226a0
 	sha256sums = 8256e3089819a4e4a865c5454876fdf3192945c9569b85d6854a31c3b3ee911f
 	sha256sums = 9d72d1f4de5e5aef909778d7ccb9de3c29072ed1dc371a252b551b828e5a74d9
-	sha256sums = d5551061bab4c176c95ea77d4c787c3f766f64a78fe0937b9a857f07073bd59e
-	sha256sums = e6c162276a58e632cd7464629c39a24671d8bacf953cb4b0261bad6efb145d24
+	sha256sums = 36448e610108a9173bac1bb672fea9447183481cfd29137eabb4d3c6864c96b7
+	sha256sums = 5aa619d539ddf8f5cfd126e62e2ecb52b7c2a9c747f714c841f06b9661047cd9
 
 pkgname = librefang-bin

--- a/packaging/aur/librefang-bin/PKGBUILD
+++ b/packaging/aur/librefang-bin/PKGBUILD
@@ -2,7 +2,7 @@ pkgname=librefang-bin
 _pkgname=librefang
 pkgver=2026.6.24_beta.23
 _upstream_ver=${pkgver/_/-}
-pkgrel=1
+pkgrel=2
 pkgdesc="Community-maintained Agent Operating System written in Rust"
 arch=('x86_64')
 url="https://librefang.ai"
@@ -30,8 +30,8 @@ sha256sums=(
   'd4330a3004bd990da1830124b1ccccb51129ebb8b5a70a0b79d5626b7c1226a0'
   '8256e3089819a4e4a865c5454876fdf3192945c9569b85d6854a31c3b3ee911f'
   '9d72d1f4de5e5aef909778d7ccb9de3c29072ed1dc371a252b551b828e5a74d9'
-  'd5551061bab4c176c95ea77d4c787c3f766f64a78fe0937b9a857f07073bd59e'
-  'e6c162276a58e632cd7464629c39a24671d8bacf953cb4b0261bad6efb145d24'
+  '36448e610108a9173bac1bb672fea9447183481cfd29137eabb4d3c6864c96b7'
+  '5aa619d539ddf8f5cfd126e62e2ecb52b7c2a9c747f714c841f06b9661047cd9'
 )
 
 package() {
@@ -45,5 +45,5 @@ package() {
   install -Dm644 "$srcdir/librefang.service" "$pkgdir/usr/lib/systemd/system/librefang.service"
   install -Dm644 "$srcdir/librefang.sysusers" "$pkgdir/usr/lib/sysusers.d/librefang.conf"
   install -Dm644 "$srcdir/librefang.tmpfiles" "$pkgdir/usr/lib/tmpfiles.d/librefang.conf"
-  install -Dm644 "$srcdir/librefang.env" "$pkgdir/etc/librefang/env"
+  install -Dm640 "$srcdir/librefang.env" "$pkgdir/etc/librefang/env"
 }

--- a/packaging/aur/librefang-bin/librefang.env
+++ b/packaging/aur/librefang-bin/librefang.env
@@ -1,4 +1,6 @@
 # Optional environment for librefang.service.
+# Keep this file owned by root:librefang with mode 0640 because provider and
+# channel credentials placed here are read by the dedicated service account.
 #
 # Examples:
 # OPENAI_API_KEY=

--- a/packaging/aur/librefang-bin/librefang.tmpfiles
+++ b/packaging/aur/librefang-bin/librefang.tmpfiles
@@ -1,2 +1,3 @@
 d /var/lib/librefang 0750 librefang librefang -
 d /etc/librefang 0755 root root -
+z /etc/librefang/env 0640 root librefang -

--- a/packaging/aur/librefang-docker/.SRCINFO
+++ b/packaging/aur/librefang-docker/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = librefang-docker
 	pkgdesc = Container-managed LibreFang Agent OS service
 	pkgver = 2026.6.24_beta.23
-	pkgrel = 2
+	pkgrel = 3
 	url = https://librefang.ai
 	install = librefang-docker.install
 	arch = any
@@ -15,8 +15,8 @@ pkgbase = librefang-docker
 	source = librefang-docker.service
 	source = librefang-docker.env
 	sha256sums = d4330a3004bd990da1830124b1ccccb51129ebb8b5a70a0b79d5626b7c1226a0
-	sha256sums = 4cda49f3a630072e8b57579d908e4c4a97a9fe976e3b2b735f6f3e75ffa42da6
+	sha256sums = 7faa652fc88e75de178b101936f759617bea33a76aa9fff3a909af1ecb0b0d70
 	sha256sums = b49ff94ecd34a4b9a6edc5a7be614ecc31f9f93024434d24b771138dd4a8e0a4
-	sha256sums = 99992ba5a6fe18d67e04e165af8b4c038c6a4db1b3510a501d655c0ccb92dc6f
+	sha256sums = fa29d944c0bdc12a48e060d6be866b73b692f057cb32e2c57bc7b19be013f99f
 
 pkgname = librefang-docker

--- a/packaging/aur/librefang-docker/PKGBUILD
+++ b/packaging/aur/librefang-docker/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=librefang-docker
 pkgver=2026.6.24_beta.23
 _upstream_ver=${pkgver/_/-}
-pkgrel=2
+pkgrel=3
 pkgdesc="Container-managed LibreFang Agent OS service"
 arch=('any')
 url="https://librefang.ai"
@@ -19,14 +19,14 @@ source=(
 )
 sha256sums=(
   'd4330a3004bd990da1830124b1ccccb51129ebb8b5a70a0b79d5626b7c1226a0'
-  '4cda49f3a630072e8b57579d908e4c4a97a9fe976e3b2b735f6f3e75ffa42da6'
+  '7faa652fc88e75de178b101936f759617bea33a76aa9fff3a909af1ecb0b0d70'
   'b49ff94ecd34a4b9a6edc5a7be614ecc31f9f93024434d24b771138dd4a8e0a4'
-  '99992ba5a6fe18d67e04e165af8b4c038c6a4db1b3510a501d655c0ccb92dc6f'
+  'fa29d944c0bdc12a48e060d6be866b73b692f057cb32e2c57bc7b19be013f99f'
 )
 
 package() {
   install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/${pkgname}/LICENSE"
   install -Dm755 "$srcdir/librefang-docker" "$pkgdir/usr/bin/librefang-docker"
   install -Dm644 "$srcdir/librefang-docker.service" "$pkgdir/usr/lib/systemd/system/librefang-docker.service"
-  install -Dm644 "$srcdir/librefang-docker.env" "$pkgdir/etc/librefang/docker.env"
+  install -Dm600 "$srcdir/librefang-docker.env" "$pkgdir/etc/librefang/docker.env"
 }

--- a/packaging/aur/librefang-docker/librefang-docker
+++ b/packaging/aur/librefang-docker/librefang-docker
@@ -8,22 +8,54 @@ if [[ -f "$ENV_FILE" ]]; then
   source "$ENV_FILE"
 fi
 
-IMAGE="${LIBREFANG_DOCKER_IMAGE:-ghcr.io/librefang/librefang:2026.6.24-beta.23}"
+IMAGE="${LIBREFANG_DOCKER_IMAGE:-ghcr.io/librefang/librefang:2026.7.31}"
 CONTAINER_NAME="${LIBREFANG_DOCKER_NAME:-librefang}"
 DATA_VOLUME="${LIBREFANG_DOCKER_DATA_VOLUME:-librefang-data}"
 PORT="${LIBREFANG_DOCKER_PORT:-4545}"
+MANAGED_LABEL="ai.librefang.managed"
 
 docker_args=(
   --name "$CONTAINER_NAME"
   --publish "127.0.0.1:${PORT}:4545"
   --volume "${DATA_VOLUME}:/data"
   --env "LIBREFANG_LISTEN=0.0.0.0:4545"
+  --label "${MANAGED_LABEL}=true"
 )
 
 append_env_if_set() {
   local name="$1"
   if [[ -n "${!name:-}" ]]; then
-    docker_args+=(--env "${name}=${!name}")
+    export "$name"
+    docker_args+=(--env "$name")
+  fi
+}
+
+container_exists() {
+  docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1
+}
+
+require_managed_container() {
+  local managed
+  managed=$(docker container inspect \
+    --format "{{ index .Config.Labels \"${MANAGED_LABEL}\" }}" \
+    "$CONTAINER_NAME") || return 1
+  if [[ "$managed" != "true" ]]; then
+    echo "Refusing to modify container '$CONTAINER_NAME': it is not managed by librefang-docker." >&2
+    return 1
+  fi
+}
+
+remove_managed_container_if_present() {
+  if container_exists; then
+    require_managed_container
+    docker rm -f "$CONTAINER_NAME"
+  fi
+}
+
+require_existing_container() {
+  if ! container_exists; then
+    echo "LibreFang container '$CONTAINER_NAME' does not exist." >&2
+    return 1
   fi
 }
 
@@ -66,28 +98,35 @@ case "$cmd" in
   run)
     append_known_provider_env
     docker pull "$IMAGE"
-    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    remove_managed_container_if_present
     exec docker run --rm "${docker_args[@]}" "$IMAGE"
     ;;
   start)
     append_known_provider_env
     docker pull "$IMAGE"
-    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    remove_managed_container_if_present
     docker run --detach --restart unless-stopped "${docker_args[@]}" "$IMAGE"
     ;;
   stop)
+    if ! container_exists; then
+      echo "LibreFang container '$CONTAINER_NAME' is already stopped."
+      exit 0
+    fi
+    require_managed_container
     docker rm -f "$CONTAINER_NAME"
     ;;
   pull)
     docker pull "$IMAGE"
     ;;
   logs)
+    require_existing_container
     docker logs --follow "$CONTAINER_NAME"
     ;;
   status)
     docker ps --all --filter "name=^/${CONTAINER_NAME}$"
     ;;
   shell)
+    require_existing_container
     exec docker exec -it "$CONTAINER_NAME" /bin/sh
     ;;
   -h|--help|help)

--- a/packaging/aur/librefang-docker/librefang-docker.env
+++ b/packaging/aur/librefang-docker/librefang-docker.env
@@ -1,7 +1,7 @@
 # LibreFang Docker runtime settings.
 #
 # This package pins the upstream release image instead of using "latest".
-LIBREFANG_DOCKER_IMAGE=ghcr.io/librefang/librefang:2026.6.24-beta.23
+LIBREFANG_DOCKER_IMAGE=ghcr.io/librefang/librefang:2026.7.31
 LIBREFANG_DOCKER_NAME=librefang
 LIBREFANG_DOCKER_DATA_VOLUME=librefang-data
 LIBREFANG_DOCKER_PORT=4545

--- a/packaging/aur/librefang-docker/librefang-docker.install
+++ b/packaging/aur/librefang-docker/librefang-docker.install
@@ -1,4 +1,5 @@
 post_install() {
+  chmod 600 /etc/librefang/docker.env 2>/dev/null || true
   echo "LibreFang Docker runner installed."
   echo "Authentication is required by default: set LIBREFANG_API_KEY or LIBREFANG_DASHBOARD_USER/LIBREFANG_DASHBOARD_PASS in /etc/librefang/docker.env before first start, or the daemon will refuse to start."
   echo "Edit /etc/librefang/docker.env if you need provider API keys or a custom port."
@@ -6,8 +7,10 @@ post_install() {
 }
 
 post_upgrade() {
+  chmod 600 /etc/librefang/docker.env 2>/dev/null || true
   echo "LibreFang Docker runner upgraded."
   echo "Security: pacman preserves /etc/librefang/docker.env."
   echo "Review any existing LIBREFANG_ALLOW_NO_AUTH=1 setting and change it to 0 unless no-auth is intentional."
+  echo "Containers created before this release have no management label. Remove the old 'librefang' container manually once before restarting; the wrapper will not delete an unlabeled container."
   echo "Restart the service with: systemctl restart librefang-docker.service"
 }

--- a/packaging/aur/tests/test-librefang-docker.sh
+++ b/packaging/aur/tests/test-librefang-docker.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUNNER="$ROOT/packaging/aur/librefang-docker/librefang-docker"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >>"$MOCK_LOG"
+if [[ "$*" == "container inspect"* ]]; then
+  [[ "${MOCK_CONTAINER_STATE:-missing}" != "missing" ]] || exit 1
+  if [[ "$*" == *"--format"* ]]; then
+    [[ "$MOCK_CONTAINER_STATE" == "managed" ]] && printf 'true\n' || printf 'false\n'
+  fi
+fi
+if [[ "${1:-}" == "run" ]]; then
+  printf '%s\n' "${OPENAI_API_KEY:-}" >"$MOCK_SECRET_LOG"
+fi
+MOCK
+chmod +x "$TMP/bin/docker"
+
+cat >"$TMP/docker.env" <<'ENV'
+OPENAI_API_KEY=secret-that-must-not-enter-argv
+ENV
+
+export PATH="$TMP/bin:$PATH"
+export LIBREFANG_DOCKER_ENV="$TMP/docker.env"
+export MOCK_LOG="$TMP/docker.log"
+export MOCK_SECRET_LOG="$TMP/secret.log"
+
+: >"$MOCK_LOG"
+MOCK_CONTAINER_STATE=missing "$RUNNER" start >/dev/null
+grep -q -- '--env OPENAI_API_KEY' "$MOCK_LOG"
+! grep -q 'secret-that-must-not-enter-argv' "$MOCK_LOG"
+grep -q -- '--label ai.librefang.managed=true' "$MOCK_LOG"
+grep -qx 'secret-that-must-not-enter-argv' "$MOCK_SECRET_LOG"
+
+: >"$MOCK_LOG"
+if MOCK_CONTAINER_STATE=unmanaged "$RUNNER" start >"$TMP/unmanaged.out" 2>&1; then
+  echo "unmanaged container was replaced" >&2
+  exit 1
+fi
+grep -q 'Refusing to modify container' "$TMP/unmanaged.out"
+! grep -q '^rm -f ' "$MOCK_LOG"
+
+: >"$MOCK_LOG"
+MOCK_CONTAINER_STATE=managed "$RUNNER" start >/dev/null
+grep -q '^rm -f librefang$' "$MOCK_LOG"
+
+MOCK_CONTAINER_STATE=missing "$RUNNER" stop >"$TMP/stop.out"
+grep -q 'already stopped' "$TMP/stop.out"
+
+if MOCK_CONTAINER_STATE=missing "$RUNNER" logs >"$TMP/logs.out" 2>&1; then
+  echo "logs unexpectedly succeeded without a container" >&2
+  exit 1
+fi
+grep -q 'does not exist' "$TMP/logs.out"


### PR DESCRIPTION
## Changes
- install native and Docker environment files as 0640/0600 and enforce upgrade permissions
- pass Docker secret names through `--env` while exporting values, keeping values out of argv
- label managed containers and refuse to remove an unlabeled same-name container
- make stop idempotent and provide explicit missing-container diagnostics for logs/shell
- update the Docker runner default to the verified `2026.7.31` stable image
- broaden AUR build-artifact ignores across root and nested package directories
- update pkgrel, SRCINFO, and local source checksums

## Verification
- `packaging/aur/tests/test-librefang-docker.sh`
- `bash -n` for the runner, install script, and fixture
- verified `ghcr.io/librefang/librefang:2026.7.31` with `docker manifest inspect`
- verified all modified local-file SHA-256 values match PKGBUILD and SRCINFO
- exercised root/nested archive ignore patterns with `git check-ignore --no-index`
- `git diff --check`

## Out of scope
- existing pre-label containers require the one-time manual removal described by the upgrade message
- the internal container listener remains `0.0.0.0` because Docker port publishing cannot reach container loopback
- AUR package version publication remains owned by the release publishing workflow