### PR TITLE
refactor(dashboard): remove stale xterm type shim

### DIFF
--- a/crates/librefang-api/dashboard/src/vite-env.d.ts
+++ b/crates/librefang-api/dashboard/src/vite-env.d.ts
@@ -1,11 +1,1 @@
 /// <reference types="vite/client" />
-
-// xterm.js shipped `cursorInactiveStyle` in 5.5.0 but the
-// `@xterm/xterm` type bundle hasn't picked up the field yet (as of
-// 5.5.x). Augment the option type so TerminalPage can set it without
-// an `as any` cast — values mirror the runtime accepted set.
-declare module "@xterm/xterm" {
-  interface ITerminalOptions {
-    cursorInactiveStyle?: "block" | "underline" | "bar" | "outline" | "none";
-  }
-}


### PR DESCRIPTION
## Substantive changes

- remove the dashboard's local `ITerminalOptions.cursorInactiveStyle` augmentation
- rely on the identical field now shipped by `@xterm/xterm` 6.0.0
- remove the obsolete comment describing the old 5.5.x type gap

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (101 files, 1075 tests)
- `pnpm build`

## Out of scope

- terminal runtime behavior and styling
- dependency upgrades
- other dashboard ambient declarations