### PR TITLE
fix(test): pin fixture line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,8 @@
-# Force LF line endings on golden fixtures and other generated/compared
-# text artifacts so Windows git checkouts don't drift from CI on other OSes.
-# Without this, a Windows checkout would materialize CRLF and fixture-diff
-# tests would fail cross-platform. (Rust source + JSON are fine as-is; the
-# explicit `eol=lf` here is a safety rail for tests that byte-compare.)
-crates/librefang-api/tests/fixtures/*.json text eol=lf
+# Force LF line endings on golden fixtures and embedded comparison data so
+# Windows checkouts preserve the bytes used by tests. The API JSON test also
+# normalizes CRLF, but the attribute remains defense in depth for new fixtures.
+crates/librefang-api/tests/fixtures/**/*.json text eol=lf
+crates/librefang-rl-export/tests/fixtures/kernel_redaction_patterns.txt text eol=lf
 
 # login_page.html is embedded verbatim via include_str! and its inline <script> is pinned by an exact SHA-256 in the CSP (middleware.rs).
 # A Windows checkout with core.autocrlf=true rewrites it to CRLF, which shifts the hash and fails dashboard_login_page_script_is_allowed_by_csp_hash on Windows only.

--- a/changelog.d/fixed/fixture-line-endings.md
+++ b/changelog.d/fixed/fixture-line-endings.md
@@ -1,0 +1,1 @@
+Pin recursive golden fixtures and embedded redaction patterns to LF line endings across platforms. (@xiaomo)

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -2025,6 +2025,8 @@ pub async fn auth(
 }
 
 const LOGIN_PAGE_HTML: &str = include_str!("login_page.html");
+// If the inline script in login_page.html changes, recompute its script-src
+// SHA-256 below. dashboard_login_page_script_is_allowed_by_csp_hash enforces it.
 const CONTENT_SECURITY_POLICY: &str = "default-src 'self'; script-src 'self' 'sha256-TDA4xCzDRyoMM+fopfpKCyivlfu44tSPBzidGFvUgNM='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; font-src 'self' https://fonts.gstatic.com; media-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'";
 
 /// Security headers middleware — applied to ALL API responses.


### PR DESCRIPTION
## Changes

- apply LF attributes recursively to API JSON fixtures
- pin the embedded runtime-redaction comparison fixture to LF
- clarify that API JSON normalization makes its attribute defense in depth
- document the login-page CSP hash maintenance invariant beside the literal

## Verification

- `git check-attr text eol -- crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json crates/librefang-api/tests/fixtures/nested/future.json crates/librefang-rl-export/tests/fixtures/kernel_redaction_patterns.txt`
- `cargo test -p librefang-api dashboard_login_page_script_is_allowed_by_csp_hash --lib`
- `cargo test -p librefang-rl-export regex_set_matches_kernel_snapshot --lib`
- `git diff --check`
- commit hooks (gitleaks unavailable locally; CI remains the gate)

## Out of scope

- no CSP policy or fixture content changes
- unrelated text fixtures retain their existing attributes