### PR TITLE
fix: harden task queue API contract

### DIFF
--- a/crates/librefang-api/src/routes/task_queue.rs
+++ b/crates/librefang-api/src/routes/task_queue.rs
@@ -5,7 +5,7 @@
 //! `/tasks/{id}/retry`.
 
 use super::AppState;
-use crate::middleware::RequestLanguage;
+use crate::middleware::{AuthenticatedApiUser, RequestLanguage};
 use crate::types::ApiErrorResponse;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -100,7 +100,13 @@ pub async fn task_queue_status(
                     "in_progress" => in_progress += 1,
                     "completed" => completed += 1,
                     "failed" => failed += 1,
-                    _ => {}
+                    unknown => {
+                        tracing::warn!(
+                            status = unknown,
+                            task_id = t["id"].as_str().unwrap_or("<unknown>"),
+                            "task queue status summary encountered an unknown status"
+                        );
+                    }
                 }
             }
             (
@@ -171,12 +177,11 @@ pub async fn task_queue_retry(
             StatusCode::OK,
             Json(serde_json::json!({"status": "retried", "id": id})),
         ),
-        Ok(false) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({
-                "error": err_task_not_retryable
-            })),
-        ),
+        Ok(false) => match state.kernel.task_get(&id).await {
+            Ok(Some(_)) => ApiErrorResponse::conflict(err_task_not_retryable).into_json_tuple(),
+            Ok(None) => ApiErrorResponse::not_found(err_task_not_retryable).into_json_tuple(),
+            Err(e) => map_kernel_op_err(e).into_json_tuple(),
+        },
         Err(e) => map_kernel_op_err(e).into_json_tuple(),
     }
 }
@@ -197,13 +202,13 @@ pub async fn task_queue_list_root(
             if let Some(assignee) = params.get("assigned_to") {
                 tasks.retain(|t| t["assigned_to"].as_str().unwrap_or("") == assignee.as_str());
             }
+            let total = tasks.len();
             // Apply limit
             if let Some(limit_str) = params.get("limit") {
                 if let Ok(limit) = limit_str.parse::<usize>() {
                     tasks.truncate(limit);
                 }
             }
-            let total = tasks.len();
             (
                 StatusCode::OK,
                 Json(serde_json::json!({"tasks": tasks, "total": total})),
@@ -215,15 +220,16 @@ pub async fn task_queue_list_root(
 
 /// POST /api/tasks — Enqueue a task on behalf of an external caller.
 ///
-/// Body: `{"title": "...", "description": "...", "assigned_to": "<agent-id>"?, "created_by": "<agent-id>"?}`
+/// Body: `{"title": "...", "description": "...", "assigned_to": "<agent-id>"?}`
 ///
 /// Wraps `KernelHandle::task_post` so HTTP clients (skill subprocesses,
 /// cron scripts, external integrations) can enqueue tasks without a
 /// runtime/agent context. The agent-side `task_post` tool keeps the
-/// caller's agent id automatically; this HTTP form takes `created_by`
-/// as an optional explicit field for provenance.
+/// caller's agent id automatically; this HTTP form derives `created_by`
+/// from the authenticated principal so clients cannot spoof provenance.
 pub async fn task_queue_post_root(
     State(state): State<Arc<AppState>>,
+    api_user: Option<axum::Extension<AuthenticatedApiUser>>,
     _lang: Option<axum::Extension<RequestLanguage>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
@@ -246,10 +252,10 @@ pub async fn task_queue_post_root(
         }
     };
     let assigned_to = body["assigned_to"].as_str();
-    let created_by = body["created_by"].as_str();
+    let created_by = api_user.as_ref().map(|user| user.0.user_id.to_string());
     match state
         .kernel
-        .task_post(title, description, assigned_to, created_by)
+        .task_post(title, description, assigned_to, created_by.as_deref())
         .await
     {
         Ok(task_id) => (
@@ -280,7 +286,7 @@ pub async fn task_queue_get(
 /// PATCH /api/tasks/{id} — Update task status.
 ///
 /// Body: `{"status": "pending"}` or `{"status": "cancelled"}`
-/// - `pending`: resets a failed/in_progress task so it can be re-claimed
+/// - `pending`: resets a failed task so it can be re-claimed
 /// - `cancelled`: cancels a pending/in_progress task
 pub async fn task_queue_patch(
     State(state): State<Arc<AppState>>,
@@ -314,7 +320,14 @@ pub async fn task_queue_patch(
             StatusCode::OK,
             Json(serde_json::json!({"id": id, "status": new_status})),
         ),
-        Ok(false) => ApiErrorResponse::not_found(err_not_found).into_json_tuple(),
+        Ok(false) => match state.kernel.task_get(&id).await {
+            Ok(Some(_)) => ApiErrorResponse::conflict(format!(
+                "task '{id}' cannot transition to '{new_status}' from its current status"
+            ))
+            .into_json_tuple(),
+            Ok(None) => ApiErrorResponse::not_found(err_not_found).into_json_tuple(),
+            Err(e) => map_kernel_op_err(e).into_json_tuple(),
+        },
         Err(e) => map_kernel_op_err(e).into_json_tuple(),
     }
 }

--- a/crates/librefang-api/tests/task_queue_routes_integration.rs
+++ b/crates/librefang-api/tests/task_queue_routes_integration.rs
@@ -1,0 +1,189 @@
+//! Integration coverage for the task-queue HTTP contract.
+//!
+//! The focused router uses the real SQLite-backed task substrate from
+//! `TestAppState`. Authentication middleware is not mounted, so tests that
+//! need a principal inject `AuthenticatedApiUser` as a request extension.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use librefang_api::middleware::AuthenticatedApiUser;
+use librefang_api::routes::{self, AppState};
+use librefang_kernel::auth::UserRole;
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_types::agent::UserId;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct Harness {
+    app: Router,
+    state: Arc<AppState>,
+    _test: TestAppState,
+}
+
+fn boot() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new());
+    let state = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::task_queue::router())
+        .with_state(state.clone());
+    Harness {
+        app,
+        state,
+        _test: test,
+    }
+}
+
+fn api_user(name: &str) -> AuthenticatedApiUser {
+    AuthenticatedApiUser {
+        name: name.to_string(),
+        role: UserRole::User,
+        user_id: UserId::from_name(name),
+    }
+}
+
+async fn json_request(
+    h: &Harness,
+    method: Method,
+    path: &str,
+    body: Option<serde_json::Value>,
+    user: Option<AuthenticatedApiUser>,
+) -> (StatusCode, serde_json::Value) {
+    let mut builder = Request::builder().method(method).uri(path);
+    let bytes = match body {
+        Some(value) => {
+            builder = builder.header("content-type", "application/json");
+            serde_json::to_vec(&value).unwrap()
+        }
+        None => Vec::new(),
+    };
+    let mut request = builder.body(Body::from(bytes)).unwrap();
+    if let Some(user) = user {
+        request.extensions_mut().insert(user);
+    }
+
+    let response = h.app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, body)
+}
+
+async fn post_task(h: &Harness, title: &str) -> String {
+    let (status, body) = json_request(
+        h,
+        Method::POST,
+        "/api/tasks",
+        Some(serde_json::json!({
+            "title": title,
+            "description": "integration test"
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "task post failed: {body:?}");
+    body["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_total_describes_filtered_result_before_limit() {
+    let h = boot();
+    post_task(&h, "one").await;
+    post_task(&h, "two").await;
+    post_task(&h, "three").await;
+
+    let (status, body) = json_request(&h, Method::GET, "/api/tasks?limit=1", None, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 3);
+    assert_eq!(body["tasks"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_uses_authenticated_principal_for_provenance() {
+    let h = boot();
+    let caller = api_user("alice");
+    let expected_creator = caller.user_id.to_string();
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/tasks",
+        Some(serde_json::json!({
+            "title": "owned",
+            "description": "integration test",
+            "created_by": "forged-agent"
+        })),
+        Some(caller),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let id = body["id"].as_str().unwrap();
+    let (status, task) =
+        json_request(&h, Method::GET, &format!("/api/tasks/{id}"), None, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(task["created_by"], expected_creator);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn retry_distinguishes_missing_from_ineligible_task() {
+    let h = boot();
+    let id = post_task(&h, "pending").await;
+
+    let (status, _) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/tasks/{id}/retry"),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let (status, _) = json_request(&h, Method::POST, "/api/tasks/missing/retry", None, None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_only_requeues_failed_tasks() {
+    let h = boot();
+    let id = post_task(&h, "stateful").await;
+    let patch = serde_json::json!({"status": "pending"});
+
+    let (status, _) = json_request(
+        &h,
+        Method::PATCH,
+        &format!("/api/tasks/{id}"),
+        Some(patch.clone()),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let pool = h.state.kernel.memory_substrate().pool();
+    let conn = pool.get().unwrap();
+    let changed = conn
+        .execute(
+            "UPDATE task_queue SET status = 'failed' WHERE id = ?1",
+            rusqlite::params![&id],
+        )
+        .unwrap();
+    assert_eq!(changed, 1);
+    drop(conn);
+
+    let (status, body) = json_request(
+        &h,
+        Method::PATCH,
+        &format!("/api/tasks/{id}"),
+        Some(patch),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "pending");
+}

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1398,7 +1398,7 @@ impl MemorySubstrate {
 
     /// Update a task's status to `pending` (reset) or `cancelled`.
     ///
-    /// Only `in_progress` / `pending` tasks can be reset to `pending`.
+    /// Only failed tasks can be reset to `pending`.
     /// Any non-terminal task can be cancelled.
     /// Returns `false` when the task was not found or the transition is invalid.
     pub async fn task_update_status(
@@ -1422,7 +1422,7 @@ impl MemorySubstrate {
                     "UPDATE task_queue \
                      SET status = 'pending', claimed_at = NULL, assigned_to = '', \
                          finished_at = NULL \
-                     WHERE id = ?1 AND status IN ('in_progress', 'failed')",
+                     WHERE id = ?1 AND status = 'failed'",
                     rusqlite::params![task_id],
                 ),
                 // Cancellation is a terminal transition like complete/fail,
@@ -2523,6 +2523,33 @@ mod tests {
             finished_at.is_none(),
             "reset to pending must clear finished_at"
         );
+    }
+
+    #[tokio::test]
+    async fn test_task_reset_to_pending_rejects_in_progress_task() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let task_id = substrate
+            .task_post("t", "d", Some("worker"), None)
+            .await
+            .unwrap();
+
+        let claimed = substrate
+            .task_claim("worker-id", Some("worker"))
+            .await
+            .unwrap();
+        assert_eq!(claimed.unwrap()["id"], task_id);
+
+        let changed = substrate
+            .task_update_status(&task_id, "pending")
+            .await
+            .unwrap();
+        assert!(
+            !changed,
+            "an in-progress task must not be re-queued while its worker may still be running"
+        );
+
+        let task = substrate.task_get(&task_id).await.unwrap().unwrap();
+        assert_eq!(task["status"], "in_progress");
     }
 
     /// #3501: `remove_agent` cascade-deletes sessions, memories, and the


### PR DESCRIPTION
## Summary

- prevent `in_progress` tasks from being reset to `pending` while a worker may still be executing them
- report list totals before applying `limit`, and distinguish missing tasks from invalid retry/status transitions
- derive HTTP task provenance from the authenticated principal instead of trusting `created_by` request data
- emit a warning when task status summaries encounter an unknown persisted status
- add focused SQLite-backed route integration coverage and a substrate transition regression test

## Verification

- `cargo test -p librefang-memory test_task_reset_to_pending --lib`
- `cargo test -p librefang-api --test task_queue_routes_integration`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- no task-queue schema or public route changes
- no changes to agent-side task tools
