### PR TITLE
fix(ci): harden npm binary release

### DIFF
--- a/.github/workflows/release-npm-binaries.yml
+++ b/.github/workflows/release-npm-binaries.yml
@@ -39,6 +39,7 @@ jobs:
   cli_npm:
     name: CLI / npm (binary packages)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release-npm
     permissions:
       id-token: write   # OIDC token for npm provenance attestations
@@ -47,27 +48,24 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag }}
+          fetch-depth: 1 # HEAD is sufficient; version and tag are explicit inputs.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish CLI binaries to npm (OIDC + provenance)
-        # No NODE_AUTH_TOKEN set — the publish call relies on npm's
-        # OIDC trusted-publisher exchange. `cargo xtask
-        # publish-npm-binaries` must propagate `--provenance` to its
-        # underlying `npm publish` invocation; if it does not, the
-        # follow-up cutover PR adds that flag before flipping traffic
-        # to this workflow. Maintainer must configure the npm trusted
-        # publisher BEFORE enabling this workflow as the real publish
-        # path.
+        # No NODE_AUTH_TOKEN is set because the publish call relies on npm's OIDC trusted-publisher exchange.
+        # Maintainers must configure the npm trusted publisher before enabling this workflow as the real publish path.
         env:
           TAG: ${{ inputs.tag }}
-          NPM_CONFIG_PROVENANCE: "true"
+          REPO: ${{ github.repository }}
         run: |
           VERSION="${TAG#v}"
           cargo xtask publish-npm-binaries \
             --version "$VERSION" \
-            --repo "${{ github.repository }}" \
-            --tag "$TAG"
+            --repo "$REPO" \
+            --tag "$TAG" \
+            --provenance

--- a/changelog.d/fixed/7308-npm-binary-release.md
+++ b/changelog.d/fixed/7308-npm-binary-release.md
@@ -1,0 +1,2 @@
+Make the split npm binary release path explicitly request OIDC provenance for every package instead of relying on unverified environment inheritance.
+The job now bounds network and build time, caches Rust dependencies, and keeps repository context out of shell source while the existing PAT release path remains unchanged (#7308) (@xiaomo)

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -88,12 +88,7 @@ relying on these workflows for real releases. Recommended settings:
       `@librefang/cli`, and the per-arch binary packages emitted by
       `cargo xtask publish-npm-binaries`. Workflow filename is the
       split file; environment name is `release-npm`.
-- [ ] Confirm `cargo xtask publish-npm-binaries` propagates
-      `--provenance` to its underlying `npm publish` calls. If it does
-      not, add the flag in `xtask/src/publish_npm_binaries.rs` (or
-      whichever module owns it) before any cutover PR — otherwise the
-      OIDC-equipped split workflow still publishes without provenance
-      attestations.
+- [x] The split workflow passes `--provenance` to `cargo xtask publish-npm-binaries`, which propagates it to every underlying `npm publish` call. The unified PAT path omits the opt-in flag and remains unchanged.
 - [ ] Smoke-test each split workflow on a real tag that already
       shipped. The split jobs use `gh release upload --clobber`, so
       re-uploading identical artifacts is a no-op as far as

--- a/xtask/src/publish_npm_binaries.rs
+++ b/xtask/src/publish_npm_binaries.rs
@@ -21,6 +21,10 @@ pub struct PublishNpmBinariesArgs {
     /// Dry run — show what would be published
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Request npm OIDC provenance attestations for every published package.
+    #[arg(long)]
+    pub provenance: bool,
 }
 
 struct Target {
@@ -29,6 +33,13 @@ struct Target {
     arch: &'static str,
     ext: &'static str,
     exe: &'static str,
+}
+
+fn configure_publish(cmd: &mut Command, provenance: bool) {
+    cmd.args(["--access", "public", "--ignore-scripts"]);
+    if provenance {
+        cmd.arg("--provenance");
+    }
 }
 
 const TARGETS: &[Target] = &[
@@ -278,13 +289,8 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
         } else {
             // --ignore-scripts blocks lifecycle hooks so a malicious dep cannot exfiltrate NODE_AUTH_TOKEN.
             let mut cmd = Command::new("npm");
-            cmd.args([
-                "publish",
-                &pkg_dir.to_string_lossy(),
-                "--access",
-                "public",
-                "--ignore-scripts",
-            ]);
+            cmd.args(["publish", &pkg_dir.to_string_lossy()]);
+            configure_publish(&mut cmd, args.provenance);
             for a in &npm_tag_args {
                 cmd.arg(a);
             }
@@ -345,8 +351,8 @@ pub fn run(args: PublishNpmBinariesArgs) -> Result<(), Box<dyn std::error::Error
             fs::write(&pkg_path, serde_json::to_string_pretty(&pkg)? + "\n")?;
 
             let mut cmd = Command::new("npm");
-            cmd.args(["publish", "--access", "public", "--ignore-scripts"])
-                .current_dir(&wrapper_dir);
+            cmd.arg("publish").current_dir(&wrapper_dir);
+            configure_publish(&mut cmd, args.provenance);
             for a in &npm_tag_args {
                 cmd.arg(a);
             }
@@ -378,4 +384,26 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), Box<dyn std::error::
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn provenance_is_an_explicit_publish_opt_in() {
+        for (enabled, expected) in [(false, false), (true, true)] {
+            let mut command = Command::new("npm");
+            command.arg("publish");
+            configure_publish(&mut command, enabled);
+            let arguments: Vec<&OsStr> = command.get_args().collect();
+
+            assert_eq!(arguments.contains(&OsStr::new("--provenance")), expected);
+            assert!(arguments.contains(&OsStr::new("--ignore-scripts")));
+            assert!(arguments
+                .windows(2)
+                .any(|pair| pair == [OsStr::new("--access"), OsStr::new("public")]));
+        }
+    }
 }


### PR DESCRIPTION
## Changes

- Bound the manual npm binary release job, cache Rust dependencies, and document the intentional shallow checkout.
- Pass repository identity through the shell environment instead of interpolating workflow context into the script.
- Add an explicit xtask `--provenance` opt-in and propagate it to every npm publish while leaving the unified PAT release path unchanged.
- Update the release cutover checklist and add a focused command-construction regression test.

## Verification

- `cargo test -p xtask provenance_is_an_explicit_publish_opt_in`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `actionlint .github/workflows/release-npm-binaries.yml` using actionlint v1.7.7
- `git diff --check`

## Out-of-scope follow-ups

- A real trusted-publisher smoke test still requires maintainer npm configuration and a release tag; the documented cutover checklist keeps that external verification open.
