### PR TITLE
perf(dashboard): scope passkey invalidation

### DIFF
--- a/changelog.d/fixed/7324-dashboard-passkey-invalidation.md
+++ b/changelog.d/fixed/7324-dashboard-passkey-invalidation.md
@@ -1,0 +1,1 @@
+- Scope dashboard passkey registration and revocation cache invalidation to passkey lists. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/passkeys.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/passkeys.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import * as api from "../../api";
+import { createQueryClientWrapper } from "../test/query-client";
+import { passkeyKeys } from "../queries/keys";
+import { useRegisterPasskey, useRevokePasskey } from "./passkeys";
+
+vi.mock("../../api", async () => {
+  const actual = await vi.importActual<typeof import("../../api")>("../../api");
+  return {
+    ...actual,
+    registerPasskey: vi.fn().mockResolvedValue({}),
+    revokePasskey: vi.fn().mockResolvedValue({}),
+  };
+});
+
+describe("passkey mutations", () => {
+  it("invalidates only passkey list queries after registration", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRegisterPasskey(), { wrapper });
+
+    await result.current.mutateAsync("laptop");
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledOnce());
+    expect(api.registerPasskey).toHaveBeenCalledWith("laptop");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: passkeyKeys.lists() });
+  });
+
+  it("invalidates only passkey list queries after revocation", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRevokePasskey(), { wrapper });
+
+    await result.current.mutateAsync("credential-1");
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledOnce());
+    expect(api.revokePasskey).toHaveBeenCalledWith("credential-1");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: passkeyKeys.lists() });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/passkeys.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/passkeys.ts
@@ -6,7 +6,7 @@ export function useRegisterPasskey() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (label?: string) => registerPasskey(label),
-    onSuccess: () => qc.invalidateQueries({ queryKey: passkeyKeys.all }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: passkeyKeys.lists() }),
   });
 }
 
@@ -14,6 +14,6 @@ export function useRevokePasskey() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (credentialId: string) => revokePasskey(credentialId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: passkeyKeys.all }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: passkeyKeys.lists() }),
   });
 }


### PR DESCRIPTION
## Summary

- invalidate the passkey list namespace after registration
- invalidate the passkey list namespace after revocation
- preserve future passkey detail or nested caches from unrelated refetches
- add hook-level regressions for both mutation paths

## Verification

- `corepack pnpm exec vitest run src/lib/mutations/passkeys.test.tsx` (2 tests)
- `corepack pnpm test` (97 files, 1010 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- changing passkey API behavior or query freshness settings