### PR TITLE
fix(dashboard): contain modal focus

### DIFF
--- a/changelog.d/fixed/dashboard-focus-trap.md
+++ b/changelog.d/fixed/dashboard-focus-trap.md
@@ -1,0 +1,1 @@
+- Keep dashboard modal focus contained when focus escapes, lands on a non-tabbable child, or has no visible target. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/useFocusTrap.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/useFocusTrap.test.tsx
@@ -1,0 +1,92 @@
+import { useRef, type ReactNode } from "react";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFocusTrap } from "./useFocusTrap";
+
+function Harness({ children }: { children?: ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(true, ref);
+  return (
+    <div ref={ref} tabIndex={-1} data-testid="trap">
+      {children}
+    </div>
+  );
+}
+
+const pressTab = (shiftKey = false): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", {
+    key: "Tab",
+    shiftKey,
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => window.dispatchEvent(event));
+  return event;
+};
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "getClientRects").mockImplementation(
+    function getClientRects(this: HTMLElement) {
+      return (this.dataset.hidden === "true" ? [] : [{}]) as unknown as DOMRectList;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("useFocusTrap", () => {
+  it("uses the same visibility filter for initial focus", () => {
+    render(
+      <Harness>
+        <button data-hidden="true">Hidden</button>
+        <button>Visible</button>
+      </Harness>,
+    );
+    expect(screen.getByRole("button", { name: "Visible" })).toHaveFocus();
+  });
+
+  it("pulls escaped focus back to the first or last element", () => {
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    render(
+      <Harness>
+        <button>First</button>
+        <button>Last</button>
+      </Harness>,
+    );
+
+    outside.focus();
+    expect(pressTab().defaultPrevented).toBe(true);
+    expect(screen.getByRole("button", { name: "First" })).toHaveFocus();
+
+    outside.focus();
+    expect(pressTab(true).defaultPrevented).toBe(true);
+    expect(screen.getByRole("button", { name: "Last" })).toHaveFocus();
+  });
+
+  it("recovers when focus is on a non-tabbable descendant", () => {
+    render(
+      <Harness>
+        <button>First</button>
+        <span tabIndex={-1}>Programmatic</span>
+        <button>Last</button>
+      </Harness>,
+    );
+    screen.getByText("Programmatic").focus();
+
+    expect(pressTab().defaultPrevented).toBe(true);
+    expect(screen.getByRole("button", { name: "First" })).toHaveFocus();
+  });
+
+  it("keeps focus on the container when it has no focusable descendants", () => {
+    render(<Harness />);
+    const trap = screen.getByTestId("trap");
+    expect(trap).toHaveFocus();
+
+    expect(pressTab().defaultPrevented).toBe(true);
+    expect(trap).toHaveFocus();
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/useFocusTrap.ts
+++ b/crates/librefang-api/dashboard/src/lib/useFocusTrap.ts
@@ -9,6 +9,15 @@ const FOCUSABLE_SELECTOR = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(", ");
 
+export function getVisibleFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter(
+    (element) =>
+      !element.hasAttribute("disabled") && element.getClientRects().length > 0,
+  );
+}
+
 /// Traps Tab / Shift+Tab focus movement within the given container while
 /// `isOpen` is true, restores focus to the previously-active element on
 /// close, and autofocuses the first focusable element inside the
@@ -51,9 +60,7 @@ export function useFocusTrap(
     // programmatically without joining the tab order).
     const container = containerRef.current;
     if (container) {
-      const focusable = Array.from(
-        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      );
+      const focusable = getVisibleFocusable(container);
       if (focusable.length > 0) {
         focusable[0].focus();
       } else if (container.tabIndex >= -1) {
@@ -75,17 +82,22 @@ export function useFocusTrap(
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Tab" || !container) return;
-      const focusable = Array.from(
-        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      ).filter(
-        (el) => !el.hasAttribute("disabled") && el.getClientRects().length > 0,
-      );
-      if (focusable.length === 0) return;
+      const focusable = getVisibleFocusable(container);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        container.focus();
+        return;
+      }
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
       const active = document.activeElement as HTMLElement | null;
-      // Shift+Tab on first → cycle to last; Tab on last → cycle to first.
-      if (e.shiftKey && active === first) {
+      const activeIsFocusable = active !== null && focusable.includes(active);
+      // Pull escaped or non-tabbable focus back into the trap, then cycle at
+      // either boundary in the requested direction.
+      if (!container.contains(active) || !activeIsFocusable) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+      } else if (e.shiftKey && active === first) {
         e.preventDefault();
         last.focus();
       } else if (!e.shiftKey && active === last) {


### PR DESCRIPTION
## Summary

- share one visible/enabled focusable-element filter for initial focus and Tab handling
- pull escaped or non-tabbable focus back into the modal in the requested direction
- prevent Tab from leaving an empty trap and keep focus on its container

## Verification

- `corepack pnpm exec vitest run src/lib/useFocusTrap.test.tsx src/components/ui/Modal.test.tsx` (9 tests)
- `corepack pnpm test` (97 files, 1016 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`

## Out of scope

- non-modal drawer behavior and focus restoration policy remain unchanged