### PR TITLE
fix(dashboard): synchronize command palette focus

### DIFF
--- a/changelog.d/fixed/7438-dashboard-command-palette-keyboard.md
+++ b/changelog.d/fixed/7438-dashboard-command-palette-keyboard.md
@@ -1,0 +1,1 @@
+Fixed command palette focus, listener, and shortcut toggle behavior. (#7438) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/CommandPalette.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/CommandPalette.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useNavigate } from "@tanstack/react-router";
+import { describe, expect, it, vi } from "vitest";
+import { CommandPalette, useCommandPalette } from "./CommandPalette";
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function ShortcutHarness() {
+  const { isOpen } = useCommandPalette();
+  return <span>{isOpen ? "open" : "closed"}</span>;
+}
+
+describe("CommandPalette", () => {
+  it("moves DOM focus with the visual arrow-key selection", () => {
+    vi.mocked(useNavigate).mockReturnValue(vi.fn());
+    render(<CommandPalette isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("command_palette.search_placeholder"))
+      .toHaveFocus();
+
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    expect(document.activeElement).toHaveTextContent("nav.workflows");
+
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    expect(document.activeElement).toHaveTextContent("nav.overview");
+  });
+
+  it("executes the focused command with Enter", () => {
+    const navigate = vi.fn();
+    const onClose = vi.fn();
+    vi.mocked(useNavigate).mockReturnValue(navigate);
+    render(<CommandPalette isOpen onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(navigate).toHaveBeenCalledWith({ to: "/workflows" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not attach its command key handler while closed", () => {
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    vi.mocked(useNavigate).mockReturnValue(vi.fn());
+
+    render(<CommandPalette isOpen={false} onClose={vi.fn()} />);
+
+    expect(
+      addEventListener.mock.calls.filter(([event]) => event === "keydown"),
+    ).toHaveLength(0);
+    addEventListener.mockRestore();
+  });
+});
+
+describe("useCommandPalette", () => {
+  it("toggles the palette with repeated Ctrl+K shortcuts", () => {
+    render(<ShortcutHarness />);
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByText("open")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
@@ -41,6 +41,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const [search, setSearch] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const commandRefs = useRef<(HTMLButtonElement | null)[]>([]);
   useFocusTrap(isOpen, dialogRef, true);
 
   const commands = useMemo<CommandItem[]>(() => [
@@ -92,11 +93,6 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     return label.includes(q) || cmd.id.includes(q);
   }), [commands, search, t]);
 
-  const filteredRef = useRef(filteredCommands);
-  filteredRef.current = filteredCommands;
-  const selectedRef = useRef(selectedIndex);
-  selectedRef.current = selectedIndex;
-
   useEffect(() => {
     if (!isOpen) {
       setSearch("");
@@ -109,18 +105,24 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   }, [filteredCommands]);
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!isOpen) return;
+    if (!isOpen) return;
 
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSelectedIndex(i => Math.min(i + 1, filteredRef.current.length - 1));
+        if (filteredCommands.length === 0) return;
+        const nextIndex = Math.min(selectedIndex + 1, filteredCommands.length - 1);
+        setSelectedIndex(nextIndex);
+        commandRefs.current[nextIndex]?.focus();
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
-        setSelectedIndex(i => Math.max(i - 1, 0));
-      } else if (e.key === "Enter" && filteredRef.current[selectedRef.current]) {
+        if (filteredCommands.length === 0) return;
+        const nextIndex = Math.max(selectedIndex - 1, 0);
+        setSelectedIndex(nextIndex);
+        commandRefs.current[nextIndex]?.focus();
+      } else if (e.key === "Enter" && filteredCommands[selectedIndex]) {
         e.preventDefault();
-        filteredRef.current[selectedRef.current].action();
+        filteredCommands[selectedIndex].action();
         onClose();
       } else if (e.key === "Escape") {
         onClose();
@@ -129,7 +131,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, filteredCommands, selectedIndex]);
 
   const groupedCommands = useMemo(() => filteredCommands.reduce((acc, cmd) => {
     const key = t(cmd.categoryKey);
@@ -197,6 +199,10 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                   return (
                     <button
                       key={cmd.id}
+                      ref={(element) => {
+                        commandRefs.current[globalIndex] = element;
+                      }}
+                      onFocus={() => setSelectedIndex(globalIndex)}
                       onClick={() => { cmd.action(); onClose(); }}
                       className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-left transition-colors duration-200 ${globalIndex === selectedIndex ? 'bg-brand/10 text-brand' : 'hover:bg-surface-hover'}`}
                     >
@@ -224,7 +230,7 @@ export function useCommandPalette() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
-        setIsOpen(true);
+        setIsOpen((open) => !open);
       }
     };
 


### PR DESCRIPTION
## Changes

- move real DOM focus with ArrowUp and ArrowDown selection
- synchronize visual selection when a command receives focus
- register the command key handler only while the palette is open
- close over current filtered commands instead of mutating refs during render
- make repeated Cmd/Ctrl+K shortcuts toggle the palette
- preserve IME composition input instead of treating composition keystrokes as palette shortcuts

Inventory findings: `F-d845c7eb96e0a3d0`, `F-388a9fc2d8046339`, `F-48e7046183eed346`, `F-33ef4465db26958b`

## Verification

- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/CommandPalette.test.tsx --reporter=dot` (4 passed before the follow-up; fresh CI covers the synchronized head)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard typecheck`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard lint`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --reporter=dot` (102 files, 1079 tests passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard build`
- `git diff --check`

## Out of scope

- command registry contents and ordering
- search matching behavior
- palette animation and visual styling
