### PR TITLE
fix(dashboard): expose safe storage failures

### DIFF
--- a/changelog.d/fixed/dashboard-safe-storage-results.md
+++ b/changelog.d/fixed/dashboard-safe-storage-results.md
@@ -1,0 +1,1 @@
+Make unavailable dashboard preference writes observable and expose discriminated local-storage read failures. (#7313) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/safeStorage.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/safeStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { safeStorageGet, safeStorageSet } from "./safeStorage";
+import { safeStorageGet, safeStorageRead, safeStorageSet } from "./safeStorage";
 
 // jsdom (v29) does not ship a working `localStorage` global, and the
 // helper deliberately reads `globalThis.localStorage?.` so it degrades
@@ -44,11 +44,13 @@ describe("safeStorageGet", () => {
 
   it("returns null for a missing key", () => {
     expect(safeStorageGet("missing")).toBeNull();
+    expect(safeStorageRead("missing")).toEqual({ ok: true, value: null });
   });
 
   it("returns null when localStorage is absent (SSR / non-browser)", () => {
     install(undefined);
     expect(safeStorageGet("k")).toBeNull();
+    expect(safeStorageRead("k")).toEqual({ ok: false, reason: "unavailable" });
   });
 
   it("returns null instead of throwing when getItem throws (Safari private mode)", () => {
@@ -60,6 +62,7 @@ describe("safeStorageGet", () => {
     });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(safeStorageGet("k")).toBeNull();
+    expect(safeStorageRead("k")).toMatchObject({ ok: false, reason: "error" });
     expect(warn).toHaveBeenCalled();
   });
 });
@@ -70,9 +73,13 @@ describe("safeStorageSet", () => {
     expect(globalThis.localStorage.getItem("k")).toBe("v");
   });
 
-  it("is a no-op when localStorage is absent", () => {
+  it("warns when a write is skipped because localStorage is absent", () => {
     install(undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(() => safeStorageSet("k", "v")).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      'safeStorageSet("k") skipped: localStorage unavailable',
+    );
   });
 
   it("swallows QuotaExceededError instead of throwing", () => {

--- a/crates/librefang-api/dashboard/src/lib/safeStorage.ts
+++ b/crates/librefang-api/dashboard/src/lib/safeStorage.ts
@@ -10,19 +10,50 @@
 // try/catch pattern already used in `components/TerminalTabs.tsx`
 // (#5140) so every site degrades to a sensible default instead.
 
-export function safeStorageGet(key: string): string | null {
+export type StorageReadResult =
+  | { ok: true; value: string | null }
+  | { ok: false; reason: "unavailable" | "error"; error?: unknown };
+
+type StorageAccessResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: "unavailable" | "error"; error?: unknown };
+
+function withStorage<T>(
+  operation: "safeStorageGet" | "safeStorageSet",
+  key: string,
+  access: (storage: Storage) => T,
+  warnUnavailable: boolean,
+): StorageAccessResult<T> {
+  let storage: Storage | undefined;
   try {
-    return globalThis.localStorage?.getItem(key) ?? null;
-  } catch (e) {
-    console.warn(`safeStorageGet("${key}") failed:`, e);
-    return null;
+    storage = globalThis.localStorage;
+  } catch (error) {
+    console.warn(`${operation}("${key}") failed:`, error);
+    return { ok: false, reason: "error", error };
+  }
+  if (typeof storage === "undefined") {
+    if (warnUnavailable) {
+      console.warn(`${operation}("${key}") skipped: localStorage unavailable`);
+    }
+    return { ok: false, reason: "unavailable" };
+  }
+  try {
+    return { ok: true, value: access(storage) };
+  } catch (error) {
+    console.warn(`${operation}("${key}") failed:`, error);
+    return { ok: false, reason: "error", error };
   }
 }
 
+export function safeStorageRead(key: string): StorageReadResult {
+  return withStorage("safeStorageGet", key, (storage) => storage.getItem(key), false);
+}
+
+export function safeStorageGet(key: string): string | null {
+  const result = safeStorageRead(key);
+  return result.ok ? result.value : null;
+}
+
 export function safeStorageSet(key: string, value: string): void {
-  try {
-    globalThis.localStorage?.setItem(key, value);
-  } catch (e) {
-    console.warn(`safeStorageSet("${key}") failed:`, e);
-  }
+  withStorage("safeStorageSet", key, (storage) => storage.setItem(key, value), true);
 }


### PR DESCRIPTION
## Summary

- warn when a dashboard preference write is skipped because local storage is unavailable
- expose a discriminated read result for unavailable storage, access errors, and missing values
- preserve the compatibility getter for callers that intentionally fall back on any read failure
- consolidate storage access and warning formatting in one helper
- extend safe-storage regressions

## Verification

- `corepack pnpm test` (96 files, 1,008 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Existing preference callers retain their deliberate default-on-failure behavior.
- This helper remains limited to non-secret dashboard preferences.