### PR TITLE
fix(dashboard): harden channel liveness fallback

### DIFF
--- a/changelog.d/fixed/7331-dashboard-channel-liveness.md
+++ b/changelog.d/fixed/7331-dashboard-channel-liveness.md
@@ -1,0 +1,1 @@
+- Classify unconfigured dashboard channels neutrally and fail visibly on unknown liveness states or malformed error payloads. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/channelLiveness.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/channelLiveness.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { channelLiveness, livenessLabel, type ChannelLivenessState } from "./channelLiveness";
 import type { ChannelItem } from "../api";
 
@@ -8,6 +8,14 @@ describe("channelLiveness", () => {
   function ch(overrides: Partial<ChannelItem>): ChannelItem {
     return { name: "c", configured: true, ...overrides };
   }
+
+  it("reports a neutral setup state for an unconfigured catalog row", () => {
+    expect(channelLiveness(ch({ configured: false }))).toEqual({
+      state: "unconfigured",
+      variant: "default",
+      error: null,
+    });
+  });
 
   it("reports not_supervised when no adapter is registered", () => {
     expect(channelLiveness(ch({ supervised: false, connected: false }))).toMatchObject({
@@ -89,10 +97,28 @@ describe("channelLiveness", () => {
       channelLiveness(ch({ supervised: true, connected: true, last_error: "   " })).error,
     ).toBeNull();
   });
+
+  it("fails visibly when last_error drifts to a non-string payload", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const channel = ch({
+      supervised: true,
+      connected: false,
+      last_error: { message: "boom" } as unknown as string,
+    });
+
+    expect(channelLiveness(channel)).toMatchObject({
+      state: "failed",
+      variant: "error",
+      error: "Invalid last_error payload",
+    });
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
 });
 
 describe("livenessLabel", () => {
   const states: ChannelLivenessState[] = [
+    "unconfigured",
     "not_supervised",
     "failed",
     "stopped",
@@ -108,6 +134,7 @@ describe("livenessLabel", () => {
     // colour-only indicator #6606 exists to remove.
     const keys = states.map((s) => livenessLabel(s, (k) => k));
     expect(keys).toEqual([
+      "common.setup",
       "channels.liveness.not_supervised",
       "channels.liveness.failed",
       "channels.liveness.stopped",
@@ -117,5 +144,9 @@ describe("livenessLabel", () => {
       "channels.liveness.connected",
     ]);
     expect(new Set(keys).size).toBe(states.length);
+  });
+
+  it("falls back to an unknown runtime state instead of returning undefined", () => {
+    expect(livenessLabel("future" as ChannelLivenessState, (key) => key)).toBe("future");
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/channelLiveness.ts
+++ b/crates/librefang-api/dashboard/src/lib/channelLiveness.ts
@@ -11,6 +11,7 @@ export type TFunc = (key: string, opts?: Record<string, unknown>) => string;
  * Every state is derived from a fact the backend can substantiate — see `sidecar_channel_rows` in `crates/librefang-api/src/routes/channels.rs`.
  */
 export type ChannelLivenessState =
+  | "unconfigured"
   | "not_supervised"
   | "failed"
   | "stopped"
@@ -37,38 +38,46 @@ export interface ChannelLiveness {
  *
  * The mapping, in evaluation order, and why each state has the colour it does:
  *
- * 1. `not_supervised` — amber.
+ * 1. `unconfigured` — neutral.
+ *    The catalog knows the adapter, but the operator has not configured it.
+ * 2. `not_supervised` — amber.
  *    Configured in `config.toml` but no adapter is registered: the sidecar was never started, or its start failed and the registration was rolled back.
  *    Amber rather than grey deliberately — grey reads as "fine, just quiet", which is exactly the misreading this fix exists to remove.
- * 2. `failed` — red.
+ * 3. `failed` — red.
  *    Down, and the supervisor recorded why.
- * 3. `stopped` — red.
+ * 4. `stopped` — red.
  *    Down after having been up (`started_at` is set) with no error recorded — a silent exit.
- * 4. `starting` — amber.
+ * 5. `starting` — amber.
  *    Registered, never yet connected, nothing wrong reported.
  *    The transient window between registration and first spawn.
- * 5. `degraded` — amber.
+ * 6. `degraded` — amber.
  *    Connected, but carrying an error.
  *    `last_error` is sticky (the supervisor never clears it, not even on the successful respawn that follows), so this means "failed at least once since the adapter was created", not "broken right now".
  *    Amber, not red — but it must not read as healthy either.
- * 6. `active` — green.
+ * 7. `active` — green.
  *    Connected with messages in either direction.
- * 7. `connected` — green.
+ * 8. `connected` — green.
  *    Connected, no traffic yet.
  *    Distinguished from `active` by label, not colour: a quiet channel is healthy, and colouring it differently is what made a healthy-but-quiet bot look dead.
  *
  * Traffic here is the supervisor's own per-instance counters, which are since-adapter-creation.
  * The 24h figure on the payload is per channel type and deliberately plays no part in this mapping.
  *
- * Only meaningful for a `configured` row.
- * An unconfigured catalog row carries none of these fields and would read `not_supervised`, which is wrong — it is not broken, it was never set up.
- * Callers that list unconfigured rows must branch on `configured` first; see `CommsPage.tsx`.
+ * Unconfigured catalog rows are classified explicitly so every caller gets a
+ * neutral setup state without needing to duplicate a guard.
  */
 export function channelLiveness(c: ChannelItem): ChannelLiveness {
-  const error =
-    typeof c.last_error === "string" && c.last_error.trim().length > 0
-      ? c.last_error
-      : null;
+  if (c.configured === false) {
+    return { state: "unconfigured", variant: "default", error: null };
+  }
+
+  let error: string | null = null;
+  if (typeof c.last_error === "string") {
+    error = c.last_error.trim() || null;
+  } else if (c.last_error != null) {
+    console.warn("Channel last_error has an invalid non-string payload", c.last_error);
+    error = "Invalid last_error payload";
+  }
   if (!c.supervised) {
     return { state: "not_supervised", variant: "warning", error };
   }
@@ -91,6 +100,8 @@ export function channelLiveness(c: ChannelItem): ChannelLiveness {
  */
 export function livenessLabel(state: ChannelLivenessState, t: TFunc): string {
   switch (state) {
+    case "unconfigured":
+      return t("common.setup", { defaultValue: "Setup" });
     case "active":
       return t("channels.liveness.active", { defaultValue: "Active" });
     case "connected":
@@ -107,5 +118,7 @@ export function livenessLabel(state: ChannelLivenessState, t: TFunc): string {
       return t("channels.liveness.not_supervised", {
         defaultValue: "Not started",
       });
+    default:
+      return state;
   }
 }


### PR DESCRIPTION
## Summary

- classify unconfigured catalog rows as a dedicated neutral Setup state
- keep liveness classification correct for every caller, including details views
- treat non-string runtime error payloads as visible failures/degradation and warn on contract drift
- return an unknown runtime state as the label fallback instead of undefined
- extend helper and page-level liveness regressions

## Verification

- `corepack pnpm exec vitest run src/lib/channelLiveness.test.ts src/pages/ChannelsPage.test.tsx src/pages/CommsPage.test.tsx` (45 tests)
- `corepack pnpm test` (96 files, 1011 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope

- changing supervisor liveness fields or sticky-error semantics