### PR TITLE
fix(ci): cover Nix source inputs

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -23,7 +23,15 @@ on:
       - 'nix/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
+      # Keep this aligned with the source fileset assembled in flake.nix.
+      - '.cargo/**'
+      - 'crates/**'
+      - 'xtask/**'
+      - 'examples/**'
+      - 'sdk/rust/**'
+      - 'sdk/python/librefang/**'
+      - 'packages/whatsapp-gateway/**'
+      - 'deploy/**'
       - '.github/workflows/nix-build.yml'
   pull_request:
     paths:
@@ -32,7 +40,14 @@ on:
       - 'nix/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
+      - '.cargo/**'
+      - 'crates/**'
+      - 'xtask/**'
+      - 'examples/**'
+      - 'sdk/rust/**'
+      - 'sdk/python/librefang/**'
+      - 'packages/whatsapp-gateway/**'
+      - 'deploy/**'
       - '.github/workflows/nix-build.yml'
   workflow_dispatch:
 
@@ -84,9 +99,10 @@ jobs:
 
   nix-build:
     name: nix build (${{ matrix.package }})
+    needs: nix-eval
     # Post-merge and manual dispatch only.
     # The nix-eval job above is what gates a PR; this leg is the expensive compile the header comment reserves for push-to-main.
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && needs.nix-eval.result == 'success'
     runs-on: ubuntu-latest
     # Cold builds are the norm here: the Rust CI lanes churn through the repo's 10 GB Actions cache quota daily, so the /nix/store cache below is usually evicted before the next run and each leg rebuilds the full crane deps + workspace closure from scratch.
     # A cold librefang-cli leg takes ~80-95 minutes (it was still compiling workspace crates when a 60-minute limit cancelled it), so 120 covers a cold build with margin while still catching a genuinely hung one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
+- Trigger Nix evaluation and post-merge builds for every flake source root, and require the cheap eval gate before starting the expensive build matrix. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
-- Trigger Nix evaluation and post-merge builds for every flake source root, and require the cheap eval gate before starting the expensive build matrix. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/changelog.d/fixed/7303-nix-build-coverage.md
+++ b/changelog.d/fixed/7303-nix-build-coverage.md
@@ -1,0 +1,1 @@
+Trigger Nix evaluation and post-merge builds for every flake source root, and require the cheap eval gate before starting the expensive build matrix. (#7303) (@xiaomo)


### PR DESCRIPTION
## Changes

- trigger both PR evaluation and post-merge Nix builds for every current crane source root
- cover Rust sources under crates, xtask, examples, and the Rust SDK plus the explicitly embedded Python SDK, WhatsApp gateway, deploy assets, and Cargo configuration
- keep the push and pull-request path contracts identical
- require the fast `nix-eval` job to succeed before starting either expensive build-matrix leg

## Verification

- parsed `.github/workflows/nix-build.yml` with Ruby YAML
- asserted push and pull-request path lists are identical and exactly match the intended source-root contract
- enumerated current tracked Rust/Cargo/Nix and explicit flake asset inputs and proved all 1,016 files match a workflow trigger path
- asserted `nix-build` needs `nix-eval` and explicitly requires its successful result outside PR events
- asserted all five workflow actions remain pinned to exact 40-character commit SHAs
- ran `git diff --check`

## Out of scope

- the expensive build matrix remains post-merge/manual only; PRs still run evaluation without compiling
- package matrix, cache policy, runner cleanup, and timeouts are unchanged
- the source trigger intentionally follows the current broad crane fileset, even where a changed source is not compiled by both package legs
