### PR TITLE
fix(dashboard): reconcile skill mutation caches

### DIFF
--- a/changelog.d/fixed/skill-mutation-caches.md
+++ b/changelog.d/fixed/skill-mutation-caches.md
@@ -1,0 +1,1 @@
+Refresh all affected skill hub and workshop file caches after dashboard skill mutations. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/skills-cache.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/skills-cache.test.tsx
@@ -1,0 +1,121 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import {
+  clawhubCnKeys,
+  clawhubKeys,
+  fanghubKeys,
+  skillhubKeys,
+  skillKeys,
+} from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import {
+  useCreateSkill,
+  useEvolvePatchSkill,
+  useEvolveRemoveFile,
+  useEvolveRollbackSkill,
+  useEvolveUpdateSkill,
+  useEvolveWriteFile,
+} from "./skills";
+
+vi.mock("../http/client", () => ({
+  installSkill: vi.fn(),
+  uninstallSkill: vi.fn(),
+  clawhubInstall: vi.fn(),
+  clawhubCnInstall: vi.fn(),
+  skillhubInstall: vi.fn(),
+  createSkill: vi.fn(),
+  reloadSkills: vi.fn(),
+  evolveUpdateSkill: vi.fn(),
+  evolvePatchSkill: vi.fn(),
+  evolveRollbackSkill: vi.fn(),
+  evolveDeleteSkill: vi.fn(),
+  evolveWriteFile: vi.fn(),
+  evolveRemoveFile: vi.fn(),
+  proposeSkillToRegistry: vi.fn(),
+  approvePendingCandidate: vi.fn(),
+  rejectPendingCandidate: vi.fn(),
+  proposePendingToRegistry: vi.fn(),
+}));
+
+const allSkillSurfaces = [
+  skillKeys.all,
+  fanghubKeys.all,
+  clawhubKeys.all,
+  clawhubCnKeys.all,
+  skillhubKeys.all,
+] as const;
+
+describe("skill mutation caches", () => {
+  beforeEach(() => {
+    const result = { success: true, message: "ok", skill_name: "skill-a" };
+    vi.mocked(http.createSkill).mockReset().mockResolvedValue(result);
+    vi.mocked(http.evolveUpdateSkill).mockReset().mockResolvedValue(result);
+    vi.mocked(http.evolvePatchSkill).mockReset().mockResolvedValue(result);
+    vi.mocked(http.evolveRollbackSkill).mockReset().mockResolvedValue(result);
+    vi.mocked(http.evolveWriteFile).mockReset().mockResolvedValue(result);
+    vi.mocked(http.evolveRemoveFile).mockReset().mockResolvedValue(result);
+  });
+
+  it("refreshes installed state on every hub after local skill creation", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useCreateSkill(), { wrapper });
+
+    await result.current.mutateAsync({
+      name: "new-skill",
+      description: "description",
+      prompt_context: "context",
+    });
+
+    for (const queryKey of allSkillSurfaces) {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey });
+    }
+  });
+
+  it.each([
+    ["update", useEvolveUpdateSkill, { name: "skill-a", params: { prompt_context: "new", changelog: "update" } }],
+    ["patch", useEvolvePatchSkill, { name: "skill-a", params: { old_string: "old", new_string: "new", changelog: "patch", replace_all: false } }],
+    ["rollback", useEvolveRollbackSkill, { name: "skill-a" }],
+  ] as const)("refreshes detail, list, and file tree after evolve %s", async (_label, hook, variables) => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => hook(), { wrapper });
+
+    await result.current.mutateAsync(variables as never);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: skillKeys.detail("skill-a") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: skillKeys.lists() });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: skillKeys.supportingFiles("skill-a") });
+  });
+
+  it("refreshes the file tree and written file", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useEvolveWriteFile(), { wrapper });
+
+    await result.current.mutateAsync({
+      name: "skill-a",
+      params: { path: "references/new.md", content: "new" },
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: skillKeys.supportingFiles("skill-a") });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.supportingFile("skill-a", "references/new.md"),
+    });
+  });
+
+  it("refreshes the file tree and removes the deleted file cache", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
+    const { result } = renderHook(() => useEvolveRemoveFile(), { wrapper });
+
+    await result.current.mutateAsync({ name: "skill-a", path: "references/old.md" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: skillKeys.supportingFiles("skill-a") });
+    expect(removeSpy).toHaveBeenCalledWith({
+      queryKey: skillKeys.supportingFile("skill-a", "references/old.md"),
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/skills.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/skills.ts
@@ -85,14 +85,7 @@ export function useSkillHubInstall() {
   });
 }
 
-export function useFangHubInstall() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ name, hand }: { name: string; hand?: string }) =>
-      installSkill(name, hand),
-    onSuccess: () => invalidateAllSkillSurfaces(qc),
-  });
-}
+export const useFangHubInstall = useInstallSkill;
 
 export function useCreateSkill() {
   const qc = useQueryClient();
@@ -108,7 +101,7 @@ export function useCreateSkill() {
       const { signal, ...params } = vars;
       return createSkill(params, signal);
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: skillKeys.lists() }),
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -122,6 +115,15 @@ export function useReloadSkills() {
   });
 }
 
+function invalidateEvolvedSkill(
+  qc: ReturnType<typeof useQueryClient>,
+  name: string,
+) {
+  qc.invalidateQueries({ queryKey: skillKeys.detail(name) });
+  qc.invalidateQueries({ queryKey: skillKeys.lists() });
+  qc.invalidateQueries({ queryKey: skillKeys.supportingFiles(name) });
+}
+
 export function useEvolveUpdateSkill() {
   const qc = useQueryClient();
   return useMutation({
@@ -133,8 +135,7 @@ export function useEvolveUpdateSkill() {
       params: { prompt_context: string; changelog: string };
     }) => evolveUpdateSkill(name, params),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: skillKeys.detail(variables.name) });
-      qc.invalidateQueries({ queryKey: skillKeys.lists() });
+      invalidateEvolvedSkill(qc, variables.name);
     },
   });
 }
@@ -155,8 +156,7 @@ export function useEvolvePatchSkill() {
       };
     }) => evolvePatchSkill(name, params),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: skillKeys.detail(variables.name) });
-      qc.invalidateQueries({ queryKey: skillKeys.lists() });
+      invalidateEvolvedSkill(qc, variables.name);
     },
   });
 }
@@ -195,8 +195,7 @@ export function useEvolveRollbackSkill() {
   return useMutation({
     mutationFn: ({ name }: { name: string }) => evolveRollbackSkill(name),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: skillKeys.detail(variables.name) });
-      qc.invalidateQueries({ queryKey: skillKeys.lists() });
+      invalidateEvolvedSkill(qc, variables.name);
     },
   });
 }
@@ -225,6 +224,7 @@ export function useEvolveWriteFile() {
     }) => evolveWriteFile(name, params),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: skillKeys.detail(variables.name) });
+      qc.invalidateQueries({ queryKey: skillKeys.supportingFiles(variables.name) });
       qc.invalidateQueries({ queryKey: skillKeys.supportingFile(variables.name, variables.params.path) });
     },
   });
@@ -237,6 +237,7 @@ export function useEvolveRemoveFile() {
       evolveRemoveFile(name, path),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: skillKeys.detail(variables.name) });
+      qc.invalidateQueries({ queryKey: skillKeys.supportingFiles(variables.name) });
       qc.removeQueries({ queryKey: skillKeys.supportingFile(variables.name, variables.path) });
     },
   });


### PR DESCRIPTION
## Changes
- make FangHub installation reuse the canonical skill-install hook
- refresh every hub installed-state surface after local skill creation
- share detail/list/supporting-file-tree invalidation across evolve update, patch, and rollback
- refresh the parent supporting-file tree after file writes and removals while retaining exact file invalidation/eviction

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/skills-cache.test.tsx src/lib/mutations/runtime-skills.test.tsx` (20 tests)
- `corepack pnpm test` (98 files, 1031 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- changing skill install/evolve API behavior
- changing hub polling intervals or workshop query schemas