### PR TITLE
fix(dashboard): roll back failed prompt binds

### DIFF
--- a/changelog.d/fixed/prompt-bind-rollback.md
+++ b/changelog.d/fixed/prompt-bind-rollback.md
@@ -1,0 +1,1 @@
+Restore the previous live prompt when dashboard prompt-version activation fails. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/prompts.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/prompts.test.tsx
@@ -1,0 +1,92 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { agentKeys, promptsKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import { PromptBindRollbackError, useBindPromptVersionToAgent } from "./prompts";
+
+vi.mock("../http/client", () => ({
+  createPromptVersion: vi.fn(),
+  deletePromptVersion: vi.fn(),
+  activatePromptVersion: vi.fn(),
+  patchAgent: vi.fn(),
+}));
+
+const version = {
+  id: "version-2",
+  agent_id: "agent-1",
+  version: 2,
+  content_hash: "hash",
+  system_prompt: "new prompt",
+  tools: [],
+  variables: [],
+  created_at: "2026-01-01T00:00:00Z",
+  created_by: "dashboard",
+  is_active: false,
+};
+
+describe("useBindPromptVersionToAgent", () => {
+  beforeEach(() => {
+    vi.mocked(http.patchAgent).mockReset().mockResolvedValue({});
+    vi.mocked(http.activatePromptVersion).mockReset().mockResolvedValue(version);
+  });
+
+  it("restores the previous live prompt when activation fails", async () => {
+    const activationError = new Error("activation failed");
+    vi.mocked(http.activatePromptVersion).mockRejectedValueOnce(activationError);
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useBindPromptVersionToAgent(), { wrapper });
+
+    await expect(result.current.mutateAsync({
+      agentId: "agent-1",
+      version,
+      previousSystemPrompt: "old prompt",
+    })).rejects.toBe(activationError);
+
+    expect(http.patchAgent).toHaveBeenNthCalledWith(1, "agent-1", {
+      system_prompt: "new prompt",
+    });
+    expect(http.patchAgent).toHaveBeenNthCalledWith(2, "agent-1", {
+      system_prompt: "old prompt",
+    });
+  });
+
+  it("reports both failures when compensating rollback also fails", async () => {
+    const activationError = new Error("activation failed");
+    const rollbackError = new Error("rollback failed");
+    vi.mocked(http.activatePromptVersion).mockRejectedValueOnce(activationError);
+    vi.mocked(http.patchAgent)
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(rollbackError);
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useBindPromptVersionToAgent(), { wrapper });
+
+    const failure = await result.current.mutateAsync({
+      agentId: "agent-1",
+      version,
+      previousSystemPrompt: "old prompt",
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(PromptBindRollbackError);
+    expect(failure).toMatchObject({ activationError, rollbackError });
+  });
+
+  it("reconciles prompt and agent caches after a partial failure", async () => {
+    vi.mocked(http.activatePromptVersion).mockRejectedValueOnce(new Error("activation failed"));
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useBindPromptVersionToAgent(), { wrapper });
+
+    await expect(result.current.mutateAsync({
+      agentId: "agent-1",
+      version,
+      previousSystemPrompt: "old prompt",
+    })).rejects.toThrow("activation failed");
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.promptVersions("agent-1") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: promptsKeys.list() });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: promptsKeys.details() });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.detail("agent-1") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: agentKeys.lists() });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/prompts.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/prompts.ts
@@ -8,6 +8,22 @@ import {
 import type { PromptVersion } from "../../api";
 import { agentKeys, promptsKeys } from "../queries/keys";
 
+function invalidatePromptRepo(qc: ReturnType<typeof useQueryClient>, agentId: string) {
+  qc.invalidateQueries({ queryKey: agentKeys.promptVersions(agentId) });
+  qc.invalidateQueries({ queryKey: promptsKeys.list() });
+  qc.invalidateQueries({ queryKey: promptsKeys.details() });
+}
+
+export class PromptBindRollbackError extends Error {
+  constructor(
+    public readonly activationError: unknown,
+    public readonly rollbackError: unknown,
+  ) {
+    super("Prompt activation failed and the previous live prompt could not be restored");
+    this.name = "PromptBindRollbackError";
+  }
+}
+
 // Prompt repository mutations (#6160).
 //
 // These are the repository-page counterparts of the per-agent prompt
@@ -37,17 +53,14 @@ export function useCreatePromptVersionForRepo() {
       version: Parameters<typeof createPromptVersion>[1];
     }) => createPromptVersion(agentId, version),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({
-        queryKey: agentKeys.promptVersions(variables.agentId),
-      });
-      qc.invalidateQueries({ queryKey: promptsKeys.list() });
-      qc.invalidateQueries({ queryKey: promptsKeys.details() });
+      invalidatePromptRepo(qc, variables.agentId);
     },
   });
 }
 
 /**
- * Delete an inactive prompt version (repository surface).
+ * Delete a prompt version (repository surface). The backend rejects deletion
+ * when its prompt-store policy does not permit it.
  */
 export function useDeletePromptVersionForRepo() {
   const qc = useQueryClient();
@@ -61,11 +74,7 @@ export function useDeletePromptVersionForRepo() {
       agentId: string;
     }) => deletePromptVersion(versionId),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({
-        queryKey: agentKeys.promptVersions(variables.agentId),
-      });
-      qc.invalidateQueries({ queryKey: promptsKeys.list() });
-      qc.invalidateQueries({ queryKey: promptsKeys.details() });
+      invalidatePromptRepo(qc, variables.agentId);
     },
   });
 }
@@ -94,23 +103,30 @@ export function useBindPromptVersionToAgent() {
     mutationFn: async ({
       agentId,
       version,
+      previousSystemPrompt,
     }: {
       agentId: string;
       version: PromptVersion;
+      previousSystemPrompt: string;
     }) => {
       // 1. Hot-swap the live system prompt onto the manifest.
       await patchAgent(agentId, { system_prompt: version.system_prompt });
       // 2. Flip the store's active flag to match.
-      return activatePromptVersion(version.id, agentId);
+      try {
+        return await activatePromptVersion(version.id, agentId);
+      } catch (activationError) {
+        try {
+          await patchAgent(agentId, { system_prompt: previousSystemPrompt });
+        } catch (rollbackError) {
+          throw new PromptBindRollbackError(activationError, rollbackError);
+        }
+        throw activationError;
+      }
     },
-    onSuccess: (_data, variables) => {
-      qc.invalidateQueries({
-        queryKey: agentKeys.promptVersions(variables.agentId),
-      });
+    onSettled: (_data, _error, variables) => {
+      invalidatePromptRepo(qc, variables.agentId);
       qc.invalidateQueries({ queryKey: agentKeys.detail(variables.agentId) });
       qc.invalidateQueries({ queryKey: agentKeys.lists() });
-      qc.invalidateQueries({ queryKey: promptsKeys.list() });
-      qc.invalidateQueries({ queryKey: promptsKeys.details() });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.test.tsx
@@ -107,6 +107,10 @@ describe("SystemPromptSection (#6187)", () => {
     fireEvent.click(screen.getByRole("button", { name: /Bind from library/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Bind$/i }));
     expect(bindMutate).toHaveBeenCalledTimes(1);
-    expect(bindMutate.mock.calls[0][0]).toEqual({ agentId: "agent-1", version });
+    expect(bindMutate.mock.calls[0][0]).toEqual({
+      agentId: "agent-1",
+      version,
+      previousSystemPrompt: "original prompt",
+    });
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -188,7 +188,7 @@ export function SystemPromptSection({
   const bind = (version: PromptVersion) => {
     if (bindVersion.isPending) return;
     bindVersion.mutate(
-      { agentId, version },
+      { agentId, version, previousSystemPrompt: current },
       {
         onSuccess: () => {
           addToast(

--- a/crates/librefang-api/dashboard/src/pages/PromptsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PromptsPage.test.tsx
@@ -263,6 +263,7 @@ describe("PromptsPage", () => {
     expect(arg).toMatchObject({
       agentId: "11111111-1111-1111-1111-111111111111",
       version: { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" },
+      previousSystemPrompt: "You are a careful research assistant.",
     });
   });
 

--- a/crates/librefang-api/dashboard/src/pages/PromptsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PromptsPage.tsx
@@ -178,7 +178,11 @@ function AgentPromptRepoModal({
 
   const handleBind = (version: PromptVersion) => {
     bindMutation.mutate(
-      { agentId: item.agent_id, version },
+      {
+        agentId: item.agent_id,
+        version,
+        previousSystemPrompt: item.live_system_prompt,
+      },
       {
         onSuccess: () =>
           addToast(


### PR DESCRIPTION
## Changes
- require both prompt-bind callers to pass the currently live system prompt
- restore that prompt when version activation fails after the manifest patch succeeds
- expose `PromptBindRollbackError` when activation and compensating rollback both fail
- reconcile prompt repository and agent caches on both success and failure
- share prompt-repository invalidation and correct the delete contract documentation

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/prompts.test.tsx src/pages/PromptsPage.test.tsx src/pages/AgentsPage.test.tsx` (16 tests)
- `corepack pnpm test` (98 files, 1028 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- changing the backend prompt-store activation API or manifest persistence format
- replacing compensating rollback with a cross-store server transaction