### PR TITLE
fix(dashboard): mount one push drawer body

### DIFF
--- a/changelog.d/fixed/7443.md
+++ b/changelog.d/fixed/7443.md
@@ -1,0 +1,1 @@
+Fixed push drawer bodies mounting simultaneously in hidden desktop and mobile presentations. (#7443) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.test.tsx
@@ -98,6 +98,29 @@ describe("PushDrawer breakpoint boundary (#4873)", () => {
     expect(matchMediaSpy).toHaveBeenCalledWith("(max-width: 999px)");
     matchMediaSpy.mockRestore();
   });
+
+  it("mounts drawer content only in the active viewport presentation", () => {
+    const matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query: string) => ({
+      matches: query === "(max-width: 999px)",
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }));
+    useDrawerStore.setState({
+      isOpen: true,
+      content: { body: <p data-testid="drawer-body">body</p> },
+    });
+
+    const { container } = render(withI18n(<PushDrawer />));
+
+    expect(container.querySelectorAll("[data-testid='drawer-body']")).toHaveLength(1);
+    expect(container.querySelector("[data-drawer-root] [data-testid='drawer-body']")).not.toBeNull();
+    matchMediaSpy.mockRestore();
+  });
 });
 
 describe("PushDrawer nested-dialog Esc handling (#5254 Codex P2)", () => {
@@ -141,13 +164,8 @@ describe("PushDrawer nested-dialog Esc handling (#5254 Codex P2)", () => {
     // own Esc listener confounding the assertion — this test pins the
     // PushDrawer handler's `.closest()` logic, not Modal's behaviour.
     //
-    // NB: PushDrawer renders `content.body` TWICE in the DOM — once
-    // inside the desktop `<aside>` (hidden by `lg:flex` on mobile,
-    // but still mounted), once inside the mobile drawer-root overlay.
-    // The test must dispatch Esc from the *mobile* copy, which is
-    // the descendant of `[data-drawer-root]`. We use a
-    // `data-testid="nested-dialog"` on the dialog wrapper to scope
-    // querySelector to the mobile copy via the drawer-root subtree.
+    // Scope the query to the mobile drawer-root so this test pins the
+    // relevant ancestor relationship independently of presentation.
     useDrawerStore.setState({
       isOpen: true,
       content: {
@@ -165,11 +183,7 @@ describe("PushDrawer nested-dialog Esc handling (#5254 Codex P2)", () => {
 
     const drawerRoot = container.querySelector("[data-drawer-root]");
     expect(drawerRoot).not.toBeNull();
-    // Scope to the mobile copy that lives INSIDE the drawer-root.
-    // querySelector against the document tree returns the first
-    // match (which would be the desktop aside's copy on a real
-    // mobile-viewport browser too, but in jsdom both subtrees are
-    // mounted and DOM-order returns desktop first).
+    // Scope to the body that lives inside the mobile drawer-root.
     const pickerInput = drawerRoot!.querySelector(
       "[data-testid='picker-input']",
     ) as HTMLElement;

--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
@@ -146,7 +146,7 @@ export function PushDrawer() {
         className={`hidden lg:flex shrink-0 ${desktopWidth} flex-col border-l border-border-subtle bg-surface overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`}
         aria-hidden={!isOpen}
       >
-        {content && (
+        {isOpen && content && !isMobile && (
           <div className={`flex flex-col h-full ${minWidth}`}>
             {header}
             <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">
@@ -163,7 +163,7 @@ export function PushDrawer() {
           banner is a daemon-disconnect signal that must remain visible even
           when a drawer is open — and below dropdown menus (z-[90]/z-[100]).
           z-[55] threads the needle. */}
-      {isOpen && content && (
+      {isOpen && content && isMobile && (
         <div
           className="fixed inset-0 z-[55] lg:hidden bg-black/40 backdrop-blur-sm flex items-stretch justify-end"
           onClick={triggerClose}


### PR DESCRIPTION
## Changes\n\n- render drawer content only in the active desktop or mobile presentation\n- unmount the inactive viewport subtree instead of hiding a second live copy with CSS\n- remove stale test assumptions about duplicate drawer bodies\n- add a regression asserting one body under a mobile viewport\n\nFinding: F-d6f96ac6170a2d55\n\n## Verification\n\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/PushDrawer.test.tsx --reporter=dot (5 passed)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot (101 files, 1076 tests)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build\n- git diff --check\n\n## Out of scope\n\n- drawer store ownership and close-callback architecture\n- focus trapping and Escape behavior\n- remounting the body when the live viewport crosses the desktop breakpoint