### PR TITLE
fix(dashboard): stabilize create shortcut

### DIFF
--- a/changelog.d/fixed/dashboard-create-shortcut.md
+++ b/changelog.d/fixed/dashboard-create-shortcut.md
@@ -1,0 +1,1 @@
+- Keep the dashboard create-shortcut listener stable across renders while invoking the latest page handler. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/useCreateShortcut.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/useCreateShortcut.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CREATE_EVENT } from "./useKeyboardShortcuts";
+import { useCreateShortcut } from "./useCreateShortcut";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("useCreateShortcut", () => {
+  it("subscribes once across rerenders and invokes the latest handler", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    const { rerender, unmount } = renderHook(
+      ({ handler }) => useCreateShortcut(handler),
+      { initialProps: { handler: first } },
+    );
+
+    const createAdds = () =>
+      addEventListener.mock.calls.filter(([type]) => type === CREATE_EVENT);
+    const createRemovals = () =>
+      removeEventListener.mock.calls.filter(([type]) => type === CREATE_EVENT);
+
+    expect(createAdds()).toHaveLength(1);
+    rerender({ handler: second });
+    expect(createAdds()).toHaveLength(1);
+    expect(createRemovals()).toHaveLength(0);
+
+    act(() => window.dispatchEvent(new Event(CREATE_EVENT)));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+
+    unmount();
+    expect(createRemovals()).toHaveLength(1);
+    expect(createRemovals()[0][1]).toBe(createAdds()[0][1]);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/useCreateShortcut.ts
+++ b/crates/librefang-api/dashboard/src/lib/useCreateShortcut.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { CREATE_EVENT } from "./useKeyboardShortcuts";
 
 /// Subscribe to the global `n` keyboard shortcut. When the user presses
@@ -9,8 +9,12 @@ import { CREATE_EVENT } from "./useKeyboardShortcuts";
 /// a page removes its listener, so navigating away automatically
 /// re-wires `n` to whatever the next page registers.
 export function useCreateShortcut(handler: () => void) {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
   useEffect(() => {
-    window.addEventListener(CREATE_EVENT, handler);
-    return () => window.removeEventListener(CREATE_EVENT, handler);
-  }, [handler]);
+    const listener = () => handlerRef.current();
+    window.addEventListener(CREATE_EVENT, listener);
+    return () => window.removeEventListener(CREATE_EVENT, listener);
+  }, []);
 }


### PR DESCRIPTION
## Summary

- subscribe to the global create event once per mounted page
- retain the latest inline handler through a ref without listener churn
- verify rerenders do not rewire the listener and unmount removes the exact subscription

## Verification

- `corepack pnpm exec vitest run src/lib/useCreateShortcut.test.ts`
- `corepack pnpm test` (97 files, 1013 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`

## Out of scope

- keyboard filtering and event dispatch behavior remain unchanged