### PR TITLE
fix(dashboard): gate offline recovery refetch

### DIFF
--- a/changelog.d/fixed/7450.md
+++ b/changelog.d/fixed/7450.md
@@ -1,0 +1,1 @@
+Fixed offline retries refetching the full runtime after failed liveness checks and keeping the retry spinner active during background recovery. (#7450) (@houko)

--- a/crates/librefang-api/dashboard/src/components/OfflineBanner.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OfflineBanner } from "./OfflineBanner";
+
+const { healthRefetch, runtimeRefetch } = vi.hoisted(() => ({
+  healthRefetch: vi.fn(),
+  runtimeRefetch: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ refetchQueries: runtimeRefetch }),
+}));
+
+vi.mock("../lib/queries/runtime", () => ({
+  useHealthLiveness: () => ({
+    isError: true,
+    isFetching: false,
+    refetch: healthRefetch,
+  }),
+}));
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+beforeEach(() => {
+  healthRefetch.mockReset();
+  runtimeRefetch.mockReset();
+  runtimeRefetch.mockResolvedValue(undefined);
+});
+
+describe("OfflineBanner", () => {
+  it("skips broad runtime refetch when liveness still fails", async () => {
+    healthRefetch.mockResolvedValue({ isError: true });
+    const user = userEvent.setup();
+    render(<OfflineBanner />);
+
+    await user.click(screen.getByRole("button", { name: "offline_banner.retry" }));
+
+    await waitFor(() => expect(healthRefetch).toHaveBeenCalledTimes(1));
+    expect(runtimeRefetch).not.toHaveBeenCalled();
+  });
+
+  it("ends retry UI before the background runtime refresh settles", async () => {
+    healthRefetch.mockResolvedValue({ isError: false });
+    runtimeRefetch.mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+    render(<OfflineBanner />);
+    const retryButton = screen.getByRole("button", { name: "offline_banner.retry" });
+
+    await user.click(retryButton);
+
+    await waitFor(() => expect(runtimeRefetch).toHaveBeenCalledTimes(1));
+    expect(retryButton).not.toBeDisabled();
+    expect(retryButton.querySelector("svg")).not.toHaveClass("animate-spin");
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/OfflineBanner.tsx
+++ b/crates/librefang-api/dashboard/src/components/OfflineBanner.tsx
@@ -30,10 +30,12 @@ export function OfflineBanner() {
   const retry = async () => {
     setRetrying(true);
     try {
-      await refetch();
+      const result = await refetch();
+      if (result.isError) return;
+      setRetrying(false);
       // Once connectivity is back, prod any other queries that may have
       // failed during the outage so the rest of the dashboard refreshes.
-      await qc.refetchQueries({ queryKey: runtimeKeys.all, exact: false });
+      void qc.refetchQueries({ queryKey: runtimeKeys.all, exact: false });
     } finally {
       setRetrying(false);
     }


### PR DESCRIPTION
## Changes\n\n- inspect the liveness refetch result before refreshing other runtime queries\n- skip broad runtime traffic while the daemon remains unreachable\n- clear the banner retry state as soon as liveness returns\n- refresh other runtime data in the background instead of holding the exit spinner\n- add regressions for failed liveness and an unsettled background refresh\n\nFindings: F-caf3ff8e0ff40758, F-e8afd7038693d422\n\n## Verification\n\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec vitest run src/components/OfflineBanner.test.tsx --reporter=dot (2 passed)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard exec tsc --noEmit\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run lint\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard test -- --run --reporter=dot (102 files, 1077 tests)\n- corepack pnpm@10.33.0 --dir crates/librefang-api/dashboard run build\n- git diff --check\n\n## Out of scope\n\n- liveness polling cadence\n- runtime query-key scope\n- banner animation, placement, and copy