### PR TITLE
fix(dashboard): batch typewriter markdown renders

### DIFF
--- a/crates/librefang-api/dashboard/src/components/Typewriter_v2.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/Typewriter_v2.test.tsx
@@ -1,0 +1,76 @@
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Typewriter_v2 } from "./Typewriter_v2";
+
+const { animateMock, mathPluginsMock } = vi.hoisted(() => ({
+  animateMock: vi.fn(),
+  mathPluginsMock: vi.fn(() => ({ remarkPlugins: [], rehypePlugins: [] })),
+}));
+
+vi.mock("motion/react", () => ({ animate: animateMock }));
+vi.mock("../lib/hooks/useMathPlugins", () => ({
+  useMathPlugins: mathPluginsMock,
+}));
+
+interface AnimationOptions {
+  duration: number;
+  onUpdate: (latest: number) => void;
+  onComplete: () => void;
+}
+
+function latestAnimation(): AnimationOptions {
+  return animateMock.mock.calls[animateMock.mock.calls.length - 1]?.[2] as AnimationOptions;
+}
+
+describe("Typewriter_v2", () => {
+  beforeEach(() => {
+    animateMock.mockReset();
+    animateMock.mockReturnValue({ stop: vi.fn() });
+    mathPluginsMock.mockClear();
+  });
+
+  it("batches markdown renders and always commits the final text", () => {
+    render(<Typewriter_v2 text="abcdefghij" speed={10} />);
+    const animation = latestAnimation();
+
+    act(() => animation.onUpdate(4));
+    expect(screen.queryByText("abcd")).toBeNull();
+
+    act(() => animation.onUpdate(5));
+    expect(screen.getByText("abcde")).toBeInTheDocument();
+
+    act(() => animation.onUpdate(9));
+    expect(screen.queryByText("abcdefghi")).toBeNull();
+
+    act(() => animation.onComplete());
+    expect(screen.getByText("abcdefghij")).toBeInTheDocument();
+  });
+
+  it("selects math plugins from the rendered substring", () => {
+    render(<Typewriter_v2 text="$x$ suffix" speed={10} />);
+    expect(mathPluginsMock).toHaveBeenLastCalledWith("");
+
+    act(() => latestAnimation().onUpdate(5));
+    expect(mathPluginsMock).toHaveBeenLastCalledWith("$x$ s");
+  });
+
+  it("rewinds without a synchronous flush when the source shrinks", () => {
+    const view = render(<Typewriter_v2 text="abcdefghij" speed={10} />);
+    act(() => latestAnimation().onUpdate(10));
+
+    view.rerender(<Typewriter_v2 text="xy" speed={10} />);
+    expect(screen.queryByText("abcdefghij")).toBeNull();
+    expect(animateMock).toHaveBeenLastCalledWith(0, 2, expect.any(Object));
+  });
+
+  it("applies a changed speed to the next text update", () => {
+    const view = render(<Typewriter_v2 text="abcdefghij" speed={10} />);
+    expect(latestAnimation().duration).toBe(0.1);
+
+    view.rerender(<Typewriter_v2 text="abcdefghij" speed={20} />);
+    expect(animateMock).toHaveBeenCalledTimes(1);
+
+    view.rerender(<Typewriter_v2 text="abcdefghijk" speed={20} />);
+    expect(latestAnimation().duration).toBe(0.22);
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/Typewriter_v2.tsx
+++ b/crates/librefang-api/dashboard/src/components/Typewriter_v2.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { flushSync } from 'react-dom';
 import { animate } from 'motion/react';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -29,6 +28,11 @@ const mdComponents: Components = {
   a: ({ href, children }) => <a href={href} className="text-brand underline" target="_blank" rel="noopener noreferrer">{children}</a>,
 };
 
+// Parsing markdown is substantially more expensive than advancing the motion
+// value. Batch several characters into one render while keeping the reveal
+// responsive enough to look continuous.
+const MIN_RENDER_INTERVAL_MS = 50;
+
 /// Streams `text` character-by-character into the markdown output to
 /// give an LLM-style "typing" effect. The reveal is driven by motion's
 /// `animate()` (instead of a hand-rolled RAF) so it joins the same
@@ -41,31 +45,45 @@ const mdComponents: Components = {
 export function Typewriter_v2({ text, speed = 20 }: { text: string; speed?: number }) {
   const [displayed, setDisplayed] = useState("");
   const lastIdxRef = useRef(0);
-  const { remarkPlugins: mathRemark, rehypePlugins: mathRehype } = useMathPlugins(text);
+  const speedRef = useRef(speed);
+  speedRef.current = speed;
+  const { remarkPlugins: mathRemark, rehypePlugins: mathRehype } = useMathPlugins(displayed);
 
   useEffect(() => {
     const needsReset = lastIdxRef.current > text.length;
     if (needsReset) {
-      flushSync(() => setDisplayed(""));
+      setDisplayed("");
       lastIdxRef.current = 0;
     }
 
     const start = lastIdxRef.current;
     const remaining = text.length - start;
     if (remaining <= 0) return;
+    const animationSpeed = speedRef.current;
+    const charsPerRender = Math.max(
+      1,
+      Math.ceil(MIN_RENDER_INTERVAL_MS / animationSpeed),
+    );
     const controls = animate(start, text.length, {
-      duration: (remaining * speed) / 1000,
+      duration: (remaining * animationSpeed) / 1000,
       ease: "linear",
       onUpdate: (latest) => {
         const idx = Math.min(Math.floor(latest), text.length);
-        if (idx !== lastIdxRef.current) {
+        const isComplete = idx === text.length;
+        if (isComplete || idx - lastIdxRef.current >= charsPerRender) {
           lastIdxRef.current = idx;
           setDisplayed(text.slice(0, idx));
         }
       },
+      onComplete: () => {
+        if (lastIdxRef.current !== text.length) {
+          lastIdxRef.current = text.length;
+          setDisplayed(text);
+        }
+      },
     });
     return () => controls.stop();
-  }, [text, speed]);
+  }, [text]);
 
   const remarkPlugins = useMemo(
     () => [remarkGfm, ...mathRemark],


### PR DESCRIPTION
## Substantive changes

- batch typewriter display updates into roughly 50 ms render intervals so long replies do not rebuild the Markdown tree for every character
- select math plugins from the substring that is actually rendered
- remove the synchronous reset flush and keep speed changes from restarting an in-flight animation
- add regression coverage for batching, final commits, math-plugin input, rewinds, and speed updates

## Verification

- `pnpm exec vitest run src/components/Typewriter_v2.test.tsx` (4 tests)
- `pnpm test` (102 files, 1079 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:i18n-parity` reproduces the existing main-branch-only drift: eight extra plural keys in each of `pl.json` and `uk.json`; Korean and Chinese pass

## Out of scope

- existing locale parity drift
- changes to ChatPage streaming or transport behavior