### PR TITLE
fix(ci): tighten gitleaks allowlists

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -62,6 +62,9 @@ jobs:
         # fails the job; --redact keeps the secret value out of the logs.
         run: gitleaks dir . --config .gitleaks.toml --redact --no-banner --verbose
 
+      - name: Verify allowlists do not hide credential-shaped values
+        run: scripts/tests/gitleaks-allowlist.sh
+
       - name: Verify pre-push hook is present and executable
         # #5664 sub-finding 3 asserts the file exists and stays executable so
         # `git config core.hooksPath scripts/hooks` keeps working after every

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,7 +20,7 @@ title = "LibreFang gitleaks config"
 # Inherit gitleaks' built-in rule set; we only layer allowlist entries on top.
 useDefault = true
 
-[allowlist]
+[[allowlists]]
 description = "Paths and patterns where high-entropy strings are expected and are not real credentials."
 
 # File paths (matched against the path) where high-entropy strings are inherent
@@ -35,9 +35,7 @@ paths = [
   '''(^|/)go\.sum$''',
   '''(^|/)mise\.lock$''',
   '''(^|/)flake\.lock$''',
-  '''\.lock$''',
   # Generated / vendored artifacts.
-  '''^sdk/''',
   '''^openapi\.json$''',
   '''^crates/librefang-api/dashboard/dist/''',
   '''^crates/librefang-api/dashboard/node_modules/''',
@@ -54,45 +52,54 @@ paths = [
   '''(^|/)examples/''',
 ]
 
-# Matched against the detected secret value. Common placeholder shapes that
-# appear in docs and examples. Kept narrow so a real secret cannot hide behind
-# a generic prefix.
+# Matched against the complete detected secret value. Every entry is anchored
+# so a real credential cannot hide by containing a fixture as a substring.
 regexes = [
-  '''(?i)(example|dummy|placeholder|changeme|redacted|your[-_]?(api[-_]?)?(key|token|secret))''',
-  '''AKIA[0-9A-Z]{12}EXAMPLE''',
-  # `api_key_env` (and similar `*_env` config fields) hold an ENV VAR NAME, never
-  # the secret itself — an all-caps `[A-Z0-9_]` identifier with at least one
-  # underscore. Requiring an underscore keeps real AWS keys (AKIA…, no
-  # underscore) in scope. Covers the docs config examples and X_API_KEY-style
-  # source fixtures.
-  '''^[A-Z][A-Z0-9]*(_[A-Z0-9]+)+$''',
+  '''^AKIAIOSFODNN7EXAMPLE$''',
   # The canonical jwt.io HS256 example token (its fixed public signature),
   # embedded in JWT-handling tests and docs; not a real signing key.
-  '''SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c''',
+  '''^SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c$''',
   # The `Sec-WebSocket-Key` example value from RFC 6455 section 1.3 — base64 of the ASCII string "the sample nonce".
   # A WebSocket handshake nonce is client-generated per connection and carries no authorization; it is echoed back hashed as `Sec-WebSocket-Accept` purely to prove the peer speaks the protocol.
   # Used verbatim by the raw-socket upgrade tests, which have to write the handshake by hand.
-  '''dGhlIHNhbXBsZSBub25jZQ==''',
+  '''^dGhlIHNhbXBsZSBub25jZQ==$''',
   # Intentional fake credentials embedded in redaction / sanitization / driver
   # tests (the tests assert these get stripped) and one openfang→librefang doc
   # example. Each is a fixed literal or a tight test-only convention, so
   # allowlisting it cannot mask a real secret. The retired detect-secrets
   # baseline covered the same fixtures; add new test fixtures here if they trip
   # the scan, rather than reviving a per-finding snapshot.
-  '''sk-abc123xyz''',
-  '''sk-proj-abcdefg12345''',
-  '''sk-(open|libre)fang-abc123''',
-  '''test-nvidia-key-12345''',
-  '''ABCDEFGHIJ1234567890XYZ''',
-  '''(keep-me|strip-(groq|openai|gemini|suffix))-5006''',
+  '''^sk-abc123xyz$''',
+  '''^sk-proj-abcdefg12345$''',
+  '''^sk-(open|libre)fang-abc123$''',
+  '''^test-nvidia-key-12345$''',
+  '''^ABCDEFGHIJ1234567890XYZ$''',
+  '''^(keep-me|strip-(groq|openai|gemini|suffix))-5006$''',
+  # Exact environment-variable names and credential-shaped literals used by
+  # validation and redaction regressions. Full-value anchors keep unrelated
+  # credentials in scope even when they share a prefix or suffix.
+  '''^(MY_PROVIDER_API_KEY|X_API_KEY|FOO123_API_KEY|LIBREFANG_TEST_MISSING_KEY_ZXQ99|ANTHROPIC_API_KEY_[12])$''',
+  '''^your-api-key$''',
+  '''^ghp_S3nt1nelMustNeverAppearInAnyResponse$''',
+  '''^ghp_SECRETabcdef0123456789SECRETabcdef01$''',
+  '''^ghp_SECRETabcdef0123456789SECRETabcdef0123$''',
+  '''^ghp_abcdefghij1234567890abcdefghij123456$''',
+  '''^ghp_123456789012345678901234567890123456$''',
+  '''^sk_live_abcdef0123456789ABCDEF$''',
+  '''^sk-12345678901234567890123456789012$''',
+  '''^xoxb-0000-0000-xxxxxxxxxxxx$''',
+  '''^AIzaSyDummyGoogleKeyLooksLikeThis00$''',
+  '''^eyJhbGciOiJIUzI1NiJ9\.eyJzdWIiOiIxMjM0NTY3ODkwIn0\.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c$''',
+  '''^eyJhbGciOiJIUzI1NiJ9\.eyJzdWIiOiIxMjM0NSJ9\.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c$''',
 ]
 
-# A finding whose surrounding context contains one of these substrings is
-# ignored. Conservative list — only unambiguous test / placeholder markers.
+# Stopwords target the extracted secret itself, not the surrounding line.
+# Retain only the project's unambiguous test marker.
 stopwords = [
-  "example",
-  "EXAMPLE",
-  "dummy",
-  "placeholder",
   "test-only",
 ]
+
+[[allowlists]]
+description = "Pre-generated private key used only by the Google Chat adapter tests."
+targetRules = ["private-key"]
+paths = ['''^sdk/python/tests/test_google_chat_adapter\.py$''']

--- a/changelog.d/fixed/gitleaks-allowlists.md
+++ b/changelog.d/fixed/gitleaks-allowlists.md
@@ -1,0 +1,1 @@
+Tighten secret-scanner allowlists so fixture markers, lockfile suffixes, SDK source paths, and environment-shaped values cannot suppress unrelated credentials. (@xiaomo)

--- a/scripts/tests/gitleaks-allowlist.sh
+++ b/scripts/tests/gitleaks-allowlist.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+FIXTURE="$TEST_TMP/fixture"
+REPORT="$TEST_TMP/report.json"
+mkdir -p "$FIXTURE/sdk/generated"
+
+# Assemble credential-shaped values so this regression source is not itself a
+# gitleaks finding. None is a real credential.
+prefix=ghp_
+printf 'token = "%s"\n' "${prefix}S3nt1nelMustNeverAppearInAnyResponsF" \
+  > "$FIXTURE/sdk/generated/source.rs"
+printf 'token = "%s"\n' "${prefix}SECRETabcdef0123456789SECRETabcdef00" \
+  > "$FIXTURE/dependency.lock"
+printf 'token = "%s" # dummy example\n' \
+  "${prefix}abcdefghij1234567890abcdefghij123455" \
+  > "$FIXTURE/context.txt"
+
+set +e
+gitleaks dir "$FIXTURE" --config "$REPO_ROOT/.gitleaks.toml" \
+  --report-format json --report-path "$REPORT" --redact --no-banner
+status=$?
+set -e
+
+[[ $status -eq 1 ]] || {
+  echo "expected gitleaks to reject the negative allowlist fixtures, got $status" >&2
+  exit 1
+}
+for path in sdk/generated/source.rs dependency.lock context.txt; do
+  grep -q "$path" "$REPORT" || {
+    echo "gitleaks did not report $path" >&2
+    exit 1
+  }
+done


### PR DESCRIPTION
## Changes

- remove the catch-all `.lock` and entire `sdk/` path exclusions
- replace substring placeholder and environment-shape exemptions with anchored known literals
- remove common stopwords that could suppress credential-shaped values
- migrate the global configuration to current `[[allowlists]]` syntax
- scope the pre-generated Google Chat test key to its exact path and `private-key` rule
- add a CI regression proving SDK, lockfile, and common-context credentials remain detectable

## Verification

- verified gitleaks 8.30.1 Darwin archive against its upstream checksum
- `gitleaks dir . --config .gitleaks.toml --redact --no-banner --verbose` (44.62 MB, no leaks)
- `scripts/tests/gitleaks-allowlist.sh` (3/3 negative fixtures detected)
- `bash -n scripts/tests/gitleaks-allowlist.sh`
- Ruby YAML parse of `.github/workflows/secret-scan.yml`
- `git diff --check`

## Out of scope

- existing fixture and snapshot path exclusions are unchanged
- default gitleaks rules and pinned scanner version remain unchanged