### PR TITLE
fix(build): pin Android cross image

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,12 @@
 [target.aarch64-unknown-linux-gnu]
+# The glibc target enables the keyring crate's Secret Service backend, which
+# requires the target-architecture D-Bus development library. Keep libssl for
+# the remaining native TLS consumers in the cross sysroot.
 pre-build = [
-  "dpkg --add-architecture $CROSS_DEB_ARCH",
-  "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libdbus-1-dev:$CROSS_DEB_ARCH"
+  "dpkg --add-architecture $CROSS_DEB_ARCH && apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libdbus-1-dev:$CROSS_DEB_ARCH"
 ]
 
 [target.aarch64-linux-android]
-image = "ghcr.io/cross-rs/aarch64-linux-android:main"
+# cross-rs main snapshot resolved on 2026-08-14. Bump deliberately after an
+# Android release build verifies the replacement image.
+image = "ghcr.io/cross-rs/aarch64-linux-android@sha256:a6aa29659aec359b512717f89c71e885012fd3e07423e74da0a9945b2cd623dc"

--- a/changelog.d/fixed/cross-image-pin.md
+++ b/changelog.d/fixed/cross-image-pin.md
@@ -1,0 +1,1 @@
+Pin the Android cross-compilation image by OCI digest and make Linux cross-sysroot setup fail atomically. (@xiaomo)


### PR DESCRIPTION
## Changes

- pin the cross-rs Android builder to its resolved OCI index digest
- document the deliberate digest-bump verification requirement
- make architecture registration, package-index refresh, and native dependency installation one fail-fast command
- document the D-Bus/keyring dependency behind the cross sysroot packages

## Verification

- `docker buildx imagetools inspect ghcr.io/cross-rs/aarch64-linux-android@sha256:a6aa29659aec359b512717f89c71e885012fd3e07423e74da0a9945b2cd623dc`
- verified the pinned index contains the expected `linux/amd64` manifest
- `git diff --check`
- commit hooks (gitleaks unavailable locally; CI remains the gate)

## Out of scope

- no Rust target, feature, or release workflow changes
- a full Android release build remains CI-owned because it requires the cross image and complete release compilation