### PR TITLE
fix(dashboard): parse animated numbers strictly

### DIFF
--- a/changelog.d/fixed/7436-dashboard-animated-number-parsing.md
+++ b/changelog.d/fixed/7436-dashboard-animated-number-parsing.md
@@ -1,0 +1,1 @@
+Fixed animated counters silently misparsing malformed and locale-formatted strings. (#7436) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/AnimatedNumber.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/AnimatedNumber.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AnimatedNumber } from "./AnimatedNumber";
+
+describe("AnimatedNumber", () => {
+  it.each(["1.234.56", "12-3", "1,5", "$1,234.50"])(
+    "renders the invalid numeric string %s unchanged",
+    (value) => {
+      render(<AnimatedNumber value={value} />);
+
+      expect(screen.getByText(value)).toBeInTheDocument();
+    },
+  );
+
+  it("animates a complete decimal string", () => {
+    render(<AnimatedNumber value="-42.5" decimals={1} />);
+
+    expect(screen.getByText("-42.5")).toBeInTheDocument();
+  });
+
+  it("renders non-finite numbers unchanged", () => {
+    render(<AnimatedNumber value={Number.POSITIVE_INFINITY} />);
+
+    expect(screen.getByText("Infinity")).toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/AnimatedNumber.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/AnimatedNumber.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import { animate, motion, useMotionValue, useTransform } from "motion/react";
 
-const NON_NUMERIC_RE = /[^0-9.-]/g;
+const NUMERIC_STRING_RE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 interface AnimatedNumberProps {
+  /** Strings animate only when the complete value is a finite decimal or exponent literal. */
   value: number | string;
   /** Animation duration in milliseconds (matches the legacy API). Defaults to 800. */
   duration?: number;
@@ -13,8 +14,16 @@ interface AnimatedNumberProps {
   className?: string;
 }
 
-function parseValue(value: number | string): number {
-  return typeof value === "string" ? parseFloat(value.replace(NON_NUMERIC_RE, "")) : value;
+function parseValue(value: number | string): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const normalized = value.trim();
+  if (!NUMERIC_STRING_RE.test(normalized)) return null;
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 /// Smoothly tweens a numeric display when `value` changes — used for
@@ -31,20 +40,20 @@ export function AnimatedNumber({
   className = "",
 }: AnimatedNumberProps) {
   const target = parseValue(value);
-  const isNumeric = !isNaN(target);
-  const motionValue = useMotionValue(isNumeric ? target : 0);
+  const isNumeric = target !== null;
+  const motionValue = useMotionValue(target ?? 0);
   const display = useTransform(motionValue, (latest) =>
     `${prefix}${latest.toFixed(decimals)}${suffix}`,
   );
 
   useEffect(() => {
-    if (!isNumeric) return;
+    if (target === null) return;
     const controls = animate(motionValue, target, {
       duration: duration / 1000,
       ease: [0.25, 0.1, 0.25, 1],
     });
     return () => controls.stop();
-  }, [target, duration, motionValue, isNumeric]);
+  }, [target, duration, motionValue]);
 
   if (!isNumeric) return <span className={className}>{String(value)}</span>;
   return <motion.span className={className}>{display}</motion.span>;


### PR DESCRIPTION
## Changes

- accept string animation targets only when the complete value is a finite decimal or exponent literal
- render malformed, currency-formatted, locale-formatted, and non-finite inputs unchanged
- document the string contract and cover prior silent misparses

Inventory finding: `F-72b433c3cb503c1a`

## Verification

- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/AnimatedNumber.test.tsx --reporter=dot` (6 passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard typecheck`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard lint`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --reporter=dot` (102 files, 1081 tests passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard build`
- `git diff --check`

## Out of scope

- locale-aware number parsing
- formatting numeric outputs beyond existing prefix, suffix, and decimals props
- changing TelemetryPage data shapes