### PR TITLE
fix(dashboard): reconcile session metadata caches

### DIFF
--- a/changelog.d/fixed/session-mutation-owners.md
+++ b/changelog.d/fixed/session-mutation-owners.md
@@ -1,0 +1,1 @@
+Require explicit session ownership in dashboard metadata mutations and refresh cached labels in chat snapshots. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
@@ -105,7 +105,7 @@ describe("useResetAgentSession", () => {
 });
 
 describe("useSetSessionLabel", () => {
-  it("with agentId invalidates session lists, detail and agent sessions", async () => {
+  it("with agentId invalidates session lists, detail, agent sessions, and snapshots", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -120,7 +120,7 @@ describe("useSetSessionLabel", () => {
     });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(3);
+      expect(invalidateSpy).toHaveBeenCalledTimes(4);
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: sessionKeys.lists(),
@@ -131,9 +131,12 @@ describe("useSetSessionLabel", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: agentKeys.sessions("agent-1"),
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.sessionSnapshots("agent-1"),
+    });
   });
 
-  it("without agentId invalidates session lists and detail", async () => {
+  it("with an explicit null owner invalidates only global session caches", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -141,7 +144,11 @@ describe("useSetSessionLabel", () => {
       wrapper,
     });
 
-    await result.current.mutateAsync({ sessionId: "sess-1", label: "test label" });
+    await result.current.mutateAsync({
+      sessionId: "sess-1",
+      label: "test label",
+      agentId: null,
+    });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);
@@ -192,7 +199,7 @@ describe("useSetSessionModelOverride", () => {
     });
   });
 
-  it("without agentId only invalidates session lists and detail", async () => {
+  it("with an explicit null owner only invalidates session lists and detail", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -200,7 +207,11 @@ describe("useSetSessionModelOverride", () => {
       wrapper,
     });
 
-    await result.current.mutateAsync({ sessionId: "sess-1", modelOverride: null });
+    await result.current.mutateAsync({
+      sessionId: "sess-1",
+      modelOverride: null,
+      agentId: null,
+    });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledTimes(2);

--- a/crates/librefang-api/dashboard/src/lib/mutations/sessions.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/sessions.ts
@@ -10,13 +10,14 @@ import { agentKeys, sessionKeys } from "../queries/keys";
 export function useSetSessionLabel() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ sessionId, label, agentId: _agentId }: { sessionId: string; label: string; agentId?: string }) =>
+    mutationFn: ({ sessionId, label, agentId: _agentId }: { sessionId: string; label: string; agentId: string | null }) =>
       setSessionLabel(sessionId, label),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: sessionKeys.lists() });
       qc.invalidateQueries({ queryKey: sessionKeys.detail(variables.sessionId) });
       if (variables.agentId) {
         qc.invalidateQueries({ queryKey: agentKeys.sessions(variables.agentId) });
+        qc.invalidateQueries({ queryKey: agentKeys.sessionSnapshots(variables.agentId) });
       }
     },
   });
@@ -31,7 +32,7 @@ export function useSetSessionModelOverride() {
     }: {
       sessionId: string;
       modelOverride: string | null;
-      agentId?: string;
+      agentId: string | null;
     }) => setSessionModelOverride(sessionId, modelOverride),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: sessionKeys.lists() });

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -60,7 +60,7 @@ export function SessionsPage() {
 
   const activeCount = sessions.filter(s => s.active).length;
 
-  function saveLabel(sessionId: string, label: string, agentId?: string) {
+  function saveLabel(sessionId: string, label: string, agentId: string | null) {
     labelMutation.mutate({ sessionId, label, agentId }, { onSuccess: () => setEditingLabelId(null) });
   }
 
@@ -186,11 +186,11 @@ export function SessionsPage() {
                           autoFocus
                           value={labelValue}
                           onChange={e => setLabelValue(e.target.value)}
-                          onKeyDown={e => { if (e.key === "Enter") saveLabel(s.session_id, labelValue, s.agent_id ?? undefined); if (e.key === "Escape") setEditingLabelId(null); }}
+                          onKeyDown={e => { if (e.key === "Enter") saveLabel(s.session_id, labelValue, s.agent_id ?? null); if (e.key === "Escape") setEditingLabelId(null); }}
                           className="px-1.5 py-0.5 rounded border border-brand bg-main text-[10px] w-24 outline-none"
                           placeholder={t("sessions.label_placeholder", { defaultValue: "Label..." })}
                         />
-                        <button onClick={() => saveLabel(s.session_id, labelValue, s.agent_id ?? undefined)} className="text-success"><Check className="w-3 h-3" /></button>
+                        <button onClick={() => saveLabel(s.session_id, labelValue, s.agent_id ?? null)} className="text-success"><Check className="w-3 h-3" /></button>
                         <button onClick={() => setEditingLabelId(null)} className="text-text-dim"><X className="w-3 h-3" /></button>
                       </span>
                     ) : (


### PR DESCRIPTION
## Changes
- require metadata mutation callers to state session ownership explicitly as `string | null`
- preserve valid ownerless-session edits while preventing accidental omission of agent-scoped invalidation
- invalidate all cached chat/session snapshots after a label update, matching model-override behavior
- update Sessions page and regressions for owned and explicitly ownerless paths

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/misc-mutations.test.tsx src/pages/SessionsPage.test.tsx` (11 tests)
- `corepack pnpm test` (97 files, 1025 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- changing the API response to return an owner after metadata writes
- changing the backend schema that permits sessions without an `agent_id`