### PR TITLE
fix(dashboard): restore keyboard nav chord

### DIFF
--- a/changelog.d/fixed/dashboard-keyboard-shortcuts.md
+++ b/changelog.d/fixed/dashboard-keyboard-shortcuts.md
@@ -1,0 +1,1 @@
+- Restore `g n` Channels navigation and type-check dashboard shortcut destinations against registered routes. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/useKeyboardShortcuts.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/useKeyboardShortcuts.test.ts
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CREATE_EVENT, useKeyboardShortcuts } from "./useKeyboardShortcuts";
+
+const navigate = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+afterEach(() => {
+  navigate.mockReset();
+  vi.restoreAllMocks();
+});
+
+const press = (key: string): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => window.dispatchEvent(event));
+  return event;
+};
+
+describe("useKeyboardShortcuts", () => {
+  it("resolves g+n as Channels navigation instead of create", () => {
+    const onCreate = vi.fn();
+    window.addEventListener(CREATE_EVENT, onCreate);
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcuts({ onShowHelp: vi.fn() }),
+    );
+
+    press("g");
+    const second = press("n");
+
+    expect(second.defaultPrevented).toBe(true);
+    expect(navigate).toHaveBeenCalledWith({ to: "/channels" });
+    expect(onCreate).not.toHaveBeenCalled();
+
+    unmount();
+    window.removeEventListener(CREATE_EVENT, onCreate);
+  });
+
+  it("still dispatches create for a standalone n", () => {
+    const onCreate = vi.fn();
+    window.addEventListener(CREATE_EVENT, onCreate);
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcuts({ onShowHelp: vi.fn() }),
+    );
+
+    const event = press("n");
+    expect(event.defaultPrevented).toBe(true);
+    expect(onCreate).toHaveBeenCalledOnce();
+    expect(navigate).not.toHaveBeenCalled();
+
+    unmount();
+    window.removeEventListener(CREATE_EVENT, onCreate);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/useKeyboardShortcuts.ts
+++ b/crates/librefang-api/dashboard/src/lib/useKeyboardShortcuts.ts
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import type { router } from "../router";
+
+type DashboardRoutePath = keyof typeof router.routesByPath;
 
 /// Vim-style `g` + letter navigation bindings. The first letter of the
 /// route is canonical; collisions (scheduler vs skills, providers vs
@@ -13,7 +16,10 @@ import { useNavigate } from "@tanstack/react-router";
 /// namespace at render time — see `ShortcutsHelp.tsx`. The constant lives
 /// outside React context so it can also drive the actual key-handler
 /// below, where labels are not needed.
-export const G_NAV_SHORTCUTS: Record<string, { to: string; labelKey: string }> = {
+export const G_NAV_SHORTCUTS: Record<
+  string,
+  { to: DashboardRoutePath; labelKey: string }
+> = {
   o: { to: "/overview", labelKey: "overview" },
   c: { to: "/chat", labelKey: "chat" },
   a: { to: "/agents", labelKey: "agents" },
@@ -80,6 +86,20 @@ export function useKeyboardShortcuts({ onShowHelp }: KeyboardShortcutsOptions) {
         return;
       }
 
+      const now = Date.now();
+
+      // A fresh `g` prefix owns the next key. Consume the chord before
+      // single-key actions so `g n` navigates instead of creating.
+      if (gPressedAt && now - gPressedAt < G_TIMEOUT_MS) {
+        gPressedAt = 0;
+        const target = G_NAV_SHORTCUTS[e.key.toLowerCase()];
+        if (target) {
+          e.preventDefault();
+          navigate({ to: target.to });
+        }
+        return;
+      }
+
       // `?` opens the help modal. Shift is held to produce `?` on most
       // layouts, so we check the character rather than `e.shiftKey`.
       if (e.key === "?") {
@@ -105,20 +125,6 @@ export function useKeyboardShortcuts({ onShowHelp }: KeyboardShortcutsOptions) {
       if (e.key === "n") {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent(CREATE_EVENT));
-        return;
-      }
-
-      const now = Date.now();
-
-      // If the previous keypress was `g` and still fresh, consume this
-      // key as the second half of a `g<x>` navigation binding.
-      if (gPressedAt && now - gPressedAt < G_TIMEOUT_MS) {
-        gPressedAt = 0;
-        const target = G_NAV_SHORTCUTS[e.key.toLowerCase()];
-        if (target) {
-          e.preventDefault();
-          navigate({ to: target.to } as never);
-        }
         return;
       }
 


### PR DESCRIPTION
## Summary

- consume an active `g` prefix before standalone shortcut handlers
- restore `g n` navigation to Channels without dispatching create
- derive shortcut destinations from the registered router path keys
- remove the unsafe navigation argument cast

## Verification

- `corepack pnpm exec vitest run src/lib/useKeyboardShortcuts.test.ts` (2 tests)
- `corepack pnpm test` (97 files, 1020 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`

## Out of scope

- shortcut assignments and timeout duration remain unchanged