### PR TITLE
fix(dashboard): migrate persisted UI state

### DIFF
--- a/changelog.d/fixed/dashboard-ui-store.md
+++ b/changelog.d/fixed/dashboard-ui-store.md
@@ -1,0 +1,1 @@
+- Version and sanitize persisted dashboard UI state, synchronize language changes, and prune stale navigation keys. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -877,6 +877,7 @@ export function App() {
   const navLayout = useUIStore((s) => s.navLayout);
   const collapsedNavGroups = useUIStore((s) => s.collapsedNavGroups);
   const toggleNavGroup = useUIStore((s) => s.toggleNavGroup);
+  const pruneCollapsedNavGroups = useUIStore((s) => s.pruneCollapsedNavGroups);
   const { isOpen: isPaletteOpen, setIsOpen: setPaletteOpen } = useCommandPalette();
   const [authNeeded, setAuthNeeded] = useState(false);
   const [authChecked, setAuthChecked] = useState(false);
@@ -1070,6 +1071,10 @@ export function App() {
       },
     ];
   }, [t, terminalEnabled]);
+
+  useEffect(() => {
+    pruneCollapsedNavGroups(new Set(navGroups.map((group) => group.key)));
+  }, [navGroups, pruneCollapsedNavGroups]);
 
   const currentPageLabel = useMemo(() => {
     const current = navGroups

--- a/crates/librefang-api/dashboard/src/lib/store.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/store.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const changeLanguage = vi.hoisted(() => vi.fn<() => Promise<void>>());
+
+vi.mock("./i18n", () => ({
+  default: {
+    language: "en",
+    changeLanguage,
+  },
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+  changeLanguage.mockReset().mockResolvedValue(undefined);
+  vi.resetModules();
+});
+
+describe("UI store persistence", () => {
+  it("sanitizes legacy persisted state before merging defaults", async () => {
+    localStorage.setItem(
+      "librefang-ui-storage",
+      JSON.stringify({
+        version: 0,
+        state: {
+          theme: "removed-theme",
+          language: "zh",
+          navLayout: "removed-layout",
+          isSidebarCollapsed: true,
+          collapsedNavGroups: { runtime: true, invalid: "yes" },
+          hiddenModelKeys: ["valid", 42],
+        },
+      }),
+    );
+
+    const { useUIStore } = await import("./store");
+    const state = useUIStore.getState();
+    expect(state.theme).toBe("dark");
+    expect(state.language).toBe("zh");
+    expect(state.navLayout).toBe("grouped");
+    expect(state.isSidebarCollapsed).toBe(true);
+    expect(state.collapsedNavGroups).toEqual({ runtime: true });
+    expect(state.hiddenModelKeys).toEqual(["valid"]);
+  });
+
+  it("syncs i18n after persisted language rehydration", async () => {
+    localStorage.setItem(
+      "librefang-ui-storage",
+      JSON.stringify({ version: 1, state: { language: "uk" } }),
+    );
+
+    await import("./store");
+    expect(changeLanguage).toHaveBeenCalledWith("uk");
+  });
+
+  it("commits a language only after i18n succeeds", async () => {
+    const { useUIStore } = await import("./store");
+    useUIStore.setState({ language: "en" });
+
+    changeLanguage.mockRejectedValueOnce(new Error("unavailable"));
+    await expect(useUIStore.getState().setLanguage("ko")).resolves.toBe(false);
+    expect(useUIStore.getState().language).toBe("en");
+
+    await expect(useUIStore.getState().setLanguage("pl")).resolves.toBe(true);
+    expect(useUIStore.getState().language).toBe("pl");
+  });
+
+  it("prunes stale collapsed navigation keys", async () => {
+    const { useUIStore } = await import("./store");
+    useUIStore.setState({
+      collapsedNavGroups: { primary: true, runtime: false, removed: true },
+    });
+
+    useUIStore.getState().pruneCollapsedNavGroups(new Set(["primary", "runtime"]));
+    expect(useUIStore.getState().collapsedNavGroups).toEqual({
+      primary: true,
+      runtime: false,
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/store.ts
+++ b/crates/librefang-api/dashboard/src/lib/store.ts
@@ -2,6 +2,10 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import i18n from "./i18n";
 
+export const UI_STORE_VERSION = 1;
+export const MAX_TOASTS = 50;
+export const MAX_SKILL_OUTPUTS = 50;
+
 export function createClientId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
@@ -43,7 +47,7 @@ interface UIState {
   setDeepThinking: (value: boolean) => void;
   setShowThinkingProcess: (value: boolean) => void;
   toggleTheme: () => void;
-  setLanguage: (lang: string) => void;
+  setLanguage: (lang: string) => Promise<boolean>;
   setMobileMenuOpen: (open: boolean) => void;
   toggleSidebar: () => void;
   setNavLayout: (layout: "grouped" | "collapsible") => void;
@@ -56,7 +60,80 @@ interface UIState {
   hideModel: (key: string) => void;
   unhideModel: (key: string) => void;
   pruneHiddenKeys: (validKeys: Set<string>) => void;
+  pruneCollapsedNavGroups: (validKeys: Set<string>) => void;
   setTerminalEnabled: (enabled: boolean) => void;
+}
+
+type PersistedUIState = Pick<
+  UIState,
+  | "theme"
+  | "language"
+  | "isSidebarCollapsed"
+  | "navLayout"
+  | "collapsedNavGroups"
+  | "hiddenModelKeys"
+  | "modelsAvailableOnly"
+  | "deepThinking"
+  | "showThinkingProcess"
+>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export function migratePersistedUIState(
+  persistedState: unknown,
+): PersistedUIState {
+  const migrated: PersistedUIState = {
+    theme: "dark",
+    language: i18n.language || "en",
+    isSidebarCollapsed: false,
+    navLayout: "grouped",
+    collapsedNavGroups: {},
+    hiddenModelKeys: [],
+    modelsAvailableOnly: true,
+    deepThinking: false,
+    showThinkingProcess: true,
+  };
+  if (!isRecord(persistedState)) return migrated;
+
+  if (persistedState.theme === "light" || persistedState.theme === "dark") {
+    migrated.theme = persistedState.theme;
+  }
+  if (typeof persistedState.language === "string" && persistedState.language.trim()) {
+    migrated.language = persistedState.language;
+  }
+  if (typeof persistedState.isSidebarCollapsed === "boolean") {
+    migrated.isSidebarCollapsed = persistedState.isSidebarCollapsed;
+  }
+  if (
+    persistedState.navLayout === "grouped" ||
+    persistedState.navLayout === "collapsible"
+  ) {
+    migrated.navLayout = persistedState.navLayout;
+  }
+  if (isRecord(persistedState.collapsedNavGroups)) {
+    migrated.collapsedNavGroups = Object.fromEntries(
+      Object.entries(persistedState.collapsedNavGroups).filter(
+        (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+      ),
+    );
+  }
+  if (Array.isArray(persistedState.hiddenModelKeys)) {
+    migrated.hiddenModelKeys = persistedState.hiddenModelKeys.filter(
+      (key): key is string => typeof key === "string",
+    );
+  }
+  for (const key of [
+    "modelsAvailableOnly",
+    "deepThinking",
+    "showThinkingProcess",
+  ] as const) {
+    if (typeof persistedState[key] === "boolean") {
+      migrated[key] = persistedState[key];
+    }
+  }
+
+  return migrated;
 }
 
 export const useUIStore = create<UIState>()(
@@ -80,11 +157,15 @@ export const useUIStore = create<UIState>()(
       setShowThinkingProcess: (value) => set({ showThinkingProcess: value }),
       toggleTheme: () =>
         set((state) => ({ theme: state.theme === "light" ? "dark" : "light" })),
-      setLanguage: (lang) => {
-        set({ language: lang });
-        void i18n.changeLanguage(lang).catch((err) => {
+      setLanguage: async (lang) => {
+        try {
+          await i18n.changeLanguage(lang);
+          set({ language: lang });
+          return true;
+        } catch (err) {
           console.error("Failed to change language:", err);
-        });
+          return false;
+        }
       },
       setMobileMenuOpen: (open) => set({ isMobileMenuOpen: open }),
       toggleSidebar: () => set((state) => ({ isSidebarCollapsed: !state.isSidebarCollapsed })),
@@ -92,7 +173,6 @@ export const useUIStore = create<UIState>()(
       toggleNavGroup: (key) => set((state) => ({ collapsedNavGroups: { ...state.collapsedNavGroups, [key]: !state.collapsedNavGroups[key] } })),
       addToast: (message, type = "info") =>
         set((state) => {
-          const MAX_TOASTS = 50;
           const next = [...state.toasts, { id: createClientId(), message, type }];
           return {
             toasts: next.length > MAX_TOASTS ? next.slice(-MAX_TOASTS) : next,
@@ -107,7 +187,7 @@ export const useUIStore = create<UIState>()(
           skillOutputs: [
             { ...output, id: createClientId(), timestamp: Date.now() },
             ...state.skillOutputs,
-          ].slice(0, 50),
+          ].slice(0, MAX_SKILL_OUTPUTS),
         })),
       dismissSkillOutput: (id) =>
         set((state) => ({
@@ -128,10 +208,26 @@ export const useUIStore = create<UIState>()(
         set((state) => ({
           hiddenModelKeys: state.hiddenModelKeys.filter((k) => validKeys.has(k)),
         })),
+      pruneCollapsedNavGroups: (validKeys) =>
+        set((state) => ({
+          collapsedNavGroups: Object.fromEntries(
+            Object.entries(state.collapsedNavGroups).filter(([key]) =>
+              validKeys.has(key),
+            ),
+          ),
+        })),
       setTerminalEnabled: (enabled) => set({ terminalEnabled: enabled }),
     }),
     {
       name: "librefang-ui-storage",
+      version: UI_STORE_VERSION,
+      migrate: (persistedState) => migratePersistedUIState(persistedState),
+      onRehydrateStorage: () => (state) => {
+        if (!state?.language) return;
+        void i18n.changeLanguage(state.language).catch((err) => {
+          console.error("Failed to restore persisted language:", err);
+        });
+      },
       partialize: (state) => ({
         theme: state.theme,
         language: state.language,


### PR DESCRIPTION
## Summary

- version the persisted UI slice and sanitize legacy enum, boolean, map, and array fields
- commit language state only after i18n changes successfully and resync i18n on hydration
- prune collapsed navigation state against the App’s live group keys
- name the toast and skill-output capacity limits at module scope

## Verification

- `corepack pnpm exec vitest run src/lib/store.test.ts src/lib/queryClient.test.ts` (6 tests)
- `corepack pnpm test` (97 files, 1016 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`

## Out of scope

- persisted key names and current UI defaults remain unchanged