### PR TITLE
fix(dashboard): separate toast live regions

### DIFF
--- a/changelog.d/fixed/7439-dashboard-toast-live-regions.md
+++ b/changelog.d/fixed/7439-dashboard-toast-live-regions.md
@@ -1,0 +1,1 @@
+Fixed duplicate and mistimed screen-reader announcements for dashboard toasts. (#7439) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/Toast.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Toast.test.tsx
@@ -1,0 +1,42 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUIStore } from "../../lib/store";
+import { ToastContainer } from "./Toast";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+  }),
+}));
+
+describe("ToastContainer", () => {
+  beforeEach(() => {
+    act(() =>
+      useUIStore.setState({
+        toasts: [
+          { id: "success", message: "Saved", type: "success" },
+          { id: "error", message: "Failed", type: "error" },
+        ],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    act(() => useUIStore.setState({ toasts: [] }));
+  });
+
+  it("lets each toast role define its own announcement priority", () => {
+    render(<ToastContainer />);
+
+    const status = screen.getByRole("status");
+    const alert = screen.getByRole("alert");
+    const container = status.parentElement;
+
+    expect(status).toHaveTextContent("Saved");
+    expect(alert).toHaveTextContent("Failed");
+    expect(container).not.toHaveAttribute("aria-live");
+    expect(container).not.toHaveAttribute("aria-atomic");
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/Toast.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Toast.tsx
@@ -26,8 +26,6 @@ export function ToastContainer() {
   return (
     <div
       className="fixed bottom-6 right-6 z-100 flex flex-col gap-2 pointer-events-none"
-      aria-live="polite"
-      aria-atomic="false"
     >
       <AnimatePresence>
         {toasts.slice(-MAX_TOASTS).map((toast) => (


### PR DESCRIPTION
## Changes

- remove the outer polite live region from the toast stack
- preserve per-toast status and alert roles so success/info stay polite and errors stay assertive
- cover item roles and the absence of nested live-region attributes

Inventory finding: `F-c816869f2a5cf196`

## Verification

- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/Toast.test.tsx --reporter=dot` (1 passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard typecheck`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard lint`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --reporter=dot` (102 files, 1076 tests passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard build`
- `git diff --check`

## Out of scope

- toast queue limits and expiration timing
- toast placement, animation, and styling
- live-region behavior outside the toast stack