### PR TITLE
fix(ci): preserve build timing failures

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: build-timings
+  cancel-in-progress: false
+
 jobs:
   collect:
     name: Collect build timings
@@ -47,11 +51,9 @@ jobs:
       - name: Collect snapshot
         run: cargo xtask build-timings
       - name: Compare against baseline
-        # Soft-fail: regressions are surfaced via an annotation but do NOT
-        # block the workflow — the trend artifact is the primary deliverable.
-        # If the team wants hard gating later, flip this to `false`.
-        continue-on-error: true
-        run: cargo xtask compare-build-timings
+        # Regressions are warnings, while missing/corrupt snapshots and other
+        # comparator failures still fail the job.
+        run: cargo xtask compare-build-timings --warn-only
       - name: Upload timing snapshot
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
+- Serialize weekly build-timing collection and keep comparator data failures fatal while reporting compile-time regressions as non-blocking workflow warnings. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
-- Serialize weekly build-timing collection and keep comparator data failures fatal while reporting compile-time regressions as non-blocking workflow warnings. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/changelog.d/fixed/7294-build-timings-reliability.md
+++ b/changelog.d/fixed/7294-build-timings-reliability.md
@@ -1,0 +1,1 @@
+Serialize weekly build-timing collection and keep comparator data failures fatal while reporting compile-time regressions as non-blocking workflow warnings. (#7294) (@xiaomo)

--- a/xtask/src/build_timings.rs
+++ b/xtask/src/build_timings.rs
@@ -7,8 +7,8 @@
 //! `cargo xtask compare-build-timings` diffs the latest snapshot against
 //! `bench-results/build-timings/baseline.json` and exits non-zero when any
 //! crate's compile time has regressed by more than the configured threshold
-//! (default 10%). The non-zero exit is intended to be wired into a weekly
-//! CI job as a soft alert (`continue-on-error: true`), not a blocking gate.
+//! (default 10%). CI uses `--warn-only` to emit annotations for regressions
+//! while preserving non-zero exits for malformed or missing timing data.
 
 use crate::common::repo_root;
 use clap::Parser;
@@ -45,6 +45,11 @@ pub struct CompareBuildTimingsArgs {
     /// Regression threshold as a fraction (0.10 = 10%).
     #[arg(long, default_value_t = 0.10)]
     pub threshold: f64,
+
+    /// Emit GitHub Actions warnings and exit successfully for regressions.
+    /// Operational failures still return an error.
+    #[arg(long)]
+    pub warn_only: bool,
 }
 
 /// Parsed snapshot we persist to disk. Map ordered for deterministic diffs
@@ -151,6 +156,15 @@ pub fn run_compare(args: CompareBuildTimingsArgs) -> Result<(), Box<dyn std::err
             "  {name:<40} {base:>7.2}s -> {cur:>7.2}s  ({:+.1}%)",
             pct * 100.0
         );
+        if args.warn_only {
+            println!(
+                "::warning title=Build-time regression::{name}: {base:.2}s -> {cur:.2}s ({:+.1}%)",
+                pct * 100.0
+            );
+        }
+    }
+    if args.warn_only {
+        return Ok(());
     }
     Err(format!(
         "{} crate(s) regressed by more than {:.0}%",
@@ -417,6 +431,33 @@ mod tests {
         let back = read_snapshot(&path).unwrap();
         assert!((back.crates["librefang-kernel"] - 12.345).abs() < 0.01);
         assert!((back.crates["librefang-api"] - 7.89).abs() < 0.01);
+    }
+
+    #[test]
+    fn warn_only_softens_regressions_but_not_invalid_snapshots() {
+        let dir = tempdir().join("warn-only");
+        fs::create_dir_all(&dir).unwrap();
+        let baseline = dir.join("baseline.json");
+        let current = dir.join("current.json");
+        fs::write(&baseline, "{\"slow-crate\": 10.0}\n").unwrap();
+        fs::write(&current, "{\"slow-crate\": 12.0}\n").unwrap();
+
+        assert!(run_compare(CompareBuildTimingsArgs {
+            baseline: Some(baseline.clone()),
+            current: Some(current.clone()),
+            threshold: 0.10,
+            warn_only: true,
+        })
+        .is_ok());
+
+        fs::write(&current, "not json\n").unwrap();
+        assert!(run_compare(CompareBuildTimingsArgs {
+            baseline: Some(baseline),
+            current: Some(current),
+            threshold: 0.10,
+            warn_only: true,
+        })
+        .is_err());
     }
 
     fn tempdir() -> PathBuf {


### PR DESCRIPTION
## Changes

- serialize scheduled and manually dispatched build-timing collections without cancelling an active measurement
- add `compare-build-timings --warn-only` so compile regressions produce workflow warnings and exit successfully
- keep missing, unreadable, or malformed timing snapshots fatal instead of masking them with step-level `continue-on-error`
- retain the immutable artifact action pin already present on current `main`

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p xtask build_timings` (4 passed)
- parsed `.github/workflows/build-timings.yml` with Ruby YAML
- asserted the exact concurrency contract, `--warn-only` command, and absence of `continue-on-error`
- `cargo run -q -p xtask -- compare-build-timings --help | rg -- '--warn-only'`
- `git diff --check`

## Out of scope

- the 10% regression threshold and baseline-seeding policy are unchanged
- the workflow remains a weekly/manual measurement rather than a blocking PR gate
- artifact contents and retention are unchanged
