### PR TITLE
fix(ci): harden manual release tag checks

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -92,6 +92,15 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          # Environment approval and validation can take long enough for main to advance.
+          # Fail instead of tagging a stale checkout whose version was validated against an older manifest.
+          git fetch --no-tags origin refs/heads/main
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          CURRENT_MAIN_SHA=$(git rev-parse FETCH_HEAD)
+          if [ "$CHECKED_OUT_SHA" != "$CURRENT_MAIN_SHA" ]; then
+            echo "::error::main advanced from $CHECKED_OUT_SHA to $CURRENT_MAIN_SHA; rerun the workflow"
+            exit 1
+          fi
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git tag -- "$VERSION"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   tag:
     name: Create release tag
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release-tag
     timeout-minutes: 10
@@ -40,6 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: main
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Verify tag format

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -35,6 +35,7 @@ jobs:
     name: Create release tag
     runs-on: ubuntu-latest
     environment: release-tag
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -58,7 +59,14 @@ jobs:
           # Same gate as release.yml `create_release` — the manifest
           # section must match the tag the maintainer is requesting.
           TAG="$VERSION"
-          WS_VERSION=$(sed -n '/^\[workspace\.package\]/,/^\[/{ s/^version *= *"\([^"]*\)".*/\1/p }' Cargo.toml | head -1)
+          if ! WS_VERSION=$(python3 -c 'import sys, tomllib; data = tomllib.load(sys.stdin.buffer); print(data["workspace"]["package"]["version"])' < Cargo.toml); then
+            echo "::error::could not parse [workspace.package].version from Cargo.toml"
+            exit 1
+          fi
+          if [ -z "$WS_VERSION" ]; then
+            echo "::error::[workspace.package].version is empty"
+            exit 1
+          fi
           if [ "${TAG#v}" != "$WS_VERSION" ]; then
             echo "::error::requested tag $TAG does not match [workspace.package].version $WS_VERSION"
             exit 1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -104,6 +104,9 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git tag -- "$VERSION"
-          git push origin "refs/tags/$VERSION"
+          # Include a no-change main update in the atomic push. If main moves
+          # after the fetch above, this refspec becomes non-fast-forward and
+          # GitHub rejects both the branch ref and the new tag.
+          git push --atomic origin "HEAD:refs/heads/main" "refs/tags/$VERSION"
           echo "✓ Pushed tag $VERSION"
           echo "Note: this push will trigger release.yml on the tag — split workflows below are only needed if individual targets need to be re-run."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
+- Parse manual release tags against Cargo.toml with Python’s TOML parser and bound the privileged tag-creation job to ten minutes. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ _474 PRs from 5 contributors since v2026.7.31._
 
 ### Fixed
 
+- Parse manual release tags against Cargo.toml with Python’s TOML parser and bound the privileged tag-creation job to ten minutes. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 - `browser_read_page` no longer drops the destination of every link nested inside a list item, and no longer returns a single card from a feed or search-results page.
   The extraction script's `li` branch flattened the item to `textContent` and returned before descending, so a nested anchor reached the model as bare text with no URL — 1,100 of 1,723 anchors on the Rust Wikipedia article and 11 of 11 on a DuckDuckGo results page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,6 @@ _474 PRs from 5 contributors since v2026.7.31._
 
 ### Fixed
 
-- Parse manual release tags against Cargo.toml with Python’s TOML parser and bound the privileged tag-creation job to ten minutes. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 - `browser_read_page` no longer drops the destination of every link nested inside a list item, and no longer returns a single card from a feed or search-results page.
   The extraction script's `li` branch flattened the item to `textContent` and returned before descending, so a nested anchor reached the model as bare text with no URL — 1,100 of 1,723 anchors on the Rust Wikipedia article and 11 of 11 on a DuckDuckGo results page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
-- Parse manual release tags against Cargo.toml with Python’s TOML parser and bound the privileged tag-creation job to ten minutes. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/changelog.d/fixed/7284-release-tag-guardrails.md
+++ b/changelog.d/fixed/7284-release-tag-guardrails.md
@@ -1,0 +1,1 @@
+Parse manual release tags against Cargo.toml with Python’s TOML parser and bound the privileged tag-creation job to ten minutes. (#7284) (@xiaomo)

--- a/changelog.d/fixed/7284-release-tag-guardrails.md
+++ b/changelog.d/fixed/7284-release-tag-guardrails.md
@@ -1,1 +1,1 @@
-Restrict manual release tags to `main`, parse the workspace version with Python's TOML parser, and bound the privileged tag-creation job to ten minutes. (#7284) (@houko)
+Restrict manual release tags to `main`, parse workspace versions as TOML, reject a checkout if `main` advances before tagging, and bound the privileged job to ten minutes. (#7284) (@houko)

--- a/changelog.d/fixed/7284-release-tag-guardrails.md
+++ b/changelog.d/fixed/7284-release-tag-guardrails.md
@@ -1,1 +1,1 @@
-Restrict manual release tags to `main`, parse workspace versions as TOML, reject a checkout if `main` advances before tagging, and bound the privileged job to ten minutes. (#7284) (@houko)
+Restrict manual release tags to `main`, parse workspace versions as TOML, atomically reject tagging if `main` advances, and bound the privileged job to ten minutes. (#7284) (@xiaomo)

--- a/changelog.d/fixed/7284-release-tag-guardrails.md
+++ b/changelog.d/fixed/7284-release-tag-guardrails.md
@@ -1,0 +1,1 @@
+Restrict manual release tags to `main`, parse the workspace version with Python's TOML parser, and bound the privileged tag-creation job to ten minutes. (#7284) (@houko)

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -208,6 +208,27 @@ def main() -> None:
     workspace_script = workspace_step.get("run") if isinstance(workspace_step, dict) else None
     if not isinstance(workspace_script, str) or "tomllib.load" not in workspace_script:
         raise SystemExit("release-tag workflow does not parse workspace version as TOML")
+    create_tag_step = next(
+        (
+            step
+            for step in release_tag_job.get("steps", [])
+            if step.get("name") == "Create + push tag"
+        ),
+        None,
+    )
+    create_tag_script = (
+        create_tag_step.get("run") if isinstance(create_tag_step, dict) else None
+    )
+    if not isinstance(create_tag_script, str) or not all(
+        fragment in create_tag_script
+        for fragment in (
+            "git fetch --no-tags origin refs/heads/main",
+            "CHECKED_OUT_SHA=$(git rev-parse HEAD)",
+            "CURRENT_MAIN_SHA=$(git rev-parse FETCH_HEAD)",
+            'if [ "$CHECKED_OUT_SHA" != "$CURRENT_MAIN_SHA" ]',
+        )
+    ):
+        raise SystemExit("release-tag workflow can tag a stale main checkout")
     manifest_text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
     manifest = tomllib.loads(manifest_text)
     current_version = manifest["workspace"]["package"]["version"]

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -5,7 +5,9 @@ import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
+import tomllib
 from pathlib import Path
 
 import yaml
@@ -179,6 +181,40 @@ def main() -> None:
         dashboard_needs = [dashboard_needs]
     if "validate_release_tag" not in dashboard_needs:
         raise SystemExit("release-cli build_dashboard bypasses release tag validation")
+
+    release_tag_job = documents["release-tag.yml"].get("jobs", {}).get("tag", {})
+    if release_tag_job.get("timeout-minutes") != 10:
+        raise SystemExit("release-tag job does not have the expected timeout")
+    workspace_step = next(
+        (
+            step
+            for step in release_tag_job.get("steps", [])
+            if step.get("name") == "Verify tag matches workspace version"
+        ),
+        None,
+    )
+    workspace_script = workspace_step.get("run") if isinstance(workspace_step, dict) else None
+    if not isinstance(workspace_script, str) or "tomllib.load" not in workspace_script:
+        raise SystemExit("release-tag workflow does not parse workspace version as TOML")
+    manifest = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+    current_version = manifest["workspace"]["package"]["version"]
+    workspace_environment = os.environ.copy()
+    workspace_environment["PATH"] = (
+        f"{Path(sys.executable).parent}{os.pathsep}{workspace_environment['PATH']}"
+    )
+    workspace_result = subprocess.run(
+        ["bash", "-eu", "-o", "pipefail", "-c", workspace_script],
+        cwd=ROOT,
+        env={**workspace_environment, "VERSION": f"v{current_version}"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if workspace_result.returncode != 0:
+        raise SystemExit(
+            "release-tag workspace-version gate rejected the current manifest: "
+            + workspace_result.stderr
+        )
 
     format_step = next(
         (

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -226,6 +226,7 @@ def main() -> None:
             "CHECKED_OUT_SHA=$(git rev-parse HEAD)",
             "CURRENT_MAIN_SHA=$(git rev-parse FETCH_HEAD)",
             'if [ "$CHECKED_OUT_SHA" != "$CURRENT_MAIN_SHA" ]',
+            'git push --atomic origin "HEAD:refs/heads/main" "refs/tags/$VERSION"',
         )
     ):
         raise SystemExit("release-tag workflow can tag a stale main checkout")

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -183,8 +183,20 @@ def main() -> None:
         raise SystemExit("release-cli build_dashboard bypasses release tag validation")
 
     release_tag_job = documents["release-tag.yml"].get("jobs", {}).get("tag", {})
+    if release_tag_job.get("if") != "github.ref == 'refs/heads/main'":
+        raise SystemExit("release-tag job can run from a non-main ref")
     if release_tag_job.get("timeout-minutes") != 10:
         raise SystemExit("release-tag job does not have the expected timeout")
+    release_tag_checkout = next(
+        (
+            step
+            for step in release_tag_job.get("steps", [])
+            if step.get("uses", "").startswith("actions/checkout@")
+        ),
+        {},
+    )
+    if release_tag_checkout.get("with", {}).get("ref") != "main":
+        raise SystemExit("release-tag checkout is not pinned to main")
     workspace_step = next(
         (
             step
@@ -196,25 +208,47 @@ def main() -> None:
     workspace_script = workspace_step.get("run") if isinstance(workspace_step, dict) else None
     if not isinstance(workspace_script, str) or "tomllib.load" not in workspace_script:
         raise SystemExit("release-tag workflow does not parse workspace version as TOML")
-    manifest = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+    manifest_text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    manifest = tomllib.loads(manifest_text)
     current_version = manifest["workspace"]["package"]["version"]
     workspace_environment = os.environ.copy()
     workspace_environment["PATH"] = (
         f"{Path(sys.executable).parent}{os.pathsep}{workspace_environment['PATH']}"
     )
-    workspace_result = subprocess.run(
-        ["bash", "-eu", "-o", "pipefail", "-c", workspace_script],
-        cwd=ROOT,
-        env={**workspace_environment, "VERSION": f"v{current_version}"},
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+
+    def run_workspace_gate(candidate_manifest: str, version: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "Cargo.toml").write_text(
+                candidate_manifest,
+                encoding="utf-8",
+            )
+            return subprocess.run(
+                ["bash", "-eu", "-o", "pipefail", "-c", workspace_script],
+                cwd=temp_dir,
+                env={**workspace_environment, "VERSION": version},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    workspace_result = run_workspace_gate(manifest_text, f"v{current_version}")
     if workspace_result.returncode != 0:
         raise SystemExit(
             "release-tag workspace-version gate rejected the current manifest: "
+            + workspace_result.stdout
             + workspace_result.stderr
         )
+    for candidate_manifest, version, expected_error in (
+        (manifest_text, "v0.0.0", "does not match"),
+        ("[workspace.package\n", "v1.0.0", "could not parse"),
+        ('[workspace.package]\nversion = ""\n', "v1.0.0", "is empty"),
+    ):
+        rejected = run_workspace_gate(candidate_manifest, version)
+        output = rejected.stdout + rejected.stderr
+        if rejected.returncode == 0 or expected_error not in output:
+            raise SystemExit(
+                f"release-tag workspace-version gate did not reject {expected_error!r} fixture"
+            )
 
     format_step = next(
         (


### PR DESCRIPTION
## Changes

- restrict manual release tagging to dispatches from `main` and explicitly check out `main`
- parse `[workspace.package].version` with Python `tomllib` instead of formatting-sensitive text extraction
- report malformed, empty, and mismatched manifest versions explicitly
- fetch current `main` immediately before tag creation and reject stale checkouts
- atomically push a no-change `main` ref with the new tag so a last-moment `main` advance prevents tag creation
- bound the privileged release-tag job to ten minutes
- extend the release workflow regression with ref, timeout, manifest, stale-checkout, and atomic-push contracts

## Verification

- `uv run --no-project --with pyyaml python scripts/tests/test_release_tag_workflow_safety.py`
- parsed `.github/workflows/release-tag.yml` with Ruby YAML
- passed all four release-tag shell blocks through `bash -n`
- `git diff --check`

The executable manifest fixtures cover the live Cargo.toml, mismatched versions, malformed TOML, and an empty version.

## Out of scope

- The existing environment reviewer gate and CalVer policy are unchanged.
- Tag pushes still use the existing PAT because `GITHUB_TOKEN` pushes do not trigger the downstream release workflow. Credential replacement requires separately provisioned release credentials.
