### PR TITLE
refactor(dashboard): clarify safe URL contract

### DIFF
--- a/changelog.d/fixed/dashboard-safe-url-contract.md
+++ b/changelog.d/fixed/dashboard-safe-url-contract.md
@@ -1,0 +1,1 @@
+Clarify protocol-relative URL validation and remove its redundant synthetic-scheme check. (#7314) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/safeUrl.ts
+++ b/crates/librefang-api/dashboard/src/lib/safeUrl.ts
@@ -15,9 +15,9 @@
 // else (including parse failures and protocol-relative URLs that the
 // URL parser can't resolve without a base) returns null.
 //
-// Protocol-relative URLs (`//example.com/x`) get a synthetic base so
-// they round-trip through the URL parser; if the result is `http`
-// or `https` they're accepted.
+// Protocol-relative URLs (`//example.com/x`) get a synthetic `https:`
+// scheme so they round-trip through the URL parser. A successful parse
+// is accepted; the resulting scheme is necessarily `https:`.
 //
 // Callers should treat a `null` return as "do not render the link";
 // the canonical pattern is `const safe = safeUrl(input); return safe
@@ -45,10 +45,10 @@ export function safeUrl(input: string | undefined | null): string | null {
   }
   if (trimmed.startsWith("//")) {
     try {
-      const u = new URL(`https:${trimmed}`);
-      if (u.protocol === "https:") {
-        return trimmed;
-      }
+      // Prepending `https:` fixes the scheme, so parse success is the
+      // complete acceptance condition for protocol-relative input.
+      new URL(`https:${trimmed}`);
+      return trimmed;
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary

- document that protocol-relative URLs are parsed with a synthetic HTTPS scheme
- remove the redundant protocol check that was guaranteed true after that construction
- preserve the existing accepted and rejected URL contract

## Verification

- `corepack pnpm exec vitest run src/lib/safeUrl.test.ts` (14 passed)
- `corepack pnpm test` (96 files, 1,008 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- The accepted scheme allowlist remains HTTP, HTTPS, and mailto.
- Relative paths without an authority remain rejected.