### PR TITLE
fix(dashboard): guard notification actions

### DIFF
--- a/changelog.d/fixed/7448.md
+++ b/changelog.d/fixed/7448.md
@@ -1,0 +1,1 @@
+Prevented duplicate or conflicting notification approval actions while a request is in flight. (#7448) (@houko)

--- a/crates/librefang-api/dashboard/src/components/NotificationCenter.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/NotificationCenter.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // Keep i18n predictable — return the default value when one is supplied,
@@ -24,6 +24,10 @@ vi.mock("react-i18next", () => ({
 }));
 
 const navigateMock = vi.fn();
+const { approveMutateAsync, rejectMutateAsync } = vi.hoisted(() => ({
+  approveMutateAsync: vi.fn(),
+  rejectMutateAsync: vi.fn(),
+}));
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => navigateMock,
 }));
@@ -52,14 +56,18 @@ vi.mock("../lib/queries/skills", () => ({
 }));
 
 vi.mock("../lib/mutations/approvals", () => ({
-  useApproveApproval: () => ({ mutateAsync: vi.fn() }),
-  useRejectApproval: () => ({ mutateAsync: vi.fn() }),
+  useApproveApproval: () => ({ mutateAsync: approveMutateAsync }),
+  useRejectApproval: () => ({ mutateAsync: rejectMutateAsync }),
 }));
 
 import { NotificationCenter } from "./NotificationCenter";
 
 beforeEach(() => {
   navigateMock.mockReset();
+  approveMutateAsync.mockReset();
+  approveMutateAsync.mockResolvedValue(undefined);
+  rejectMutateAsync.mockReset();
+  rejectMutateAsync.mockResolvedValue(undefined);
   document.body.focus();
 });
 
@@ -210,5 +218,36 @@ describe("NotificationCenter keyboard navigation", () => {
     const zeros = items.filter((el) => el.tabIndex === 0);
     expect(zeros.length).toBe(1);
     expect(zeros[0]).toBe(items[1]);
+  });
+});
+
+describe("NotificationCenter approval actions", () => {
+  it("blocks duplicate or conflicting actions for an approval in flight", async () => {
+    const user = userEvent.setup();
+    let resolveApproval: (() => void) | undefined;
+    approveMutateAsync.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveApproval = resolve;
+      }),
+    );
+    render(<NotificationCenter />);
+    await user.click(getTrigger());
+
+    const approveButtons = screen.getAllByRole("button", { name: "approvals.approve" });
+    const rejectButtons = screen.getAllByRole("button", { name: "approvals.reject" });
+    await user.click(approveButtons[0]);
+
+    expect(approveMutateAsync).toHaveBeenCalledTimes(1);
+    expect(approveButtons[0]).toBeDisabled();
+    expect(rejectButtons[0]).toBeDisabled();
+    expect(approveButtons[1]).not.toBeDisabled();
+
+    await user.click(approveButtons[0]);
+    await user.click(rejectButtons[0]);
+    expect(approveMutateAsync).toHaveBeenCalledTimes(1);
+    expect(rejectMutateAsync).not.toHaveBeenCalled();
+
+    resolveApproval?.();
+    await waitFor(() => expect(approveButtons[0]).not.toBeDisabled());
   });
 });

--- a/crates/librefang-api/dashboard/src/components/NotificationCenter.tsx
+++ b/crates/librefang-api/dashboard/src/components/NotificationCenter.tsx
@@ -23,6 +23,10 @@ export function NotificationCenter() {
   // currently-focused menuitem index. Drives roving tabindex on render and
   // is the source of truth for ArrowUp/Down navigation.
   const [activeIndex, setActiveIndex] = useState(-1);
+  const actionIdsRef = useRef(new Set<string>());
+  const [actionIds, setActionIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   // Stable ids so the trigger's aria-controls and the menu's
@@ -91,6 +95,9 @@ export function NotificationCenter() {
       addToast(t("approvals.totpRequired", "TOTP code required. Use the Approvals page."), "info");
       return;
     }
+    if (actionIdsRef.current.has(id)) return;
+    actionIdsRef.current.add(id);
+    setActionIds(new Set(actionIdsRef.current));
     try {
       if (action === "approve") await approveMutation.mutateAsync({ id });
       else await rejectMutation.mutateAsync(id);
@@ -100,6 +107,9 @@ export function NotificationCenter() {
       );
     } catch {
       addToast(t("approvals.action_failed", "Action failed"), "error");
+    } finally {
+      actionIdsRef.current.delete(id);
+      setActionIds(new Set(actionIdsRef.current));
     }
   }, [totpEnforced, approveMutation, rejectMutation, addToast, navigate, t]);
 
@@ -387,11 +397,12 @@ export function NotificationCenter() {
                               <div className="flex gap-1 shrink-0">
                                 <button
                                   tabIndex={-1}
+                                  disabled={actionIds.has(item.id)}
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     handleAction(item.id, "approve");
                                   }}
-                                  className="p-1 rounded hover:bg-success/10 text-success transition-colors"
+                                  className="p-1 rounded hover:bg-success/10 text-success transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                                   title={t("approvals.approve")}
                                   aria-label={t("approvals.approve")}
                                 >
@@ -399,11 +410,12 @@ export function NotificationCenter() {
                                 </button>
                                 <button
                                   tabIndex={-1}
+                                  disabled={actionIds.has(item.id)}
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     handleAction(item.id, "reject");
                                   }}
-                                  className="p-1 rounded hover:bg-error/10 text-error transition-colors"
+                                  className="p-1 rounded hover:bg-error/10 text-error transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                                   title={t("approvals.reject")}
                                   aria-label={t("approvals.reject")}
                                 >


### PR DESCRIPTION
## Changes\n\n- track approval action requests by approval ID\n- ignore duplicate approve or reject dispatches while that approval is in flight\n- disable both conflicting action buttons for only the affected row\n- leave other approval rows available for concurrent operator work\n- add a pending-promise regression covering double approve and approve/reject races\n\nFinding: F-3e108c286cec74aa\n\n## Verification\n\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/NotificationCenter.test.tsx --reporter=dot (10 passed)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot (101 files, 1076 tests)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build\n- git diff --check\n\n## Out of scope\n\n- approval mutation API or backend idempotency\n- TOTP redirect behavior\n- menu keyboard navigation and polling cadence