### PR TITLE
fix(dashboard): reconcile workflow mutation caches

### DIFF
--- a/changelog.d/fixed/workflow-mutation-cache.md
+++ b/changelog.d/fixed/workflow-mutation-cache.md
@@ -1,0 +1,1 @@
+Reconcile rerun and update workflow caches in the dashboard. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import {
   useRunWorkflow,
+  useRerunWorkflowRun,
   useDryRunWorkflow,
   useDeleteWorkflow,
   useCreateWorkflow,
@@ -15,6 +16,7 @@ import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", () => ({
   runWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
+  rerunWorkflowRun: vi.fn().mockResolvedValue({ status: "ok" }),
   dryRunWorkflow: vi.fn().mockResolvedValue({ valid: true, steps: [] }),
   deleteWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
   createWorkflow: vi.fn().mockResolvedValue({ id: "wf-1" }),
@@ -65,6 +67,31 @@ describe("useRunWorkflow", () => {
       queryKey: workflowKeys.runDetails(),
     });
     expect(invalidateSpy.mock.calls).toHaveLength(2);
+  });
+});
+
+describe("useRerunWorkflowRun", () => {
+  it("invalidates workflow runs, lists, and the returned run detail", async () => {
+    vi.mocked(httpClient.rerunWorkflowRun).mockResolvedValueOnce({
+      status: "ok",
+      run_id: "run-2",
+    });
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useRerunWorkflowRun(), { wrapper });
+
+    await result.current.mutateAsync({ runId: "run-1", workflowId: "wf-1" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.runs("wf-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.lists(),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: workflowKeys.runDetail("run-2"),
+    });
   });
 });
 
@@ -143,5 +170,23 @@ describe("useDeleteWorkflow detail eviction", () => {
     expect(removeSpy).toHaveBeenCalledWith({
       queryKey: workflowKeys.detail("wf-1"),
     });
+  });
+});
+
+describe("useUpdateWorkflow detail cache", () => {
+  it("does not replace a complete entity with a partial response", async () => {
+    vi.mocked(httpClient.updateWorkflow).mockResolvedValueOnce({ id: "wf-1" } as never);
+
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const cached = { id: "wf-1", name: "Existing workflow", steps: 4 };
+    queryClient.setQueryData(workflowKeys.detail("wf-1"), cached);
+    const { result } = renderHook(() => useUpdateWorkflow(), { wrapper });
+
+    await result.current.mutateAsync({
+      workflowId: "wf-1",
+      payload: { name: "Updated workflow" },
+    });
+
+    expect(queryClient.getQueryData(workflowKeys.detail("wf-1"))).toEqual(cached);
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
@@ -66,11 +66,21 @@ export function useRerunWorkflowRun() {
   return useMutation({
     mutationFn: ({ runId }: { runId: string; workflowId: string }) =>
       rerunWorkflowRun(runId),
-    onSuccess: (_data, variables) =>
-      Promise.all([
+    onSuccess: (data, variables) => {
+      const invalidations: Array<Promise<unknown>> = [
         invalidateWorkflowLists(qc),
         qc.invalidateQueries({ queryKey: workflowKeys.runs(variables.workflowId) }),
-      ]),
+      ];
+      const runId = typeof data.run_id === "string" ? data.run_id : undefined;
+
+      if (runId) {
+        invalidations.push(
+          qc.invalidateQueries({ queryKey: workflowKeys.runDetail(runId) }),
+        );
+      }
+
+      return Promise.all(invalidations);
+    },
   });
 }
 
@@ -119,7 +129,12 @@ export function useUpdateWorkflow() {
       // shared fields (name, description, last_run, success_rate); we still
       // invalidate the lists for safety since they may include aggregates.
       const hasEntity =
-        data && typeof data === "object" && "id" in data && (data as WorkflowItem).id;
+        data &&
+        typeof data === "object" &&
+        "id" in data &&
+        "name" in data &&
+        typeof data.id === "string" &&
+        typeof data.name === "string";
       if (hasEntity) {
         qc.setQueryData<WorkflowItem>(
           workflowKeys.detail(variables.workflowId),
@@ -155,8 +170,9 @@ export function useSaveWorkflowAsTemplate() {
  *  to `POST /api/workflows/runs/:run_id/operator`. The endpoint replies
  *  200 immediately and the run resumes asynchronously, so on success we
  *  invalidate the operator-pause inspector + the worklist + the run
- *  detail + the workflow's run list so every surface re-fetches the new
- *  state. */
+ *  detail so every surface identified by the run id re-fetches the new
+ *  state. The endpoint does not return the workflow id needed to target
+ *  that workflow's run list. */
 export function useResolveOperatorStep() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Changes

- invalidate the newly-created run detail after rerunning a workflow
- avoid replacing a complete workflow detail cache with a partial update response
- align operator-step cache documentation with the mutation contract
- add focused mutation cache regression coverage

## Verification

- `corepack pnpm exec vitest run src/lib/mutations/workflows.test.tsx src/lib/mutations/memory-providers-workflows.test.tsx` (16 tests)
- `corepack pnpm test` (97 files, 1027 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- no API or backend workflow behavior changes
- malformed `run_id` responses remain safely ignored; the generated client contract already types this field