### PR TITLE
perf(dashboard): cache stable agent metadata

### DIFF
--- a/changelog.d/changed/agent-query-cache-policy.md
+++ b/changelog.d/changed/agent-query-cache-policy.md
@@ -1,0 +1,1 @@
+Reduce redundant dashboard requests for stable agent metadata. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/agents-options.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents-options.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { agentQueries } from "./agents";
+
+describe("agentQueries cache policy", () => {
+  it.each([
+    ["detail", agentQueries.detail("agent-1")],
+    ["templates", agentQueries.templates()],
+    ["prompt versions", agentQueries.promptVersions("agent-1")],
+    ["experiments", agentQueries.experiments("agent-1")],
+    ["experiment metrics", agentQueries.experimentMetrics("experiment-1")],
+    ["agent tools", agentQueries.agentTools("agent-1")],
+    ["agent skills", agentQueries.agentSkills("agent-1")],
+    ["tool list", agentQueries.toolsList()],
+  ])("keeps stable %s reads fresh for 30 seconds", (_name, options) => {
+    expect(options.staleTime).toBe(30_000);
+  });
+
+  it("retains the faster live-event refresh policy", () => {
+    const options = agentQueries.events("agent-1");
+
+    expect(options.staleTime).toBe(10_000);
+    expect(options.refetchInterval).toBe(15_000);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -20,6 +20,9 @@ import { withOverrides, type QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const REFRESH_MS = 30_000;
+const LIVE_STALE_MS = 10_000;
+const STATS_STALE_MS = 15_000;
+const LIVE_REFRESH_MS = 15_000;
 
 export const agentQueries = {
   list: (opts: { includeHands?: boolean } = {}) =>
@@ -35,22 +38,22 @@ export const agentQueries = {
       queryKey: agentKeys.detail(agentId),
       queryFn: () => getAgentDetail(agentId),
       enabled: !!agentId,
-      staleTime: 30_000,
+      staleTime: STALE_MS,
     }),
   sessions: (agentId: string) =>
     queryOptions({
       queryKey: agentKeys.sessions(agentId),
       queryFn: () => listAgentSessions(agentId),
       enabled: !!agentId,
-      staleTime: 10_000,
+      staleTime: LIVE_STALE_MS,
     }),
   stats: (agentId: string) =>
     queryOptions({
       queryKey: agentKeys.stats(agentId),
       queryFn: () => getAgentStats(agentId),
       enabled: !!agentId,
-      staleTime: 15_000,
-      refetchInterval: 30_000,
+      staleTime: STATS_STALE_MS,
+      refetchInterval: REFRESH_MS,
       refetchIntervalInBackground: false, // #3393
     }),
   events: (agentId: string, limit = 30) =>
@@ -58,32 +61,36 @@ export const agentQueries = {
       queryKey: agentKeys.events(agentId, limit),
       queryFn: () => listAgentEvents(agentId, limit),
       enabled: !!agentId,
-      staleTime: 10_000,
-      refetchInterval: 15_000,
+      staleTime: LIVE_STALE_MS,
+      refetchInterval: LIVE_REFRESH_MS,
       refetchIntervalInBackground: false, // #3393
     }),
   templates: () =>
     queryOptions({
       queryKey: agentKeys.templates(),
       queryFn: listAgentTemplates,
+      staleTime: STALE_MS,
     }),
   promptVersions: (agentId: string) =>
     queryOptions({
       queryKey: agentKeys.promptVersions(agentId),
       queryFn: () => listPromptVersions(agentId),
       enabled: !!agentId,
+      staleTime: STALE_MS,
     }),
   experiments: (agentId: string) =>
     queryOptions({
       queryKey: agentKeys.experiments(agentId),
       queryFn: () => listExperiments(agentId),
       enabled: !!agentId,
+      staleTime: STALE_MS,
     }),
   experimentMetrics: (experimentId: string) =>
     queryOptions({
       queryKey: agentKeys.experimentMetrics(experimentId),
       queryFn: () => getExperimentMetrics(experimentId),
       enabled: !!experimentId,
+      staleTime: STALE_MS,
     }),
   // Snapshot of the (agent, session) chat history. ChatPage hydrates from
   // this on first navigation and on session switch; subsequent turns are
@@ -107,8 +114,8 @@ export const agentQueries = {
       queryKey: agentKeys.sessionContext(agentId, sessionId ?? null),
       queryFn: () => getAgentSessionContext(agentId, sessionId ?? null),
       enabled: !!agentId && !!sessionId,
-      staleTime: 10_000,
-      refetchInterval: 15_000,
+      staleTime: LIVE_STALE_MS,
+      refetchInterval: LIVE_REFRESH_MS,
       refetchIntervalInBackground: false, // #3393
     }),
   agentTools: (agentId: string) =>
@@ -116,17 +123,20 @@ export const agentQueries = {
       queryKey: agentKeys.tools(agentId),
       queryFn: () => getAgentTools(agentId),
       enabled: !!agentId,
+      staleTime: STALE_MS,
     }),
   agentSkills: (agentId: string) =>
     queryOptions({
       queryKey: agentKeys.skills(agentId),
       queryFn: () => getAgentSkills(agentId),
       enabled: !!agentId,
+      staleTime: STALE_MS,
     }),
   toolsList: () =>
     queryOptions({
       queryKey: toolKeys.list(),
       queryFn: listTools,
+      staleTime: STALE_MS,
     }),
 };
 


### PR DESCRIPTION
## Changes

- keep stable agent templates, prompt versions, experiments, tools, and skills fresh for 30 seconds
- replace repeated timing literals with cache-policy constants while preserving faster live polling
- add direct query-option regression coverage

## Verification

- `corepack pnpm exec vitest run src/lib/queries/agents-options.test.ts src/lib/queries/agents-experiments.test.tsx` (18 tests)
- `corepack pnpm test` (98 files, 1034 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- `useAgentEvents` keeps its existing typed `(agentId, limit, options)` contract; its only caller supplies the limit explicitly
- no agent API or mutation invalidation behavior changes