### PR TITLE
fix(docker): pin dashboard Corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ WORKDIR /build/dashboard
 # Node ≥20.19 is also required by vite 8 / rolldown's optional native
 # bindings (engines: ^20.19.0), without which `pnpm install` silently skips
 # the linux-x64-musl binding and `vite build` fails at require-time.
-RUN npm install --global corepack@latest \
+# Dependency lifecycle scripts are intentionally disabled in this build
+# stage. Vite/rolldown and esbuild ship their musl binaries through pinned
+# optional dependencies, so the dashboard build needs no postinstall code.
+RUN npm install --global corepack@0.34.6 \
     && corepack enable \
     && corepack prepare pnpm@10.33.0 --activate \
     && pnpm install --frozen-lockfile --ignore-scripts \
@@ -73,6 +76,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --bin librefang --features telemetry && \
     cp target/release/librefang /usr/local/bin/librefang
 
+# Node remains in the runtime image for JavaScript sidecars such as the
+# WhatsApp gateway copied under /opt/librefang/packages.
 # Pinned to a specific Node 22 LTS minor (not floating `node:lts-bookworm-slim`)
 # so a rebuild months later doesn't quietly land on a new major when the
 # `lts` alias rolls forward. `curl` is added for the HEALTHCHECK below.

--- a/changelog.d/fixed/dockerfile-toolchain-pin.md
+++ b/changelog.d/fixed/dockerfile-toolchain-pin.md
@@ -1,0 +1,1 @@
+Pin the Docker dashboard's Corepack version and document intentional lifecycle-script and Node runtime requirements. (@xiaomo)


### PR DESCRIPTION
## Changes

- replace floating `corepack@latest` with Node-20-compatible Corepack 0.34.6
- document why dashboard dependency lifecycle scripts remain disabled
- document that the runtime Node installation serves JavaScript sidecars such as the WhatsApp gateway

## Verification

- `npm view corepack@0.34.6 engines --json` (`^20.10.0 || ^22.11.0 || >=24.0.0`)
- `docker build --target dashboard-builder -t librefang-dashboard-audit:7253 .`
- dashboard Vite production build completed successfully with pnpm 10.33.0
- removed the test image by exact tag
- `git diff --check`
- commit hooks (gitleaks unavailable locally; CI remains the gate)

## Out of scope

- base image versions and runtime packages are unchanged
- no dashboard dependency or lockfile changes