### PR TITLE
refactor(dashboard): clarify approval query policy

### DIFF
--- a/changelog.d/changed/approval-query-policy.md
+++ b/changelog.d/changed/approval-query-policy.md
@@ -1,0 +1,1 @@
+Clarify shared dashboard approval polling and pending-query enablement. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
@@ -9,10 +9,8 @@ import {
 import { approvalKeys, totpKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
 
-const STALE_APPROVALS = 10_000;
-const REFETCH_APPROVALS = 15_000;
-const STALE_COUNT = 10_000;
-const REFETCH_COUNT = 15_000;
+const STALE_DEFAULT = 10_000;
+const REFETCH_DEFAULT = 15_000;
 const STALE_PENDING = 3_000;
 const REFETCH_PENDING = 5_000;
 const STALE_TOTP = 60_000;
@@ -22,16 +20,16 @@ export const approvalQueries = {
     queryOptions({
       queryKey: approvalKeys.lists(),
       queryFn: listApprovals,
-      staleTime: STALE_APPROVALS,
-      refetchInterval: REFETCH_APPROVALS,
+      staleTime: STALE_DEFAULT,
+      refetchInterval: REFETCH_DEFAULT,
       refetchIntervalInBackground: false, // #3393
     }),
   count: () =>
     queryOptions({
       queryKey: approvalKeys.count(),
       queryFn: fetchApprovalCount,
-      staleTime: STALE_COUNT,
-      refetchInterval: REFETCH_COUNT,
+      staleTime: STALE_DEFAULT,
+      refetchInterval: REFETCH_DEFAULT,
       refetchIntervalInBackground: false, // #3393
     }),
   pending: (agentId?: string) =>
@@ -73,10 +71,10 @@ export function usePendingApprovals(
   agentId?: string,
   options: QueryOverrides = {},
 ) {
-  return useQuery({
-    ...withOverrides(approvalQueries.pending(agentId), options),
-    enabled: options.enabled ?? Boolean(agentId),
-  });
+  return useQuery(withOverrides(approvalQueries.pending(agentId), {
+    enabled: Boolean(agentId),
+    ...options,
+  }));
 }
 
 export function useApprovalAudit(


### PR DESCRIPTION
## Changes

- share the identical list/count freshness and polling constants
- resolve pending-approval default enablement and caller overrides through one options path
- preserve the missing-agent guard and explicit caller override behavior

## Verification

- `corepack pnpm exec vitest run src/lib/queries/queries-enabled-guards.test.tsx src/pages/ApprovalsPage.test.tsx` (48 tests)
- `corepack pnpm test` (97 files, 1025 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- no polling cadence, approval API, or page behavior changes