### PR TITLE
fix(dashboard): harden credential and pairing boundaries

### DIFF
--- a/changelog.d/fixed/dashboard-tauri-credential-boundaries.md
+++ b/changelog.d/fixed/dashboard-tauri-credential-boundaries.md
@@ -1,0 +1,1 @@
+Keep browser connection credentials in memory, propagate keyring failures consistently, and distinguish QR scan outcomes. (#7311) (@xiaomo)

--- a/changelog.d/fixed/dashboard-tauri-credential-boundaries.md
+++ b/changelog.d/fixed/dashboard-tauri-credential-boundaries.md
@@ -1,1 +1,1 @@
-Keep browser connection credentials in memory, propagate keyring failures consistently, and distinguish QR scan outcomes. (#7311) (@xiaomo)
+Keep browser connection credentials in memory, propagate keyring failures consistently, distinguish QR scan outcomes, and reject malformed pairing expiries without interrupting user edits or leaking navigation timers. (#7311) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/tauri.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/tauri.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function setUserAgent(value: string) {
+  Object.defineProperty(navigator, "userAgent", { value, configurable: true });
+}
+
+describe("tauri bridge", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sessionStorage.clear();
+    setUserAgent("Desktop Browser");
+    delete window.__TAURI__;
+  });
+
+  it("keeps browser credentials in memory and removes legacy plaintext storage", async () => {
+    sessionStorage.setItem("lf_creds", "{corrupted-json");
+    const { getCredentials, storeCredentials } = await import("./tauri");
+    await storeCredentials({ base_url: "https://example.test", api_key: "secret" });
+
+    expect(sessionStorage.getItem("lf_creds")).toBeNull();
+    expect(await getCredentials()).toEqual({
+      base_url: "https://example.test",
+      api_key: "secret",
+    });
+    expect(sessionStorage.getItem("lf_creds")).toBeNull();
+  });
+
+  it("propagates mobile credential storage failures consistently", async () => {
+    setUserAgent("Android");
+    const invoke = vi.fn().mockRejectedValue(new Error("keyring unavailable"));
+    window.__TAURI__ = { core: { invoke } };
+    const { clearCredentials, getCredentials, storeCredentials } = await import("./tauri");
+
+    await expect(
+      storeCredentials({ base_url: "https://example.test", api_key: "secret" }),
+    ).rejects.toThrow("keyring unavailable");
+    await expect(getCredentials()).rejects.toThrow("keyring unavailable");
+    await expect(clearCredentials()).rejects.toThrow("keyring unavailable");
+  });
+
+  it("distinguishes unsupported, cancelled, failed, and successful QR scans", async () => {
+    const desktop = await import("./tauri");
+    await expect(desktop.scanQrCode()).resolves.toEqual({ status: "unsupported" });
+
+    vi.resetModules();
+    setUserAgent("Android");
+    const invoke = vi.fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("camera denied"))
+      .mockResolvedValueOnce({ content: "payload" });
+    window.__TAURI__ = { core: { invoke } };
+    const mobile = await import("./tauri");
+    await expect(mobile.scanQrCode()).resolves.toEqual({ status: "cancelled" });
+    await expect(mobile.scanQrCode()).resolves.toMatchObject({ status: "error" });
+    await expect(mobile.scanQrCode()).resolves.toEqual({
+      status: "success",
+      content: "payload",
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/tauri.ts
+++ b/crates/librefang-api/dashboard/src/lib/tauri.ts
@@ -31,9 +31,16 @@ export interface StoredCredentials {
   api_key: string;
 }
 
+let webCredentials: StoredCredentials | null = null;
+
+function removeLegacyWebCredentials(): void {
+  sessionStorage.removeItem("lf_creds");
+}
+
 export async function storeCredentials(creds: StoredCredentials): Promise<void> {
   if (!isMobileTauri()) {
-    sessionStorage.setItem("lf_creds", JSON.stringify(creds));
+    removeLegacyWebCredentials();
+    webCredentials = { ...creds };
     return;
   }
   await invoke("store_credentials", {
@@ -44,39 +51,40 @@ export async function storeCredentials(creds: StoredCredentials): Promise<void> 
 
 export async function getCredentials(): Promise<StoredCredentials | null> {
   if (!isMobileTauri()) {
-    const raw = sessionStorage.getItem("lf_creds");
-    return raw ? (JSON.parse(raw) as StoredCredentials) : null;
+    removeLegacyWebCredentials();
+    return webCredentials ? { ...webCredentials } : null;
   }
-  try {
-    return await invoke<StoredCredentials | null>("get_credentials");
-  } catch {
-    return null;
-  }
+  return invoke<StoredCredentials | null>("get_credentials");
 }
 
 export async function clearCredentials(): Promise<void> {
   if (!isMobileTauri()) {
-    sessionStorage.removeItem("lf_creds");
+    removeLegacyWebCredentials();
+    webCredentials = null;
     return;
   }
-  try {
-    await invoke("clear_credentials");
-  } catch {
-    // ignore if nothing stored
-  }
+  await invoke("clear_credentials");
 }
 
 // ── Barcode scanner (mobile only) ─────────────────────────────────────────
 
-export async function scanQrCode(): Promise<string | null> {
-  if (!isMobileTauri()) return null;
+export type QrScanResult =
+  | { status: "success"; content: string }
+  | { status: "unsupported" }
+  | { status: "cancelled" }
+  | { status: "error"; error: unknown };
+
+export async function scanQrCode(): Promise<QrScanResult> {
+  if (!isMobileTauri()) return { status: "unsupported" };
   try {
     const result = await invoke<{ content: string }>(
       "plugin:barcode-scanner|scan",
       { formats: ["QR_CODE"] },
     );
-    return result?.content ?? null;
-  } catch {
-    return null;
+    return result?.content
+      ? { status: "success", content: result.content }
+      : { status: "cancelled" };
+  } catch (error) {
+    return { status: "error", error };
   }
 }

--- a/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.test.ts
+++ b/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeQrPayload } from "./ConnectWizardPage";
+
+function qrFor(payload: unknown): string {
+  const encoded = btoa(JSON.stringify(payload))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `librefang://pair?payload=${encoded}`;
+}
+
+describe("decodeQrPayload", () => {
+  it("rejects an invalid expiry", () => {
+    expect(() => decodeQrPayload(qrFor({
+      v: 1,
+      base_url: "https://daemon.example",
+      token: "pairing-token",
+      expires_at: "not-a-date",
+    }))).toThrow("expired or has an invalid expiry");
+  });
+
+  it("reports damaged payloads with a pairing-specific error", () => {
+    expect(() => decodeQrPayload("librefang://pair?payload=%%%"))
+      .toThrow("Invalid QR code: could not decode payload");
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx
@@ -90,26 +90,35 @@ export function ConnectWizardPage() {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const creds = await getCredentials();
-      if (!creds || cancelled) return;
       try {
-        // lint-disable-next-line dashboard/no-inline-fetch -- one-shot probe at user-supplied URL, must not be cached
-        const resp = await fetch(`${creds.base_url}/api/health`, {
-          headers: { Authorization: `Bearer ${creds.api_key}` },
-          signal: AbortSignal.timeout(5_000),
-        });
+        const creds = await getCredentials();
+        if (!creds || cancelled) return;
+        let resp: Response;
+        try {
+          // lint-disable-next-line dashboard/no-inline-fetch -- one-shot probe at user-supplied URL, must not be cached
+          resp = await fetch(`${creds.base_url}/api/health`, {
+            headers: { Authorization: `Bearer ${creds.api_key}` },
+            signal: AbortSignal.timeout(5_000),
+          });
+        } catch {
+          if (!cancelled) await clearCredentials();
+          return;
+        }
         if (cancelled) return;
         if (resp.ok) {
           navigateToDashboard(creds.base_url);
         } else {
           await clearCredentials();
         }
-      } catch {
-        if (!cancelled) await clearCredentials();
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setStep("error");
+          setErrorMsg(err instanceof Error ? err.message : t("connect_wizard.error_default_connect"));
+        }
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [t]);
 
   function handleManualSubmit() {
     const url = baseUrl.trim().replace(/\/$/, "");
@@ -141,11 +150,13 @@ export function ConnectWizardPage() {
     setStep("scanning");
     setErrorMsg("");
     try {
-      const raw = await scanQrCode();
-      if (!raw) {
+      const scan = await scanQrCode();
+      if (scan.status === "cancelled" || scan.status === "unsupported") {
         setStep("idle");
         return;
       }
+      if (scan.status === "error") throw scan.error;
+      const raw = scan.content;
       const payload = decodeQrPayload(raw);
       const pairingUrl = payload.base_url.replace(/\/$/, "");
 

--- a/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Wifi, QrCode, Loader2, CheckCircle, AlertCircle, RefreshCw } from "lucide-react";
 import { isMobileTauri, scanQrCode, getCredentials, clearCredentials } from "../lib/tauri";
@@ -43,7 +43,7 @@ interface PairingPayload {
   expires_at: string;
 }
 
-function decodeQrPayload(raw: string): PairingPayload {
+export function decodeQrPayload(raw: string): PairingPayload {
   let uri: URL;
   try {
     uri = new URL(raw);
@@ -56,11 +56,17 @@ function decodeQrPayload(raw: string): PairingPayload {
   // base64url (no-pad) → standard base64 → JSON. atob tolerates missing
   // padding in modern engines; explicit padEnd is not needed.
   const stdB64 = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
-  const payload = JSON.parse(atob(stdB64)) as PairingPayload;
+  let payload: PairingPayload;
+  try {
+    payload = JSON.parse(atob(stdB64)) as PairingPayload;
+  } catch {
+    throw new Error("Invalid QR code: could not decode payload");
+  }
 
   if (payload.v !== 1) throw new Error("Unsupported QR format version");
-  if (new Date(payload.expires_at).getTime() < Date.now()) {
-    throw new Error("QR code has expired — refresh it on the desktop");
+  const expiryMs = new Date(payload.expires_at).getTime();
+  if (!Number.isFinite(expiryMs) || expiryMs < Date.now()) {
+    throw new Error("QR code has expired or has an invalid expiry — refresh it on the desktop");
   }
   if (
     !payload.base_url.startsWith("http://") &&
@@ -80,9 +86,24 @@ export function ConnectWizardPage() {
   const [apiKey, setApiKey] = useState("");
   const [displayName, setDisplayName] = useState(() => uaDisplayName(fallbackName));
   const [errorMsg, setErrorMsg] = useState("");
+  const userInteractedRef = useRef(false);
+  const navigationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const connectManual = useConnectManual();
   const connectQr = useConnectViaQr();
+
+  function markUserInteraction() {
+    userInteractedRef.current = true;
+  }
+
+  function scheduleNavigation(url: string) {
+    if (navigationTimerRef.current) clearTimeout(navigationTimerRef.current);
+    navigationTimerRef.current = setTimeout(() => navigateToDashboard(url), 1200);
+  }
+
+  useEffect(() => () => {
+    if (navigationTimerRef.current) clearTimeout(navigationTimerRef.current);
+  }, []);
 
   // Already connected → verify creds still work, then skip wizard.
   // Stale creds (e.g. master key rotated) are cleared so the user lands
@@ -105,7 +126,7 @@ export function ConnectWizardPage() {
           return;
         }
         if (cancelled) return;
-        if (resp.ok) {
+        if (resp.ok && !userInteractedRef.current) {
           navigateToDashboard(creds.base_url);
         } else {
           await clearCredentials();
@@ -136,7 +157,7 @@ export function ConnectWizardPage() {
       {
         onSuccess: () => {
           setStep("done");
-          setTimeout(() => navigateToDashboard(url), 1200);
+          scheduleNavigation(url);
         },
         onError: (err: unknown) => {
           setStep("error");
@@ -171,7 +192,7 @@ export function ConnectWizardPage() {
         {
           onSuccess: (result) => {
             setStep("done");
-            setTimeout(() => navigateToDashboard(result.baseUrl), 1200);
+            scheduleNavigation(result.baseUrl);
           },
           onError: (err: unknown) => {
             setStep("error");
@@ -222,7 +243,7 @@ export function ConnectWizardPage() {
             aria-selected={tab === "manual"}
             aria-controls="connect-panel-manual"
             tabIndex={tab === "manual" ? 0 : -1}
-            onClick={() => { setTab("manual"); reset(); }}
+            onClick={() => { markUserInteraction(); setTab("manual"); reset(); }}
             disabled={busy}
             className={`rounded-lg py-2 text-sm font-semibold transition-colors ${
               tab === "manual"
@@ -238,7 +259,7 @@ export function ConnectWizardPage() {
             aria-selected={tab === "qr"}
             aria-controls="connect-panel-qr"
             tabIndex={tab === "qr" ? 0 : -1}
-            onClick={() => { setTab("qr"); reset(); }}
+            onClick={() => { markUserInteraction(); setTab("qr"); reset(); }}
             disabled={busy}
             className={`rounded-lg py-2 text-sm font-semibold transition-colors ${
               tab === "qr"
@@ -266,7 +287,7 @@ export function ConnectWizardPage() {
                 spellCheck={false}
                 placeholder={t("connect_wizard.url_placeholder", { defaultValue: `${window.location.protocol}//${window.location.hostname}:4545` })}
                 value={baseUrl}
-                onChange={(e) => { setBaseUrl(e.target.value); reset(); }}
+                onChange={(e) => { markUserInteraction(); setBaseUrl(e.target.value); reset(); }}
                 disabled={busy}
                 className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors placeholder:text-text-dim/40 disabled:opacity-50"
               />
@@ -280,7 +301,7 @@ export function ConnectWizardPage() {
                 type="password"
                 placeholder="••••••••••••••••"
                 value={apiKey}
-                onChange={(e) => { setApiKey(e.target.value); reset(); }}
+                onChange={(e) => { markUserInteraction(); setApiKey(e.target.value); reset(); }}
                 disabled={busy}
                 className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors placeholder:text-text-dim/40 disabled:opacity-50"
               />
@@ -314,7 +335,7 @@ export function ConnectWizardPage() {
                 type="text"
                 placeholder={t("connect_wizard.device_name_placeholder")}
                 value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
+                onChange={(e) => { markUserInteraction(); setDisplayName(e.target.value); }}
                 disabled={busy}
                 className="w-full rounded-xl border border-border-subtle bg-surface px-4 py-3 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors placeholder:text-text-dim/40 disabled:opacity-50"
               />


### PR DESCRIPTION
## Summary

- keep non-mobile connection credentials in module memory instead of plaintext session storage
- remove legacy `lf_creds` session data whenever credential helpers run
- propagate keyring and storage failures consistently across store, get, and clear
- return discriminated QR scan outcomes for unsupported, cancelled, failed, and successful scans
- reject undecodable QR payloads and missing, malformed, or expired pairing deadlines
- prevent saved-credential probes from redirecting after the user begins editing
- replace untracked navigation timeouts with one timer that is cleared on reschedule or unmount
- preserve stale-credential cleanup while surfacing storage failures

## Verification

- `corepack pnpm exec vitest run src/pages/ConnectWizardPage.test.ts src/lib/tauri.test.ts` (5 tests)
- `corepack pnpm test` (98 files, 1,013 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Active-page XSS can still act with credentials held by the running application; this change removes DOM storage persistence rather than claiming an XSS boundary.
- Mobile credentials continue to use the native Tauri keyring commands.