### PR TITLE
fix(dashboard): bound unified diff memory

### DIFF
--- a/changelog.d/fixed/dashboard-unified-diff.md
+++ b/changelog.d/fixed/dashboard-unified-diff.md
@@ -1,0 +1,1 @@
+- Bound dashboard unified-diff LCS allocation and fall back to a flat replacement for oversized inputs. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/unifiedDiff.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/unifiedDiff.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { unifiedLineDiff, hasChanges } from "./unifiedDiff";
+import {
+  unifiedLineDiff,
+  hasChanges,
+  MAX_DIFF_LINES,
+  MAX_LCS_CELLS,
+} from "./unifiedDiff";
 
 describe("unifiedLineDiff", () => {
   it("returns all-context when texts are identical", () => {
@@ -51,5 +56,26 @@ describe("unifiedLineDiff", () => {
       { kind: "context", text: "a" },
       { kind: "add", text: "b" },
     ]);
+  });
+
+  it("falls back to a flat replacement beyond the line-count ceiling", () => {
+    const oldLines = Array.from({ length: MAX_DIFF_LINES + 1 }, (_, i) => `old-${i}`);
+    const diff = unifiedLineDiff(oldLines.join("\n"), "new");
+
+    expect(diff).toHaveLength(MAX_DIFF_LINES + 2);
+    expect(diff.slice(0, MAX_DIFF_LINES + 1).every((line) => line.kind === "remove")).toBe(true);
+    expect(diff[diff.length - 1]).toEqual({ kind: "add", text: "new" });
+  });
+
+  it("falls back before two moderate inputs exceed the LCS cell budget", () => {
+    const side = Math.floor(Math.sqrt(MAX_LCS_CELLS));
+    const oldLines = Array.from({ length: side }, (_, i) => `same-${i}`);
+    const newLines = Array.from({ length: side }, (_, i) => `same-${i}`);
+    const diff = unifiedLineDiff(oldLines.join("\n"), newLines.join("\n"));
+
+    expect((side + 1) * (side + 1)).toBeGreaterThan(MAX_LCS_CELLS);
+    expect(diff).toHaveLength(side * 2);
+    expect(diff.slice(0, side).every((line) => line.kind === "remove")).toBe(true);
+    expect(diff.slice(side).every((line) => line.kind === "add")).toBe(true);
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/unifiedDiff.ts
+++ b/crates/librefang-api/dashboard/src/lib/unifiedDiff.ts
@@ -15,6 +15,14 @@ export interface DiffLine {
   text: string;
 }
 
+export const MAX_DIFF_LINES = 4_000;
+export const MAX_LCS_CELLS = 1_000_000;
+
+const flatReplacement = (oldLines: string[], newLines: string[]): DiffLine[] => [
+  ...oldLines.map((text): DiffLine => ({ kind: "remove", text })),
+  ...newLines.map((text): DiffLine => ({ kind: "add", text })),
+];
+
 /**
  * Compute a line-level unified diff between `oldText` and `newText`.
  *
@@ -26,11 +34,20 @@ export function unifiedLineDiff(oldText: string, newText: string): DiffLine[] {
   const a = splitLines(oldText);
   const b = splitLines(newText);
 
-  // LCS length table over lines. n/m are bounded by the skill body size,
-  // which the daemon caps (MAX_PROMPT_CONTEXT_CHARS) — fine for an O(n*m)
-  // table here.
   const n = a.length;
   const m = b.length;
+  // The daemon's body limit is measured in characters, not lines. Dense
+  // short-line inputs can therefore make an O(n*m) table enormous. Preserve
+  // a useful preview without risking a synchronous browser OOM.
+  if (
+    n > MAX_DIFF_LINES ||
+    m > MAX_DIFF_LINES ||
+    (n + 1) * (m + 1) > MAX_LCS_CELLS
+  ) {
+    return flatReplacement(a, b);
+  }
+
+  // LCS length table over lines, bounded by the guards above.
   const lcs: number[][] = Array.from({ length: n + 1 }, () =>
     new Array<number>(m + 1).fill(0),
   );


### PR DESCRIPTION
## Summary

- cap line-level LCS previews at 4000 lines per side
- cap the allocated matrix at one million cells for moderately large two-sided inputs
- fall back deterministically to all removals followed by all additions
- correct the previous character-limit safety assumption in source comments

## Verification

- `corepack pnpm exec vitest run src/lib/unifiedDiff.test.ts` (8 tests)
- `corepack pnpm test` (96 files, 1014 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`

## Out of scope

- diff rendering and small-input LCS semantics remain unchanged