### PR TITLE
fix(dashboard): surface A2A mutation failures

### DIFF
--- a/changelog.d/fixed/a2a-mutation-errors.md
+++ b/changelog.d/fixed/a2a-mutation-errors.md
@@ -1,0 +1,1 @@
+Surface dashboard A2A discovery failures and route task sends through the shared mutation hook. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/network.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/network.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { a2aKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import { useDiscoverA2AAgent, useSendA2ATask } from "./network";
+
+vi.mock("../http/client", () => ({
+  discoverA2AAgent: vi.fn().mockResolvedValue({}),
+  sendA2ATask: vi.fn().mockResolvedValue({ task_id: "task-1" }),
+}));
+
+describe("A2A mutations", () => {
+  it("invalidates discovered agents", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDiscoverA2AAgent(), { wrapper });
+
+    await result.current.mutateAsync("https://agent.example");
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: a2aKeys.agents() });
+  });
+
+  it("routes task sends through the shared HTTP client hook", async () => {
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useSendA2ATask(), { wrapper });
+    const payload = { agent_url: "https://agent.example", message: "run" };
+
+    await expect(result.current.mutateAsync(payload)).resolves.toEqual({ task_id: "task-1" });
+    expect(http.sendA2ATask).toHaveBeenCalledWith(payload, expect.any(Object));
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/A2APage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/A2APage.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { A2APage } from "./A2APage";
+
+const addToast = vi.fn();
+const discover = vi.fn();
+
+vi.mock("../lib/queries/network", () => ({
+  useA2AAgents: () => ({
+    data: [],
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("../lib/mutations/network", () => ({
+  useDiscoverA2AAgent: () => ({ mutateAsync: discover, isPending: false }),
+  useSendA2ATask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("../lib/http/client", () => ({ getA2ATaskStatus: vi.fn() }));
+vi.mock("../lib/store", () => ({
+  useUIStore: (selector: (state: { addToast: typeof addToast }) => unknown) =>
+    selector({ addToast }),
+}));
+vi.mock("../lib/useCreateShortcut", () => ({ useCreateShortcut: vi.fn() }));
+
+describe("A2APage", () => {
+  beforeEach(() => {
+    addToast.mockClear();
+    discover.mockReset();
+  });
+
+  it("surfaces discovery failures", async () => {
+    discover.mockRejectedValueOnce(new Error("discovery unavailable"));
+    render(<A2APage />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "a2a.discover" })[0]);
+    fireEvent.change(screen.getByPlaceholderText("a2a.discover_placeholder"), {
+      target: { value: "https://agent.example" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "a2a.discover" })[1]);
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith("discovery unavailable", "error");
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/A2APage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/A2APage.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "motion/react";
 import { fadeInScale } from "../lib/motion";
 import { StaggerList } from "../components/ui/StaggerList";
-import { sendA2ATask, getA2ATaskStatus } from "../lib/http/client";
+import { getA2ATaskStatus } from "../lib/http/client";
 import type { A2AAgentItem, A2ATaskStatus } from "../lib/http/client";
 import { useA2AAgents } from "../lib/queries/network";
-import { useDiscoverA2AAgent } from "../lib/mutations/network";
+import { useDiscoverA2AAgent, useSendA2ATask } from "../lib/mutations/network";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { DrawerPanel } from "../components/ui/DrawerPanel";
@@ -33,12 +33,12 @@ export function A2APage() {
   // Send task state
   const [taskAgent, setTaskAgent] = useState<A2AAgentItem | null>(null);
   const [taskMessage, setTaskMessage] = useState("");
-  const [isSending, setIsSending] = useState(false);
   const [trackedTasks, setTrackedTasks] = useState<A2ATaskStatus[]>([]);
   const addToast = useUIStore((s) => s.addToast);
 
   const agentsQuery = useA2AAgents();
   const discoverMutation = useDiscoverA2AAgent();
+  const sendTaskMutation = useSendA2ATask();
 
   const agents = agentsQuery.data ?? [];
 
@@ -48,16 +48,15 @@ export function A2APage() {
       await discoverMutation.mutateAsync(discoverUrl.trim());
       setDiscoverUrl("");
       setShowDiscover(false);
-    } catch {
-      // error handled by UI
+    } catch (error) {
+      addToast(toastErr(error, t("common.error")), "error");
     }
   }
 
   async function handleSendTask() {
     if (!taskAgent?.url || !taskMessage.trim()) return;
-    setIsSending(true);
     try {
-      const result = await sendA2ATask({
+      const result = await sendTaskMutation.mutateAsync({
         agent_url: taskAgent.url,
         message: taskMessage.trim(),
       });
@@ -76,8 +75,6 @@ export function A2APage() {
       setTaskAgent(null);
     } catch (err) {
       addToast(toastErr(err, t("common.error")), "error");
-    } finally {
-      setIsSending(false);
     }
   }
 
@@ -259,10 +256,10 @@ export function A2APage() {
                   </button>
                   <button
                     onClick={handleSendTask}
-                    disabled={isSending || !taskMessage.trim()}
+                    disabled={sendTaskMutation.isPending || !taskMessage.trim()}
                     className="flex items-center gap-2 rounded-xl bg-brand px-5 py-2 text-sm font-bold text-white hover:bg-brand/90 disabled:opacity-40 transition-colors"
                   >
-                    {isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                    {sendTaskMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
                     {t("a2a.send")}
                   </button>
                 </div>


### PR DESCRIPTION
## Changes
- surface A2A discovery failures through the dashboard error toast
- route A2A task sends through `useSendA2ATask` so the page uses the shared mutation contract
- cover discovery invalidation, task-send routing, and page-level error feedback

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/network.test.tsx src/pages/A2APage.test.tsx`
- `corepack pnpm test` (99 files, 1028 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- task-status polling still keeps its existing best-effort refresh behavior; changing that UX belongs in a separate issue/PR