### PR TITLE
fix(dev): preserve direnv diagnostics

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
-use flake 2> >(grep -v '/bin/bash:' >&2)
+use flake 2> >(grep -v '^/bin/bash: warning:' >&2)
 
-# Preserve user's local bin paths for tools not in nixpkgs (e.g. claude)
-PATH_add "$HOME/.npm-global/bin"
-PATH_add "$HOME/.local/bin"
+# Existing user-local tools intentionally take precedence over nixpkgs tools.
+[[ -d "$HOME/.npm-global/bin" ]] && PATH_add "$HOME/.npm-global/bin"
+[[ -d "$HOME/.local/bin" ]] && PATH_add "$HOME/.local/bin"

--- a/changelog.d/fixed/direnv-diagnostics.md
+++ b/changelog.d/fixed/direnv-diagnostics.md
@@ -1,0 +1,1 @@
+Preserve real Nix flake errors in direnv output and add only existing user-local binary directories to `PATH`. (@xiaomo)


### PR DESCRIPTION
## Changes

- narrow the direnv stderr filter to the known Bash warning prefix
- keep real Bash and Nix evaluation errors visible
- add user-local bin directories only when they exist
- document that existing user-local tools intentionally precede nixpkgs tools

## Verification

- `bash -n .envrc`
- focused filter assertion covering a suppressed warning plus retained Bash and Nix errors
- `git diff --check`
- commit hooks (gitleaks unavailable locally; CI remains the gate)

## Out of scope

- Nix flake contents and package selection are unchanged