### PR TITLE
refactor(dashboard): align plugin scaffold payload

### DIFF
--- a/changelog.d/fixed/plugin-scaffold-description.md
+++ b/changelog.d/fixed/plugin-scaffold-description.md
@@ -1,0 +1,1 @@
+Align the dashboard plugin scaffold mutation's description field with the API contract. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/plugins.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/plugins.test.tsx
@@ -1,0 +1,31 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { pluginKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import { useScaffoldPlugin } from "./plugins";
+
+vi.mock("../http/client", () => ({
+  scaffoldPlugin: vi.fn().mockResolvedValue({ status: "ok" }),
+}));
+
+describe("useScaffoldPlugin", () => {
+  it("maps the named description to the scaffold API and invalidates plugin views", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useScaffoldPlugin(), { wrapper });
+
+    await result.current.mutateAsync({
+      name: "example-plugin",
+      description: "Example description",
+      runtime: "python",
+    });
+
+    expect(http.scaffoldPlugin).toHaveBeenCalledWith(
+      "example-plugin",
+      "Example description",
+      "python",
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: pluginKeys.all });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/plugins.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/plugins.ts
@@ -28,8 +28,8 @@ export function useUninstallPlugin() {
 export function useScaffoldPlugin() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ name, desc, runtime }: { name: string; desc: string; runtime?: string }) =>
-      scaffoldPlugin(name, desc, runtime),
+    mutationFn: ({ name, description, runtime }: { name: string; description: string; runtime?: string }) =>
+      scaffoldPlugin(name, description, runtime),
     onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.all }),
   });
 }

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.test.tsx
@@ -405,7 +405,7 @@ describe("PluginsPage", () => {
     const [payload] = scaffoldMutate.mock.calls[0];
     expect(payload).toEqual({
       name: "my-plugin",
-      desc: "scaffold from test",
+      description: "scaffold from test",
       runtime: "python",
     });
   });

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -549,7 +549,7 @@ export function PluginsPage() {
           <div className="flex gap-2 pt-2">
             <Button variant="primary" className="flex-1"
               onClick={() => scaffoldMutation.mutate(
-                { name: scaffoldName, desc: scaffoldDesc, runtime: scaffoldRuntime },
+                { name: scaffoldName, description: scaffoldDesc, runtime: scaffoldRuntime },
                 {
                   onSuccess: () => {
                     setShowScaffold(false);


### PR DESCRIPTION
## Changes
- rename the plugin scaffold mutation input from `desc` to `description` to match the HTTP API contract
- update the Plugins page and its existing form regression to use the explicit field
- add hook-level coverage for positional API mapping and plugin-domain invalidation

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/plugins.test.tsx`
- `corepack pnpm test` (98 files, 1026 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- hook-level error toasts; all current Plugins page calls provide translated `onError` feedback, and adding mutation-level toasts would duplicate those notices
- plugin API payloads and cache invalidation scope