### PR TITLE
refactor(dashboard): share analytics query policy

### DIFF
--- a/changelog.d/changed/analytics-query-policy.md
+++ b/changelog.d/changed/analytics-query-policy.md
@@ -1,0 +1,1 @@
+Keep dashboard analytics queries on one shared foreground polling policy. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/analytics-options.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/analytics-options.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { budgetQueries, usageQueries } from "./analytics";
+
+describe("analytics query policy", () => {
+  it.each([
+    ["usage summary", usageQueries.summary()],
+    ["usage by agent", usageQueries.byAgent()],
+    ["usage by model", usageQueries.byModel()],
+    ["daily usage", usageQueries.daily()],
+    ["model performance", usageQueries.modelPerformance()],
+    ["budget status", budgetQueries.status()],
+    ["provider budgets", budgetQueries.providers()],
+  ])("applies the shared foreground polling policy to %s", (_name, options) => {
+    expect(options.staleTime).toBe(20_000);
+    expect(options.refetchInterval).toBe(30_000);
+    expect(options.refetchIntervalInBackground).toBe(false);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
@@ -13,47 +13,43 @@ import { withOverrides, type QueryOverrides } from "./options";
 
 const REFRESH_MS = 30_000;
 const STALE_MS = 20_000;
+// #3393: analytics stay live while visible without polling hidden tabs.
+const analyticsQueryPolicy = {
+  staleTime: STALE_MS,
+  refetchInterval: REFRESH_MS,
+  refetchIntervalInBackground: false,
+} as const;
 
 export const usageQueries = {
   summary: () =>
     queryOptions({
       queryKey: usageKeys.summary(),
       queryFn: getUsageSummary,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false, // #3393: skip polling when tab is hidden
+      ...analyticsQueryPolicy,
     }),
   byAgent: () =>
     queryOptions({
       queryKey: usageKeys.byAgent(),
       queryFn: listUsageByAgent,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false,
+      ...analyticsQueryPolicy,
     }),
   byModel: () =>
     queryOptions({
       queryKey: usageKeys.byModel(),
       queryFn: listUsageByModel,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false,
+      ...analyticsQueryPolicy,
     }),
   daily: () =>
     queryOptions({
       queryKey: usageKeys.daily(),
       queryFn: getUsageDaily,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false,
+      ...analyticsQueryPolicy,
     }),
   modelPerformance: () =>
     queryOptions({
       queryKey: usageKeys.modelPerformance(),
       queryFn: getUsageByModelPerformance,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false,
+      ...analyticsQueryPolicy,
     }),
 };
 
@@ -62,9 +58,7 @@ export const budgetQueries = {
     queryOptions({
       queryKey: budgetKeys.status(),
       queryFn: getBudgetStatus,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false, // #3393
+      ...analyticsQueryPolicy,
     }),
   // Per-provider spend snapshot (#5650). Same refresh cadence as the
   // global budget query so the dashboard's two budget cards stay in
@@ -73,9 +67,7 @@ export const budgetQueries = {
     queryOptions({
       queryKey: budgetKeys.providers(),
       queryFn: getProviderBudgets,
-      staleTime: STALE_MS,
-      refetchInterval: REFRESH_MS,
-      refetchIntervalInBackground: false, // #3393
+      ...analyticsQueryPolicy,
     }),
 };
 


### PR DESCRIPTION
## Changes

- centralize the polling and freshness options shared by all usage and budget queries
- retain foreground-only polling and the existing 20/30-second freshness cadence
- add regression coverage for every analytics query factory

## Verification

- `corepack pnpm exec vitest run src/lib/queries/analytics-options.test.ts src/pages/AnalyticsPage.test.tsx src/pages/OverviewPage.test.tsx` (25 tests)
- `corepack pnpm test` (98 files, 1032 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- the 20-second stale window remains intentionally shorter than the 30-second poll so focus/remount can refresh visible analytics before the next timer tick
- no analytics API or page behavior changes