### PR TITLE
fix(dashboard): align tool grant globs

### DIFF
--- a/changelog.d/fixed/dashboard-tool-grants.md
+++ b/changelog.d/fixed/dashboard-tool-grants.md
@@ -1,0 +1,1 @@
+- Match multi-wildcard dashboard tool grants with the kernel's recursive glob semantics. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/toolGrants.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/toolGrants.test.ts
@@ -37,6 +37,13 @@ describe("toolPatternMatches", () => {
     expect(toolPatternMatches("mcp_*_search", "mcp_brave_fetch")).toBe(false);
   });
 
+  it("matches multi-wildcard patterns with the kernel's recursive prefix stripping", () => {
+    expect(toolPatternMatches("a*b*c", "abc")).toBe(true);
+    expect(toolPatternMatches("ab*cd*ef", "abcdef")).toBe(true);
+    expect(toolPatternMatches("a*b*c", "axbxc")).toBe(false);
+    expect(toolPatternMatches("ab*cd*ef", "abxcdyef")).toBe(false);
+  });
+
   it("does not let prefix and suffix overlap the same characters", () => {
     // `a*b` requires at least "ab" worth of distinct characters.
     expect(toolPatternMatches("ab*ab", "abab")).toBe(true);

--- a/crates/librefang-api/dashboard/src/lib/toolGrants.ts
+++ b/crates/librefang-api/dashboard/src/lib/toolGrants.ts
@@ -27,22 +27,27 @@ export function toolPatternMatches(pattern: string, value: string): boolean {
   if (pattern === value) return true;
   if (!pattern.includes("*")) return false;
 
-  const parts = pattern.split("*");
-  // Leading literal must be a prefix.
-  const first = parts[0];
-  if (first && !value.startsWith(first)) return false;
-  // Trailing literal must be a suffix.
-  const last = parts[parts.length - 1];
-  if (last && !value.endsWith(last)) return false;
-  // Interior literals must appear in order, and the prefix/suffix must not overlap — `a*b` should not match `ab` twice over the same characters.
-  let cursor = first.length;
-  for (const segment of parts.slice(1, -1)) {
-    if (!segment) continue;
-    const at = value.indexOf(segment, cursor);
-    if (at === -1) return false;
-    cursor = at + segment.length;
+  if (pattern.startsWith("*")) {
+    const suffix = pattern.slice(1);
+    if (!suffix.includes("*")) return value.endsWith(suffix);
   }
-  return cursor + last.length <= value.length;
+  if (pattern.endsWith("*")) {
+    const prefix = pattern.slice(0, -1);
+    if (!prefix.includes("*")) return value.startsWith(prefix);
+  }
+
+  const starIndex = pattern.indexOf("*");
+  const prefix = pattern.slice(0, starIndex);
+  const suffix = pattern.slice(starIndex + 1);
+  if (suffix.includes("*")) {
+    if (!value.startsWith(prefix)) return false;
+    return toolPatternMatches(suffix, value.slice(prefix.length));
+  }
+  return (
+    value.startsWith(prefix) &&
+    value.endsWith(suffix) &&
+    value.length >= prefix.length + suffix.length
+  );
 }
 
 /** Whether `toolName` is filtered out by a `tool_blocklist`. */
@@ -64,7 +69,7 @@ export function resolveMcpGrantMode(
   mcpServers: readonly string[] | undefined,
   mode: McpGrantMode | undefined,
 ): McpGrantMode {
-  if (mode) return mode;
+  if (mode !== undefined) return mode;
   const servers = mcpServers ?? [];
   if (servers.length === 0) return "none";
   if (servers.some((s) => s === "*")) return "all";


### PR DESCRIPTION
## Summary

- port the kernel’s recursive prefix-stripping behavior for multi-wildcard tool patterns
- prevent dashboard grant displays from overmatching patterns such as `a*b*c`
- distinguish an absent backend MCP mode explicitly instead of relying on string truthiness

## Verification

- `corepack pnpm exec vitest run src/lib/toolGrants.test.ts` (25 tests)
- `corepack pnpm test` (96 files, 1013 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`

## Out of scope

- kernel glob semantics and grant policy remain unchanged