### PR TITLE
fix(ci): parse API runtime dependency edges

### DIFF
--- a/changelog.d/fixed/api-runtime-decoupling-guard.md
+++ b/changelog.d/fixed/api-runtime-decoupling-guard.md
@@ -1,0 +1,1 @@
+Inspect Cargo's parsed dependency graph and enforce the production API/runtime boundary without rejecting integration-test dependencies. (@xiaomo)

--- a/scripts/check-api-runtime-decoupling.sh
+++ b/scripts/check-api-runtime-decoupling.sh
@@ -1,44 +1,71 @@
 #!/usr/bin/env bash
 # refs #3596 — API → Kernel → Runtime layering, compiler-enforced.
 #
-# As of 2/N (#3596), `librefang-api` no longer declares a direct
-# `librefang-runtime` dependency in `Cargo.toml` — `cargo check`
-# rejects any new `use librefang_runtime::*` outright. This script
-# is now a defence-in-depth guard against re-introducing the dep:
-#   1. asserts the `librefang-runtime = { path = ... }` line is gone
-#      from `crates/librefang-api/Cargo.toml`,
-#   2. asserts no `use librefang_runtime::*` slipped back into
-#      `crates/librefang-api/{src,tests}/` via a path-style import.
+# Production `librefang-api` reaches runtime types through kernel-handle
+# contracts. Integration tests may use a runtime dev-dependency to exercise
+# real backends, but normal/build dependencies and direct references under
+# `src/` remain forbidden. This script enforces that boundary from Cargo's
+# parsed graph and Rust source.
 #
 # Failure means the layering invariant has regressed. Fix the diff,
 # don't suppress this script.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-API_TOML="$ROOT/crates/librefang-api/Cargo.toml"
-API_SRC="$ROOT/crates/librefang-api/src"
-API_TESTS="$ROOT/crates/librefang-api/tests"
+ROOT="${LIBREFANG_API_DECOUPLING_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+API_TOML_REL="crates/librefang-api/Cargo.toml"
+API_SRC_REL="crates/librefang-api/src"
+API_TESTS_REL="crates/librefang-api/tests"
+API_TOML="$ROOT/$API_TOML_REL"
+API_SRC="$ROOT/$API_SRC_REL"
+API_TESTS="$ROOT/$API_TESTS_REL"
 
 fail=0
 
-# 1. Cargo.toml must not declare a direct runtime dep. Anchor the
-# regex on a real dep-line (key = value), so doc / comment mentions
-# of the crate name don't false-trip the check.
-if grep -E '^[[:space:]]*librefang-runtime[[:space:]]*=' "$API_TOML" >/dev/null 2>&1; then
-  echo "::error file=$API_TOML::librefang-runtime dependency reintroduced. API → Kernel → Runtime layering (#3596) requires reaching runtime types through librefang-kernel re-exports."
+# 1. Inspect Cargo's parsed dependency graph. This catches table, dotted-key,
+# target-specific, renamed, dev, and build dependency spellings. Dev-only
+# runtime edges are permitted for integration tests; normal/build edges are not.
+for required in "$API_TOML" "$API_SRC" "$API_TESTS"; do
+  if [ ! -e "$required" ]; then
+    relative=${required#"$ROOT"/}
+    echo "::error file=$relative::required API decoupling scan target is missing."
+    fail=1
+  fi
+done
+
+if [ "$fail" = "0" ]; then
+  metadata=$(cargo metadata --format-version 1 --no-deps --manifest-path "$API_TOML")
+  runtime_dep=$(printf '%s' "$metadata" | python3 -c '
+import json, os, sys
+manifest = os.path.realpath(sys.argv[1])
+data = json.load(sys.stdin)
+package = next((p for p in data["packages"] if os.path.realpath(p["manifest_path"]) == manifest), None)
+if package is None:
+    raise SystemExit("librefang-api package missing from cargo metadata")
+matches = [
+    d for d in package["dependencies"]
+    if d["name"] == "librefang-runtime" and d.get("kind") != "dev"
+]
+print("yes" if matches else "no")
+' "$API_TOML")
+else
+  runtime_dep=no
+fi
+
+if [ "$runtime_dep" = "yes" ]; then
+  echo "::error file=$API_TOML_REL::librefang-runtime dependency reintroduced. API → Kernel → Runtime layering (#3596) requires reaching runtime types through librefang-kernel re-exports."
   fail=1
 fi
 
-# 2. Source / test imports must not name librefang_runtime directly.
+# 2. Production source imports must not name librefang_runtime directly.
 # Use grep (not rg) to avoid a hard dep on ripgrep in CI; filter doc
 # comments (lines that are pure /// or // mentions).
 hits=$(grep -rEn 'use librefang_runtime|librefang_runtime::' \
-        "$API_SRC" "$API_TESTS" --include='*.rs' 2>/dev/null \
-        | grep -vE '^[^:]+:[0-9]+:[[:space:]]*///' \
+        "$API_SRC" --include='*.rs' 2>/dev/null \
+        | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//' \
         || true)
 if [ -n "$hits" ]; then
   echo "::error::direct librefang_runtime reference in librefang-api source (#3596 regression):"
-  printf '%s\n' "$hits" | sed 's|^|  |'
+  printf '%s\n' "$hits" | sed "s|$ROOT/||; s|^|  |"
   fail=1
 fi
 
@@ -48,5 +75,5 @@ if [ "$fail" != "0" ]; then
   exit 1
 fi
 
-echo "[check-api-runtime-decoupling] OK — librefang-api has no direct librefang_runtime imports or Cargo dep."
+echo "[check-api-runtime-decoupling] OK — librefang-api production code has no direct librefang_runtime edge."
 exit 0

--- a/scripts/tests/check-api-runtime-decoupling.sh
+++ b/scripts/tests/check-api-runtime-decoupling.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+CHECK="$ROOT/scripts/check-api-runtime-decoupling.sh"
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/librefang-api-decoupling-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/crates/librefang-api/src" "$FIXTURE/crates/librefang-api/tests" "$FIXTURE/bin"
+touch "$FIXTURE/crates/librefang-api/Cargo.toml"
+cat >"$FIXTURE/bin/cargo" <<'SH'
+#!/bin/sh
+printf '%s\n' "${FAKE_CARGO_METADATA:?}"
+SH
+chmod +x "$FIXTURE/bin/cargo"
+
+clean_metadata=$(printf '{"packages":[{"manifest_path":"%s","dependencies":[]}]}' \
+  "$FIXTURE/crates/librefang-api/Cargo.toml")
+dev_runtime_metadata=$(printf '{"packages":[{"manifest_path":"%s","dependencies":[{"name":"librefang-runtime","rename":"runtime_alias","kind":"dev","target":"cfg(unix)"}]}]}' \
+  "$FIXTURE/crates/librefang-api/Cargo.toml")
+normal_runtime_metadata=$(printf '{"packages":[{"manifest_path":"%s","dependencies":[{"name":"librefang-runtime","rename":"runtime_alias","kind":null,"target":"cfg(unix)"}]}]}' \
+  "$FIXTURE/crates/librefang-api/Cargo.toml")
+
+run_check() {
+  PATH="$FIXTURE/bin:$PATH" \
+    LIBREFANG_API_DECOUPLING_ROOT="$FIXTURE" \
+    FAKE_CARGO_METADATA="$1" \
+    bash "$CHECK"
+}
+
+printf '%s\n' '// librefang_runtime::DocOnly' '//! use librefang_runtime::Other' \
+  >"$FIXTURE/crates/librefang-api/src/lib.rs"
+run_check "$clean_metadata" >/dev/null
+run_check "$dev_runtime_metadata" >/dev/null
+
+if run_check "$normal_runtime_metadata" >/dev/null 2>&1; then
+  echo "FAIL: parsed target-specific renamed normal dependency was accepted" >&2
+  exit 1
+fi
+
+printf '%s\n' 'use librefang_runtime::AgentLoop;' \
+  >"$FIXTURE/crates/librefang-api/src/lib.rs"
+if run_check "$clean_metadata" >/dev/null 2>&1; then
+  echo "FAIL: direct source import was accepted" >&2
+  exit 1
+fi
+
+rm -rf "$FIXTURE/crates/librefang-api/tests"
+if run_check "$clean_metadata" >/dev/null 2>&1; then
+  echo "FAIL: missing scan directory was accepted" >&2
+  exit 1
+fi
+
+echo "OK: check-api-runtime-decoupling.sh"


### PR DESCRIPTION
## Changes
- inspect Cargo metadata instead of matching one dependency-line spelling
- forbid normal/build runtime dependencies while preserving the existing integration-test dev dependency
- scan production Rust sources, filter every line-comment form, validate scan inputs, and emit repository-relative diagnostics
- add a hermetic fake-metadata regression fixture

## Verification
- `bash -n scripts/check-api-runtime-decoupling.sh scripts/tests/check-api-runtime-decoupling.sh`
- `bash scripts/tests/check-api-runtime-decoupling.sh`
- `bash scripts/check-api-runtime-decoupling.sh`
- `git diff --check`
- repository pre-commit hook

## Out of scope
- adding the standalone guard to `ci.yml`, which is occupied by existing CI PRs; Cargo already compiler-enforces the production dependency boundary
- integration tests that intentionally exercise runtime backends through a dev dependency