### PR TITLE
fix(ci): protect long-lived PRs from stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
 permissions:
   issues: write
   pull-requests: write
@@ -12,6 +16,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
@@ -33,4 +38,5 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: 'pinned,good first issue,help wanted'
-          exempt-pr-labels: 'pinned,work-in-progress'
+          exempt-pr-labels: 'pinned,work-in-progress,dependencies,security'
+          exempt-draft-pr: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
-- Serialize scheduled stale reconciliation, bound runtime, and protect dependency, security, and draft PRs from automated stale closure. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
+- Serialize scheduled stale reconciliation, bound runtime, and protect dependency, security, and draft PRs from automated stale closure. (@xiaomo)
 - Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
 
 ## [2026.7.31] - 2026-07-31

--- a/changelog.d/fixed/7304-stale-issue-policy.md
+++ b/changelog.d/fixed/7304-stale-issue-policy.md
@@ -1,0 +1,1 @@
+Serialize scheduled stale reconciliation, bound runtime, and protect dependency, security, and draft PRs from automated stale closure. (#7304) (@xiaomo)


### PR DESCRIPTION
## Changes

- serialize scheduled and manual stale reconciliation without cancelling partial label/close mutations
- bound the unattended maintenance job to thirty minutes
- exempt dependency and security PRs using labels that exist in the live repository
- exempt draft PRs through the pinned action's dedicated input

## Verification

- parsed `.github/workflows/stale.yml` with Ruby YAML
- asserted the exact non-cancelling concurrency group, timeout, permissions, immutable action pin, label list, and draft exemption
- fetched the pinned `actions/stale` manifest and verified `exempt-pr-labels` and `exempt-draft-pr` are supported inputs
- queried live repository labels and verified `dependencies` and `security` both exist
- ran `git diff --check`

## Out of scope

- stale and close age thresholds are unchanged
- issue exemptions and all notification wording are unchanged
- existing legacy `pinned` and `work-in-progress` exemptions remain harmless for repositories that may restore those labels
