### PR TITLE
fix(dashboard): refresh hand-derived caches

### DIFF
--- a/changelog.d/fixed/7325-dashboard-hand-cache-invalidation.md
+++ b/changelog.d/fixed/7325-dashboard-hand-cache-invalidation.md
@@ -1,0 +1,1 @@
+- Refresh all dashboard Hand-derived views after secret and message mutations, and preserve cached fields when partial lifecycle responses contain undefined values. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import * as http from "../http/client";
 import { renderHook } from "@testing-library/react";
-import type { HandMessageResponse } from "../../api";
+import type { HandInstanceItem, HandMessageResponse } from "../../api";
 import {
   useActivateHand,
   useDeactivateHand,
@@ -107,6 +107,24 @@ describe("usePauseHand", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
   });
+
+  it("does not overwrite cached fields with undefined response values", async () => {
+    vi.mocked(http.pauseHand).mockResolvedValue({
+      instance_id: "inst-1",
+      hand_id: undefined,
+      status: "Paused",
+    } as unknown as HandInstanceItem);
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(handKeys.active(), [
+      { instance_id: "inst-1", hand_id: "hand-1", status: "Active" },
+    ]);
+
+    const { result } = renderHook(() => usePauseHand(), { wrapper });
+    await result.current.mutateAsync("inst-1");
+
+    expect(queryClient.getQueryData<HandInstanceItem[]>(handKeys.active())?.[0])
+      .toMatchObject({ hand_id: "hand-1", status: "Paused" });
+  });
 });
 
 describe("useResumeHand", () => {
@@ -153,7 +171,7 @@ describe("useUninstallHand", () => {
 });
 
 describe("useSetHandSecret", () => {
-  it("invalidates handKeys.lists() and handKeys.detail(handId)", async () => {
+  it("invalidates hand, agent, overview, and detail caches", async () => {
     const args: SetHandSecretInput = { handId: "h1", key: "k", value: "v" };
     vi.mocked(http.setHandSecret).mockResolvedValue({ ok: true });
     const { queryClient, wrapper } = createQueryClientWrapper();
@@ -164,8 +182,10 @@ describe("useSetHandSecret", () => {
     await result.current.mutateAsync(args);
 
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: handKeys.lists(),
+      queryKey: handKeys.all,
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.detail("h1"),
     });
@@ -208,7 +228,7 @@ describe("useUpdateHandSettings", () => {
 });
 
 describe("useSendHandMessage", () => {
-  it("invalidates the session query and calls mutationFn with correct args", async () => {
+  it("invalidates message-derived caches and calls mutationFn with correct args", async () => {
     const response: HandMessageResponse = { response: "ok" };
     vi.mocked(http.sendHandMessage).mockResolvedValue(response);
     const { queryClient, wrapper } = createQueryClientWrapper();
@@ -221,6 +241,9 @@ describe("useSendHandMessage", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.session("inst-1"),
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: handKeys.stats("inst-1") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: overviewKeys.snapshot() });
     expect(http.sendHandMessage).toHaveBeenCalledWith("inst-1", "hello");
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.ts
@@ -19,10 +19,13 @@ import { agentKeys, handKeys, overviewKeys } from "../queries/keys";
 // then run the broad invalidation (covers agentKeys / overviewKeys derived
 // state).
 function patchActiveHandsCache(qc: QueryClient, updated: HandInstanceItem) {
+  const definedPatch = Object.fromEntries(
+    Object.entries(updated).filter(([, value]) => value !== undefined),
+  );
   qc.setQueryData<HandInstanceItem[]>(handKeys.active(), (prev) => {
     if (!prev) return prev;
     return prev.map((item) =>
-      item.instance_id === updated.instance_id ? { ...item, ...updated } : item,
+      item.instance_id === updated.instance_id ? { ...item, ...definedPatch } : item,
     );
   });
 }
@@ -116,7 +119,7 @@ export function useSetHandSecret() {
       value: string;
     }) => setHandSecret(handId, key, value),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: handKeys.lists() });
+      invalidateHandAndAgentCaches(qc);
       qc.invalidateQueries({ queryKey: handKeys.detail(variables.handId) });
     },
   });
@@ -173,6 +176,9 @@ export function useSendHandMessage() {
     }) => sendHandMessage(instanceId, message),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: handKeys.session(variables.instanceId) });
+      qc.invalidateQueries({ queryKey: handKeys.stats(variables.instanceId) });
+      qc.invalidateQueries({ queryKey: agentKeys.all });
+      qc.invalidateQueries({ queryKey: overviewKeys.snapshot() });
     },
   });
 }


### PR DESCRIPTION
## Summary

- refresh Hands, Agents, and Overview caches after saving a Hand secret
- refresh Hand session/stats plus Agents and Overview state after sending a Hand message
- ignore explicit `undefined` fields when patching active Hand instances from lifecycle responses
- extend mutation-hook coverage for all three contracts

## Verification

- `corepack pnpm exec vitest run src/lib/mutations/hands.test.tsx` (9 tests)
- `corepack pnpm test` (96 files, 1009 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- changing backend Hand response schemas or query freshness intervals