### PR TITLE
fix(dashboard): notify replaced drawer owners

### DIFF
--- a/changelog.d/fixed/7329-dashboard-drawer-replacement.md
+++ b/changelog.d/fixed/7329-dashboard-drawer-replacement.md
@@ -1,0 +1,1 @@
+- Notify replaced dashboard drawers without double-closing owner-scoped picker-to-config transitions, and retain no content after close. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/drawerStore.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/drawerStore.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useDrawerStore } from "./drawerStore";
+
+afterEach(() => {
+  useDrawerStore.setState({ isOpen: false, content: null });
+});
+
+describe("drawer store replacement", () => {
+  it("notifies the previous owner when another drawer replaces it", async () => {
+    const onClose = vi.fn();
+    const firstOwner = {};
+
+    useDrawerStore.getState().open({ body: "first", owner: firstOwner, onClose });
+    useDrawerStore.getState().open({ body: "second", owner: {} });
+
+    expect(onClose).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not notify when the same owner refreshes its content", async () => {
+    const onClose = vi.fn();
+    const owner = {};
+
+    useDrawerStore.getState().open({ body: "first", owner, onClose });
+    useDrawerStore.getState().open({ body: "updated", owner, onClose });
+
+    await Promise.resolve();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("suppresses replacement notification when the old owner closes itself", async () => {
+    const onClose = vi.fn();
+    const firstOwner = {};
+
+    useDrawerStore.getState().open({ body: "first", owner: firstOwner, onClose });
+    useDrawerStore.getState().open({ body: "second", owner: {} });
+    useDrawerStore.getState().close(firstOwner);
+
+    await Promise.resolve();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(useDrawerStore.getState().content?.body).toBe("second");
+  });
+
+  it("clears retained content when the active drawer closes", () => {
+    useDrawerStore.getState().open({ body: "first" });
+
+    useDrawerStore.getState().close();
+
+    expect(useDrawerStore.getState()).toMatchObject({ isOpen: false, content: null });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/drawerStore.ts
+++ b/crates/librefang-api/dashboard/src/lib/drawerStore.ts
@@ -22,6 +22,11 @@ interface DrawerState {
   close: (owner?: object) => void;
 }
 
+// A previous DrawerPanel can relinquish ownership in the same React commit
+// that a new panel claims the global slot. Record that owner-scoped close so
+// the deferred replacement notification does not double-fire its onClose.
+const silentlyClosedOwners = new WeakSet<object>();
+
 // Single global push-drawer slot. The `<DrawerPanel>` adapter is the primary
 // caller — it pushes its `children` here on every render so the slot stays
 // in sync with parent state. The `<PushDrawer>` host in App.tsx is a flex
@@ -33,9 +38,21 @@ interface DrawerState {
 export const useDrawerStore = create<DrawerState>((set) => ({
   isOpen: false,
   content: null,
-  open: (content) => set({ isOpen: true, content }),
+  open: (content) => set((state) => {
+    const previous = state.content;
+    if (previous && previous.owner !== content.owner) {
+      queueMicrotask(() => {
+        if (previous.owner && silentlyClosedOwners.delete(previous.owner)) return;
+        previous.onClose?.();
+      });
+    }
+    return { isOpen: true, content };
+  }),
   close: (owner) => set((state) => {
-    if (owner !== undefined && state.content?.owner !== owner) return state;
+    if (owner !== undefined && state.content?.owner !== owner) {
+      silentlyClosedOwners.add(owner);
+      return state;
+    }
     return { isOpen: false, content: null };
   }),
 }));


### PR DESCRIPTION
## Summary

- notify the previous drawer owner when a different drawer replaces the global slot
- defer replacement notification so same-commit owner cleanup can suppress duplicate callbacks
- preserve same-owner content refreshes without firing `onClose`
- retain the existing owner guard that prevents picker cleanup from closing a new config drawer
- add direct store regressions alongside the existing DrawerPanel and PushDrawer suites

## Verification

- `corepack pnpm exec vitest run src/lib/drawerStore.test.tsx src/components/ui/DrawerPanel.test.tsx src/components/ui/PushDrawer.test.tsx` (15 tests)
- `corepack pnpm test` (97 files, 1012 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- supporting more than one globally visible push drawer