### PR TITLE
fix(dashboard): disambiguate hidden model keys

### DIFF
--- a/changelog.d/fixed/7327-dashboard-hidden-model-keys.md
+++ b/changelog.d/fixed/7327-dashboard-hidden-model-keys.md
@@ -1,0 +1,1 @@
+- Make persisted dashboard hidden-model keys collision-safe when providers or model IDs contain colons. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/hiddenModels.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/hiddenModels.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import type { ModelItem } from "../api";
+import { filterVisible, modelKey } from "./hiddenModels";
+
+describe("hidden model keys", () => {
+  it("keeps provider/id partitions distinct when either contains colons", () => {
+    const providerColon = modelKey({ provider: "a:b", id: "c" });
+    const idColon = modelKey({ provider: "a", id: "b:c" });
+
+    expect(providerColon).not.toBe(idColon);
+  });
+
+  it("filters only the exact hidden model", () => {
+    const models = [
+      { provider: "a:b", id: "c" },
+      { provider: "a", id: "b:c" },
+    ] as ModelItem[];
+
+    expect(filterVisible(models, new Set([modelKey(models[0])]))).toEqual([models[1]]);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/hiddenModels.ts
+++ b/crates/librefang-api/dashboard/src/lib/hiddenModels.ts
@@ -1,8 +1,8 @@
 import type { ModelItem } from "../api";
 
-/** Build the storage key for a model: "provider:id" */
+/** Build an unambiguous storage key for a model. */
 export function modelKey(m: Pick<ModelItem, "provider" | "id">): string {
-  return `${m.provider}:${m.id}`;
+  return `${m.provider}\u001f${m.id}`;
 }
 
 /** Filter to only visible (non-hidden) models */


### PR DESCRIPTION
## Summary

- replace ambiguous `provider:id` hidden-model keys with a unit-separator boundary
- keep colon-bearing provider/model partitions collision-free
- add direct filtering regressions for the formerly colliding pairs
- rely on the existing Models page validity pass to prune legacy persisted keys

## Verification

- `corepack pnpm exec vitest run src/lib/hiddenModels.test.ts` (2 tests)
- `corepack pnpm test` (97 files, 1010 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- preserving legacy ambiguous hidden-state entries; they cannot be mapped safely to one provider/model pair