### PR TITLE
fix(dashboard): reconcile provider mutation failures

### DIFF
--- a/changelog.d/fixed/provider-mutation-outcomes.md
+++ b/changelog.d/fixed/provider-mutation-outcomes.md
@@ -1,0 +1,1 @@
+Reconcile provider caches after failed probes and distinguish partial EveryAPI connection failures. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { modelKeys, providerKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import {
+  EveryApiConnectError,
+  ProviderProbeError,
+  useConnectEveryApi,
+  useCreateRegistryContent,
+  useValidateProviderKey,
+} from "./providers";
+
+vi.mock("../http/client", () => ({
+  testProvider: vi.fn(),
+  setProviderKey: vi.fn(),
+  deleteProviderKey: vi.fn(),
+  enableProvider: vi.fn(),
+  setProviderUrl: vi.fn(),
+  setProviderDiscovery: vi.fn(),
+  setDefaultProvider: vi.fn(),
+  createRegistryContent: vi.fn(),
+}));
+
+describe("provider mutation outcomes", () => {
+  beforeEach(() => {
+    vi.mocked(http.setProviderKey).mockReset().mockResolvedValue({ status: "ok" });
+    vi.mocked(http.testProvider).mockReset().mockResolvedValue({
+      status: "ok",
+      message: "connected",
+    });
+    vi.mocked(http.createRegistryContent).mockReset().mockResolvedValue({
+      ok: true,
+      content_type: "provider",
+      identifier: "everyapi",
+      path: "providers/everyapi.toml",
+    });
+  });
+
+  it("retains probe status and reconciles caches after a persisted key fails validation", async () => {
+    vi.mocked(http.testProvider).mockResolvedValueOnce({
+      status: "unauthorized",
+      message: "invalid credential",
+    });
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useValidateProviderKey(), { wrapper });
+
+    const failure = await result.current.mutateAsync({
+      providerId: "openai",
+      apiKey: "secret",
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ProviderProbeError);
+    expect(failure).toMatchObject({ status: "unauthorized", message: "invalid credential" });
+    expect(http.setProviderKey).toHaveBeenCalledWith("openai", "secret");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: providerKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: modelKeys.lists() });
+  });
+
+  it("distinguishes EveryAPI provider creation failures", async () => {
+    vi.mocked(http.createRegistryContent).mockRejectedValueOnce(new Error("registry unavailable"));
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useConnectEveryApi(), { wrapper });
+
+    const failure = await result.current.mutateAsync({ relayKey: "relay-key" })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(EveryApiConnectError);
+    expect(failure).toMatchObject({ phase: "create" });
+    expect(http.setProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes relay-key failures after EveryAPI creation", async () => {
+    vi.mocked(http.setProviderKey).mockRejectedValueOnce(new Error("key store unavailable"));
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useConnectEveryApi(), { wrapper });
+
+    const failure = await result.current.mutateAsync({ relayKey: "relay-key" })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(EveryApiConnectError);
+    expect(failure).toMatchObject({ phase: "key_after_create" });
+  });
+
+  it("applies provider invalidation unconditionally to the provider-only registry hook", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useCreateRegistryContent(), { wrapper });
+
+    await result.current.mutateAsync({
+      contentType: "provider",
+      values: { id: "custom-provider" },
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: providerKeys.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: modelKeys.lists() });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
@@ -11,6 +11,29 @@ import {
 } from "../http/client";
 import { modelKeys, providerKeys, runtimeKeys } from "../queries/keys";
 
+export class ProviderProbeError extends Error {
+  constructor(public readonly status: string, message?: string) {
+    super(message || "test_failed");
+    this.name = "ProviderProbeError";
+  }
+}
+
+export type EveryApiConnectPhase = "create" | "key_after_create";
+
+export class EveryApiConnectError extends Error {
+  public readonly cause: unknown;
+
+  constructor(public readonly phase: EveryApiConnectPhase, cause: unknown) {
+    const detail = cause instanceof Error && cause.message ? `: ${cause.message}` : "";
+    const summary = phase === "create"
+      ? "EveryAPI provider creation failed"
+      : "EveryAPI provider was created, but its relay key could not be saved";
+    super(`${summary}${detail}`);
+    this.name = "EveryApiConnectError";
+    this.cause = cause;
+  }
+}
+
 // Probes the provider and persists `latency_ms` + `last_tested` on the
 // kernel side, so callers must refetch the provider list to see the new
 // values. Use `onSettled` (not `onSuccess`) because the backend records the
@@ -108,14 +131,11 @@ export function useSetProviderDiscovery() {
 }
 
 /**
- * POST /registry/content/{contentType} — generic registry content creation.
+ * POST /registry/content/provider — provider registry creation.
  *
- * Today the only call site is the "Add provider" wizard on ProvidersPage,
- * which writes a `provider` content entry. We invalidate `providerKeys.all`
- * (list refresh) and `modelKeys.lists()` (a new provider may surface new
- * models on the next list fetch) for that case. Other content types are
- * accepted but currently invalidate the same scoped slices because no other
- * caller exists yet — extend here when a non-provider call site lands.
+ * This hook is intentionally provider-specific even though the transport API
+ * accepts arbitrary registry content. A future content type must define its
+ * own cache contract instead of silently inheriting provider invalidation.
  */
 export function useCreateRegistryContent() {
   const qc = useQueryClient();
@@ -124,14 +144,12 @@ export function useCreateRegistryContent() {
       contentType,
       values,
     }: {
-      contentType: string;
+      contentType: "provider";
       values: Record<string, unknown>;
     }) => createRegistryContent(contentType, values),
-    onSuccess: (_data, variables) => {
-      if (variables.contentType === "provider") {
-        qc.invalidateQueries({ queryKey: providerKeys.all });
-        qc.invalidateQueries({ queryKey: modelKeys.lists() });
-      }
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: providerKeys.all });
+      qc.invalidateQueries({ queryKey: modelKeys.lists() });
     },
   });
 }
@@ -194,15 +212,23 @@ export function useConnectEveryApi() {
       const trimmedKey = relayKey.trim();
       if (!trimmedKey) throw new Error("empty_relay_key");
       const trimmedBase = (baseUrl ?? "").trim();
-      await createRegistryContent("provider", {
-        id: EVERYAPI_PROVIDER.id,
-        display_name: EVERYAPI_PROVIDER.displayName,
-        api_key_env: EVERYAPI_PROVIDER.apiKeyEnv,
-        base_url: trimmedBase || EVERYAPI_PROVIDER.defaultBaseUrl,
-        key_required: true,
-        models: [],
-      });
-      await setProviderKey(EVERYAPI_PROVIDER.id, trimmedKey);
+      try {
+        await createRegistryContent("provider", {
+          id: EVERYAPI_PROVIDER.id,
+          display_name: EVERYAPI_PROVIDER.displayName,
+          api_key_env: EVERYAPI_PROVIDER.apiKeyEnv,
+          base_url: trimmedBase || EVERYAPI_PROVIDER.defaultBaseUrl,
+          key_required: true,
+          models: [],
+        });
+      } catch (error) {
+        throw new EveryApiConnectError("create", error);
+      }
+      try {
+        await setProviderKey(EVERYAPI_PROVIDER.id, trimmedKey);
+      } catch (error) {
+        throw new EveryApiConnectError("key_after_create", error);
+      }
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: providerKeys.all });
@@ -239,10 +265,10 @@ export function useValidateProviderKey() {
       }
       const test = await testProvider(providerId);
       if (!TEST_SUCCESS_STATUSES.has(test.status ?? "")) {
-        throw new Error(test.message || "test_failed");
+        throw new ProviderProbeError(test.status ?? "unknown", test.message);
       }
     },
-    onSuccess: () => {
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: providerKeys.all });
       qc.invalidateQueries({ queryKey: modelKeys.lists() });
     },


### PR DESCRIPTION
## Changes
- invalidate provider and model caches after validation settles, including key-persisted/probe-failed outcomes
- preserve the provider probe status in `ProviderProbeError`
- distinguish EveryAPI creation failures from relay-key failures after durable provider creation
- narrow the registry-content hook to its actual `provider` contract and invalidate its provider/model caches unconditionally
- add focused regressions for all failure and invalidation paths

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/providers.test.tsx src/lib/mutations/memory-providers-workflows.test.tsx src/pages/ProvidersPage.test.tsx` (27 tests)
- `corepack pnpm test` (98 files, 1029 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- making registry creation and credential persistence transactional on the daemon
- adding non-provider registry-content mutation hooks or their cache contracts