### PR TITLE
fix(dashboard): validate bundle daemon bases

### DIFF
--- a/changelog.d/security/7326-dashboard-bundle-base-validation.md
+++ b/changelog.d/security/7326-dashboard-bundle-base-validation.md
@@ -1,0 +1,1 @@
+- Validate persisted mobile bundle daemon origins and consistently constrain fetch and WebSocket rewrites to supported API paths. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/bundleMode.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/bundleMode.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isApiPath, parseHttpBase, setupBundleMode } from "./bundleMode";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly url: string;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+  }
+}
+
+function stubTauriWindow(hash = "") {
+  const fetch = vi.fn().mockResolvedValue(new Response());
+  const fakeWindow = {
+    location: {
+      protocol: "tauri:",
+      hash,
+      pathname: "/index.html",
+      search: "",
+    },
+    fetch,
+    WebSocket: FakeWebSocket,
+  } as unknown as Window & typeof globalThis;
+  vi.stubGlobal("window", fakeWindow);
+  return { fakeWindow, fetch };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("bundle-mode base validation", () => {
+  it("accepts only HTTP(S) daemon bases", () => {
+    expect(parseHttpBase("https://daemon.example/")).toBe("https://daemon.example");
+    expect(parseHttpBase("http://127.0.0.1:4545")).toBe("http://127.0.0.1:4545");
+    expect(parseHttpBase("javascript:alert(1)")).toBeNull();
+    expect(parseHttpBase("wss://daemon.example")).toBeNull();
+    expect(parseHttpBase("not a url")).toBeNull();
+  });
+
+  it("does not classify the bare root as an API path", () => {
+    expect(isApiPath("/")).toBe(false);
+    expect(isApiPath("/api/health")).toBe(true);
+  });
+
+  it("does not persist or activate an invalid hash base", () => {
+    const { fakeWindow, fetch } = stubTauriWindow("#api=javascript%3Aalert(1)");
+    vi.spyOn(history, "replaceState").mockImplementation(() => undefined);
+
+    setupBundleMode();
+
+    expect(localStorage.getItem("librefang-api-base")).toBeNull();
+    expect(fakeWindow.fetch).toBe(fetch);
+  });
+
+  it("rejects poisoned stored bases before patching globals", () => {
+    localStorage.setItem("librefang-api-base", "wss://attacker.example");
+    const { fakeWindow, fetch } = stubTauriWindow();
+
+    setupBundleMode();
+
+    expect(fakeWindow.fetch).toBe(fetch);
+    expect(fakeWindow.WebSocket).toBe(FakeWebSocket);
+  });
+
+  it("rewrites API fetch and WebSocket URLs but leaves root untouched", async () => {
+    localStorage.setItem("librefang-api-base", "https://daemon.example/");
+    const { fakeWindow, fetch } = stubTauriWindow();
+
+    setupBundleMode();
+
+    await fakeWindow.fetch("/api/health");
+    await fakeWindow.fetch("http://localhost:4545/api/agents?limit=1");
+    await fakeWindow.fetch("/");
+
+    expect(fetch).toHaveBeenNthCalledWith(1, "https://daemon.example/api/health", undefined);
+    expect(fetch).toHaveBeenNthCalledWith(2, "https://daemon.example/api/agents?limit=1", undefined);
+    expect(fetch).toHaveBeenNthCalledWith(3, "/", undefined);
+
+    const relative = new fakeWindow.WebSocket("/api/events") as unknown as FakeWebSocket;
+    const localhost = new fakeWindow.WebSocket("ws://localhost/api/events") as unknown as FakeWebSocket;
+    const root = new fakeWindow.WebSocket("/") as unknown as FakeWebSocket;
+    expect(relative.url).toBe("wss://daemon.example/api/events");
+    expect(localhost.url).toBe("wss://daemon.example/api/events");
+    expect(root.url).toBe("/");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/bundleMode.ts
+++ b/crates/librefang-api/dashboard/src/lib/bundleMode.ts
@@ -41,9 +41,18 @@ const SAME_ORIGIN_PREFIXES = [
   "/mcp",
 ];
 
-function isApiPath(path: string): boolean {
-  if (path === "/") return true;
+export function isApiPath(path: string): boolean {
   return SAME_ORIGIN_PREFIXES.some((p) => path.startsWith(p));
+}
+
+export function parseHttpBase(raw: string): string | null {
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    return raw.replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
 }
 
 function rewritePath(httpBase: string, path: string): string {
@@ -53,6 +62,21 @@ function rewritePath(httpBase: string, path: string): string {
 function maybeStripTauriOrigin(url: string): string | null {
   if (url.startsWith("tauri://localhost")) {
     return url.slice("tauri://localhost".length) || "/";
+  }
+  return null;
+}
+
+function maybeStripHttpLocalhost(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      parsed.hostname === "localhost"
+    ) {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+  } catch {
+    // Relative and malformed URLs are handled by the caller's other paths.
   }
   return null;
 }
@@ -69,16 +93,15 @@ export function setupBundleMode(): void {
     const encoded = hash.slice("#api=".length);
     try {
       const decoded = decodeURIComponent(encoded);
-      if (decoded) {
-        localStorage.setItem(BASE_KEY, decoded);
-      }
+      const validBase = parseHttpBase(decoded);
+      if (validBase) localStorage.setItem(BASE_KEY, validBase);
     } catch {
       // Malformed hash — ignore, fall back to whatever localStorage has.
     }
     history.replaceState(null, "", window.location.pathname + window.location.search);
   }
 
-  const stored = (localStorage.getItem(BASE_KEY) || "").replace(/\/$/, "");
+  const stored = parseHttpBase(localStorage.getItem(BASE_KEY) || "");
   if (!stored) return;
 
   const httpBase = stored;
@@ -102,9 +125,15 @@ export function setupBundleMode(): void {
       if (stripped && isApiPath(stripped)) {
         return ORIG_FETCH(rewritePath(httpBase, stripped), init);
       }
+      const localhostPath = maybeStripHttpLocalhost(url);
+      if (localhostPath && isApiPath(localhostPath)) {
+        return ORIG_FETCH(rewritePath(httpBase, localhostPath), init);
+      }
     }
     return ORIG_FETCH(input as RequestInfo, init);
   }) as typeof window.fetch;
+
+  if (!/^wss?:\/\//i.test(wsBase)) return;
 
   const ORIG_WS = window.WebSocket;
   // Replace the global with a subclass that rewrites relative /


### PR DESCRIPTION
## Summary

- accept only HTTP(S) daemon bases from mobile bundle hashes
- revalidate persisted daemon bases before patching globals
- leave the bare root outside the API rewrite allowlist
- rewrite absolute HTTP(S) localhost fetches consistently with WebSockets
- install the WebSocket patch only when a valid WS(S) base is derived
- add bootstrap-level regressions for hash, storage, fetch, and WebSocket boundaries

## Verification

- `corepack pnpm exec vitest run src/lib/bundleMode.test.ts` (5 tests)
- `corepack pnpm test` (97 files, 1013 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- changing the mobile pairing transport or daemon CORS policy