### PR TITLE
refactor(dashboard): clarify scheduler mutation domains

### DIFF
--- a/changelog.d/fixed/schedule-mutation-contracts.md
+++ b/changelog.d/fixed/schedule-mutation-contracts.md
@@ -1,0 +1,1 @@
+Remove unused scheduler mutation fields and keep trigger invalidation within its independent cache domain. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/components/AgentSchedulePanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentSchedulePanel.tsx
@@ -314,7 +314,6 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
           }
           await updateCron.mutateAsync({
             id,
-            agentId: agent.id,
             data: {
               name: cronName.trim(),
               schedule,
@@ -434,7 +433,6 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
           await updateTrigger.mutateAsync({
             id: triggerModal.trigger.id,
             data: patch,
-            agentId: agent.id,
           });
           addToast(
             t("agents.detail.trigger.updated", { defaultValue: "Trigger updated" }),
@@ -473,7 +471,7 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
   const confirmDeleteCron = useCallback(
     async (id: string) => {
       try {
-        await deleteCron.mutateAsync({ id, agentId: agent.id });
+        await deleteCron.mutateAsync({ id });
         addToast(
           t("agents.detail.cron.deleted", { defaultValue: "Cron job deleted" }),
           "success",
@@ -484,13 +482,13 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
         addToast(msg || t("common.error", { defaultValue: "Error" }), "error");
       }
     },
-    [deleteCron, agent.id, addToast, t],
+    [deleteCron, addToast, t],
   );
 
   const confirmDeleteTrigger = useCallback(
     async (id: string) => {
       try {
-        await deleteTrigger.mutateAsync({ id, agentId: agent.id });
+        await deleteTrigger.mutateAsync({ id });
         addToast(
           t("agents.detail.trigger.deleted", { defaultValue: "Trigger deleted" }),
           "success",
@@ -501,7 +499,7 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
         addToast(msg || t("common.error", { defaultValue: "Error" }), "error");
       }
     },
-    [deleteTrigger, agent.id, addToast, t],
+    [deleteTrigger, addToast, t],
   );
 
   // ----- continuous mode toggle / interval edit ----------------------------
@@ -724,7 +722,7 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
                     className="text-[9px] cursor-pointer"
                     onClick={() =>
                       toggleCron.mutate(
-                        { id, enabled: !enabled, agentId: agent.id },
+                        { id, enabled: !enabled },
                         {
                           onError: (err) =>
                             addToast(
@@ -844,7 +842,7 @@ export function AgentSchedulePanel({ agent }: AgentSchedulePanelProps) {
                   className="text-[9px] cursor-pointer"
                   onClick={() =>
                     updateTrigger.mutate(
-                      { id: tr.id, data: { enabled: !enabled }, agentId: agent.id },
+                      { id: tr.id, data: { enabled: !enabled } },
                       {
                         onError: (err) =>
                           addToast(

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.test.tsx
@@ -126,7 +126,7 @@ describe("useUpdateTrigger", () => {
     vi.mocked(http.updateTrigger).mockResolvedValue(actionResponse);
   });
 
-  it("invalidates triggerKeys.all and cronKeys.all", async () => {
+  it("invalidates only the independent trigger namespace", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -135,14 +135,12 @@ describe("useUpdateTrigger", () => {
     await result.current.mutateAsync({ id: "trig-1", data: { enabled: true } });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: triggerKeys.all,
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: cronKeys.all,
-    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: cronKeys.all });
   });
 });
 
@@ -151,23 +149,23 @@ describe("useDeleteTrigger", () => {
     vi.mocked(http.deleteTrigger).mockResolvedValue(actionResponse);
   });
 
-  it("invalidates triggerKeys.all and cronKeys.all", async () => {
+  it("evicts the detail and invalidates only the trigger namespace", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
 
     const { result } = renderHook(() => useDeleteTrigger(), { wrapper });
 
     await result.current.mutateAsync({ id: "trig-1" });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: triggerKeys.all,
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: cronKeys.all,
-    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: cronKeys.all });
+    expect(removeSpy).toHaveBeenCalledWith({ queryKey: triggerKeys.detail("trig-1") });
   });
 });
 
@@ -225,7 +223,6 @@ describe("useUpdateCronJob", () => {
 
     await result.current.mutateAsync({
       id: "job-1",
-      agentId: "agent-1",
       data: { name: "renamed" },
     });
 
@@ -248,7 +245,7 @@ describe("useDeleteCronJob", () => {
 
     const { result } = renderHook(() => useDeleteCronJob(), { wrapper });
 
-    await result.current.mutateAsync({ id: "job-1", agentId: "agent-1" });
+    await result.current.mutateAsync({ id: "job-1" });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);
@@ -269,7 +266,7 @@ describe("useToggleCronJob", () => {
 
     const { result } = renderHook(() => useToggleCronJob(), { wrapper });
 
-    await result.current.mutateAsync({ id: "job-1", enabled: false, agentId: "agent-1" });
+    await result.current.mutateAsync({ id: "job-1", enabled: false });
 
     expect(http.toggleCronJob).toHaveBeenCalledWith("job-1", false);
     await waitFor(() => {

--- a/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/schedules.ts
@@ -84,16 +84,14 @@ export function useSetScheduleDeliveryTargets() {
   });
 }
 
-// Trigger writes must invalidate triggerKeys.all (not just the per-agent
+// Trigger writes invalidate triggerKeys.all (not just the per-agent
 // sub-key) so that SchedulerPage — which queries triggerKeys.lists() without
 // an agentId — also refreshes.  triggerKeys.list(agentId) is a strictly
 // longer key; react-query prefix matching never reaches the shorter lists()
-// key from it.
+// key from it. Triggers are event subscriptions, not CronScheduler jobs, so
+// they do not invalidate the independent cron/schedule views.
 function invalidateTriggerCaches(qc: ReturnType<typeof useQueryClient>) {
-  return Promise.all([
-    qc.invalidateQueries({ queryKey: triggerKeys.all }),
-    qc.invalidateQueries({ queryKey: cronKeys.all }),
-  ]);
+  return qc.invalidateQueries({ queryKey: triggerKeys.all });
 }
 
 export function useCreateTrigger() {
@@ -107,7 +105,7 @@ export function useCreateTrigger() {
 export function useUpdateTrigger() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: TriggerPatch; agentId?: string }) =>
+    mutationFn: ({ id, data }: { id: string; data: TriggerPatch }) =>
       updateTrigger(id, data),
     onSuccess: () => invalidateTriggerCaches(qc),
   });
@@ -116,7 +114,7 @@ export function useUpdateTrigger() {
 export function useDeleteTrigger() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id }: { id: string; agentId?: string }) => deleteTrigger(id),
+    mutationFn: ({ id }: { id: string }) => deleteTrigger(id),
     onSuccess: (_data, { id }) => {
       qc.removeQueries({ queryKey: triggerKeys.detail(id) });
       return invalidateTriggerCaches(qc);
@@ -147,7 +145,7 @@ export function useCreateCronJob() {
 export function useUpdateCronJob() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpdateCronJobPayload; agentId?: string }) =>
+    mutationFn: ({ id, data }: { id: string; data: UpdateCronJobPayload }) =>
       updateCronJob(id, data),
     onSuccess: () => invalidateCronCaches(qc),
   });
@@ -156,7 +154,7 @@ export function useUpdateCronJob() {
 export function useDeleteCronJob() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id }: { id: string; agentId?: string }) => deleteCronJob(id),
+    mutationFn: ({ id }: { id: string }) => deleteCronJob(id),
     onSuccess: () => invalidateCronCaches(qc),
   });
 }
@@ -164,7 +162,7 @@ export function useDeleteCronJob() {
 export function useToggleCronJob() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, enabled }: { id: string; enabled: boolean; agentId?: string }) =>
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
       toggleCronJob(id, enabled),
     onSuccess: () => invalidateCronCaches(qc),
   });

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.test.tsx
@@ -290,7 +290,7 @@ describe("SchedulerPage", () => {
     expect(mutate).toHaveBeenCalledWith("sched-1");
   });
 
-  it("toggles a trigger via useUpdateTrigger including its agentId", () => {
+  it("toggles a trigger via useUpdateTrigger", () => {
     const mutate = vi.fn();
     useUpdateTriggerMock.mockReturnValue(makeMutation({ mutate }));
 
@@ -305,7 +305,6 @@ describe("SchedulerPage", () => {
     expect(mutate).toHaveBeenCalledWith({
       id: "trig-1",
       data: { enabled: false },
-      agentId: "agent-1",
     });
   });
 

--- a/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SchedulerPage.tsx
@@ -206,7 +206,7 @@ export function SchedulerPage() {
     patch.session_mode = te.sessionMode === "" ? null : te.sessionMode;
     patch.target_agent_id = te.targetAgent === "" ? null : te.targetAgent;
     try {
-      await updateTriggerMut.mutateAsync({ id: te.trigger.id, data: patch, agentId: te.trigger.agent_id });
+      await updateTriggerMut.mutateAsync({ id: te.trigger.id, data: patch });
       setTriggerEdit(prev => ({ ...prev, trigger: null }));
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -235,8 +235,7 @@ export function SchedulerPage() {
     }
     setConfirmDelete(null);
     try {
-      const agentId = triggersQuery.data?.find((tr: TriggerItem) => tr.id === id)?.agent_id;
-      await deleteTriggerMut.mutateAsync({ id, agentId });
+      await deleteTriggerMut.mutateAsync({ id });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       addToast(msg || t("common.error"), "error");
@@ -394,7 +393,7 @@ export function SchedulerPage() {
                       <h3 className="text-xs sm:text-sm font-bold truncate">{formatTriggerPattern(tr.pattern) || truncateId(tr.id, 12)}</h3>
                     </div>
                     <button
-                      onClick={() => updateTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled }, agentId: tr.agent_id })}
+                      onClick={() => updateTriggerMut.mutate({ id: tr.id, data: { enabled: !isEnabled } })}
                       className={`px-2 py-0.5 rounded-full text-[10px] font-bold transition-colors ${isEnabled ? "bg-success/10 text-success hover:bg-success/20" : "bg-main text-text-dim/40 hover:text-text-dim"}`}
                       disabled={updateTriggerMut.isPending && updateTriggerMut.variables?.id === tr.id}
                     >


### PR DESCRIPTION
## Changes
- remove unused `agentId` fields from trigger and cron update/delete/toggle mutation contracts and all callers
- keep schedule and cron invalidation symmetric because both API views share the CronScheduler store
- stop trigger writes from invalidating the independent cron namespace
- retain and explicitly test trigger-detail eviction on delete

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/schedules.test.tsx src/pages/SchedulerPage.test.tsx src/components/AgentSchedulePanel.test.tsx` (30 tests)
- `corepack pnpm test` (97 files, 1025 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- adding schedule or cron detail query keys; neither detail endpoint currently has a dashboard query/cache consumer
- changing scheduler, cron, or trigger API behavior