### PR TITLE
fix(dashboard): constrain shortcuts dialog

### DIFF
--- a/changelog.d/fixed/7445.md
+++ b/changelog.d/fixed/7445.md
@@ -1,0 +1,1 @@
+Fixed the keyboard shortcuts dialog overflowing short viewports and updating callback refs during render. (#7445) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/ShortcutsHelp.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ShortcutsHelp.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ShortcutsHelp } from "./ShortcutsHelp";
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+describe("ShortcutsHelp", () => {
+  it("uses the latest close callback for Escape", () => {
+    const firstClose = vi.fn();
+    const latestClose = vi.fn();
+    const { rerender } = render(<ShortcutsHelp isOpen onClose={firstClose} />);
+
+    rerender(<ShortcutsHelp isOpen onClose={latestClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(latestClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("constrains the complete dialog and scrolls only its body", () => {
+    render(<ShortcutsHelp isOpen onClose={() => {}} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveClass("max-h-[90vh]", "flex-col");
+    expect(dialog.querySelector(".overflow-y-auto")).toHaveClass("min-h-0", "flex-1");
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/ShortcutsHelp.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ShortcutsHelp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard, X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -30,7 +30,9 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
   useFocusTrap(isOpen, dialogRef, true);
 
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useLayoutEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -44,7 +46,7 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
   return (
     <AnimatePresence>
       {isOpen && (
-        <div className="fixed inset-0 z-100 flex items-end sm:items-start justify-center sm:pt-[10vh] p-0 sm:p-4">
+        <div className="fixed inset-0 z-100 flex items-end sm:items-center justify-center p-0 sm:p-4">
           <motion.div
             className="fixed inset-0 bg-black/60 backdrop-blur-sm"
             aria-hidden="true"
@@ -59,7 +61,7 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="shortcuts-help-title"
-            className="relative w-full sm:max-w-2xl rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl overflow-hidden"
+            className="relative flex max-h-[90vh] w-full flex-col overflow-hidden rounded-t-2xl border border-border-subtle bg-surface shadow-2xl sm:max-w-2xl sm:rounded-2xl"
             variants={fadeInScale}
             initial="initial"
             animate="animate"
@@ -81,7 +83,7 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
           </button>
         </div>
 
-        <div className="max-h-[70vh] overflow-y-auto p-5 scrollbar-thin">
+        <div className="min-h-0 flex-1 overflow-y-auto p-5 scrollbar-thin">
           <section className="mb-6">
             <h3 className="text-[10px] font-bold uppercase tracking-widest text-text-dim/60 mb-3">{t("shortcuts_help.general_heading")}</h3>
             <div className="space-y-2">


### PR DESCRIPTION
## Changes\n\n- update the Escape callback ref after commit instead of mutating it during render\n- constrain the complete shortcuts dialog to the viewport\n- make the content region flex and scroll inside the bounded dialog\n- vertically center the desktop dialog instead of combining a top offset with an independent body height\n- add regressions for callback freshness and viewport classes\n\nFindings: F-b970c564d21a7497, F-1e0fa0c99295d856\n\n## Verification\n\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/ShortcutsHelp.test.tsx --reporter=dot (2 passed)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot (102 files, 1077 tests)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build\n- git diff --check\n\n## Out of scope\n\n- body scroll locking, which must share the stacked lock introduced by #7442 after that PR merges\n- changing shortcut definitions or translations\n- replacing the custom dialog with Modal