### PR TITLE
fix(packaging): validate desktop data archive

### DIFF
--- a/changelog.d/fixed/aur-desktop-archive.md
+++ b/changelog.d/fixed/aur-desktop-archive.md
@@ -1,0 +1,1 @@
+Require exactly one Debian data archive when building the AUR desktop package and publish its provided package capability with the matching version. (@xiaomo)

--- a/packaging/aur/librefang-desktop-bin/.SRCINFO
+++ b/packaging/aur/librefang-desktop-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = librefang-desktop-bin
 	pkgdesc = Native LibreFang desktop app
 	pkgver = 2026.6.24_beta.23
-	pkgrel = 1
+	pkgrel = 2
 	url = https://librefang.ai
 	arch = x86_64
 	license = MIT
@@ -9,7 +9,7 @@ pkgbase = librefang-desktop-bin
 	depends = webkit2gtk-4.1
 	optdepends = python: first-party channel sidecar adapters when running a local daemon
 	optdepends = docker: Docker-backed tools and sandbox workflows when running a local daemon
-	provides = librefang-desktop
+	provides = librefang-desktop=2026.6.24_beta.23
 	conflicts = librefang-desktop
 	options = !debug
 	source = https://github.com/librefang/librefang/releases/download/v2026.6.24-beta.23/LibreFang_26.6.32263_amd64.deb

--- a/packaging/aur/librefang-desktop-bin/PKGBUILD
+++ b/packaging/aur/librefang-desktop-bin/PKGBUILD
@@ -2,7 +2,7 @@ pkgname=librefang-desktop-bin
 pkgver=2026.6.24_beta.23
 _upstream_ver=${pkgver/_/-}
 _desktop_ver=26.6.32263
-pkgrel=1
+pkgrel=2
 pkgdesc="Native LibreFang desktop app"
 arch=('x86_64')
 url="https://librefang.ai"
@@ -12,7 +12,7 @@ optdepends=(
   'python: first-party channel sidecar adapters when running a local daemon'
   'docker: Docker-backed tools and sandbox workflows when running a local daemon'
 )
-provides=('librefang-desktop')
+provides=("librefang-desktop=${pkgver}")
 conflicts=('librefang-desktop')
 options=('!debug')
 source=(
@@ -25,7 +25,17 @@ sha256sums=(
 )
 
 package() {
-  local data_archive=("$srcdir"/data.tar.*)
-  bsdtar --no-same-owner -xf "${data_archive[0]}" -C "$pkgdir"
+  local nullglob_was_set=0
+  shopt -q nullglob && nullglob_was_set=1
+  shopt -s nullglob
+  local data_archives=("$srcdir"/data.tar.*)
+  (( nullglob_was_set )) || shopt -u nullglob
+
+  if (( ${#data_archives[@]} != 1 )) || [[ ! -f "${data_archives[0]:-}" ]]; then
+    error "expected exactly one data.tar.* archive, found ${#data_archives[@]}"
+    return 1
+  fi
+
+  bsdtar --no-same-owner -xf "${data_archives[0]}" -C "$pkgdir"
   install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/packaging/aur/tests/test-desktop-pkgbuild.sh
+++ b/packaging/aur/tests/test-desktop-pkgbuild.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+PKGBUILD="$ROOT/packaging/aur/librefang-desktop-bin/PKGBUILD"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+error() { printf '%s\n' "$*" >&2; }
+install() { :; }
+bsdtar() { printf '%s\n' "$*" >>"$TMP/bsdtar.log"; }
+
+source "$PKGBUILD"
+srcdir="$TMP/src"
+pkgdir="$TMP/pkg"
+mkdir -p "$srcdir" "$pkgdir"
+
+if package 2>"$TMP/missing.err"; then
+  echo "package accepted a missing data archive" >&2
+  exit 1
+fi
+grep -q 'found 0' "$TMP/missing.err"
+
+touch "$srcdir/data.tar.zst"
+package
+grep -q -- '--no-same-owner -xf' "$TMP/bsdtar.log"
+grep -q 'data.tar.zst' "$TMP/bsdtar.log"
+
+touch "$srcdir/data.tar.xz"
+if package 2>"$TMP/multiple.err"; then
+  echo "package accepted multiple data archives" >&2
+  exit 1
+fi
+grep -q 'found 2' "$TMP/multiple.err"
+
+grep -qx 'librefang-desktop=2026.6.24_beta.23' <(printf '%s\n' "${provides[@]}")


### PR DESCRIPTION
## Changes
- enable nullglob and require exactly one regular `data.tar.*` archive before extraction
- fail clearly for missing or ambiguous Debian payloads
- version the `librefang-desktop` provided capability
- bump pkgrel and keep SRCINFO synchronized
- add a fixture covering zero, one, and multiple archive matches

## Verification
- `packaging/aur/tests/test-desktop-pkgbuild.sh`
- `bash -n packaging/aur/librefang-desktop-bin/PKGBUILD packaging/aur/tests/test-desktop-pkgbuild.sh`
- `git diff --check`

## Out of scope
- the source `.deb` remains protected by its fixed SHA-256 and extracted by libarchive
- `_desktop_ver` is the independently assigned desktop artifact version and cannot be derived safely from the release tag