### PR TITLE
fix(dashboard): bound hand stats batches

### DIFF
--- a/changelog.d/fixed/hand-stats-batch.md
+++ b/changelog.d/fixed/hand-stats-batch.md
@@ -1,0 +1,1 @@
+Bound dashboard hand-stat requests and surface complete batch failures. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands-stats.test.tsx
@@ -4,6 +4,7 @@ import type { HandInstanceItem, HandInstanceStatus } from "../../api";
 import {
   useHandStats,
   useHandStatsBatch,
+  HandStatsBatchError,
   useHandSession,
   useHandInstanceStatus,
   useHandManifestToml,
@@ -140,15 +141,36 @@ describe("useHandStatsBatch", () => {
     expect(result.current.data).not.toHaveProperty("h2");
   });
 
-  it("should fetch all requests in parallel", async () => {
-    const resolveOrder: string[] = [];
+  it("surfaces an error when every stats request fails", async () => {
+    vi.mocked(client.getHandStats).mockRejectedValue(new Error("offline"));
+
+    const { result } = renderHook(() => useHandStatsBatch(["h1", "h2"]), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(HandStatsBatchError);
+    expect((result.current.error as HandStatsBatchError).instanceIds).toEqual([
+      "h1",
+      "h2",
+    ]);
+  });
+
+  it("limits parallel stats requests", async () => {
+    let active = 0;
+    let maxActive = 0;
     vi.mocked(client.getHandStats).mockImplementation(async (id: string) => {
-      await new Promise((r) => setTimeout(r, Math.random() * 10));
-      resolveOrder.push(id);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
       return { instance_id: id };
     });
 
-    const { result } = renderHook(() => useHandStatsBatch(["a", "b", "c"]), {
+    const ids = Array.from({ length: 14 }, (_, index) => `hand-${index}`);
+
+    const { result } = renderHook(() => useHandStatsBatch(ids), {
       wrapper: createQueryClientWrapper().wrapper,
     });
 
@@ -156,8 +178,8 @@ describe("useHandStatsBatch", () => {
       expect(result.current.data).toBeDefined();
     });
 
-    // All 3 calls should have been made (parallel, not sequential)
-    expect(client.getHandStats).toHaveBeenCalledTimes(3);
+    expect(client.getHandStats).toHaveBeenCalledTimes(14);
+    expect(maxActive).toBe(6);
   });
 });
 

--- a/crates/librefang-api/dashboard/src/lib/queries/hands.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands.ts
@@ -14,6 +14,49 @@ import { handKeys } from "./keys";
 
 const STALE_MS = 30_000;
 const REFRESH_MS = 30_000;
+const STATS_BATCH_CONCURRENCY = 6;
+
+export class HandStatsBatchError extends Error {
+  constructor(
+    readonly instanceIds: readonly string[],
+    readonly causes: readonly unknown[],
+  ) {
+    super(`Failed to load stats for ${instanceIds.length} hand instances`);
+    this.name = "HandStatsBatchError";
+  }
+}
+
+async function getHandStatsBatch(instanceIds: readonly string[]) {
+  const results: Record<string, HandStatsResponse> = {};
+  const failedIds: string[] = [];
+  const causes: unknown[] = [];
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < instanceIds.length) {
+      const id = instanceIds[nextIndex++];
+      try {
+        results[id] = await getHandStats(id);
+      } catch (error) {
+        failedIds.push(id);
+        causes.push(error);
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(STATS_BATCH_CONCURRENCY, instanceIds.length) },
+      worker,
+    ),
+  );
+
+  if (failedIds.length === instanceIds.length && instanceIds.length > 0) {
+    throw new HandStatsBatchError(failedIds, causes);
+  }
+
+  return results;
+}
 
 export const handQueries = {
   list: () =>
@@ -58,19 +101,7 @@ export const handQueries = {
   statsBatch: (instanceIds: readonly string[]) =>
     queryOptions({
       queryKey: handKeys.statsBatch(instanceIds),
-      queryFn: async () => {
-        const results: Record<string, HandStatsResponse> = {};
-        await Promise.all(
-          instanceIds.map(async (id) => {
-            try {
-              results[id] = await getHandStats(id);
-            } catch {
-              /* skip */
-            }
-          }),
-        );
-        return results;
-      },
+      queryFn: () => getHandStatsBatch(instanceIds),
       enabled: instanceIds.length > 0,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,


### PR DESCRIPTION
## Changes

- limit hand-stat batch reads to six concurrent requests
- preserve partial successful results when individual instances fail
- surface a typed query error when the complete batch fails
- include failed instance IDs and underlying causes for diagnostics
- add complete-failure and concurrency regressions

## Verification

- `corepack pnpm exec vitest run src/lib/queries/hands-stats.test.tsx src/pages/HandsPage.test.tsx` (43 tests)
- `corepack pnpm test` (97 files, 1026 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- the current page already memoizes the instance-ID list, and TanStack structurally hashes query keys
- no hand API or page presentation changes