### PR TITLE
fix(dashboard): align partner link name

### DIFF
--- a/changelog.d/fixed/partner-link-accessible-name.md
+++ b/changelog.d/fixed/partner-link-accessible-name.md
@@ -1,0 +1,1 @@
+Keep the EveryAPI sidebar link's accessible name aligned with its visible label. (@e-hu)

--- a/crates/librefang-api/dashboard/src/components/EveryApiPartnerLink.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/EveryApiPartnerLink.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EveryApiPartnerLink } from "./EveryApiPartnerLink";
+
+describe("EveryApiPartnerLink", () => {
+  it("uses the visible text as the expanded link name", () => {
+    render(<EveryApiPartnerLink collapsed={false} />);
+
+    const link = screen.getByRole("link", {
+      name: "partner.official partner.librefang_everyapi",
+    });
+    expect(link).not.toHaveAttribute("aria-label");
+  });
+
+  it("provides a name when the visible label is collapsed", () => {
+    render(<EveryApiPartnerLink collapsed />);
+
+    expect(screen.getByRole("link", { name: "partner.everyapi_label" }))
+      .toHaveAttribute("aria-label", "partner.everyapi_label");
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/EveryApiPartnerLink.tsx
+++ b/crates/librefang-api/dashboard/src/components/EveryApiPartnerLink.tsx
@@ -12,7 +12,7 @@ export function EveryApiPartnerLink({ collapsed }: { collapsed: boolean }) {
       target="_blank"
       rel="noopener noreferrer"
       title={collapsed ? t("partner.everyapi_label") : undefined}
-      aria-label={t("partner.everyapi_label")}
+      aria-label={collapsed ? t("partner.everyapi_label") : undefined}
       className={`mx-2 mb-2 flex min-h-10 items-center rounded-lg border border-brand/20 bg-brand/5 text-text-dim transition-colors hover:border-brand/40 hover:bg-brand/10 hover:text-brand ${
         collapsed ? "justify-center px-0" : "gap-2.5 px-3"
       }`}
@@ -25,6 +25,7 @@ export function EveryApiPartnerLink({ collapsed }: { collapsed: boolean }) {
           <span className="block text-[10px] font-semibold uppercase tracking-[0.1em] text-brand">
             {t("partner.official")}
           </span>
+          {" "}
           <span className="block truncate text-xs font-medium text-text">{t("partner.librefang_everyapi")}</span>
         </span>
       )}


### PR DESCRIPTION
## Substantive changes

- let the expanded EveryAPI link derive its accessible name from visible text
- preserve an explicit label when the sidebar is collapsed
- retain a whitespace boundary between the two visible label lines
- add expanded and collapsed accessible-name regressions
- add a fixed changelog fragment

## Verification

- corepack pnpm exec vitest run src/components/EveryApiPartnerLink.test.tsx (2 tests)
- corepack pnpm test (102 files, 1077 tests)
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build

## Out of scope

- partner destinations and tracking parameters remain unchanged
- logo loading and sidebar layout remain unchanged

Audit finding: F-c1f6e1eb2d6a3de7