### PR TITLE
fix(dashboard): handle string helper edges

### DIFF
--- a/changelog.d/fixed/dashboard-string-helper-edges.md
+++ b/changelog.d/fixed/dashboard-string-helper-edges.md
@@ -1,0 +1,1 @@
+Keep separator-only tool labels meaningful and define truncation behavior for non-positive limits. (#7316) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/string.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/string.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { prettifyToolName, truncate } from "./string";
+
+describe("string helpers", () => {
+  it.each(["---", "_._", "..."])(
+    "uses the tool fallback for separator-only name %s",
+    (name) => expect(prettifyToolName(name)).toBe("tool"),
+  );
+
+  it("preserves readable tool-name formatting", () => {
+    expect(prettifyToolName("MCP_call.run")).toBe("MCP Call Run");
+  });
+
+  it("returns an empty truncation for non-positive limits", () => {
+    expect(truncate("abc", 0)).toBe("");
+    expect(truncate("abc", -2)).toBe("");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/string.ts
+++ b/crates/librefang-api/dashboard/src/lib/string.ts
@@ -13,6 +13,7 @@ export function truncateId(id: string | undefined | null, length = 8): string {
  */
 export function truncate(str: string | undefined | null, maxLength: number): string {
   if (!str) return "-";
+  if (maxLength <= 0) return "";
   if (str.length <= maxLength) return str;
   return `${str.slice(0, maxLength)}…`;
 }
@@ -31,7 +32,7 @@ export function truncate(str: string | undefined | null, maxLength: number): str
  */
 export function prettifyToolName(name: string | null | undefined): string {
   if (!name) return "tool";
-  return name
+  const display = name
     .split(SPLIT_RE)
     .filter(Boolean)
     .map(word => {
@@ -40,4 +41,5 @@ export function prettifyToolName(name: string | null | undefined): string {
       return first.toUpperCase() + rest.join("");
     })
     .join(" ");
+  return display || "tool";
 }


### PR DESCRIPTION
## Summary

- return the documented tool fallback for separator-only identifiers
- define non-positive truncation limits as an empty result
- add focused edge-case and normal-format regressions

## Verification

- `corepack pnpm exec vitest run src/lib/string.test.ts` (5 passed)
- `corepack pnpm test` (97 files, 1,013 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Positive-length truncation and normal tool-name capitalization remain unchanged.