### PR TITLE
fix(dashboard): handle embedded workflow images

### DIFF
--- a/changelog.d/fixed/workflow-data-image-gallery.md
+++ b/changelog.d/fixed/workflow-data-image-gallery.md
@@ -1,0 +1,1 @@
+Avoid broken new-tab navigation for embedded workflow images and stabilize duplicate gallery entries. (@e-hu)

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
@@ -98,6 +98,30 @@ describe("WorkflowStepImageGallery", () => {
     expect(screen.getByAltText("a watercolor sunset")).toBeInTheDocument();
   });
 
+  it("does not link data URI images to a blocked top-level navigation", () => {
+    const refs = extractImageRefs(
+      JSON.stringify({ url: "data:image/png;base64,aGVsbG8=" }),
+    );
+    render(<WorkflowStepImageGallery refs={refs} />);
+
+    expect(screen.getByRole("img").closest("a")).toBeNull();
+  });
+
+  it("renders duplicate image refs without duplicate React keys", () => {
+    const onError = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A remote URL keeps this render synchronous: the duplicate-key warning is a render-time console.error, and an authenticated path would resolve its object URL after the assertions.
+    const ref = {
+      kind: "url" as const,
+      src: "https://images.example.test/duplicate.png",
+    };
+
+    render(<WorkflowStepImageGallery refs={[ref, ref]} />);
+
+    expect(screen.getAllByRole("img")).toHaveLength(2);
+    expect(onError).not.toHaveBeenCalled();
+    onError.mockRestore();
+  });
+
   it("does NOT render anything for plain text (falls back to caller)", () => {
     const refs = extractImageRefs("Just a regular workflow result, no image.");
     const { container } = render(<WorkflowStepImageGallery refs={refs} />);

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { WorkflowStepImageGallery } from "./WorkflowStepImageGallery";
 import { extractImageRefs } from "../lib/workflowOutputImages";
@@ -43,6 +43,29 @@ describe("WorkflowStepImageGallery", () => {
     );
     render(<WorkflowStepImageGallery refs={refs} />);
     expect(screen.getByAltText("a watercolor sunset")).toBeInTheDocument();
+  });
+
+  it("does not link data URI images to a blocked top-level navigation", () => {
+    const refs = extractImageRefs(
+      JSON.stringify({ url: "data:image/png;base64,aGVsbG8=" }),
+    );
+    render(<WorkflowStepImageGallery refs={refs} />);
+
+    expect(screen.getByRole("img").closest("a")).toBeNull();
+  });
+
+  it("renders duplicate image refs without duplicate React keys", () => {
+    const onError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ref = {
+      kind: "url" as const,
+      src: "/api/uploads/duplicate",
+    };
+
+    render(<WorkflowStepImageGallery refs={[ref, ref]} />);
+
+    expect(screen.getAllByRole("img")).toHaveLength(2);
+    expect(onError).not.toHaveBeenCalled();
+    onError.mockRestore();
   });
 
   it("does NOT render anything for plain text (falls back to caller)", () => {

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
@@ -1,4 +1,5 @@
 // Renders URL-safety-checked workflow images and authenticates protected same-origin API assets before exposing them to `<img>`.
+// Embedded `data:` images render bare: browsers block top-level navigation to a data URI, so wrapping them in a link only produces a dead click target.
 
 import type { ImageRef } from "../lib/workflowOutputImages";
 import { useTranslation } from "react-i18next";
@@ -20,23 +21,29 @@ export function WorkflowStepImageGallery({ refs, label }: Props) {
         <p className="text-[9px] font-bold text-text-dim/50">{label}</p>
       )}
       <div className="flex flex-wrap gap-2">
-        {refs.map((ref) => (
-          <AuthenticatedImage
-            key={ref.src}
-            src={ref.src}
-            alt={ref.alt || t("workflows.generated_image_alt", {
-              defaultValue: "generated image",
-            })}
-            loading="lazy"
-            className="block max-h-[200px] w-auto object-contain bg-main/30"
-            linkProps={{
-              target: "_blank",
-              rel: "noopener noreferrer",
-              className: "block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[200px]",
-              title: ref.alt,
-            }}
-          />
-        ))}
+        {refs.map((ref, index) => {
+          const isEmbedded = ref.kind === "data-uri";
+          return (
+            <AuthenticatedImage
+              // The same image can legitimately appear twice in one step's output, so the source alone is not a unique key.
+              key={`${ref.src}-${index}`}
+              src={ref.src}
+              alt={ref.alt || t("workflows.generated_image_alt", {
+                defaultValue: "generated image",
+              })}
+              loading="lazy"
+              className={isEmbedded
+                ? "block max-h-[200px] max-w-[200px] w-auto rounded-lg border border-border-subtle object-contain bg-main/30"
+                : "block max-h-[200px] w-auto object-contain bg-main/30"}
+              linkProps={isEmbedded ? undefined : {
+                target: "_blank",
+                rel: "noopener noreferrer",
+                className: "block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[200px]",
+                title: ref.alt,
+              }}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
@@ -22,9 +22,19 @@ export function WorkflowStepImageGallery({ refs, label }: Props) {
         <p className="text-[9px] font-bold text-text-dim/50">{label}</p>
       )}
       <div className="flex flex-wrap gap-2">
-        {refs.map((ref) => (
+        {refs.map((ref, index) => ref.kind === "data-uri" ? (
+          <img
+            key={`${ref.src}-${index}`}
+            src={ref.src}
+            alt={ref.alt || t("workflows.generated_image_alt", {
+              defaultValue: "generated image",
+            })}
+            loading="lazy"
+            className="block max-h-[200px] max-w-[200px] w-auto rounded-lg border border-border-subtle object-contain bg-main/30"
+          />
+        ) : (
           <a
-            key={ref.src}
+            key={`${ref.src}-${index}`}
             href={ref.src}
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Substantive changes

- render embedded data URI workflow images without a broken new-tab link
- give duplicate image references distinct React keys
- add regression coverage for data URI and duplicate-reference galleries
- add a fixed changelog fragment

## Verification

- corepack pnpm exec vitest run src/components/WorkflowStepImageGallery.test.tsx (7 tests)
- corepack pnpm test (101 files, 1077 tests)
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build

## Out of scope

- image-reference extraction and validation remain unchanged
- external and artifact images keep their existing new-tab behavior

Audit findings: F-68f3704fc3f32286, F-5479525f0ce51041