### PR TITLE
fix(dashboard): guard prompt experiment actions

### DIFF
--- a/crates/librefang-api/dashboard/src/components/PromptsExperimentsModal.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/PromptsExperimentsModal.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { PromptsExperimentsModal } from "./PromptsExperimentsModal";
+import { usePromptVersions } from "../lib/queries/agents";
+import { useDeletePromptVersion } from "../lib/mutations/agents";
 
 vi.mock("motion/react", () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => (
@@ -55,9 +57,22 @@ vi.mock("../lib/mutations/agents", () => ({
 
 vi.mock("./trafficSplit", () => ({
   buildEvenTrafficSplit: vi.fn().mockReturnValue([50, 50]),
+  MAX_TRAFFIC_VARIANTS: 100,
 }));
 
 describe("PromptsExperimentsModal", () => {
+  beforeEach(() => {
+    vi.mocked(usePromptVersions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as never);
+    vi.mocked(useDeletePromptVersion).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as never);
+  });
+
   it("renders a dialog with the agent name", () => {
     render(
       <PromptsExperimentsModal
@@ -119,5 +134,134 @@ describe("PromptsExperimentsModal", () => {
     await user.click(backdrop);
 
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("requires confirmation before deleting a prompt version", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(usePromptVersions).mockReturnValue({
+      data: [
+        {
+          id: "version-1",
+          version: 3,
+          is_active: false,
+          description: "candidate",
+          system_prompt: "Be concise.",
+          created_at: "2026-08-15T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    } as never);
+    vi.mocked(useDeletePromptVersion).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync,
+      isPending: false,
+    } as never);
+
+    render(
+      <PromptsExperimentsModal
+        agentId="agent-1"
+        agentName="Test Agent"
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByTitle("prompts.delete"));
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("agents.prompts_experiments.delete_version_title"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "common.delete" }));
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        versionId: "version-1",
+        agentId: "agent-1",
+      }),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("only marks a prompt preview when it is truncated", () => {
+    vi.mocked(usePromptVersions).mockReturnValue({
+      data: [
+        {
+          id: "short",
+          version: 1,
+          is_active: false,
+          system_prompt: "Short prompt",
+          created_at: "2026-08-15T00:00:00Z",
+        },
+        {
+          id: "long",
+          version: 2,
+          is_active: false,
+          system_prompt: "x".repeat(201),
+          created_at: "2026-08-15T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    } as never);
+
+    render(
+      <PromptsExperimentsModal
+        agentId="agent-1"
+        agentName="Test Agent"
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Short prompt")).toBeInTheDocument();
+    expect(screen.queryByText("Short prompt...")).toBeNull();
+    expect(screen.getByText(`${"x".repeat(200)}...`)).toBeInTheDocument();
+  });
+
+  it("stops selection when every variant has a traffic bucket", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePromptVersions).mockReturnValue({
+      data: Array.from({ length: 101 }, (_, index) => ({
+        id: `version-${index}`,
+        version: index + 1,
+        is_active: false,
+        system_prompt: `Prompt ${index + 1}`,
+        created_at: "2026-08-15T00:00:00Z",
+      })),
+      isLoading: false,
+    } as never);
+
+    const { container } = render(
+      <PromptsExperimentsModal
+        agentId="agent-1"
+        agentName="Test Agent"
+        onClose={() => {}}
+      />,
+    );
+    await user.click(
+      screen.getByRole("tab", {
+        name: "agents.prompts_experiments.experiments_tab",
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "agents.prompts_experiments.new_experiment",
+      }),
+    );
+
+    for (let index = 0; index < 100; index += 1) {
+      // The lightweight motion mock remounts its host subtree after state
+      // changes, so read each current checkbox before clicking it.
+      const checkbox = container.querySelectorAll<HTMLInputElement>(
+        'input[type="checkbox"]',
+      )[index];
+      fireEvent.click(checkbox);
+    }
+
+    expect(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')[100],
+    ).toBeDisabled();
+    expect(
+      screen.getByText("agents.prompts_experiments.variant_limit"),
+    ).toBeInTheDocument();
   });
 });

--- a/crates/librefang-api/dashboard/src/components/PromptsExperimentsModal.tsx
+++ b/crates/librefang-api/dashboard/src/components/PromptsExperimentsModal.tsx
@@ -36,7 +36,19 @@ import { Button } from "./ui/Button";
 import { Badge } from "./ui/Badge";
 import { EmptyState } from "./ui/EmptyState";
 import { CardSkeleton } from "./ui/Skeleton";
-import { buildEvenTrafficSplit } from "./trafficSplit";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
+import {
+  buildEvenTrafficSplit,
+  MAX_TRAFFIC_VARIANTS,
+} from "./trafficSplit";
+
+function metricBadgeVariant(
+  successRate: number,
+): "success" | "warning" | "default" {
+  if (successRate >= 80) return "success";
+  if (successRate >= 50) return "warning";
+  return "default";
+}
 
 export function PromptsExperimentsModal({
   agentId,
@@ -58,6 +70,9 @@ export function PromptsExperimentsModal({
   const [newExperimentName, setNewExperimentName] = useState("");
   const [selectedMetrics, setSelectedMetrics] = useState<string | null>(null);
   const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>([]);
+  const [versionToDelete, setVersionToDelete] = useState<PromptVersion | null>(
+    null,
+  );
 
   const versionsQuery = usePromptVersions(agentId);
   const experimentsQuery = useExperiments(
@@ -80,7 +95,9 @@ export function PromptsExperimentsModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-xl"
-      onClick={onClose}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
     >
       <div
         role="dialog"
@@ -218,19 +235,16 @@ export function PromptsExperimentsModal({
                                       })
                                     : t("prompts.delete")
                                 }
-                                onClick={() =>
-                                  deleteVersionMutation.mutate({
-                                    versionId: v.id,
-                                    agentId,
-                                  })
-                                }
+                                onClick={() => setVersionToDelete(v)}
                               >
                                 <Trash2 className="w-3 h-3" />
                               </Button>
                             </div>
                           </div>
                           <pre className="text-xs text-text-dim whitespace-pre-wrap max-h-24 overflow-y-auto">
-                            {v.system_prompt.slice(0, 200)}...
+                            {v.system_prompt.length > 200
+                              ? `${v.system_prompt.slice(0, 200)}...`
+                              : v.system_prompt}
                           </pre>
                           <p className="text-[10px] text-text-dim mt-2">
                             {t("agents.prompts_experiments.created_label")} {new Date(v.created_at).toLocaleDateString()}
@@ -470,13 +484,7 @@ export function PromptsExperimentsModal({
                                 {m.variant_name}
                               </span>
                               <Badge
-                                variant={
-                                  m.success_rate >= 80
-                                    ? "success"
-                                    : m.success_rate >= 50
-                                      ? "warning"
-                                      : "default"
-                                }
+                                variant={metricBadgeVariant(m.success_rate)}
                               >
                                 {m.success_rate?.toFixed(1)}%
                               </Badge>
@@ -574,18 +582,28 @@ export function PromptsExperimentsModal({
                                       checked={selectedVariantIds.includes(
                                         v.id,
                                       )}
+                                      disabled={
+                                        !selectedVariantIds.includes(v.id) &&
+                                        selectedVariantIds.length >=
+                                          MAX_TRAFFIC_VARIANTS
+                                      }
                                       onChange={(e) => {
-                                        if (e.target.checked)
-                                          setSelectedVariantIds([
-                                            ...selectedVariantIds,
-                                            v.id,
-                                          ]);
-                                        else
-                                          setSelectedVariantIds(
-                                            selectedVariantIds.filter(
+                                        const checked = e.target.checked;
+                                        setSelectedVariantIds((current) => {
+                                          if (!checked) {
+                                            return current.filter(
                                               (id) => id !== v.id,
-                                            ),
-                                          );
+                                            );
+                                          }
+                                          if (
+                                            current.includes(v.id) ||
+                                            current.length >=
+                                              MAX_TRAFFIC_VARIANTS
+                                          ) {
+                                            return current;
+                                          }
+                                          return [...current, v.id];
+                                        });
                                       }}
                                       className="rounded"
                                     />
@@ -602,6 +620,15 @@ export function PromptsExperimentsModal({
                                   </label>
                                 ))}
                               </div>
+                            )}
+                            {selectedVariantIds.length >=
+                              MAX_TRAFFIC_VARIANTS && (
+                              <p className="mt-2 text-xs text-warning">
+                                {t(
+                                  "agents.prompts_experiments.variant_limit",
+                                  { count: MAX_TRAFFIC_VARIANTS },
+                                )}
+                              </p>
                             )}
                           </div>
                         </div>
@@ -682,6 +709,24 @@ export function PromptsExperimentsModal({
           </AnimatePresence>
         </div>
       </div>
+      <ConfirmDialog
+        isOpen={versionToDelete !== null}
+        title={t("agents.prompts_experiments.delete_version_title")}
+        message={t(
+          "agents.prompts_experiments.delete_version_message",
+          { version: versionToDelete?.version ?? "" },
+        )}
+        confirmLabel={t("common.delete")}
+        tone="destructive"
+        onClose={() => setVersionToDelete(null)}
+        onConfirm={async () => {
+          if (!versionToDelete) return;
+          await deleteVersionMutation.mutateAsync({
+            versionId: versionToDelete.id,
+            agentId,
+          });
+        }}
+      />
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/components/trafficSplit.test.ts
+++ b/crates/librefang-api/dashboard/src/components/trafficSplit.test.ts
@@ -14,4 +14,10 @@ describe("buildEvenTrafficSplit", () => {
   it("returns no split for empty input", () => {
     expect(buildEvenTrafficSplit(0)).toEqual([]);
   });
+
+  it("rejects variant counts that cannot all receive traffic", () => {
+    expect(() => buildEvenTrafficSplit(101)).toThrow(
+      "variantCount (101) cannot exceed 100",
+    );
+  });
 });

--- a/crates/librefang-api/dashboard/src/components/trafficSplit.ts
+++ b/crates/librefang-api/dashboard/src/components/trafficSplit.ts
@@ -1,5 +1,12 @@
-export function buildEvenTrafficSplit(variantCount: number) {
+export const MAX_TRAFFIC_VARIANTS = 100;
+
+export function buildEvenTrafficSplit(variantCount: number): number[] {
   if (variantCount <= 0) return [];
+  if (variantCount > MAX_TRAFFIC_VARIANTS) {
+    throw new Error(
+      `variantCount (${variantCount}) cannot exceed ${MAX_TRAFFIC_VARIANTS}`,
+    );
+  }
 
   const baseShare = Math.floor(100 / variantCount);
   const remainder = 100 % variantCount;

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -537,7 +537,10 @@
       "err_label": "err",
       "system_prompt_placeholder": "You are a helpful AI assistant...",
       "description_placeholder": "What's different in this version?",
-      "experiment_name_placeholder": "My A/B Test"
+      "experiment_name_placeholder": "My A/B Test",
+      "delete_version_title": "Delete prompt version",
+      "delete_version_message": "Permanently delete v{{version}}? This cannot be undone.",
+      "variant_limit": "A percentage split supports at most {{count}} variants."
     },
     "thinking": "Extended Thinking",
     "thinking_enabled": "Enabled",

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -537,7 +537,10 @@
       "err_label": "오류",
       "system_prompt_placeholder": "당신은 유용한 AI 비서입니다 ...",
       "description_placeholder": "이 버전에서는 무엇이 다른가요?",
-      "experiment_name_placeholder": "내 A/B 테스트"
+      "experiment_name_placeholder": "내 A/B 테스트",
+      "delete_version_title": "프롬프트 버전 삭제",
+      "delete_version_message": "v{{version}}을(를) 영구적으로 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
+      "variant_limit": "백분율 트래픽 분할은 최대 {{count}}개의 변형을 지원합니다."
     },
     "thinking": "확장된 사고",
     "thinking_enabled": "활성화됨",

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -537,7 +537,10 @@
       "err_label": "błąd",
       "system_prompt_placeholder": "Jesteś pomocnym asystentem AI...",
       "description_placeholder": "Co się zmieniło w tej wersji?",
-      "experiment_name_placeholder": "Mój test A/B"
+      "experiment_name_placeholder": "Mój test A/B",
+      "delete_version_title": "Usuń wersję promptu",
+      "delete_version_message": "Trwale usunąć wersję v{{version}}? Tej operacji nie można cofnąć.",
+      "variant_limit": "Procentowy podział ruchu obsługuje maksymalnie {{count}} wariantów."
     },
     "thinking": "Rozszerzone myślenie",
     "thinking_enabled": "Włączone",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -537,7 +537,10 @@
       "err_label": "помилка",
       "system_prompt_placeholder": "Ви — корисний ШІ-асистент...",
       "description_placeholder": "Що змінилося в цій версії?",
-      "experiment_name_placeholder": "Мій A/B тест"
+      "experiment_name_placeholder": "Мій A/B тест",
+      "delete_version_title": "Видалити версію промпту",
+      "delete_version_message": "Назавжди видалити версію v{{version}}? Цю дію неможливо скасувати.",
+      "variant_limit": "Відсотковий розподіл трафіку підтримує щонайбільше {{count}} варіантів."
     },
     "thinking": "Розширене мислення",
     "thinking_enabled": "Увімкнено",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -537,7 +537,10 @@
       "err_label": "错误",
       "system_prompt_placeholder": "你是一个有用的 AI 助手...",
       "description_placeholder": "这个版本有什么不同？",
-      "experiment_name_placeholder": "我的 A/B 测试"
+      "experiment_name_placeholder": "我的 A/B 测试",
+      "delete_version_title": "删除提示词版本",
+      "delete_version_message": "永久删除版本 v{{version}}？此操作无法撤销。",
+      "variant_limit": "百分比流量分配最多支持 {{count}} 个变体。"
     },
     "thinking": "扩展思考",
     "thinking_enabled": "已启用",


### PR DESCRIPTION
## Substantive changes

- require destructive confirmation before deleting a prompt version and keep the confirmation open while deletion is pending or fails
- only append an ellipsis when a prompt preview is actually truncated
- extract the experiment metric badge thresholds into an explicit helper
- cap percentage-based experiments at 100 variants in both selection UI and the traffic-split utility, with localized guidance in all five dashboard locales
- document the traffic-split utility return type

## Verification

- `pnpm exec vitest run src/components/trafficSplit.test.ts src/components/PromptsExperimentsModal.test.tsx` (11 tests)
- `pnpm test` (101 files, 1079 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:i18n-parity` confirms Korean and Chinese parity; it reproduces only the existing eight extra plural keys in each of `pl.json` and `uk.json`

## Out of scope

- mutation-wide error feedback, already provided by the global MutationCache fallback merged in #6978
- backend prompt-version and experiment lifecycle policy
- existing Polish and Ukrainian plural-key drift