### PR TITLE
fix(dashboard): localize relative timestamps

### DIFF
--- a/changelog.d/fixed/dashboard-relative-time-locale.md
+++ b/changelog.d/fixed/dashboard-relative-time-locale.md
@@ -1,0 +1,1 @@
+Use the browser locale for relative dashboard timestamps when callers do not specify one. (#7319) (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/datetime.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/datetime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { formatDate, formatDateTime, formatRelativeTime, formatTime, formatUptime } from "./datetime";
 
 describe("date formatting", () => {
@@ -27,6 +27,14 @@ describe("date formatting", () => {
     const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
     expect(formatRelativeTime(2 * 60 * 60 * 1_000, "en", 0)).toBe(rtf.format(2, "hour"));
     expect(formatRelativeTime(2 * 24 * 60 * 60 * 1_000, "en", 0)).toBe(rtf.format(2, "day"));
+  });
+
+  it("uses the browser locale when no locale is supplied", () => {
+    vi.stubGlobal("navigator", { language: "fr" });
+    const expected = new Intl.RelativeTimeFormat("fr", { numeric: "auto" })
+      .format(-2, "minute");
+    expect(formatRelativeTime(0, undefined, 120_000)).toBe(expected);
+    vi.unstubAllGlobals();
   });
 });
 

--- a/crates/librefang-api/dashboard/src/lib/datetime.ts
+++ b/crates/librefang-api/dashboard/src/lib/datetime.ts
@@ -53,7 +53,10 @@ export function formatRelativeTime(value: string | number | Date | undefined | n
   const diff = now - date.getTime();
   const direction = diff >= 0 ? -1 : 1;
   const seconds = Math.floor(Math.abs(diff) / 1000);
-  const rtf = getRtf(locale ?? "en");
+  const defaultLocale = typeof navigator !== "undefined" && navigator.language
+    ? navigator.language
+    : "en";
+  const rtf = getRtf(locale ?? defaultLocale);
   if (seconds < 60) return rtf.format(direction * seconds, "second");
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return rtf.format(direction * minutes, "minute");


### PR DESCRIPTION
## Summary

- use the browser locale for relative timestamps when callers omit an explicit locale
- retain an English fallback for non-browser environments
- add a browser-locale regression
- confirm current source already handles epoch zero, invalid dates, invalid clocks, and invalid uptime values

## Verification

- `corepack pnpm exec vitest run src/lib/datetime.test.ts` (7 passed)
- `corepack pnpm test` (96 files, 1,009 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- Callers can continue to override locale explicitly.
- Absolute date and time formatting continues to use the platform locale APIs.