### PR TITLE
fix(dashboard): align delivery target validation

### DIFF
--- a/changelog.d/fixed/7440-dashboard-delivery-target-validation.md
+++ b/changelog.d/fixed/7440-dashboard-delivery-target-validation.md
@@ -1,0 +1,1 @@
+Fixed delivery target validation drift for webhook hosts, URL schemes, and local paths. (#7440) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/DeliveryTargetsEditor.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DeliveryTargetsEditor.test.tsx
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { buildTarget, type DraftState } from "./DeliveryTargetsEditor";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTarget,
+  DeliveryTargetsEditor,
+  type DraftState,
+} from "./DeliveryTargetsEditor";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+  }),
+}));
 
 const draft = (overrides: Partial<DraftState>): DraftState => ({
   type: "channel",
@@ -88,6 +101,38 @@ describe("buildTarget — webhook", () => {
     expect(err).toBe("scheduler.delivery.err_url_blocked_host");
   });
 
+  it.each([
+    "http://0.1.2.3/h",
+    "http://10.0.0.1/h",
+    "http://100.64.0.1/h",
+    "http://172.16.0.1/h",
+    "http://192.168.0.1/h",
+  ])("rejects blocked IPv4 range %s", (url) => {
+    const [, err] = buildTarget(draft({ type: "webhook", url }));
+    expect(err).toBe("scheduler.delivery.err_url_blocked_host");
+  });
+
+  it.each([
+    "http://[::]/h",
+    "http://[fd00::1]/h",
+    "http://[fe90::1]/h",
+    "http://[ff02::1]/h",
+    "http://[::ffff:127.0.0.1]/h",
+    "http://[::ffff:10.0.0.1]/h",
+  ])("rejects blocked IPv6 range %s", (url) => {
+    const [, err] = buildTarget(draft({ type: "webhook", url }));
+    expect(err).toBe("scheduler.delivery.err_url_blocked_host");
+  });
+
+  it.each([
+    "http://instance-data/h",
+    "http://api.localhost/h",
+    "http://service.internal/h",
+  ])("rejects blocked internal hostname %s", (url) => {
+    const [, err] = buildTarget(draft({ type: "webhook", url }));
+    expect(err).toBe("scheduler.delivery.err_url_blocked_host");
+  });
+
   it("rejects IPv6 loopback (SSRF)", () => {
     const [, err] = buildTarget(draft({ type: "webhook", url: "http://[::1]:8080/h" }));
     expect(err).toBe("scheduler.delivery.err_url_blocked_host");
@@ -97,6 +142,26 @@ describe("buildTarget — webhook", () => {
     const [t, err] = buildTarget(draft({ type: "webhook", url: "https://example.com/hook" }));
     expect(err).toBeNull();
     expect(t).toEqual({ type: "webhook", url: "https://example.com/hook" });
+  });
+
+  it("accepts a case-mixed HTTP scheme after URL normalization", () => {
+    const [t, err] = buildTarget(
+      draft({ type: "webhook", url: "HTTPS://example.com/hook" }),
+    );
+    expect(err).toBeNull();
+    expect(t).toEqual({ type: "webhook", url: "HTTPS://example.com/hook" });
+  });
+
+  it.each([
+    "http://100.63.255.255/h",
+    "http://100.128.0.1/h",
+    "http://169.253.0.1/h",
+    "http://172.15.255.255/h",
+    "http://172.32.0.1/h",
+  ])("accepts public IPv4 boundary %s", (url) => {
+    const [target, err] = buildTarget(draft({ type: "webhook", url }));
+    expect(err).toBeNull();
+    expect(target).toEqual({ type: "webhook", url });
   });
 
   it("strips empty auth_header", () => {
@@ -137,6 +202,19 @@ describe("buildTarget — local_file", () => {
     const [t, err] = buildTarget(draft({ type: "local_file", path: "logs/out.log", append: false }));
     expect(err).toBeNull();
     expect(t).toEqual({ type: "local_file", path: "logs/out.log", append: false });
+  });
+
+  it("prompts for a workspace-relative path", async () => {
+    const user = userEvent.setup();
+    render(<DeliveryTargetsEditor value={[]} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Add target" }));
+    await user.click(screen.getByRole("button", { name: "Local file" }));
+
+    expect(screen.getByPlaceholderText("logs/cron-output.log")).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("/var/log/cron-output.log"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/crates/librefang-api/dashboard/src/components/ui/DeliveryTargetsEditor.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DeliveryTargetsEditor.tsx
@@ -107,21 +107,100 @@ const SSRF_BLOCKED_HOSTS = new Set([
   "metadata",
   "metadata.google.internal",
   "metadata.aws.amazon.com",
+  "instance-data",
+  "instance-data.ec2.internal",
 ]);
 
+function parseIpv4(host: string): number[] | null {
+  const octets = host.split(".");
+  if (octets.length !== 4 || octets.some((part) => !/^\d+$/.test(part))) {
+    return null;
+  }
+  const parsed = octets.map(Number);
+  return parsed.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
+    ? parsed
+    : null;
+}
+
+function isBlockedIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function parseIpv6(host: string): number[] | null {
+  let normalized = host;
+  const dottedTail = normalized.match(/(?:^|:)(\d+\.\d+\.\d+\.\d+)$/)?.[1];
+  if (dottedTail) {
+    const ipv4 = parseIpv4(dottedTail);
+    if (!ipv4) return null;
+    const replacement = `${((ipv4[0] << 8) | ipv4[1]).toString(16)}:${((ipv4[2] << 8) | ipv4[3]).toString(16)}`;
+    normalized = `${normalized.slice(0, -dottedTail.length)}${replacement}`;
+  }
+
+  const halves = normalized.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const omitted = 8 - left.length - right.length;
+  if ((halves.length === 1 && omitted !== 0) || (halves.length === 2 && omitted < 1)) {
+    return null;
+  }
+
+  const rawSegments = [
+    ...left,
+    ...Array.from({ length: omitted }, () => "0"),
+    ...right,
+  ];
+  if (
+    rawSegments.length !== 8 ||
+    rawSegments.some((segment) => !/^[0-9a-f]{1,4}$/i.test(segment))
+  ) {
+    return null;
+  }
+  return rawSegments.map((segment) => Number.parseInt(segment, 16));
+}
+
+function isBlockedIpv6(segments: number[]): boolean {
+  const isUnspecified = segments.every((segment) => segment === 0);
+  const isLoopback = segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1;
+  if (isUnspecified || isLoopback) return true;
+
+  const first = segments[0];
+  if ((first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00) {
+    return true;
+  }
+
+  const hasIpv4Prefix =
+    segments.slice(0, 5).every((segment) => segment === 0) &&
+    (segments[5] === 0 || segments[5] === 0xffff);
+  if (!hasIpv4Prefix) return false;
+  return isBlockedIpv4([
+    segments[6] >> 8,
+    segments[6] & 0xff,
+    segments[7] >> 8,
+    segments[7] & 0xff,
+  ]);
+}
+
 function isBlockedWebhookHost(host: string): boolean {
-  const lower = host.toLowerCase();
-  if (SSRF_BLOCKED_HOSTS.has(lower)) return true;
-  // Loopback IPv4 (127.0.0.0/8) and link-local (169.254.0.0/16, the
-  // cloud-metadata range). String-only check — full CIDR parsing isn't
-  // needed for an instant-feedback UX layer; the backend has the real
-  // enforcement.
-  if (/^127\./.test(host)) return true;
-  if (/^169\.254\./.test(host)) return true;
-  // IPv6 loopback / link-local.
-  if (lower === "::1" || lower.startsWith("[::1]")) return true;
-  if (lower.startsWith("fe80:") || lower.startsWith("[fe80:")) return true;
-  return false;
+  const lower = host.toLowerCase().replace(/^\[|\]$/g, "");
+  const ipv4 = parseIpv4(lower);
+  if (ipv4) return isBlockedIpv4(ipv4);
+  const ipv6 = parseIpv6(lower);
+  if (ipv6) return isBlockedIpv6(ipv6);
+  return (
+    SSRF_BLOCKED_HOSTS.has(lower) ||
+    lower.endsWith(".localhost") ||
+    lower.endsWith(".internal")
+  );
 }
 
 /** Exported so unit tests can drive the validator directly without
@@ -145,13 +224,13 @@ export function buildTarget(d: DraftState): [CronDeliveryTarget | null, string |
   if (d.type === "webhook") {
     const url = d.url.trim();
     if (!url) return [null, "scheduler.delivery.err_url_required"];
-    if (!url.startsWith("http://") && !url.startsWith("https://")) {
-      return [null, "scheduler.delivery.err_url_scheme"];
-    }
     // Mirror the backend SSRF rejection (cron_delivery::validate_webhook_url)
     // so users see the error in the form, not after a save round-trip.
     try {
       const parsed = new URL(url);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return [null, "scheduler.delivery.err_url_scheme"];
+      }
       if (isBlockedWebhookHost(parsed.hostname)) {
         return [null, "scheduler.delivery.err_url_blocked_host"];
       }
@@ -492,7 +571,7 @@ export function DeliveryTargetsEditor({ value, onChange, disabled }: DeliveryTar
                 <input
                   value={draft.path}
                   onChange={(e) => setDraft({ ...draft, path: e.target.value })}
-                  placeholder="/var/log/cron-output.log"
+                  placeholder="logs/cron-output.log"
                   className={`${INPUT_CLASS} font-mono text-xs`}
                 />
               </div>


### PR DESCRIPTION
## Changes

- mirror backend literal-host blocking for IPv4 private/CGNAT/zero/link-local ranges
- parse IPv6 literals once and block loopback, unspecified, ULA, link-local, multicast, and embedded private IPv4
- mirror blocked metadata, .localhost, and .internal hostnames
- validate the normalized URL protocol so case-mixed HTTP(S) schemes remain valid
- show a workspace-relative local-file placeholder
- add blocked-range, public-boundary, scheme, hostname, and rendered-placeholder regressions

Inventory findings: `F-e3aa484818d4ee82`, `F-564ee431f05cf955`, `F-657189c2878d419f`, `F-1491dd3989affb4f`

## Verification

- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/DeliveryTargetsEditor.test.tsx --reporter=dot` (43 passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard typecheck`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard lint`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --reporter=dot` (101 files, 1096 tests passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard build`
- `git diff --check`

## Out of scope

- authoritative backend validation and resolver-time DNS checks
- target row identity and removal behavior
- delivery execution, retries, and credentials