### PR TITLE
fix(packaging): harden AUR publishing

### DIFF
--- a/changelog.d/fixed/aur-publish-races.md
+++ b/changelog.d/fixed/aur-publish-races.md
@@ -1,0 +1,1 @@
+Validate AUR release-derived versions, publish only an explicit source allowlist, retry delayed checksums and concurrent pushes safely, and clean builder workspaces on every exit. (@xiaomo)

--- a/packaging/aur/publish-to-aur.sh
+++ b/packaging/aur/publish-to-aur.sh
@@ -55,12 +55,18 @@ fi
 # ── Builder phase ──────────────────────────────────────────────────────────
 VER_RAW="${RELEASE_TAG#v}"   # 2026.6.26-beta.24  (matches the git tag minus the v)
 VER_PKG="${VER_RAW/-/_}"     # 2026.6.26_beta.24  (Arch pkgver cannot contain '-')
+[[ "$VER_RAW" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] || {
+  echo "::error::invalid release tag '$RELEASE_TAG'" >&2
+  exit 1
+}
 echo "Publishing AUR package '$PKG' for release $RELEASE_TAG (pkgver=$VER_PKG)"
 
-SRC="/repo/packaging/aur/$PKG"
+SRC="${AUR_SOURCE_ROOT:-/repo/packaging/aur}/$PKG"
 [[ -f "$SRC/PKGBUILD" ]] || { echo "::error::no PKGBUILD at $SRC"; exit 1; }
 
-WORK="$(mktemp -d)/$PKG"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+WORK="$TMP_ROOT/work"
 mkdir -p "$WORK"
 # Plain -R (not -a): the source tree is bind-mounted with a foreign owner, and
 # preserving ownership as the unprivileged builder would fail under `set -e`.
@@ -71,9 +77,24 @@ cd "$WORK"
 
 # Capture the committed file set BEFORE updpkgsums downloads sources, so the
 # generated LICENSE / tarball / .deb never get pushed to AUR.
-shopt -s dotglob nullglob
-SRC_FILES=( * )
-shopt -u dotglob nullglob
+case "$PKG" in
+  librefang-bin)
+    SRC_FILES=(PKGBUILD .SRCINFO librefang-bin.install librefang.env librefang.service librefang.sysusers librefang.tmpfiles)
+    ;;
+  librefang-desktop-bin)
+    SRC_FILES=(PKGBUILD .SRCINFO)
+    ;;
+  librefang-docker)
+    SRC_FILES=(PKGBUILD .SRCINFO librefang-docker librefang-docker.env librefang-docker.install librefang-docker.service)
+    ;;
+  *)
+    echo "::error::unknown package '$PKG'" >&2
+    exit 1
+    ;;
+esac
+for source_file in "${SRC_FILES[@]}"; do
+  [[ -f "$source_file" ]] || { echo "::error::missing allowlisted source '$source_file'" >&2; exit 1; }
+done
 
 api_release_json() {
   local hdr=(-H "Accept: application/vnd.github+json")
@@ -101,8 +122,17 @@ wait_for_asset() {
   return 1
 }
 
-sed -i "s/^pkgver=.*/pkgver=$VER_PKG/" PKGBUILD
-sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+rewrite_file() {
+  local file="$1" tmp
+  shift
+  tmp="$(mktemp "$TMP_ROOT/rewrite.XXXXXX")"
+  sed "$@" "$file" > "$tmp"
+  cp "$tmp" "$file"
+  rm -f "$tmp"
+}
+
+rewrite_file PKGBUILD "s/^pkgver=.*/pkgver=$VER_PKG/"
+rewrite_file PKGBUILD "s/^pkgrel=.*/pkgrel=1/"
 
 case "$PKG" in
   librefang-bin)
@@ -111,17 +141,22 @@ case "$PKG" in
   librefang-desktop-bin)
     # The Tauri bundle version differs from the release tag; read it off the
     # actual .deb asset name (LibreFang_<bundle-ver>_amd64.deb).
-    DEB="$(wait_for_asset "_amd64.deb")"
+    DEB="$(wait_for_asset "_amd64.deb")" || exit 1
     DV="${DEB#LibreFang_}"; DV="${DV%_amd64.deb}"
-    [[ -n "$DV" ]] || { echo "::error::could not parse bundle version from '$DEB'"; exit 1; }
-    sed -i "s/^_desktop_ver=.*/_desktop_ver=$DV/" PKGBUILD
+    [[ "$DEB" == LibreFang_*_amd64.deb && "$DV" =~ ^[0-9][0-9A-Za-z._-]*$ ]] || {
+      echo "::error::could not parse safe bundle version from '$DEB'"
+      exit 1
+    }
+    rewrite_file PKGBUILD "s/^_desktop_ver=.*/_desktop_ver=$DV/"
     echo "Desktop bundle version: $DV"
     ;;
   librefang-docker)
     # No release asset to download — re-pin the embedded image tag in the
     # helper + env (their sha256sums then change and are regenerated below).
-    sed -i -E "s#(ghcr\.io/librefang/librefang:)[A-Za-z0-9._-]+#\1$VER_RAW#g" \
-      librefang-docker librefang-docker.env
+    rewrite_file librefang-docker -E \
+      "s#(ghcr\.io/librefang/librefang:)[A-Za-z0-9._-]+#\1$VER_RAW#g"
+    rewrite_file librefang-docker.env -E \
+      "s#(ghcr\.io/librefang/librefang:)[A-Za-z0-9._-]+#\1$VER_RAW#g"
     ;;
   *)
     echo "::error::unknown package '$PKG'"; exit 1 ;;
@@ -130,7 +165,19 @@ esac
 # Regenerate checksums + .SRCINFO from the patched PKGBUILD. AUR rejects any
 # push whose .SRCINFO does not match `makepkg --printsrcinfo`, so always
 # produce it the same way.
-updpkgsums
+checksums_updated=false
+for attempt in 1 2 3; do
+  if updpkgsums; then
+    checksums_updated=true
+    break
+  fi
+  echo "Waiting for release assets to become downloadable ($attempt/3)..." >&2
+  sleep 10
+done
+if [[ "$checksums_updated" != true ]]; then
+  echo "::error::updpkgsums could not download and checksum release assets after 3 attempts" >&2
+  exit 1
+fi
 makepkg --printsrcinfo > .SRCINFO
 
 grep -qx "pkgver=$VER_PKG" PKGBUILD || { echo "::error::pkgver patch did not stick"; exit 1; }
@@ -141,7 +188,7 @@ git config --global user.name "${AUR_GIT_NAME:-LibreFang Release Bot}"
 git config --global user.email "${AUR_GIT_EMAIL:-release-bot@librefang.ai}"
 git config --global init.defaultBranch master
 
-CLONE="$(mktemp -d)/aur"
+CLONE="$TMP_ROOT/aur"
 git clone --quiet "ssh://aur@aur.archlinux.org/$PKG.git" "$CLONE"
 
 # Copy only the committed source files (never downloaded artifacts).
@@ -156,5 +203,25 @@ if git diff --cached --quiet; then
   exit 0
 fi
 git commit --quiet -m "Update to $VER_RAW"
-git push origin HEAD:master
+push_succeeded=false
+for attempt in 1 2 3; do
+  if git push origin HEAD:master; then
+    push_succeeded=true
+    break
+  fi
+  echo "AUR push raced with another update; fetching and rebasing ($attempt/3)..." >&2
+  if ! git fetch origin master; then
+    echo "AUR fetch failed; retrying push without changing the local commit..." >&2
+    continue
+  fi
+  if ! git rebase origin/master; then
+    git rebase --abort || true
+    echo "::error::AUR/$PKG changed concurrently and could not be rebased safely" >&2
+    exit 1
+  fi
+done
+if [[ "$push_succeeded" != true ]]; then
+  echo "::error::failed to push AUR/$PKG after 3 attempts" >&2
+  exit 1
+fi
 echo "Pushed AUR/$PKG $VER_RAW."

--- a/packaging/aur/tests/test-publish-to-aur.sh
+++ b/packaging/aur/tests/test-publish-to-aur.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+PUBLISHER="$ROOT/packaging/aur/publish-to-aur.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin" "$TMP/source"
+cp -R "$ROOT/packaging/aur/librefang-bin" "$TMP/source/"
+cp -R "$ROOT/packaging/aur/librefang-desktop-bin" "$TMP/source/"
+touch "$TMP/source/librefang-bin/.DS_Store"
+
+cat >"$TMP/bin/id" <<'MOCK'
+#!/bin/sh
+printf '1000\n'
+MOCK
+cat >"$TMP/bin/curl" <<'MOCK'
+#!/bin/sh
+if [ "${MOCK_NO_ASSET:-}" = 1 ]; then
+  printf '%s\n' '{"assets":[]}'
+  exit 0
+fi
+printf '%s\n' '{"assets":[{"name":"librefang-x86_64-unknown-linux-gnu.tar.gz"}]}'
+MOCK
+cat >"$TMP/bin/updpkgsums" <<'MOCK'
+#!/bin/sh
+count=$(cat "$MOCK_UPDATE_COUNT" 2>/dev/null || printf 0)
+count=$((count + 1))
+printf '%s\n' "$count" >"$MOCK_UPDATE_COUNT"
+[ "$count" -ge 2 ]
+MOCK
+cat >"$TMP/bin/makepkg" <<'MOCK'
+#!/bin/sh
+printf 'pkgbase = librefang-bin\n'
+MOCK
+cat >"$TMP/bin/sleep" <<'MOCK'
+#!/bin/sh
+:
+MOCK
+cat >"$TMP/bin/git" <<'MOCK'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >>"$MOCK_GIT_LOG"
+case "${1:-}" in
+  clone)
+    mkdir -p "${@: -1}"
+    ;;
+  diff)
+    exit 1
+    ;;
+  push)
+    [[ ! -e .DS_Store ]] || { echo 'stray dotfile copied' >&2; exit 2; }
+    count=$(cat "$MOCK_PUSH_COUNT" 2>/dev/null || printf 0)
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$MOCK_PUSH_COUNT"
+    [[ "$count" -ge 2 ]]
+    ;;
+esac
+MOCK
+chmod +x "$TMP/bin/"*
+
+export PATH="$TMP/bin:$PATH"
+export HOME="$TMP/home"
+export AUR_SOURCE_ROOT="$TMP/source"
+export RELEASE_TAG=v2026.7.31
+export MOCK_UPDATE_COUNT="$TMP/update-count"
+export MOCK_PUSH_COUNT="$TMP/push-count"
+export MOCK_GIT_LOG="$TMP/git.log"
+mkdir -p "$HOME/.ssh"
+
+if ! "$PUBLISHER" librefang-bin >"$TMP/output" 2>&1; then
+  cat "$TMP/output" >&2
+  exit 1
+fi
+grep -q 'Waiting for release assets to become downloadable' "$TMP/output"
+grep -q 'AUR push raced with another update' "$TMP/output"
+grep -q '^fetch origin master$' "$MOCK_GIT_LOG"
+grep -qx '2' "$MOCK_UPDATE_COUNT"
+grep -qx '2' "$MOCK_PUSH_COUNT"
+
+if RELEASE_TAG='v2026.7.31&bad' "$PUBLISHER" librefang-bin >"$TMP/invalid" 2>&1; then
+  echo 'invalid release tag was accepted' >&2
+  exit 1
+fi
+grep -q 'invalid release tag' "$TMP/invalid"
+
+if MOCK_NO_ASSET=1 "$PUBLISHER" librefang-desktop-bin >"$TMP/missing" 2>&1; then
+  echo 'publisher accepted a missing desktop asset' >&2
+  exit 1
+fi
+grep -q 'asset \*_amd64.deb not found' "$TMP/missing"
+! grep -q 'could not parse safe bundle version' "$TMP/missing"


### PR DESCRIPTION
## Changes

- validate release-derived versions before using them in package metadata or substitutions
- copy only package-specific AUR source files and clean temporary builder state on exit
- use portable file rewriting, retry delayed asset checksums, and recover safely from concurrent AUR pushes
- add a mocked regression test for retry, race, allowlist, invalid-tag, and missing-asset paths

## Verification

- `bash -n packaging/aur/publish-to-aur.sh packaging/aur/tests/test-publish-to-aur.sh`
- `packaging/aur/tests/test-publish-to-aur.sh`
- `git diff --check`
- commit hooks (gitleaks unavailable locally; CI remains the gate)

## Out of scope

- Arch repository publishing is audited separately
- release API JSON is intentionally refreshed on each bounded poll so newly visible assets can be observed