### PR TITLE
fix(dashboard): harden permission queries

### DIFF
--- a/changelog.d/fixed/authz-query-retries.md
+++ b/changelog.d/fixed/authz-query-retries.md
@@ -1,0 +1,1 @@
+Preserve dashboard permission-query guards while retrying transient failures. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/authz.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/authz.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiError, getEffectivePermissions } from "../http/client";
+import { createQueryClientWrapper } from "../test/query-client";
+import { authzQueries, useEffectivePermissions } from "./authz";
+
+vi.mock("../http/client", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../http/client")>();
+  return {
+    ...original,
+    getEffectivePermissions: vi.fn(),
+  };
+});
+
+describe("effective permission query", () => {
+  it("cannot be enabled without a user name", () => {
+    const { wrapper } = createQueryClientWrapper();
+
+    renderHook(() => useEffectivePermissions("", { enabled: true }), { wrapper });
+
+    expect(getEffectivePermissions).not.toHaveBeenCalled();
+  });
+
+  it("does not retry deterministic authorization failures", () => {
+    const retry = authzQueries.effective("alice").retry;
+    const forbidden = new ApiError(403, "FORBIDDEN", "forbidden");
+    const missing = new ApiError(404, "NOT_FOUND", "missing");
+
+    expect(typeof retry).toBe("function");
+    if (typeof retry !== "function") return;
+    expect(retry(0, forbidden)).toBe(false);
+    expect(retry(0, missing)).toBe(false);
+  });
+
+  it("retries transient failures up to three times", () => {
+    const retry = authzQueries.effective("alice").retry;
+
+    expect(typeof retry).toBe("function");
+    if (typeof retry !== "function") return;
+    expect(retry(0, new Error("offline"))).toBe(true);
+    expect(retry(2, new Error("offline"))).toBe(true);
+    expect(retry(3, new Error("offline"))).toBe(false);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/authz.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/authz.ts
@@ -7,7 +7,7 @@
 // without inline fetch handling.
 
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { getEffectivePermissions } from "../http/client";
+import { ApiError, getEffectivePermissions } from "../http/client";
 import { authzKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
 
@@ -22,7 +22,12 @@ export const authzQueries = {
       staleTime: STALE_MS,
       // Don't retry 404s (unknown user) or 403s (caller not admin) — they
       // are deterministic and a refetch storm just hides the message.
-      retry: false,
+      retry: (failureCount, error) => {
+        if (error instanceof ApiError && (error.status === 403 || error.status === 404)) {
+          return false;
+        }
+        return failureCount < 3;
+      },
     }),
 };
 
@@ -30,5 +35,8 @@ export function useEffectivePermissions(
   name: string,
   options: QueryOverrides = {},
 ) {
-  return useQuery(withOverrides(authzQueries.effective(name), options));
+  return useQuery(withOverrides(authzQueries.effective(name), {
+    ...options,
+    enabled: Boolean(name) && options.enabled !== false,
+  }));
 }


### PR DESCRIPTION
## Changes

- skip retries only for deterministic 403 and 404 permission responses
- retry transient permission-query failures up to the existing three-failure budget
- prevent caller overrides from enabling an effective-permissions request without a user name
- add focused retry and enablement regressions

## Verification

- `corepack pnpm exec vitest run src/lib/queries/authz.test.tsx` (3 tests)
- `corepack pnpm test` (98 files, 1028 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- `withOverrides` remains permissive for factories without prerequisite guards; the required-name invariant is enforced locally
- no authz API or simulator UI changes