### PR TITLE
fix(dashboard): coordinate stacked modals

### DIFF
--- a/changelog.d/fixed/7442.md
+++ b/changelog.d/fixed/7442.md
@@ -1,0 +1,1 @@
+Fixed stacked modals restoring page scroll or all closing from one Escape press, and named titleless drawer landmarks. (#7442) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { Modal } from "./Modal";
 
@@ -108,5 +108,64 @@ describe("Modal autoFocus (#5666)", () => {
 
     const input = screen.getByTestId("first-input");
     await waitFor(() => expect(document.activeElement).toBe(input));
+  });
+});
+
+describe("Modal stacking", () => {
+  it("keeps body scroll locked until the last blocking modal closes", () => {
+    document.body.style.overflow = "scroll";
+    const { rerender, unmount } = render(
+      <>
+        <Modal isOpen onClose={() => {}} title="Outer">outer</Modal>
+        <Modal isOpen onClose={() => {}} title="Inner">inner</Modal>
+      </>,
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+
+    rerender(
+      <>
+        <Modal isOpen={false} onClose={() => {}} title="Outer">outer</Modal>
+        <Modal isOpen onClose={() => {}} title="Inner">inner</Modal>
+      </>,
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+    expect(document.body.style.overflow).toBe("scroll");
+    document.body.style.overflow = "";
+  });
+
+  it("closes only the highest stacked modal on Escape", () => {
+    const outerClose = vi.fn();
+    const innerClose = vi.fn();
+    const { rerender } = render(
+      <>
+        <Modal isOpen onClose={outerClose} title="Outer" zIndex={50}>outer</Modal>
+        <Modal isOpen onClose={innerClose} title="Inner" zIndex={70}>inner</Modal>
+      </>,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(innerClose).toHaveBeenCalledTimes(1);
+    expect(outerClose).not.toHaveBeenCalled();
+
+    rerender(
+      <>
+        <Modal isOpen onClose={outerClose} title="Outer" zIndex={50}>outer</Modal>
+        <Modal isOpen={false} onClose={innerClose} title="Inner" zIndex={70}>inner</Modal>
+      </>,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(outerClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("names a titleless drawer landmark", () => {
+    render(
+      <Modal isOpen onClose={() => {}} variant="drawer-right">
+        drawer content
+      </Modal>,
+    );
+
+    expect(screen.getByRole("complementary", { name: "Details" })).toBeInTheDocument();
   });
 });

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -65,6 +65,64 @@ const SIZE_CLASSES: Record<NonNullable<ModalProps["size"]>, string> = {
   "7xl": "sm:max-w-7xl",
 };
 
+let bodyScrollLockCount = 0;
+let bodyOverflowBeforeLock = "";
+
+function lockBodyScroll(): () => void {
+  if (bodyScrollLockCount === 0) {
+    bodyOverflowBeforeLock = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  bodyScrollLockCount += 1;
+
+  return () => {
+    bodyScrollLockCount = Math.max(0, bodyScrollLockCount - 1);
+    if (bodyScrollLockCount === 0) {
+      document.body.style.overflow = bodyOverflowBeforeLock;
+    }
+  };
+}
+
+interface OpenModal {
+  token: symbol;
+  zIndex: number;
+  sequence: number;
+  close: () => void;
+}
+
+const openModals: OpenModal[] = [];
+let nextModalSequence = 0;
+
+function handleModalEscape(event: KeyboardEvent) {
+  if (event.defaultPrevented || event.key !== "Escape") return;
+  const topModal = openModals.reduce<OpenModal | undefined>((top, modal) => {
+    if (!top || modal.zIndex > top.zIndex) return modal;
+    if (modal.zIndex === top.zIndex && modal.sequence > top.sequence) return modal;
+    return top;
+  }, undefined);
+  if (!topModal) return;
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  topModal.close();
+}
+
+function registerOpenModal(modal: Omit<OpenModal, "sequence">): () => void {
+  if (openModals.length === 0) {
+    window.addEventListener("keydown", handleModalEscape);
+  }
+  const entry = { ...modal, sequence: nextModalSequence++ };
+  openModals.push(entry);
+
+  return () => {
+    const index = openModals.findIndex((candidate) => candidate.token === entry.token);
+    if (index !== -1) openModals.splice(index, 1);
+    if (openModals.length === 0) {
+      window.removeEventListener("keydown", handleModalEscape);
+    }
+  };
+}
+
 /// Shared modal shell. Handles the cross-cutting concerns every page
 /// modal needs:
 ///
@@ -164,21 +222,18 @@ export const Modal = memo(function Modal({
 
   useEffect(() => {
     if (!isOpen || isDrawer) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
+    return lockBodyScroll();
   }, [isOpen, isDrawer]);
 
   useEffect(() => {
     if (!isOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCloseRef.current();
-    };
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [isOpen]);
+    const token = Symbol("modal");
+    return registerOpenModal({
+      token,
+      zIndex,
+      close: () => onCloseRef.current(),
+    });
+  }, [isOpen, zIndex]);
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     // Stop the click from bubbling to an ancestor backdrop.
@@ -190,7 +245,7 @@ export const Modal = memo(function Modal({
     // closing this one via backdrop would otherwise also
     // close its parent. See codex review on #2722.
     e.stopPropagation();
-    onClose();
+    onCloseRef.current();
   };
 
   // Three layout shapes:
@@ -232,6 +287,9 @@ export const Modal = memo(function Modal({
               ? { role: "complementary" as const }
               : { role: "dialog" as const, "aria-modal": true })}
             {...(title ? { "aria-labelledby": titleId } : {})}
+            {...(isDrawer && !title
+              ? { "aria-label": t("common.details", { defaultValue: "Details" }) }
+              : {})}
             className={dialogClass}
             onClick={(e) => e.stopPropagation()}
             variants={dialogVariants}
@@ -247,7 +305,7 @@ export const Modal = memo(function Modal({
                 {!hideCloseButton && (
                   <button
                     ref={closeButtonRef}
-                    onClick={onClose}
+                    onClick={() => onCloseRef.current()}
                     className="h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
                     aria-label={t("common.close", { defaultValue: "Close" })}
                   >


### PR DESCRIPTION
## Changes

- reference-count body scroll locks across stacked blocking modals
- route Escape through one z-index-aware stack so only the top layer closes
- coordinate all dialog layers through the shared stack
- use the latest close callback for Escape, backdrop, and close-button dismissal
- give titleless inspector drawers a fallback landmark name
- add regressions for stacked scroll locking, Escape peeling, and drawer naming

Findings: `F-c04518a5a409cc20`, `F-07385b559ede654d`, `F-03d4aa37dd065b29`, `F-885a00195bbfeace`

## Verification

- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/Modal.test.tsx --reporter=dot` (8 passed before the follow-up; fresh CI covers the synchronized head)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint`
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot` (101 files, 1078 tests passed)
- `corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build`
- `git diff --check`

## Out of scope

- focus-trap selector changes, which overlap open #7347
- modal layout classes and animation behavior
- drawer-right page-scroll and focus-trap policy
