### PR TITLE
fix(dashboard): validate trigger pattern shapes

### DIFF
--- a/changelog.d/fixed/dashboard-trigger-pattern-shapes.md
+++ b/changelog.d/fixed/dashboard-trigger-pattern-shapes.md
@@ -1,0 +1,1 @@
+Reject malformed multi-variant trigger patterns and retain primitive payload details in dashboard labels. (#7317) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/triggerPattern.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/triggerPattern.test.ts
@@ -26,11 +26,14 @@ describe("formatTriggerPattern", () => {
     expect(formatTriggerPattern(undefined)).toBeUndefined();
     expect(formatTriggerPattern(null)).toBeUndefined();
     expect(formatTriggerPattern({})).toBeUndefined();
+    expect(formatTriggerPattern({ first: {}, second: {} })).toBeUndefined();
     expect(formatTriggerPattern(42)).toBeUndefined();
   });
 
-  it("returns just the variant name when payload has no string fields", () => {
+  it("includes primitive payload fields and ignores nested values", () => {
     expect(formatTriggerPattern({ weird_variant: {} })).toBe("weird_variant");
-    expect(formatTriggerPattern({ weird_variant: { n: 1 } })).toBe("weird_variant");
+    expect(
+      formatTriggerPattern({ weird_variant: { n: 1, enabled: false, nested: {} } }),
+    ).toBe("weird_variant: 1 false");
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/triggerPattern.ts
+++ b/crates/librefang-api/dashboard/src/lib/triggerPattern.ts
@@ -23,7 +23,7 @@ export function formatTriggerPattern(pattern: unknown): string | undefined {
   if (!isRecord(pattern)) return undefined;
 
   const entries = Object.entries(pattern);
-  if (entries.length === 0) return undefined;
+  if (entries.length !== 1) return undefined;
   const [variant, payload] = entries[0];
 
   if (!isRecord(payload)) {
@@ -32,8 +32,9 @@ export function formatTriggerPattern(pattern: unknown): string | undefined {
 
   const values: string[] = [];
   for (const v of Object.values(payload)) {
-    if (typeof v === "string" && v.length > 0) {
-      values.push(v);
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+      const value = String(v);
+      if (value.length > 0) values.push(value);
     }
   }
   return values.length > 0 ? `${variant}: ${values.join(" ")}` : variant;


### PR DESCRIPTION
## Summary

- reject multi-key objects that are not valid externally tagged trigger variants
- include string, number, and boolean payload fields in human-readable labels
- keep nested and unsupported payload values out of labels
- extend trigger-pattern shape regressions

## Verification

- `corepack pnpm exec vitest run src/lib/triggerPattern.test.ts` (4 passed)
- `corepack pnpm test` (96 files, 1,008 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Rust currently serializes only string fields in TriggerPattern struct variants.
- Unknown single-key variants retain the forward-compatible label behavior.