### PR TITLE
fix(dashboard): prevent stale TTS playback

### DIFF
--- a/changelog.d/fixed/dashboard-tts-races.md
+++ b/changelog.d/fixed/dashboard-tts-races.md
@@ -1,0 +1,1 @@
+- Prevent stale or duplicate dashboard speech requests from taking over playback, and preserve spoken currency ranges. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/tts.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/tts.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stripMarkdown, useTtsManager } from "./tts";
+
+const synthesizeSpeech = vi.hoisted(() => vi.fn());
+
+vi.mock("../api", () => ({ synthesizeSpeech }));
+
+type AudioListener = EventListenerOrEventListenerObject;
+
+class MockAudio {
+  static instances: MockAudio[] = [];
+  static playImpl: () => Promise<void> = () => Promise.resolve();
+
+  currentTime = 0;
+  readonly listeners = new Map<string, Set<AudioListener>>();
+  readonly pause = vi.fn();
+  readonly play = vi.fn(() => MockAudio.playImpl());
+
+  constructor(readonly src: string) {
+    MockAudio.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: AudioListener): void {
+    const listeners = this.listeners.get(type) ?? new Set<AudioListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: AudioListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      if (typeof listener === "function") listener(new Event(type));
+      else listener.handleEvent(new Event(type));
+    }
+  }
+}
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeEach(() => {
+  synthesizeSpeech.mockReset();
+  MockAudio.instances = [];
+  MockAudio.playImpl = () => Promise.resolve();
+  vi.stubGlobal("Audio", MockAudio);
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+describe("stripMarkdown", () => {
+  it("preserves currency ranges while removing command-based inline LaTeX", () => {
+    expect(stripMarkdown("Costs $5 to $10 today.")).toBe("Costs $5 to $10 today.");
+    expect(stripMarkdown("Before $\\frac{1}{2}$ after")).toBe("Before  after");
+  });
+});
+
+describe("useTtsManager", () => {
+  it("ignores a duplicate toggle while the same message is loading", async () => {
+    const pending = deferred<{ url: string }>();
+    synthesizeSpeech.mockReturnValueOnce(pending.promise);
+    const { result } = renderHook(() => useTtsManager());
+
+    let first!: Promise<void>;
+    act(() => {
+      first = result.current.toggle("a", "hello");
+    });
+    await waitFor(() => expect(result.current.status).toBe("loading"));
+    await act(async () => {
+      await result.current.toggle("a", "hello");
+    });
+    expect(synthesizeSpeech).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.stop());
+    await act(async () => {
+      pending.resolve({ url: "blob:cancelled" });
+      await first;
+    });
+  });
+
+  it("discards a superseded synthesis result without disturbing newer playback", async () => {
+    const firstSynthesis = deferred<{ url: string }>();
+    synthesizeSpeech
+      .mockReturnValueOnce(firstSynthesis.promise)
+      .mockResolvedValueOnce({ url: "blob:new" });
+    const { result } = renderHook(() => useTtsManager());
+
+    let first!: Promise<void>;
+    act(() => {
+      first = result.current.toggle("a", "first");
+    });
+    await waitFor(() => expect(result.current.status).toBe("loading"));
+    await act(async () => {
+      await result.current.toggle("b", "second");
+    });
+    expect(result.current.speakingMessageId).toBe("b");
+    expect(result.current.status).toBe("playing");
+
+    await act(async () => {
+      firstSynthesis.resolve({ url: "blob:old" });
+      await first;
+    });
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:old");
+    expect(MockAudio.instances.map((audio) => audio.src)).toEqual(["blob:new"]);
+    expect(result.current.speakingMessageId).toBe("b");
+    expect(result.current.status).toBe("playing");
+  });
+
+  it("ignores terminal events from a superseded audio element", async () => {
+    synthesizeSpeech
+      .mockResolvedValueOnce({ url: "blob:first" })
+      .mockResolvedValueOnce({ url: "blob:second" });
+    const { result } = renderHook(() => useTtsManager());
+
+    await act(async () => result.current.toggle("a", "first"));
+    const oldAudio = MockAudio.instances[0];
+    await act(async () => result.current.toggle("b", "second"));
+
+    act(() => oldAudio.emit("ended"));
+    act(() => oldAudio.emit("error"));
+    expect(result.current.speakingMessageId).toBe("b");
+    expect(result.current.status).toBe("playing");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("detaches terminal listeners when audio playback rejects", async () => {
+    synthesizeSpeech.mockResolvedValueOnce({ url: "blob:failed" });
+    MockAudio.playImpl = () => Promise.reject(new Error("autoplay blocked"));
+    const { result } = renderHook(() => useTtsManager());
+
+    await act(async () => result.current.toggle("a", "hello"));
+    const audio = MockAudio.instances[0];
+    expect(audio.listeners.get("ended")?.size).toBe(0);
+    expect(audio.listeners.get("error")?.size).toBe(0);
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBe("tts_error");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/tts.ts
+++ b/crates/librefang-api/dashboard/src/lib/tts.ts
@@ -24,8 +24,9 @@ export function stripMarkdown(text: string): string {
   // Remove LaTeX display blocks ($$...$$) before inline
   result = result.replace(/\$\$[\s\S]*?\$\$/g, "");
 
-  // Remove LaTeX inline ($...$)
-  result = result.replace(/\$[^$\n]+?\$/g, "");
+  // Remove inline LaTeX only when it contains a command. A broad `$...$`
+  // match also consumes ordinary currency ranges such as "$5 to $10".
+  result = result.replace(/\$[^$\n]*\\[a-zA-Z]+[^$\n]*\$/g, "");
 
   // Remove inline code
   result = result.replace(/`[^`]*`/g, "");
@@ -121,6 +122,12 @@ export function useTtsManager(config?: TtsSpeechConfig): UseTtsManagerReturn {
         return;
       }
 
+      // A second click while synthesis is pending must not launch another
+      // request for the same message.
+      if (currentMessageIdRef.current === messageId && status === "loading") {
+        return;
+      }
+
       // Different message or idle -> stop current, start new
       stop();
 
@@ -143,9 +150,16 @@ export function useTtsManager(config?: TtsSpeechConfig): UseTtsManagerReturn {
 
         try {
           const result = await synthesizeSpeech({ text: stripped, provider: config?.provider, voice: config?.voice, language: config?.language, speed: config?.speed });
+          if (currentMessageIdRef.current !== messageId) {
+            if (result.url.startsWith("blob:")) {
+              URL.revokeObjectURL(result.url);
+            }
+            return;
+          }
           objectUrl = result.url;
           cacheRef.current.set(messageId, objectUrl);
         } catch {
+          if (currentMessageIdRef.current !== messageId) return;
           setStatus("idle");
           setSpeakingMessageId(null);
           setError("tts_error");
@@ -158,28 +172,40 @@ export function useTtsManager(config?: TtsSpeechConfig): UseTtsManagerReturn {
       audioRef.current = audio;
       currentAudioUrlRef.current = objectUrl;
 
-      audio.addEventListener("ended", () => {
+      const onEnded = () => {
+        if (audioRef.current !== audio) return;
         setStatus("idle");
         setSpeakingMessageId(null);
+        audioRef.current = null;
         currentMessageIdRef.current = null;
         currentAudioUrlRef.current = null;
-      }, { once: true });
+      };
 
-      audio.addEventListener("error", () => {
+      const onError = () => {
+        if (audioRef.current !== audio) return;
         setStatus("idle");
         setSpeakingMessageId(null);
         setError("tts_error");
+        audioRef.current = null;
         currentMessageIdRef.current = null;
         currentAudioUrlRef.current = null;
-      }, { once: true });
+      };
+
+      audio.addEventListener("ended", onEnded, { once: true });
+      audio.addEventListener("error", onError, { once: true });
 
       try {
         await audio.play();
+        if (audioRef.current !== audio) return;
         setStatus("playing");
       } catch {
+        audio.removeEventListener("ended", onEnded);
+        audio.removeEventListener("error", onError);
+        if (audioRef.current !== audio) return;
         setStatus("idle");
         setSpeakingMessageId(null);
         setError("tts_error");
+        audioRef.current = null;
         currentMessageIdRef.current = null;
         currentAudioUrlRef.current = null;
       }


### PR DESCRIPTION
## Summary

- ignore duplicate toggles while the same message is synthesizing
- discard and revoke superseded synthesis results before caching or playback
- guard terminal audio events and post-play state updates by active element ownership
- detach terminal listeners when playback rejects
- preserve currency ranges while still stripping command-based inline LaTeX

## Verification

- `corepack pnpm exec vitest run src/lib/tts.test.ts` (5 tests)
- `corepack pnpm test` (97 files, 1017 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`

## Out of scope

- TTS provider selection and server synthesis behavior remain unchanged