### PR TITLE
fix(api): serialize secret environment updates

### DIFF
--- a/changelog.d/fixed/secrets-env-concurrent-upsert.md
+++ b/changelog.d/fixed/secrets-env-concurrent-upsert.md
@@ -1,0 +1,1 @@
+Serialize `secrets.env` read-modify-write updates so concurrent credential saves cannot discard each other, and create Unix staging files with mode 0600 from the first open. (@xiaomo)

--- a/crates/librefang-api/src/routes/secrets_env.rs
+++ b/crates/librefang-api/src/routes/secrets_env.rs
@@ -10,6 +10,12 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+fn secrets_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 pub fn upsert_secret(path: &Path, key: &str, value: &str) -> Result<(), String> {
     // The dotenv reader (`librefang_extensions::dotenv`) silently strips
@@ -56,6 +62,16 @@ pub fn upsert_secret(path: &Path, key: &str, value: &str) -> Result<(), String> 
         return Err(format!("invalid secret key `{key}`"));
     }
 
+    // Serialize the complete read-modify-write transaction.
+    // Unique temporary names prevent collisions but do not prevent the last
+    // rename from discarding a different key read from the same old snapshot.
+    let lock = secrets_write_lock();
+    let _write_guard = lock.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("recovering poisoned secrets.env write lock");
+        lock.clear_poison();
+        poisoned.into_inner()
+    });
+
     let original = match fs::read_to_string(path) {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -95,18 +111,16 @@ pub fn upsert_secret(path: &Path, key: &str, value: &str) -> Result<(), String> 
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let tmp = parent.join(format!(".secrets.env.tmp.{}.{seq}", std::process::id()));
     let write_result = (|| -> Result<(), String> {
-        let mut f = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&tmp)
-            .map_err(|e| format!("open {tmp:?}: {e}"))?;
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            let perm = fs::Permissions::from_mode(0o600);
-            fs::set_permissions(&tmp, perm).map_err(|e| format!("chmod 600 {tmp:?}: {e}"))?;
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
         }
+        let mut f = options
+            .open(&tmp)
+            .map_err(|e| format!("open {tmp:?}: {e}"))?;
         f.write_all(out.as_bytes())
             .map_err(|e| format!("write {tmp:?}: {e}"))?;
         f.sync_all().map_err(|e| format!("sync {tmp:?}: {e}"))?;
@@ -141,6 +155,7 @@ pub fn upsert_secret(path: &Path, key: &str, value: &str) -> Result<(), String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
     use tempfile::TempDir;
 
     fn read(path: &Path) -> String {
@@ -196,5 +211,37 @@ mod tests {
             1,
             "a read failure must not create a secret-bearing staging file"
         );
+    }
+
+    #[test]
+    fn concurrent_upserts_preserve_every_key() {
+        const WRITERS: usize = 16;
+        let dir = TempDir::new().unwrap();
+        let path = Arc::new(dir.path().join("secrets.env"));
+        let barrier = Arc::new(Barrier::new(WRITERS));
+        let threads: Vec<_> = (0..WRITERS)
+            .map(|index| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    upsert_secret(&path, &format!("KEY_{index}"), &format!("value-{index}"))
+                })
+            })
+            .collect();
+
+        for thread in threads {
+            thread.join().unwrap().unwrap();
+        }
+
+        let content = read(&path);
+        for index in 0..WRITERS {
+            assert!(
+                content
+                    .lines()
+                    .any(|line| line == format!("KEY_{index}=value-{index}")),
+                "missing KEY_{index} from {content:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- serialize the complete `secrets.env` read-modify-write transaction
- recover and clear a poisoned write mutex with an operator warning
- create Unix staging files as mode 0600 on the initial open
- retain the existing propagated fsync errors and staging cleanup paths
- add a 16-writer regression proving concurrent keys are preserved

## Validation
- `cargo test -p librefang-api --lib routes::secrets_env`
- `cargo test -p librefang-api --test secrets_env_test`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

## Out of scope
- cross-process advisory locking remains separate; supported daemon operation uses one process per home directory
- dotenv value syntax and validation remain unchanged