### PR TITLE
refactor(dashboard): remove unused video query key

### DIFF
--- a/changelog.d/changed/remove-disabled-video-key.md
+++ b/changelog.d/changed/remove-disabled-video-key.md
@@ -1,0 +1,1 @@
+Remove the unused sentinel query key for disabled dashboard video tasks. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -370,24 +370,6 @@ describe("query key factories", () => {
       expect(mediaKeys.videoTask("task-1", "fal").slice(0, taskPrefix.length)).toEqual(taskPrefix);
       expect(mediaKeys.videoTasks().slice(0, mediaKeys.all.length)).toEqual(mediaKeys.all);
     });
-
-    it("videoTaskDisabled is stable and only collides with a literal sentinel id", () => {
-      expect(mediaKeys.videoTaskDisabled()).toEqual([
-        "media",
-        "videoTasks",
-        "__disabled__",
-        "__disabled__",
-      ]);
-      // Stable across calls (so useQuery's cache identity is preserved).
-      expect(mediaKeys.videoTaskDisabled()).toEqual(mediaKeys.videoTaskDisabled());
-      // 4-segment shape matches videoTask(taskId, provider) so useQuery's
-      // generics unify cleanly across the enabled/disabled branches.
-      expect(mediaKeys.videoTaskDisabled().length).toBe(4);
-      // Shares the videoTasks prefix — consumers can invalidate all video
-      // task queries (live + disabled placeholder) in one call.
-      const prefix = mediaKeys.videoTasks();
-      expect(mediaKeys.videoTaskDisabled().slice(0, prefix.length)).toEqual(prefix);
-    });
   });
 
   describe("telemetryKeys", () => {

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -443,12 +443,6 @@ export const mediaKeys = {
   videoTasks: () => [...mediaKeys.all, "videoTasks"] as const,
   videoTask: (taskId: string, provider: string) =>
     [...mediaKeys.videoTasks(), taskId, provider] as const,
-  // Stable key for the disabled state of useVideoTask — paired with skipToken
-  // so every not-yet-submitted render shares the same (unused) cache slot.
-  // Shape mirrors `videoTask(taskId, provider)` (4 segments) so both branches
-  // of the query are type-compatible under useQuery's generic inference.
-  videoTaskDisabled: () =>
-    [...mediaKeys.videoTasks(), "__disabled__", "__disabled__"] as const,
 };
 
 export const mcpKeys = {


### PR DESCRIPTION
## Changes

- remove the unused `videoTaskDisabled` sentinel key factory
- remove its collision-prone magic task/provider values and obsolete skip-token documentation
- remove tests that preserved the dead sentinel contract

## Verification

- `corepack pnpm exec vitest run src/lib/queries/keys.test.ts` (42 tests)
- `corepack pnpm test` (97 files, 1024 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- optional `undefined` and `null` array segments already hash identically under TanStack stable JSON hashing
- the passkey broad/specific key is intentionally identical while only one list shape exists
- marketplace factory deduplication is a style-only change with no cache defect