### PR TITLE
fix(dashboard): stabilize tool call cards

### DIFF
--- a/changelog.d/fixed/7441.md
+++ b/changelog.d/fixed/7441.md
@@ -1,0 +1,1 @@
+Fixed tool call panels crashing on non-serializable inputs and losing card state after list updates. (#7441) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.test.tsx
@@ -85,4 +85,35 @@ describe("ToolCallsPanel", () => {
     expect(within(dialog).getByRole("button", { name: /Fs Read/i })).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: /Memory Recall/i })).toBeInTheDocument();
   });
+
+  it("does not serialize a circular input while the modal is closed", () => {
+    const input: Record<string, unknown> = {};
+    input.self = input;
+
+    expect(() =>
+      render(<ToolCallsPanel tools={[makeTool({ input })]} />),
+    ).not.toThrow();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("preserves fallback tool card state when an earlier tool is inserted", async () => {
+    const user = userEvent.setup();
+    const first = makeTool({ name: "first.tool", input: { order: 1 } });
+    const second = makeTool({
+      name: "second.tool",
+      input: { order: 2 },
+      result: "second result",
+    });
+    const inserted = makeTool({ name: "inserted.tool", input: { order: 0 } });
+    const { rerender } = render(<ToolCallsPanel tools={[first, second]} />);
+
+    await user.click(screen.getByRole("button", { name: /chat\.tool_calls:2/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /Second Tool/i }));
+    expect(screen.getByText("second result")).toBeInTheDocument();
+
+    rerender(<ToolCallsPanel tools={[inserted, first, second]} />);
+
+    expect(screen.getByText("second result")).toBeInTheDocument();
+  });
 });

--- a/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronRight, Wrench, Loader2, AlertCircle } from "lucide-react";
 import type { AgentTool } from "../../api";
@@ -12,19 +12,11 @@ interface ToolCallsPanelProps {
   tools: ReadonlyArray<PanelTool>;
 }
 
-function stableToolKey(tool: PanelTool, i: number): string {
-  if (tool._call_id) return tool._call_id;
-  const raw = `${tool.name ?? ""}:${JSON.stringify(tool.input ?? "")}`;
-  let h = 0;
-  for (let j = 0; j < raw.length; j++) {
-    h = ((h << 5) - h + raw.charCodeAt(j)) | 0;
-  }
-  return `${tool.name ?? "tool"}-${(h >>> 0).toString(36)}-${i}`;
-}
-
 export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: ToolCallsPanelProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const fallbackKeys = useRef(new WeakMap<PanelTool, string>());
+  const nextFallbackKey = useRef(0);
 
   const stats = useMemo(() => {
     let running = 0;
@@ -37,6 +29,15 @@ export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: Tool
   }, [tools]);
 
   if (tools.length === 0) return null;
+
+  const toolKey = (tool: PanelTool): string => {
+    if (tool._call_id) return tool._call_id;
+    const existing = fallbackKeys.current.get(tool);
+    if (existing) return existing;
+    const key = `${tool.name ?? "tool"}-fallback-${nextFallbackKey.current++}`;
+    fallbackKeys.current.set(tool, key);
+    return key;
+  };
 
   const lastTool = tools[tools.length - 1];
   const titleText = t("chat.tool_calls", { count: stats.total, defaultValue: "{{count}} tool calls" });
@@ -81,9 +82,9 @@ export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: Tool
         size="2xl"
       >
         <div className="px-4 py-3">
-          {tools.map((tool, idx) => (
+          {open && tools.map((tool) => (
             <ToolCallCard
-              key={stableToolKey(tool, idx)}
+              key={toolKey(tool)}
               tool={tool}
             />
           ))}


### PR DESCRIPTION
## Changes\n\n- assign fallback card keys by tool object identity when no call ID exists\n- avoid serializing tool payloads to construct React keys\n- defer card construction until the tool-call modal is open\n- add regressions for circular inputs and insertion-stable card state\n\nFindings: F-2cc0e11be7b4f5b0, F-6911e4e39f6489c9, F-0f682046b857d5b5\n\n## Verification\n\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/ToolCallsPanel.test.tsx --reporter=dot (6 passed)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot (101 files, 1077 tests)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build\n- git diff --check\n\n## Out of scope\n\n- assigning call IDs upstream\n- preserving state when callers replace an un-IDed tool with a different object\n- changing ToolCallCard expansion or value-formatting behavior