### PR TITLE
refactor(dashboard): share user budget cache policy

### DIFF
--- a/changelog.d/fixed/user-budget-mutation-cache.md
+++ b/changelog.d/fixed/user-budget-mutation-cache.md
@@ -1,0 +1,1 @@
+Share the dashboard user-budget cache reconciliation policy across update and delete. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/userBudget.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/userBudget.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { authzKeys, userBudgetKeys, userKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import { useDeleteUserBudget, useUpdateUserBudget } from "./userBudget";
+
+vi.mock("../http/client", () => ({
+  updateUserBudget: vi.fn(),
+  deleteUserBudget: vi.fn(),
+}));
+
+function expectBudgetDependentsInvalidated(
+  spy: ReturnType<typeof vi.spyOn>,
+  name: string,
+) {
+  expect(spy).toHaveBeenCalledWith({ queryKey: userBudgetKeys.detail(name) });
+  expect(spy).toHaveBeenCalledWith({ queryKey: userKeys.detail(name) });
+  expect(spy).toHaveBeenCalledWith({ queryKey: userKeys.lists() });
+  expect(spy).toHaveBeenCalledWith({ queryKey: authzKeys.effective(name) });
+}
+
+describe("user budget mutations", () => {
+  beforeEach(() => {
+    vi.mocked(http.updateUserBudget).mockReset().mockResolvedValue({
+      max_hourly_usd: 5,
+      max_daily_usd: 20,
+      max_monthly_usd: 50,
+      alert_threshold: 0.8,
+    });
+    vi.mocked(http.deleteUserBudget).mockReset().mockResolvedValue({ status: "ok" });
+  });
+
+  it("reconciles every dependent cache after update", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateUserBudget(), { wrapper });
+
+    await result.current.mutateAsync({
+      name: "alice",
+      payload: {
+        max_hourly_usd: 5,
+        max_daily_usd: 20,
+        max_monthly_usd: 50,
+        alert_threshold: 0.8,
+      },
+    });
+
+    expectBudgetDependentsInvalidated(invalidateSpy, "alice");
+  });
+
+  it("reconciles every dependent cache after delete", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteUserBudget(), { wrapper });
+
+    await result.current.mutateAsync("alice");
+
+    expectBudgetDependentsInvalidated(invalidateSpy, "alice");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts
@@ -8,7 +8,11 @@
 // `EffectivePermissions.budget` from the same `UserConfig` row (#3228
 // follow-up).
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import {
   updateUserBudget,
   deleteUserBudget,
@@ -16,18 +20,24 @@ import {
 } from "../http/client";
 import { authzKeys, userBudgetKeys, userKeys } from "../queries/keys";
 
+function invalidateUserBudgetDependents(qc: QueryClient, name: string) {
+  qc.invalidateQueries({ queryKey: userBudgetKeys.detail(name) });
+  qc.invalidateQueries({ queryKey: userKeys.detail(name) });
+  qc.invalidateQueries({ queryKey: userKeys.lists() });
+  qc.invalidateQueries({ queryKey: authzKeys.effective(name) });
+}
+
+// Error presentation is caller-owned. UserBudgetPage uses mutateAsync and
+// renders the translated failure beside the form; adding a hook-level toast
+// would duplicate that feedback and prevent callers from choosing context.
+
 export function useUpdateUserBudget() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (vars: { name: string; payload: UserBudgetPayload }) =>
       updateUserBudget(vars.name, vars.payload),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: userBudgetKeys.detail(variables.name) });
-      qc.invalidateQueries({ queryKey: userKeys.detail(variables.name) });
-      qc.invalidateQueries({ queryKey: userKeys.lists() });
-      qc.invalidateQueries({
-        queryKey: authzKeys.effective(variables.name),
-      });
+      invalidateUserBudgetDependents(qc, variables.name);
     },
   });
 }
@@ -37,10 +47,7 @@ export function useDeleteUserBudget() {
   return useMutation({
     mutationFn: (name: string) => deleteUserBudget(name),
     onSuccess: (_data, name) => {
-      qc.invalidateQueries({ queryKey: userBudgetKeys.detail(name) });
-      qc.invalidateQueries({ queryKey: userKeys.detail(name) });
-      qc.invalidateQueries({ queryKey: userKeys.lists() });
-      qc.invalidateQueries({ queryKey: authzKeys.effective(name) });
+      invalidateUserBudgetDependents(qc, name);
     },
   });
 }


### PR DESCRIPTION
## Changes
- centralize the four dependent cache invalidations shared by user-budget update and delete
- document that error presentation remains caller-owned because UserBudgetPage already renders contextual failures
- add symmetric hook-level regressions for both writes

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/userBudget.test.tsx src/pages/UserBudgetPage.test.tsx` (9 tests)
- `corepack pnpm test` (98 files, 1027 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- changing user-budget API payloads
- adding hook-level toasts that would duplicate UserBudgetPage feedback