### PR TITLE
fix(dashboard): stop completed goal polling

### DIFF
--- a/changelog.d/fixed/goal-run-polling.md
+++ b/changelog.d/fixed/goal-run-polling.md
@@ -1,0 +1,1 @@
+Stop dashboard goal-run polling after completion and guard missing goal IDs. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/goals.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/goals.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { getGoalRun } from "../http/client";
+import { createQueryClientWrapper } from "../test/query-client";
+import { goalQueries, useGoalRun } from "./goals";
+
+vi.mock("../http/client", () => ({
+  listGoals: vi.fn(),
+  listGoalTemplates: vi.fn(),
+  getGoalRun: vi.fn(),
+}));
+
+describe("goal run queries", () => {
+  it("cannot be enabled without a goal id", () => {
+    const { wrapper } = createQueryClientWrapper();
+
+    renderHook(() => useGoalRun("", { enabled: true }), { wrapper });
+
+    expect(getGoalRun).not.toHaveBeenCalled();
+  });
+
+  it("polls only while the run is active", () => {
+    const refetchInterval = goalQueries.run("goal-1").refetchInterval;
+
+    expect(typeof refetchInterval).toBe("function");
+    if (typeof refetchInterval !== "function") return;
+
+    expect(refetchInterval({ state: { data: { running: true } } } as never)).toBe(4_000);
+    expect(refetchInterval({ state: { data: { running: false } } } as never)).toBe(false);
+    expect(refetchInterval({ state: { data: undefined } } as never)).toBe(false);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/goals.ts
@@ -27,7 +27,8 @@ export const goalQueries = {
       queryKey: goalKeys.run(id),
       queryFn: () => getGoalRun(id),
       // Poll while a run is active so the dashboard reflects live progress.
-      refetchInterval: RUN_POLL_MS,
+      refetchInterval: (query) =>
+        query.state.data?.running ? RUN_POLL_MS : false,
       refetchIntervalInBackground: false,
     }),
 };
@@ -41,5 +42,8 @@ export function useGoalTemplates(options: QueryOverrides = {}) {
 }
 
 export function useGoalRun(id: string, options: QueryOverrides = {}) {
-  return useQuery(withOverrides(goalQueries.run(id), options));
+  return useQuery(withOverrides(goalQueries.run(id), {
+    ...options,
+    enabled: Boolean(id) && options.enabled !== false,
+  }));
 }


### PR DESCRIPTION
## Changes

- poll goal-run state every four seconds only while the run is active
- stop polling after completion, failure, or an idle response
- prevent query overrides from enabling a goal-run request without an ID
- add focused polling and enablement regressions

## Verification

- `corepack pnpm exec vitest run src/lib/queries/goals.test.tsx src/pages/GoalsPage.test.tsx` (16 tests)
- `corepack pnpm test` (98 files, 1027 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- no goal API, mutation, or page presentation changes