### PR TITLE
test(dashboard): isolate browser API mocks

### DIFF
--- a/crates/librefang-api/dashboard/src/setupTests.test.ts
+++ b/crates/librefang-api/dashboard/src/setupTests.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { MockResizeObserver } from "./setupTests";
+
+describe.sequential("dashboard browser mocks", () => {
+  it("allows a test to populate storage", () => {
+    localStorage.setItem("leaked", "value");
+    sessionStorage.setItem("leaked", "value");
+    expect(localStorage.getItem("leaked")).toBe("value");
+  });
+
+  it("starts the next test with empty writable storage", () => {
+    expect(localStorage.getItem("leaked")).toBeNull();
+    expect(sessionStorage.getItem("leaked")).toBeNull();
+    expect(
+      Object.getOwnPropertyDescriptor(globalThis, "localStorage")?.writable,
+    ).toBe(true);
+  });
+
+  it("tracks ResizeObserver targets and only delivers observed entries", () => {
+    const callback = vi.fn();
+    const observer = new MockResizeObserver(callback);
+    const observed = document.createElement("div");
+    const ignored = document.createElement("div");
+    const observedEntry = { target: observed } as unknown as ResizeObserverEntry;
+    const ignoredEntry = { target: ignored } as unknown as ResizeObserverEntry;
+
+    observer.observe(observed);
+    observer.trigger([observedEntry, ignoredEntry]);
+    expect(callback).toHaveBeenCalledWith([observedEntry], observer);
+
+    observer.unobserve(observed);
+    observer.trigger([observedEntry]);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses media queries and delivers modern and legacy change listeners", () => {
+    const first = window.matchMedia("(max-width: 999px)");
+    const second = window.matchMedia("(max-width: 999px)");
+    const modern = vi.fn();
+    const legacy = vi.fn();
+    const onchange = vi.fn();
+    first.addEventListener("change", modern);
+    first.addListener(legacy);
+    first.onchange = onchange;
+
+    const event = new Event("change");
+    first.dispatchEvent(event);
+
+    expect(second).toBe(first);
+    expect(modern).toHaveBeenCalledWith(event);
+    expect(legacy).toHaveBeenCalledWith(event);
+    expect(onchange).toHaveBeenCalledWith(event);
+  });
+});

--- a/crates/librefang-api/dashboard/src/setupTests.ts
+++ b/crates/librefang-api/dashboard/src/setupTests.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { beforeEach } from "vitest";
 
 class MemoryStorage implements Storage {
   private store = new Map<string, string>();
@@ -34,6 +35,7 @@ function installTestStorage(name: "localStorage" | "sessionStorage") {
   // while jsdom may expose a throwing Storage for opaque origins.
   Object.defineProperty(globalThis, name, {
     configurable: true,
+    writable: true,
     value: new MemoryStorage(),
   });
 }
@@ -41,27 +43,86 @@ function installTestStorage(name: "localStorage" | "sessionStorage") {
 installTestStorage("localStorage");
 installTestStorage("sessionStorage");
 
-// cmdk uses ResizeObserver internally; jsdom doesn't provide it
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+// cmdk and Recharts use ResizeObserver internally. Tests that need a resize
+// can call `trigger`; observing alone stays side-effect free like the browser.
+export class MockResizeObserver implements ResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  private readonly targets = new Set<Element>();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    this.targets.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
+
+  disconnect() {
+    this.targets.clear();
+  }
+
+  trigger(entries: ResizeObserverEntry[]) {
+    const observedEntries = entries.filter((entry) =>
+      this.targets.has(entry.target),
+    );
+    if (observedEntries.length > 0) {
+      this.callback(observedEntries, this);
+    }
+  }
+}
+
+global.ResizeObserver = MockResizeObserver;
+
+class MockMediaQueryList extends EventTarget {
+  readonly media: string;
+  matches = false;
+  onchange: ((this: MediaQueryList, ev: MediaQueryListEvent) => unknown) | null =
+    null;
+
+  constructor(query: string) {
+    super();
+    this.media = query;
+  }
+
+  addListener(callback: ((event: MediaQueryListEvent) => void) | null) {
+    if (callback) this.addEventListener("change", callback as EventListener);
+  }
+
+  removeListener(callback: ((event: MediaQueryListEvent) => void) | null) {
+    if (callback) this.removeEventListener("change", callback as EventListener);
+  }
+
+  override dispatchEvent(event: Event): boolean {
+    if (event.type === "change" && this.onchange) {
+      this.onchange.call(this, event as MediaQueryListEvent);
+    }
+    return super.dispatchEvent(event);
+  }
+}
+
+const mediaQueries = new Map<string, MockMediaQueryList>();
 
 // jsdom does not implement matchMedia; PushDrawer.useIsMobile and a few
 // pages call it during mount and crash the test render without a stub.
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
-    value: (query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-    }),
+    value: (query: string) => {
+      const existing = mediaQueries.get(query);
+      if (existing) return existing;
+      const created = new MockMediaQueryList(query);
+      mediaQueries.set(query, created);
+      return created;
+    },
   });
 }
+
+beforeEach(() => {
+  globalThis.localStorage?.clear?.();
+  globalThis.sessionStorage?.clear?.();
+  mediaQueries.clear();
+});


### PR DESCRIPTION
## Substantive changes

- clear local and session storage before every dashboard test and make both test descriptors writable
- replace the inert ResizeObserver stub with a target-aware mock that tests can trigger explicitly
- cache matchMedia results per query and deliver modern, legacy, and `onchange` listeners through EventTarget
- clear the media-query cache before every test
- add focused regressions for storage isolation and both browser API mocks

## Verification

- `pnpm exec vitest run src/setupTests.test.ts` (4 tests)
- `pnpm test` (102 files, 1079 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Out of scope

- production browser APIs
- component-specific viewport and resize behavior
- tests that install their own local browser mocks