### PR TITLE
fix(dashboard): preserve chat cache recency

### DIFF
--- a/changelog.d/fixed/7328-dashboard-chat-cache-lru.md
+++ b/changelog.d/fixed/7328-dashboard-chat-cache-lru.md
@@ -1,0 +1,1 @@
+- Preserve hot dashboard chat sessions during cache updates and export the cache capacity and TTL defaults for tuning. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/chatSessionCache.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/chatSessionCache.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CACHE_TTL_MS,
+  MAX_CACHE_ENTRIES,
+  chatSessionCacheKey,
+  clearChatSessionCacheForAgent,
+  getCachedChatMessages,
+  setCachedChatMessages,
+} from "./chatSessionCache";
+
+const AGENT_ID = "cache-contract-agent";
+
+function key(index: number): string {
+  return chatSessionCacheKey(AGENT_ID, `session-${index}`);
+}
+
+afterEach(() => clearChatSessionCacheForAgent(AGENT_ID));
+
+describe("chat session cache", () => {
+  it("exports its capacity and TTL defaults", () => {
+    expect(MAX_CACHE_ENTRIES).toBe(50);
+    expect(CACHE_TTL_MS).toBe(30 * 60 * 1000);
+  });
+
+  it("updates a full cache without evicting and refreshes LRU order", () => {
+    for (let index = 0; index < MAX_CACHE_ENTRIES; index++) {
+      setCachedChatMessages(key(index), [`value-${index}`]);
+    }
+
+    setCachedChatMessages(key(0), ["hot"]);
+
+    expect(getCachedChatMessages(key(0))).toEqual(["hot"]);
+    expect(getCachedChatMessages(key(1))).toEqual(["value-1"]);
+
+    setCachedChatMessages(key(MAX_CACHE_ENTRIES), ["new"]);
+
+    expect(getCachedChatMessages(key(0))).toEqual(["hot"]);
+    expect(getCachedChatMessages(key(1))).toBeUndefined();
+    expect(getCachedChatMessages(key(10))).toBeUndefined();
+    expect(getCachedChatMessages(key(11))).toEqual(["value-11"]);
+    expect(getCachedChatMessages(key(MAX_CACHE_ENTRIES))).toEqual(["new"]);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/chatSessionCache.ts
+++ b/crates/librefang-api/dashboard/src/lib/chatSessionCache.ts
@@ -1,5 +1,5 @@
-const MAX_CACHE_ENTRIES = 50;
-const CACHE_TTL_MS = 30 * 60 * 1000;
+export const MAX_CACHE_ENTRIES = 50;
+export const CACHE_TTL_MS = 30 * 60 * 1000;
 
 const sessionCache = new Map<string, { messages: unknown[]; expiresAt: number }>();
 
@@ -38,7 +38,10 @@ export function getCachedChatMessages<T>(key: string): T[] | undefined {
 }
 
 export function setCachedChatMessages<T>(key: string, messages: T[]) {
-  evictCacheIfNeeded();
+  if (!sessionCache.has(key)) evictCacheIfNeeded();
+  // Map#set does not update insertion order. Reinsert existing entries so
+  // message activity refreshes their LRU position without evicting a slot.
+  sessionCache.delete(key);
   sessionCache.set(key, { messages, expiresAt: Date.now() + CACHE_TTL_MS });
 }
 


### PR DESCRIPTION
## Summary

- avoid capacity eviction when updating an existing chat-session key
- reinsert updated entries so Map insertion order reflects LRU recency
- export the cache capacity and TTL defaults
- add a full-capacity regression proving hot sessions survive while colder entries are evicted

## Verification

- `corepack pnpm exec vitest run src/lib/chatSessionCache.test.ts` (2 tests)
- `corepack pnpm test` (97 files, 1010 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- runtime configuration plumbing for dashboard cache defaults