### PR TITLE
fix(dashboard): reconcile user identity caches

### DIFF
--- a/changelog.d/fixed/user-mutation-identities.md
+++ b/changelog.d/fixed/user-mutation-identities.md
@@ -1,0 +1,1 @@
+Clear stale user-detail errors after creation and avoid refetching obsolete identities after rename. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/users.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/users.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as http from "../http/client";
+import { authzKeys, userKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+import { useCreateUser, useRotateUserKey, useUpdateUser } from "./users";
+
+vi.mock("../http/client", () => ({
+  createUser: vi.fn(),
+  updateUser: vi.fn(),
+  deleteUser: vi.fn(),
+  importUsers: vi.fn(),
+  rotateUserKey: vi.fn(),
+  updateUserPolicy: vi.fn(),
+}));
+
+const user = {
+  name: "alice",
+  role: "Operator",
+  channel_bindings: {},
+  has_api_key: false,
+  has_policy: false,
+  has_memory_access: false,
+  has_budget: false,
+};
+
+describe("user identity mutation caches", () => {
+  beforeEach(() => {
+    vi.mocked(http.createUser).mockReset().mockResolvedValue(user);
+    vi.mocked(http.updateUser).mockReset().mockResolvedValue(user);
+    vi.mocked(http.rotateUserKey).mockReset().mockResolvedValue({
+      status: "rotated",
+      new_api_key: "one-time-key",
+      sessions_invalidated: 0,
+    });
+  });
+
+  it("refreshes prior detail and authz misses after create", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useCreateUser(), { wrapper });
+
+    await result.current.mutateAsync({ name: "alice", role: "Operator" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: userKeys.lists() });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: userKeys.detail("alice") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authzKeys.effective("alice") });
+  });
+
+  it("evicts the old identity and refreshes the new identity after rename", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateUser(), { wrapper });
+
+    await result.current.mutateAsync({
+      originalName: "alice",
+      payload: { name: "alicia", role: "Operator" },
+    });
+
+    expect(removeSpy).toHaveBeenCalledWith({ queryKey: userKeys.detail("alice") });
+    expect(removeSpy).toHaveBeenCalledWith({ queryKey: authzKeys.effective("alice") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: userKeys.detail("alicia") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authzKeys.effective("alicia") });
+  });
+
+  it("invalidates the existing identity after a non-rename update", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateUser(), { wrapper });
+
+    await result.current.mutateAsync({
+      originalName: "alice",
+      payload: { name: "alice", role: "Admin" },
+    });
+
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: userKeys.detail("alice") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authzKeys.effective("alice") });
+  });
+
+  it("does not refresh permissions after credential-only key rotation", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRotateUserKey(), { wrapper });
+
+    await result.current.mutateAsync("alice");
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: userKeys.detail("alice") });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: authzKeys.effective("alice") });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/users.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/users.ts
@@ -5,11 +5,11 @@
 // subtree because the import can touch arbitrary rows; that's the exact
 // "bulk reset" case AGENTS.md calls out as a legitimate `all` invalidation.
 //
-// `authzKeys.effective(name)` is also invalidated on every user-touching
-// write because the permission simulator's snapshot is derived from the
-// same `UserConfig` row (#3228 follow-up). Without these invalidations the
-// simulator pane shows stale data for up to `STALE_MS` (30s) after an
-// admin saves a policy / role / channel-binding / budget edit.
+// Writes that change user configuration also reconcile
+// `authzKeys.effective(name)` because the permission simulator derives its
+// snapshot from the same `UserConfig` row (#3228 follow-up). API-key rotation
+// is the intentional exception: it changes authentication credentials, not
+// role, policy, bindings, or any simulator input.
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -38,6 +38,7 @@ export function useCreateUser() {
       qc.invalidateQueries({ queryKey: userKeys.lists() });
       // The new user is immediately simulatable — drop any cached
       // "user not found" 404 from a prior lookup of the same name.
+      qc.invalidateQueries({ queryKey: userKeys.detail(variables.name) });
       qc.invalidateQueries({ queryKey: authzKeys.effective(variables.name) });
     },
   });
@@ -50,19 +51,22 @@ export function useUpdateUser() {
       updateUser(vars.originalName, vars.payload),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: userKeys.lists() });
-      qc.invalidateQueries({ queryKey: userKeys.detail(variables.originalName) });
+      const renamed = variables.payload.name !== variables.originalName;
       // `updateUser` can change `role` and `channel_bindings`, both of
-      // which feed the effective-permissions snapshot; invalidate the
-      // simulator cache for both old and (renamed) new identities.
-      qc.invalidateQueries({
-        queryKey: authzKeys.effective(variables.originalName),
-      });
-      // If the user renamed, also invalidate the new-name detail cache so
-      // any open detail view falls through to a fresh fetch.
-      if (variables.payload.name !== variables.originalName) {
+      // which feed the effective-permissions snapshot. A rename ends the old
+      // identity, so evict its detail/simulator entries rather than refetching
+      // endpoints that now return 404.
+      if (renamed) {
+        qc.removeQueries({ queryKey: userKeys.detail(variables.originalName) });
+        qc.removeQueries({ queryKey: authzKeys.effective(variables.originalName) });
         qc.invalidateQueries({ queryKey: userKeys.detail(variables.payload.name) });
         qc.invalidateQueries({
           queryKey: authzKeys.effective(variables.payload.name),
+        });
+      } else {
+        qc.invalidateQueries({ queryKey: userKeys.detail(variables.originalName) });
+        qc.invalidateQueries({
+          queryKey: authzKeys.effective(variables.originalName),
         });
       }
     },


### PR DESCRIPTION
## Changes
- refresh both user detail and effective-permission caches after creating a previously missing name
- remove obsolete detail and authz entries when a user is renamed instead of refetching old-name endpoints into 404s
- refresh the new identity after rename and preserve targeted invalidation for non-rename updates
- document API-key rotation as a credential-only exception to authz invalidation
- add create, rename, update, and rotate regressions

## Verification
- `corepack pnpm exec vitest run src/lib/mutations/users.test.tsx src/pages/UsersPage.test.tsx` (11 tests)
- `corepack pnpm test` (98 files, 1029 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`

## Out of scope
- user and authz API behavior
- API-key rotation session handling