### PR TITLE
fix(dashboard): normalize avatar initials

### DIFF
--- a/changelog.d/fixed/7437-dashboard-avatar-initials.md
+++ b/changelog.d/fixed/7437-dashboard-avatar-initials.md
@@ -1,0 +1,1 @@
+Fixed avatar initials for names separated by non-space whitespace. (#7437) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/Avatar.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Avatar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Avatar } from "./Avatar";
+
+describe("Avatar", () => {
+  it.each([
+    ["Jane Doe", "JD"],
+    ["  Jane   Doe  ", "JD"],
+    ["Jane\tDoe", "JD"],
+    ["Jane\nDoe", "JD"],
+    ["Jane\u00a0Doe", "JD"],
+    ["Jane", "J"],
+    ["   ", "?"],
+  ])("derives initials from %j", (fallback, expected) => {
+    render(<Avatar fallback={fallback} />);
+
+    const avatar = screen.getByRole("img");
+    expect(avatar).toHaveAttribute("aria-label", fallback);
+    expect(avatar).toHaveTextContent(expected);
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/Avatar.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Avatar.tsx
@@ -17,7 +17,9 @@ const sizeStyles: Record<AvatarSize, string> = {
 
 function getInitials(name: string): string {
   const initials = name
-    .split(" ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
     .map((n) => n[0])
     .join("")
     .toUpperCase()


### PR DESCRIPTION
## Changes

- trim avatar fallback names before deriving initials
- split names on all whitespace instead of one literal space
- avoid relying on implicit undefined coercion for empty tokens
- cover spaces, tabs, newlines, non-breaking spaces, single names, and blank fallbacks

Inventory finding: `F-1eee30f952e2bd37`

## Verification

- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/Avatar.test.tsx --reporter=dot` (7 passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard typecheck`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard lint`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --reporter=dot` (102 files, 1082 tests passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard build`
- `git diff --check`

## Out of scope

- grapheme-aware initials beyond existing first-code-unit behavior
- image loading and error fallback behavior
- avatar sizing and styling