### PR TITLE
fix(dashboard): clean up clipboard fallback

### DIFF
--- a/changelog.d/fixed/7320-dashboard-clipboard-fallback.md
+++ b/changelog.d/fixed/7320-dashboard-clipboard-fallback.md
@@ -1,0 +1,1 @@
+- Clean up the dashboard clipboard fallback after failures and allow mobile browsers to select its temporary text area. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/clipboard.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/clipboard.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyToClipboard } from "./clipboard";
+
+describe("copyToClipboard", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the clipboard API when it succeeds", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("falls back without making the textarea readonly", async () => {
+    vi.stubGlobal("navigator", {});
+    let wasReadonly = true;
+    const execCommand = vi.fn(() => {
+      wasReadonly = document.querySelector("textarea")?.readOnly ?? true;
+      return true;
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+
+    expect(execCommand).toHaveBeenCalledOnce();
+    expect(wasReadonly).toBe(false);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("removes the fallback textarea when copying throws", async () => {
+    vi.stubGlobal("navigator", {});
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => {
+        throw new Error("copy failed");
+      }),
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("removes the fallback textarea when selection throws", async () => {
+    vi.stubGlobal("navigator", {});
+    vi.spyOn(HTMLTextAreaElement.prototype, "select").mockImplementation(() => {
+      throw new Error("selection failed");
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/clipboard.ts
+++ b/crates/librefang-api/dashboard/src/lib/clipboard.ts
@@ -16,15 +16,16 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   try {
     const ta = document.createElement("textarea");
     ta.value = text;
-    ta.setAttribute("readonly", "");
     ta.style.position = "fixed";
     ta.style.top = "-1000px";
     ta.style.opacity = "0";
     document.body.appendChild(ta);
-    ta.select();
-    const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
-    return ok;
+    try {
+      ta.select();
+      return document.execCommand("copy");
+    } finally {
+      ta.remove();
+    }
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- always remove the legacy clipboard textarea, including when selection or copying throws
- keep the fallback textarea selectable on mobile browsers
- add regression coverage for native clipboard success and fallback success/failure paths

## Verification

- `corepack pnpm exec vitest run src/lib/clipboard.test.ts` (4 tests)
- `corepack pnpm test` (97 files, 1012 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`

## Out of scope

- replacing the deprecated `document.execCommand("copy")` fallback