### PR TITLE
refactor(dashboard): align raw config queries

### DIFF
--- a/changelog.d/changed/raw-config-query-overrides.md
+++ b/changelog.d/changed/raw-config-query-overrides.md
@@ -1,0 +1,1 @@
+Align raw dashboard configuration reads with the shared query override contract. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { RegistrySchema } from "../../api";
-import { useRegistrySchema, useRawConfigToml } from "./config";
+import { configQueries, useRegistrySchema, useRawConfigToml } from "./config";
 import * as client from "../http/client";
 import { registryKeys, configKeys } from "./keys";
 import { createQueryClientWrapper } from "../test/query-client";
@@ -61,6 +61,10 @@ describe("useRegistrySchema", () => {
 });
 
 describe("useRawConfigToml", () => {
+  it("keeps UI enablement out of the reusable query factory", () => {
+    expect(configQueries.rawToml().enabled).toBeUndefined();
+  });
+
   it("should not fetch when enabled is false", () => {
     const { result } = renderHook(() => useRawConfigToml(false), {
       wrapper: createQueryClientWrapper().wrapper,
@@ -89,6 +93,14 @@ describe("useRawConfigToml", () => {
 
     expect(result.current.fetchStatus).toBe("idle");
     expect(client.getRawConfigToml).toHaveBeenCalled();
+  });
+
+  it("allows callers to disable an otherwise enabled read", () => {
+    renderHook(() => useRawConfigToml(true, { enabled: false }), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    expect(client.getRawConfigToml).not.toHaveBeenCalled();
   });
 
   it("should use configKeys.rawToml() as queryKey", async () => {

--- a/crates/librefang-api/dashboard/src/lib/queries/config.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/config.ts
@@ -31,13 +31,15 @@ export const configQueries = {
       queryFn: () => fetchRegistrySchema(contentType),
       enabled: !!contentType,
       staleTime: SCHEMA_STALE_MS,
+      // Schemas are optional per content type and selected interactively;
+      // surface an unavailable schema promptly instead of keeping the form
+      // behind the default multi-retry delay.
       retry: 1,
     }),
-  rawToml: (enabled: boolean) =>
+  rawToml: () =>
     queryOptions({
       queryKey: configKeys.rawToml(),
       queryFn: getRawConfigToml,
-      enabled,
       staleTime: RAW_STALE_MS,
     }),
 };
@@ -60,6 +62,12 @@ export function useRegistrySchema(contentType: string, options: QueryOverrides =
 // Raw config.toml as text. Disabled by default — caller passes
 // `enabled: true` only when the viewer modal is open. Short staleTime
 // so re-opening shortly after a save reflects the change.
-export function useRawConfigToml(enabled: boolean) {
-  return useQuery(configQueries.rawToml(enabled));
+export function useRawConfigToml(
+  enabled: boolean,
+  options: QueryOverrides = {},
+) {
+  return useQuery(withOverrides(configQueries.rawToml(), {
+    ...options,
+    enabled: enabled && options.enabled !== false,
+  }));
 }


### PR DESCRIPTION
## Changes

- keep modal enablement out of the reusable raw-TOML query factory
- give raw configuration reads the shared typed override surface
- preserve the explicit modal guard even when callers provide overrides
- document why content-type registry schemas use a shorter retry budget
- add factory and caller-disable regressions

## Verification

- `corepack pnpm exec vitest run src/lib/queries/config.test.tsx` (8 tests)
- `corepack pnpm test` (97 files, 1027 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- no configuration API, retry count, freshness, or page behavior changes