### PR TITLE
fix(dashboard): align audit query key filters

### DIFF
--- a/changelog.d/fixed/audit-query-key-filters.md
+++ b/changelog.d/fixed/audit-query-key-filters.md
@@ -1,0 +1,1 @@
+Align dashboard audit query keys with the filters sent to the API. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -480,6 +480,23 @@ describe("query key factories", () => {
       ]);
       // Empty filters still produces a stable key.
       expect(auditKeys.query()).toEqual(["audit", "query", {}]);
+      expect(
+        auditKeys.query({
+          agent: "agent-1",
+          channel: "slack",
+          from: "2026-08-01T00:00:00Z",
+          to: "2026-08-02T00:00:00Z",
+        }),
+      ).toEqual([
+        "audit",
+        "query",
+        {
+          agent: "agent-1",
+          channel: "slack",
+          from: "2026-08-01T00:00:00Z",
+          to: "2026-08-02T00:00:00Z",
+        },
+      ]);
     });
   });
 

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -9,6 +9,8 @@
 //
 // All arrays use `as const` for structural stability.
 
+import type { AuditQueryFilters } from "../http/client";
+
 export const autoDreamKeys = {
   all: ["autoDream"] as const,
   status: () => [...autoDreamKeys.all, "status"] as const,
@@ -390,15 +392,8 @@ export const auditKeys = {
   // dashboard data layer is ready; the daemon endpoint becomes real once
   // M5 lands.
   queries: () => [...auditKeys.all, "query"] as const,
-  query: (filters: {
-    limit?: number;
-    offset?: number;
-    user?: string;
-    action?: string;
-    status?: string;
-    since?: string;
-    until?: string;
-  } = {}) => [...auditKeys.queries(), filters] as const,
+  query: (filters: AuditQueryFilters = {}) =>
+    [...auditKeys.queries(), filters] as const,
 };
 
 export const userKeys = {


### PR DESCRIPTION
## Changes

- type searchable audit query keys with the canonical HTTP filter contract
- remove obsolete offset/status/since/until key fields
- cover agent, channel, from, and to filters in key-factory regression tests

## Verification

- `corepack pnpm exec vitest run src/lib/queries/keys.test.ts` (43 tests)
- `corepack pnpm test` (97 files, 1025 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- audit freshness remains a domain-local 15 seconds; unrelated query domains intentionally use different freshness requirements
- no audit API or page behavior changes