### PR TITLE
fix(ci): harden agent instruction pair check

### DIFF
--- a/changelog.d/fixed/agents-claude-pair-paths.md
+++ b/changelog.d/fixed/agents-claude-pair-paths.md
@@ -1,0 +1,1 @@
+Handle spaces, nested generated directories, and equivalent symlink targets in the AGENTS/CLAUDE pair check. (@xiaomo)

--- a/scripts/check-agents-claude-pair.sh
+++ b/scripts/check-agents-claude-pair.sh
@@ -16,17 +16,18 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"
 
 fail=0
+agents_list=$(mktemp "${TMPDIR:-/tmp}/librefang-agents-pair.XXXXXX")
+trap 'rm -f "$agents_list"' EXIT HUP INT TERM
 
-# Capture into a variable first so the loop body runs in the parent
-# shell — `find … | while` would put it in a subshell on POSIX,
-# making the `fail=1` assignment invisible to the outer scope.
-agents_files=$(find . -name AGENTS.md \
-    -not -path './AGENTS.md' \
-    -not -path './target/*' \
-    -not -path './node_modules/*' \
-    -not -path './.git/*' 2>/dev/null)
+# Keep the loop in the parent shell so `fail=1` remains visible. Prune
+# generated/VCS directories by name at any depth. Repository paths cannot
+# contain newlines under this collaboration contract, but may contain spaces.
+find . \
+    \( -type d \( -name .git -o -name target -o -name node_modules \) -prune \) -o \
+    \( -type f -name AGENTS.md ! -path './AGENTS.md' -print \) \
+    >"$agents_list" 2>/dev/null
 
-for agents in $agents_files; do
+while IFS= read -r agents; do
     dir=$(dirname "$agents")
     claude="$dir/CLAUDE.md"
 
@@ -43,14 +44,14 @@ for agents in $agents_files; do
     fi
 
     target=$(readlink "$claude")
-    if [ "$target" != "AGENTS.md" ]; then
-        echo "::error file=$claude::CLAUDE.md symlink points to '$target', expected 'AGENTS.md'."
+    if ! (cd "$dir" && [ CLAUDE.md -ef AGENTS.md ]); then
+        echo "::error file=$claude::CLAUDE.md symlink points to '$target', expected the sibling AGENTS.md."
         fail=1
         continue
     fi
 
     echo "ok: $agents <-> $claude"
-done
+done <"$agents_list"
 
 if [ "$fail" != "0" ]; then
     echo

--- a/scripts/tests/check-agents-claude-pair.sh
+++ b/scripts/tests/check-agents-claude-pair.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+CHECK="$ROOT/scripts/check-agents-claude-pair.sh"
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/librefang-agents-pair-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT HUP INT TERM
+
+git -C "$FIXTURE" init -q
+touch "$FIXTURE/AGENTS.md"
+
+mkdir -p "$FIXTURE/path with spaces" "$FIXTURE/glob*[name]" "$FIXTURE/nested/target/ignored"
+touch "$FIXTURE/path with spaces/AGENTS.md"
+ln -s ./AGENTS.md "$FIXTURE/path with spaces/CLAUDE.md"
+touch "$FIXTURE/glob*[name]/AGENTS.md"
+ln -s AGENTS.md "$FIXTURE/glob*[name]/CLAUDE.md"
+touch "$FIXTURE/nested/target/ignored/AGENTS.md"
+
+output=$(cd "$FIXTURE" && sh "$CHECK")
+case "$output" in
+    *"path with spaces/AGENTS.md"*) ;;
+    *) echo "FAIL: path containing spaces was not checked" >&2; exit 1 ;;
+esac
+case "$output" in
+    *"glob*[name]/AGENTS.md"*) ;;
+    *) echo "FAIL: path containing glob characters was not checked" >&2; exit 1 ;;
+esac
+case "$output" in
+    *"nested/target"*) echo "FAIL: nested target directory was scanned" >&2; exit 1 ;;
+esac
+
+mkdir -p "$FIXTURE/missing"
+touch "$FIXTURE/missing/AGENTS.md"
+if (cd "$FIXTURE" && sh "$CHECK" >/dev/null 2>&1); then
+    echo "FAIL: missing CLAUDE.md was accepted" >&2
+    exit 1
+fi
+
+ln -s AGENTS.md "$FIXTURE/missing/CLAUDE.md"
+mkdir -p "$FIXTURE/wrong"
+touch "$FIXTURE/wrong/AGENTS.md" "$FIXTURE/wrong/other.md"
+ln -s other.md "$FIXTURE/wrong/CLAUDE.md"
+if (cd "$FIXTURE" && sh "$CHECK" >/dev/null 2>&1); then
+    echo "FAIL: link to a different file was accepted" >&2
+    exit 1
+fi
+
+echo "OK: check-agents-claude-pair.sh"


### PR DESCRIPTION
## Changes
- preserve spaces and glob characters while scanning nested `AGENTS.md` files
- prune `.git`, `target`, and `node_modules` directories at any depth
- accept symlinks that resolve to the sibling `AGENTS.md`, including equivalent relative spellings
- add a hermetic shell fixture for accepted and rejected layouts

## Verification
- `sh -n scripts/check-agents-claude-pair.sh scripts/tests/check-agents-claude-pair.sh`
- `sh scripts/tests/check-agents-claude-pair.sh`
- `sh scripts/check-agents-claude-pair.sh`
- `git diff --check`
- repository pre-commit hook

## Out of scope
- root `AGENTS.md` / `CLAUDE.md`, which intentionally remain separate files
- generated directories other than `.git`, `target`, and `node_modules`