### PR TITLE
fix(dashboard): reconcile terminal window caches

### DIFF
--- a/changelog.d/fixed/terminal-mutation-cache.md
+++ b/changelog.d/fixed/terminal-mutation-cache.md
@@ -1,0 +1,1 @@
+Make dashboard terminal rename and delete updates optimistic with scoped cache reconciliation. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/terminal.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/terminal.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { terminalKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import { useDeleteTerminalWindow, useRenameTerminalWindow } from "./terminal";
+
+vi.mock("../http/client", () => ({
+  createTerminalWindow: vi.fn(),
+  renameTerminalWindow: vi.fn(),
+  deleteTerminalWindow: vi.fn(),
+}));
+
+const windows = [
+  { id: "one", index: 0, name: "One", active: true },
+  { id: "two", index: 1, name: "Two", active: false },
+];
+
+describe("terminal window mutations", () => {
+  beforeEach(() => {
+    vi.mocked(http.renameTerminalWindow).mockReset().mockResolvedValue(undefined);
+    vi.mocked(http.deleteTerminalWindow).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("optimistically renames and reconciles only the windows cache", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(terminalKeys.windows(), windows);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRenameTerminalWindow(), { wrapper });
+
+    await result.current.mutateAsync({ windowId: "two", name: "Renamed" });
+
+    expect(queryClient.getQueryData(terminalKeys.windows())).toEqual([
+      windows[0],
+      { ...windows[1], name: "Renamed" },
+    ]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: terminalKeys.windows() });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: terminalKeys.all });
+  });
+
+  it("rolls a failed rename back and still reconciles", async () => {
+    vi.mocked(http.renameTerminalWindow).mockRejectedValueOnce(new Error("rename failed"));
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(terminalKeys.windows(), windows);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRenameTerminalWindow(), { wrapper });
+
+    await expect(result.current.mutateAsync({ windowId: "two", name: "Renamed" }))
+      .rejects.toThrow("rename failed");
+
+    expect(queryClient.getQueryData(terminalKeys.windows())).toEqual(windows);
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: terminalKeys.windows() });
+    });
+  });
+
+  it("optimistically removes a deleted window and reconciles", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(terminalKeys.windows(), windows);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteTerminalWindow(), { wrapper });
+
+    await result.current.mutateAsync("one");
+
+    expect(queryClient.getQueryData(terminalKeys.windows())).toEqual([windows[1]]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: terminalKeys.windows() });
+  });
+
+  it("rolls a failed delete back and still reconciles", async () => {
+    vi.mocked(http.deleteTerminalWindow).mockRejectedValueOnce(new Error("delete failed"));
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    queryClient.setQueryData(terminalKeys.windows(), windows);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteTerminalWindow(), { wrapper });
+
+    await expect(result.current.mutateAsync("one")).rejects.toThrow("delete failed");
+
+    expect(queryClient.getQueryData(terminalKeys.windows())).toEqual(windows);
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: terminalKeys.windows() });
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/terminal.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/terminal.ts
@@ -15,7 +15,7 @@ export function useCreateTerminalWindow() {
   });
 }
 
-interface RenameContext {
+interface WindowMutationContext {
   previous: TerminalWindow[] | undefined;
 }
 
@@ -25,7 +25,7 @@ export function useRenameTerminalWindow() {
     void,
     Error,
     { windowId: string; name: string },
-    RenameContext
+    WindowMutationContext
   >({
     mutationFn: ({ windowId, name }) => renameTerminalWindow(windowId, name),
     // Optimistic update: swap the tab label immediately so the UI feels
@@ -39,18 +39,36 @@ export function useRenameTerminalWindow() {
       return { previous };
     },
     onError: (_err, _vars, context) => {
-      if (context?.previous) {
+      if (context?.previous !== undefined) {
         qc.setQueryData(terminalKeys.windows(), context.previous);
       }
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: terminalKeys.all }),
+    onSettled: () => qc.invalidateQueries({ queryKey: terminalKeys.windows() }),
   });
 }
 
 export function useDeleteTerminalWindow() {
   const qc = useQueryClient();
-  return useMutation({
+  return useMutation<
+    Awaited<ReturnType<typeof deleteTerminalWindow>>,
+    Error,
+    string,
+    WindowMutationContext
+  >({
     mutationFn: (windowId: string) => deleteTerminalWindow(windowId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: terminalKeys.windows() }),
+    onMutate: async (windowId) => {
+      await qc.cancelQueries({ queryKey: terminalKeys.windows() });
+      const previous = qc.getQueryData<TerminalWindow[]>(terminalKeys.windows());
+      qc.setQueryData<TerminalWindow[]>(terminalKeys.windows(), (prev) =>
+        prev?.filter((window) => window.id !== windowId)
+      );
+      return { previous };
+    },
+    onError: (_err, _windowId, context) => {
+      if (context?.previous !== undefined) {
+        qc.setQueryData(terminalKeys.windows(), context.previous);
+      }
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: terminalKeys.windows() }),
   });
 }


### PR DESCRIPTION
## Changes
- scope terminal rename reconciliation to the windows query instead of refetching health
- optimistically remove deleted windows from the cached tab list
- restore exact snapshots when rename or delete fails
- reconcile the windows query on both success and failure
- add regressions for optimistic success, rollback, and invalidation paths

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/terminal.test.tsx` (4 tests)
- `corepack pnpm test` (98 files, 1029 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- terminal health caching and polling policy
- tmux window API behavior