### PR TITLE
fix(dashboard): merge badge class overrides

### DIFF
--- a/changelog.d/fixed/7447.md
+++ b/changelog.d/fixed/7447.md
@@ -1,0 +1,1 @@
+Made Badge class overrides deterministic when they conflict with default or variant utilities. (#7447) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/Badge.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Badge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "./Badge";
+
+describe("Badge", () => {
+  it("lets className override conflicting default and variant utilities", () => {
+    render(
+      <Badge variant="success" className="px-4 text-sm bg-error/10">
+        Offline
+      </Badge>,
+    );
+
+    const badge = screen.getByText("Offline");
+    expect(badge).toHaveClass("px-4", "text-sm", "bg-error/10");
+    expect(badge).not.toHaveClass("px-2", "text-[10px]", "bg-success/10");
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/Badge.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Badge.tsx
@@ -1,4 +1,5 @@
 import { type HTMLAttributes, type ReactNode } from "react";
+import { cn } from "../../lib/cn";
 
 export type BadgeVariant = "default" | "success" | "warning" | "error" | "info" | "brand";
 
@@ -35,13 +36,13 @@ export function Badge({
 }: BadgeProps) {
   return (
     <span
-      className={`
-        inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5
-        text-[10px] font-black uppercase tracking-wider
-        border transition-colors duration-200 whitespace-nowrap
-        ${variantStyles[variant]}
-        ${className}
-      `}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5",
+        "text-[10px] font-black uppercase tracking-wider",
+        "border transition-colors duration-200 whitespace-nowrap",
+        variantStyles[variant],
+        className,
+      )}
       {...props}
     >
       {dot ? <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full ${dotColors[variant]}`} /> : null}


### PR DESCRIPTION
## Changes\n\n- route Badge class composition through the existing clsx and tailwind-merge helper\n- preserve default and variant classes when callers do not conflict\n- make later caller padding, typography, color, and background utilities deterministic\n- add a regression covering simultaneous default and variant overrides\n\nFinding: F-46461f7959ea5c0f\n\n## Verification\n\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/ui/Badge.test.tsx --reporter=dot (1 passed)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot (102 files, 1076 tests)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build\n- git diff --check\n\n## Out of scope\n\n- changing Badge typography or density\n- migrating Button, Card, or Input while #7429, #7431, and #7430 own those files\n- changing variant colors or dot styling