### PR TITLE
fix(dashboard): redact nested toast causes

### DIFF
--- a/changelog.d/fixed/dashboard-toast-cause-redaction.md
+++ b/changelog.d/fixed/dashboard-toast-cause-redaction.md
@@ -1,0 +1,1 @@
+Keep nested internal error causes out of production dashboard toasts while retaining development diagnostics. (#7312) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/errors.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "./http/errors";
+import { formatToastError } from "./errors";
+
+function causalError(message: string, cause: Error): Error {
+  return Object.assign(new Error(message), { cause });
+}
+
+describe("formatToastError", () => {
+  it("does not disclose nested API causes in production text", () => {
+    const err = new ApiError(500, "INTERNAL", "Request failed") as ApiError & {
+      cause?: unknown;
+    };
+    err.cause = new Error("database at /srv/private/state.sqlite failed");
+    expect(formatToastError(err, "Fallback", false)).toBe("[500] Request failed");
+  });
+
+  it("does not disclose nested generic causes in production text", () => {
+    const err = causalError(
+      "Operation failed",
+      new Error("driver internals and private path"),
+    );
+    expect(formatToastError(err, "Fallback", false)).toBe("Operation failed");
+  });
+
+  it("uses one cause formatter for development diagnostics", () => {
+    const cause = new Error("deep detail");
+    expect(
+      formatToastError(
+        Object.assign(new ApiError(502, "UPSTREAM", "API failed"), { cause }),
+        "Fallback",
+        true,
+      ),
+    ).toBe("[502] API failed: deep detail");
+    expect(
+      formatToastError(causalError("Generic failed", cause), "Fallback", true),
+    ).toBe("Generic failed: deep detail");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/errors.ts
+++ b/crates/librefang-api/dashboard/src/lib/errors.ts
@@ -18,12 +18,36 @@ function deepestCauseMessage(err: Error): string | undefined {
   return found;
 }
 
+function messageWithCause(err: Error, includeCause: boolean): string {
+  if (!includeCause) return err.message;
+  const extra = deepestCauseMessage(err);
+  return extra ? `${err.message}: ${extra}` : err.message;
+}
+
+/** @internal Exported for explicit production/development contract tests. */
+export function formatToastError(
+  err: unknown,
+  fallback: string,
+  includeCause: boolean,
+): string {
+  if (err instanceof ApiError) {
+    return `[${err.status}] ${messageWithCause(err, includeCause)}`;
+  }
+
+  if (err instanceof Error && err.message) {
+    return messageWithCause(err, includeCause);
+  }
+
+  if (typeof err === "string" && err) return err;
+  return fallback;
+}
+
 /**
  * Extract a user-facing error message from an unknown thrown value.
  *
  * Priority order (highest → lowest):
- *  1. ApiError — includes status code + deepest cause message
- *  2. Error instance — message + deepest cause message
+ *  1. ApiError — includes status code and its public message
+ *  2. Error instance — includes its public message
  *  3. Raw string — returned as-is
  *  4. Fallback — caller-provided default
  */
@@ -32,17 +56,5 @@ export function toastErr(err: unknown, fallback: string): string {
     console.error("[toastErr]", err);
   }
 
-  if (err instanceof ApiError) {
-    const extra = deepestCauseMessage(err);
-    const body = extra ? `${err.message}: ${extra}` : err.message;
-    return `[${err.status}] ${body}`;
-  }
-
-  if (err instanceof Error && err.message) {
-    const extra = deepestCauseMessage(err);
-    return extra ? `${err.message}: ${extra}` : err.message;
-  }
-
-  if (typeof err === "string" && err) return err;
-  return fallback;
+  return formatToastError(err, fallback, import.meta.env.DEV);
 }


### PR DESCRIPTION
## Summary

- exclude nested error causes from production dashboard toast text
- retain cause-chain detail in development diagnostics
- use one shared formatter for API and generic errors
- add explicit production and development regressions

## Verification

- `corepack pnpm test` (97 files, 1,011 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Top-level server error messages remain user-visible by API contract.
- Console diagnostics remain development-only.