### PR TITLE
refactor(dashboard): align MCP query contracts

### DIFF
--- a/changelog.d/changed/mcp-query-contract.md
+++ b/changelog.d/changed/mcp-query-contract.md
@@ -1,0 +1,1 @@
+Align dashboard MCP query factories, overrides, and prerequisite guards. (@xiaomo)

--- a/crates/librefang-api/dashboard/src/lib/queries/mcp.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/mcp.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getMcpAuthStatus,
+  getMcpCatalogEntry,
+  getMcpServer,
+} from "../http/client";
+import { createQueryClientWrapper } from "../test/query-client";
+import {
+  mcpQueries,
+  useMcpAuthStatus,
+  useMcpCatalogEntry,
+  useMcpServer,
+} from "./mcp";
+
+vi.mock("../http/client", () => ({
+  listMcpServers: vi.fn(),
+  getMcpServer: vi.fn(),
+  listMcpCatalog: vi.fn(),
+  getMcpCatalogEntry: vi.fn(),
+  getMcpHealth: vi.fn(),
+  getMcpAuthStatus: vi.fn(),
+  listMcpTaintRules: vi.fn(),
+}));
+
+describe("MCP query contracts", () => {
+  it("keeps the catalog factory enabled by default", () => {
+    expect(mcpQueries.catalog().enabled).toBeUndefined();
+  });
+
+  it("names the short OAuth status freshness window", () => {
+    expect(mcpQueries.authStatus("server-1").staleTime).toBe(2_000);
+  });
+
+  it("cannot enable ID-scoped reads without an ID", () => {
+    const { wrapper } = createQueryClientWrapper();
+
+    renderHook(() => useMcpServer("", { enabled: true }), { wrapper });
+    renderHook(() => useMcpCatalogEntry("", { enabled: true }), { wrapper });
+    renderHook(() => useMcpAuthStatus("", { enabled: true }), { wrapper });
+
+    expect(getMcpServer).not.toHaveBeenCalled();
+    expect(getMcpCatalogEntry).not.toHaveBeenCalled();
+    expect(getMcpAuthStatus).not.toHaveBeenCalled();
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
@@ -15,6 +15,7 @@ const SERVERS_STALE_MS = 30_000;
 const SERVERS_REFRESH_MS = 30_000;
 const CATALOG_STALE_MS = 300_000;
 const HEALTH_STALE_MS = 15_000;
+const AUTH_STATUS_STALE_MS = 2_000;
 // `[[taint_rules]]` is operator-edited config, not runtime-derived state.
 // 5 minutes matches the catalog cadence — operators don't expect rule-set
 // renames to land instantly in the editor, and reload-config flows already
@@ -37,12 +38,11 @@ export const mcpQueries = {
       staleTime: SERVERS_STALE_MS,
       enabled: Boolean(id),
     }),
-  catalog: (opts: QueryOverrides = {}) =>
+  catalog: () =>
     queryOptions({
       queryKey: mcpKeys.catalog(),
       queryFn: listMcpCatalog,
       staleTime: CATALOG_STALE_MS,
-      enabled: opts.enabled,
     }),
   catalogEntry: (id: string) =>
     queryOptions({
@@ -57,13 +57,13 @@ export const mcpQueries = {
       queryFn: getMcpHealth,
       staleTime: HEALTH_STALE_MS,
     }),
-  authStatus: (id: string, opts: QueryOverrides = {}) =>
+  authStatus: (id: string) =>
     queryOptions({
       queryKey: mcpKeys.authStatus(id),
       queryFn: () => getMcpAuthStatus(id),
       // 2s staleTime balances OAuth polling freshness with request deduplication during rapid refetch cycles.
-      staleTime: 2_000,
-      enabled: opts.enabled ?? Boolean(id),
+      staleTime: AUTH_STATUS_STALE_MS,
+      enabled: Boolean(id),
     }),
   taintRules: () =>
     queryOptions({
@@ -78,7 +78,10 @@ export function useMcpServers(options: QueryOverrides = {}) {
 }
 
 export function useMcpServer(id: string, options: QueryOverrides = {}) {
-  return useQuery(withOverrides(mcpQueries.server(id), options));
+  return useQuery(withOverrides(mcpQueries.server(id), {
+    ...options,
+    enabled: Boolean(id) && options.enabled !== false,
+  }));
 }
 
 export function useMcpCatalog(options: QueryOverrides = {}) {
@@ -86,7 +89,10 @@ export function useMcpCatalog(options: QueryOverrides = {}) {
 }
 
 export function useMcpCatalogEntry(id: string, options: QueryOverrides = {}) {
-  return useQuery(withOverrides(mcpQueries.catalogEntry(id), options));
+  return useQuery(withOverrides(mcpQueries.catalogEntry(id), {
+    ...options,
+    enabled: Boolean(id) && options.enabled !== false,
+  }));
 }
 
 export function useMcpHealth(options: QueryOverrides = {}) {
@@ -94,7 +100,10 @@ export function useMcpHealth(options: QueryOverrides = {}) {
 }
 
 export function useMcpAuthStatus(id: string, options: QueryOverrides = {}) {
-  return useQuery(withOverrides(mcpQueries.authStatus(id), options));
+  return useQuery(withOverrides(mcpQueries.authStatus(id), {
+    ...options,
+    enabled: Boolean(id) && options.enabled !== false,
+  }));
 }
 
 export function useMcpTaintRules(options: QueryOverrides = {}) {


### PR DESCRIPTION
## Changes

- keep MCP query factories free of caller override state
- apply typed overrides consistently at hook boundaries
- preserve ID prerequisites even when callers request `enabled: true`
- name the OAuth status freshness constant
- add factory-default and prerequisite regressions

## Verification

- `corepack pnpm exec vitest run src/lib/queries/mcp.test.tsx src/pages/McpServersPage.test.tsx` (7 tests)
- `corepack pnpm test` (98 files, 1028 tests)
- `corepack pnpm lint`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm build`
- `git diff --check`

## Out of scope

- MCP detail reads remain invalidation-driven; the live server list continues polling for external changes
- no MCP API, freshness interval, or page behavior changes