### PR TITLE
fix(dashboard): align provider status contracts

### DIFF
--- a/changelog.d/fixed/dashboard-provider-status-contract.md
+++ b/changelog.d/fixed/dashboard-provider-status-contract.md
@@ -1,0 +1,1 @@
+Normalize provider availability statuses and verify the dashboard set against Rust `AuthStatus::is_available`. (#7315) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/status.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/status.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  AVAILABLE_PROVIDER_STATUSES,
+  getStatusVariant,
+  isProviderAvailable,
+} from "./status";
+
+function snakeCase(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+describe("provider status contracts", () => {
+  it("normalizes availability with the same case policy as badge variants", () => {
+    expect(isProviderAvailable("Validated_Key")).toBe(true);
+    expect(isProviderAvailable("CONFIGURED_CLI")).toBe(true);
+    expect(getStatusVariant("RUNNING")).toBe("success");
+  });
+
+  it("mirrors the Rust AuthStatus::is_available variant set", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "../../librefang-types/src/model_catalog.rs"),
+      "utf8",
+    );
+    const body = source.match(
+      /pub fn is_available\(self\) -> bool \{([\s\S]*?)\n[ ]{4}\}/,
+    )?.[1];
+    expect(body, "AuthStatus::is_available body must be discoverable").toBeTruthy();
+    const rustStatuses = [...(body ?? "").matchAll(/AuthStatus::([A-Za-z]+)/g)]
+      .map((match) => snakeCase(match[1]))
+      .sort();
+
+    expect([...AVAILABLE_PROVIDER_STATUSES].sort()).toEqual(rustStatuses);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/status.ts
+++ b/crates/librefang-api/dashboard/src/lib/status.ts
@@ -1,13 +1,15 @@
 import type { BadgeVariant } from "../components/ui/Badge";
 import type { ProviderItem } from "../api";
 
-const AVAILABLE_PROVIDERS = new Set([
+export const AVAILABLE_PROVIDER_STATUSES = [
   "configured",
   "validated_key",
   "not_required",
   "configured_cli",
   "auto_detected",
-]);
+] as const;
+
+const AVAILABLE_PROVIDERS = new Set<string>(AVAILABLE_PROVIDER_STATUSES);
 
 const STATUS_VARIANT_MAP = new Map<string, BadgeVariant>([
   ["running", "success"],
@@ -26,9 +28,12 @@ export function getStatusVariant(status?: string): BadgeVariant {
 }
 
 /** Check if a provider auth_status indicates the provider is usable.
- *  Mirrors the Rust AuthStatus::is_available() variants. */
+ *  Keep `AVAILABLE_PROVIDER_STATUSES` synchronized with
+ *  `AuthStatus::is_available()` in
+ *  `crates/librefang-types/src/model_catalog.rs`; the source-contract test
+ *  fails when the Rust variant set changes. */
 export function isProviderAvailable(status?: string): boolean {
-  return !!status && AVAILABLE_PROVIDERS.has(status);
+  return !!status && AVAILABLE_PROVIDERS.has(status.toLowerCase());
 }
 
 /** Check whether a provider is a coding-agent CLI passthrough (claude-code,


### PR DESCRIPTION
## Summary

- normalize provider availability values before lookup
- document the exact Rust source contract mirrored by the dashboard
- export the frontend available-status list for contract verification
- parse Rust `AuthStatus::is_available` in a dashboard test and compare every variant

## Verification

- `corepack pnpm exec vitest run src/lib/status.test.ts` (2 passed)
- `corepack pnpm test` (97 files, 1,010 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Auth status serialization remains snake_case.
- Availability policy remains owned by the Rust enum implementation.