### PR TITLE
fix(dashboard): harden numeric formatters

### DIFF
--- a/changelog.d/fixed/dashboard-number-format-contracts.md
+++ b/changelog.d/fixed/dashboard-number-format-contracts.md
@@ -1,0 +1,1 @@
+Handle signed, non-finite, and unit-boundary values consistently in dashboard number formatters. (#7318) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/format.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes, formatCompact, formatCost } from "./format";
+
+const oneDecimal = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+describe("numeric formatters", () => {
+  it("compacts positive and negative values with locale decimals", () => {
+    expect(formatCompact(1_500)).toBe(`${oneDecimal.format(1.5)}K`);
+    expect(formatCompact(-1_500)).toBe(`${oneDecimal.format(-1.5)}K`);
+  });
+
+  it("promotes values that round across a compact tier", () => {
+    expect(formatCompact(999_999)).toBe(`${oneDecimal.format(1)}M`);
+    expect(formatCompact(-999_950_000)).toBe(`${oneDecimal.format(-1)}B`);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "uses a safe fallback for non-finite value %s",
+    (value) => {
+      expect(formatCompact(value)).toBe("—");
+      expect(formatCost(value)).toBe("—");
+      expect(formatBytes(value)).toBe("—");
+    },
+  );
+
+  it("formats negative costs with the sign before the currency marker", () => {
+    expect(formatCost(-0.005)).toBe("-$0.0050");
+    expect(formatCost(-1.5)).toBe("-$1.50");
+  });
+
+  it("clamps negative byte counts to zero", () => {
+    expect(formatBytes(-5)).toBe("0 B");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/format.ts
+++ b/crates/librefang-api/dashboard/src/lib/format.ts
@@ -2,10 +2,17 @@
  * Format a number with compact units (K / M / B).
  * Hover-friendly: callers can use the raw number as a `title` attribute.
  */
+const COMPACT_DECIMAL = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
 export function formatCompact(n: number): string {
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  if (!Number.isFinite(n)) return "—";
+  const abs = Math.abs(n);
+  if (abs >= 999_950_000) return `${COMPACT_DECIMAL.format(n / 1_000_000_000)}B`;
+  if (abs >= 999_950) return `${COMPACT_DECIMAL.format(n / 1_000_000)}M`;
+  if (abs >= 1_000) return `${COMPACT_DECIMAL.format(n / 1_000)}K`;
   return n.toLocaleString();
 }
 
@@ -14,14 +21,19 @@ export function formatCompact(n: number): string {
  * Small amounts show 4 decimals, larger amounts show 2.
  */
 export function formatCost(usd: number): string {
-  if (usd < 0.01) return `$${usd.toFixed(4)}`;
-  return `$${usd.toFixed(2)}`;
+  if (!Number.isFinite(usd)) return "—";
+  const sign = usd < 0 ? "-" : "";
+  const abs = Math.abs(usd);
+  const body = abs < 0.01 ? abs.toFixed(4) : abs.toFixed(2);
+  return `${sign}$${body}`;
 }
 
 /**
  * Format byte sizes with appropriate units (B / KB / MB / GB).
  */
 export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) return "—";
+  bytes = Math.max(0, bytes);
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;


### PR DESCRIPTION
## Summary

- use a safe fallback for non-finite compact, cost, and byte values
- compact positive and negative magnitudes symmetrically
- promote values that round across K, M, or B boundaries
- use locale-aware one-decimal formatting for compact tiers
- format negative currency signs before the dollar marker
- clamp invalid negative byte counts to zero
- add numeric boundary regressions

## Verification

- `corepack pnpm exec vitest run src/lib/format.test.ts` (7 passed)
- `corepack pnpm test` (97 files, 1,015 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Currency remains explicitly USD.
- Byte units remain binary thresholds with the existing KB, MB, and GB labels.