### PR TITLE
refactor(dashboard): align comms query overrides

### DIFF
--- a/changelog.d/changed/comms-query-overrides.md
+++ b/changelog.d/changed/comms-query-overrides.md
@@ -1,0 +1,1 @@
+Align dashboard communications event overrides with sibling query hooks. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels-models.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { useCommsEvents } from "./channels";
+import { commsQueries, useCommsEvents } from "./channels";
 import { useModels, useModelOverrides } from "./models";
 import * as httpClient from "../http/client";
 import { commsKeys, modelKeys } from "./keys";
@@ -17,6 +17,14 @@ beforeEach(() => {
 });
 
 describe("useCommsEvents", () => {
+  it("defines foreground polling in the reusable query factory", () => {
+    const options = commsQueries.events(50);
+
+    expect(options.staleTime).toBe(10_000);
+    expect(options.refetchInterval).toBe(30_000);
+    expect(options.refetchIntervalInBackground).toBe(false);
+  });
+
   it("should fetch when enabled is undefined (default)", async () => {
     const mockEvents = [{ id: "evt-1", kind: "message" }];
     vi.mocked(httpClient.listCommsEvents).mockResolvedValue(mockEvents);

--- a/crates/librefang-api/dashboard/src/lib/queries/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels.ts
@@ -56,6 +56,8 @@ export const commsQueries = {
       queryKey: commsKeys.events(limit),
       queryFn: () => listCommsEvents(limit),
       staleTime: EVENTS_STALE_MS,
+      refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 
@@ -88,12 +90,7 @@ export function useCommsTopology(options: QueryOverrides = {}) {
 
 export function useCommsEvents(
   limit = 200,
-  options: { enabled?: boolean; refetchInterval?: number | false } = {},
+  options: QueryOverrides = {},
 ) {
-  return useQuery({
-    ...commsQueries.events(limit),
-    enabled: options.enabled,
-    refetchInterval: options.refetchInterval ?? REFRESH_MS,
-    refetchIntervalInBackground: false, // #3393
-  });
+  return useQuery(withOverrides(commsQueries.events(limit), options));
 }


### PR DESCRIPTION
## Changes

- move communications-event polling defaults into the reusable query factory
- accept the same typed query overrides as sibling channel and topology hooks
- retain foreground-only 30-second polling and 10-second staleness
- add direct polling-policy coverage

## Verification

- `corepack pnpm exec vitest run src/lib/queries/channels-models.test.tsx src/pages/CommsPage.test.tsx src/pages/ChannelsPage.test.tsx` (55 tests)
- `corepack pnpm test` (97 files, 1026 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- QR reads remain immediately stale so every focus/remount can observe authentication transitions
- daemon queries retain TanStack Query bounded retries for transient outages
- no channel or communications API changes