### PR TITLE
fix: harden telemetry metrics parsing

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
@@ -15,153 +15,13 @@ import {
   RotateCcw, Users, ChevronDown, ChevronUp,
 } from "lucide-react";
 import { StaggerList } from "../components/ui/StaggerList";
+import {
+  parseMetrics,
+  type HttpMetric,
+} from "./telemetryMetrics";
 
-// ── Parsed metric types ──────────────────────────────────────────────
-
-interface HttpMetric {
-  method: string;
-  path: string;
-  status: string;
-  count: number;
-}
-
-interface AgentTokenMetric {
-  agent: string;
-  provider: string;
-  model: string;
-  tokens: number;
-  inputTokens: number;
-  outputTokens: number;
-  toolCalls: number;
-  llmCalls: number;
-}
-
-interface SystemMetrics {
-  uptime: number;
-  agentsActive: number;
-  agentsTotal: number;
-  activeSessions: number;
-  costToday: number;
-  panics: number;
-  restarts: number;
-  version: string;
-}
-
-interface ParsedMetrics {
-  requests: HttpMetric[];
-  agents: AgentTokenMetric[];
-  system: SystemMetrics;
-}
-
-// ── Parser ───────────────────────────────────────────────────────────
-
-function ensureAgentEntry(map: Map<string, AgentTokenMetric>, agent: string): AgentTokenMetric {
-  if (!map.has(agent)) {
-    map.set(agent, {
-      agent,
-      provider: "",
-      model: "",
-      tokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
-      toolCalls: 0,
-      llmCalls: 0,
-    });
-  }
-  return map.get(agent)!;
-}
-
-function parseMetrics(text: string): ParsedMetrics {
-  const requests: HttpMetric[] = [];
-  const agentMap = new Map<string, AgentTokenMetric>();
-  const gaugeMap = new Map<string, number>();
-  const lines = text.split("\n");
-  let version = "";
-
-  for (const line of lines) {
-    if (line.startsWith("#")) continue;
-
-    const spaceIdx = line.indexOf(" ");
-    if (spaceIdx > 0) {
-      const namePart = line.slice(0, spaceIdx);
-      if (!namePart.includes("{")) {
-        gaugeMap.set(namePart, parseFloat(line.slice(spaceIdx + 1)) || 0);
-      }
-    }
-
-    if (line.startsWith("librefang_http_requests_total{")) {
-      const match = line.match(
-        /librefang_http_requests_total\{method="([^"]+)",path="([^"]+)",status="([^"]+)"\}\s+(\d+)/
-      );
-      if (match) {
-        requests.push({ method: match[1], path: match[2], status: match[3], count: parseInt(match[4], 10) });
-      }
-    }
-
-    if (line.startsWith("librefang_tokens{")) {
-      const match = line.match(
-        /librefang_tokens\{agent="([^"]+)",provider="([^"]+)",model="([^"]+)"\}\s+([\d.]+)/
-      );
-      if (match) {
-        const key = match[1];
-        if (!agentMap.has(key)) {
-          agentMap.set(key, {
-            agent: match[1], provider: match[2], model: match[3],
-            tokens: 0, inputTokens: 0, outputTokens: 0, toolCalls: 0, llmCalls: 0,
-          });
-        }
-        agentMap.get(key)!.tokens = parseFloat(match[4]);
-      }
-    }
-    if (line.startsWith("librefang_tokens_input{")) {
-      const match = line.match(/librefang_tokens_input\{agent="([^"]+)"[^}]*\}\s+([\d.]+)/);
-      if (match) {
-        ensureAgentEntry(agentMap, match[1]).inputTokens = parseFloat(match[2]);
-      }
-    }
-    if (line.startsWith("librefang_tokens_output{")) {
-      const match = line.match(/librefang_tokens_output\{agent="([^"]+)"[^}]*\}\s+([\d.]+)/);
-      if (match) {
-        ensureAgentEntry(agentMap, match[1]).outputTokens = parseFloat(match[2]);
-      }
-    }
-    if (line.startsWith("librefang_tool_calls{")) {
-      const match = line.match(/librefang_tool_calls\{agent="([^"]+)"[^}]*\}\s+([\d.]+)/);
-      if (match) {
-        ensureAgentEntry(agentMap, match[1]).toolCalls = parseFloat(match[2]);
-      }
-    }
-    if (line.startsWith("librefang_llm_calls{")) {
-      const match = line.match(/librefang_llm_calls\{agent="([^"]+)"[^}]*\}\s+([\d.]+)/);
-      if (match) {
-        ensureAgentEntry(agentMap, match[1]).llmCalls = parseFloat(match[2]);
-      }
-    }
-
-    if (!version && line.startsWith("librefang_info{")) {
-      const match = line.match(/version="([^"]+)"/);
-      if (match) version = match[1];
-    }
-  }
-
-  const system: SystemMetrics = {
-    uptime: gaugeMap.get("librefang_uptime_seconds") || 0,
-    agentsActive: gaugeMap.get("librefang_agents_active") || 0,
-    agentsTotal: gaugeMap.get("librefang_agents_total") || 0,
-    activeSessions: gaugeMap.get("librefang_active_sessions") || 0,
-    costToday: gaugeMap.get("librefang_cost_usd_today") || 0,
-    panics: gaugeMap.get("librefang_panics_total") || 0,
-    restarts: gaugeMap.get("librefang_restarts_total") || 0,
-    version,
-  };
-
-  return {
-    requests,
-    // Skip rollup rows emitted for namespace-like aggregate metrics.
-    agents: Array.from(agentMap.values()).filter(a => !a.agent.includes(":")),
-    system,
-  };
-}
+const METRICS_ENDPOINT = "/api/metrics";
+const RAW_METRICS_TRUNCATE = 8000;
 
 // Roll up `(method, path, status)` rows into one row per `(method, path)`,
 // with the status counts collapsed into a per-class summary. Lets the
@@ -317,6 +177,20 @@ export function TelemetryPage() {
   }, [parsed]);
 
   const errorRate = totalRequests > 0 ? (errorCount / totalRequests) * 100 : 0;
+  let errorRateColor = "";
+  let errorRateIconColor = "text-text-dim/40";
+  let errorRateVariant: MetricVariant = "success";
+  let errorRateDigits = 2;
+  if (errorRate > 1) {
+    errorRateColor = "text-error";
+    errorRateIconColor = "text-error";
+    errorRateVariant = "error";
+  } else if (errorRate > 0) {
+    errorRateColor = "text-warning";
+    errorRateIconColor = "text-warning";
+    errorRateVariant = "warning";
+    if (errorRate < 0.01) errorRateDigits = 3;
+  }
 
   const agentsByTokens = useMemo(
     () => [...parsed.agents].sort((a, b) => b.tokens - a.tokens),
@@ -481,13 +355,13 @@ export function TelemetryPage() {
             />
             <MetricCard
               label={t("telemetry.error_rate")}
-              icon={<AlertTriangle className={`w-3.5 h-3.5 ${errorRate > 1 ? "text-error" : "text-text-dim/40"}`} />}
+              icon={<AlertTriangle className={`w-3.5 h-3.5 ${errorRateIconColor}`} />}
               value={
-                <p className={`text-xl font-black tracking-tight ${errorRate > 1 ? "text-error" : errorRate > 0 ? "text-warning" : ""}`}>
-                  {errorRate.toFixed(errorRate > 0 && errorRate < 0.01 ? 3 : 2)}%
+                <p className={`text-xl font-black tracking-tight ${errorRateColor}`}>
+                  {errorRate.toFixed(errorRateDigits)}%
                 </p>
               }
-              variant={errorRate > 1 ? "error" : errorRate > 0 ? "warning" : "success"}
+              variant={errorRateVariant}
               sub={totalRequests > 0 ? `${errorCount.toLocaleString()} / ${totalRequests.toLocaleString()}` : undefined}
             />
           </StaggerList>
@@ -601,7 +475,7 @@ export function TelemetryPage() {
                 )}
               </button>
               <a
-                href="/api/metrics"
+                href={METRICS_ENDPOINT}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-brand hover:underline shrink-0"
@@ -612,9 +486,9 @@ export function TelemetryPage() {
             {rawExpanded && (
               <>
                 <pre className="mt-4 text-xs font-mono bg-main rounded-lg p-4 overflow-auto max-h-96 text-text-dim">
-                  {metricsQuery.data?.slice(0, 8000) || ""}
+                  {metricsQuery.data?.slice(0, RAW_METRICS_TRUNCATE) || ""}
                 </pre>
-                {(metricsQuery.data?.length || 0) > 8000 && (
+                {(metricsQuery.data?.length || 0) > RAW_METRICS_TRUNCATE && (
                   <span className="text-xs text-text-dim mt-2 block">{t("telemetry.truncated")}</span>
                 )}
               </>

--- a/crates/librefang-api/dashboard/src/pages/telemetryMetrics.test.ts
+++ b/crates/librefang-api/dashboard/src/pages/telemetryMetrics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { parseMetrics } from "./telemetryMetrics";
+
+describe("parseMetrics", () => {
+  it("parses reordered and extended label sets by name", () => {
+    const parsed = parseMetrics(`
+librefang_http_requests_total{status="200",extra="kept",path="/api/agents",method="GET"} 12
+librefang_tokens_output{model="gpt-5",agent="alpha",provider="openai"} 30
+librefang_tool_calls{provider="openai",agent="alpha",model="gpt-5"} 2
+librefang_tokens{model="gpt-5",region="us",agent="alpha",provider="openai"} 100
+librefang_tokens_input{agent="alpha",provider="openai",model="gpt-5"} 70
+librefang_llm_calls{agent="alpha",provider="openai",model="gpt-5"} 4
+`);
+
+    expect(parsed.requests).toEqual([
+      { method: "GET", path: "/api/agents", status: "200", count: 12 },
+    ]);
+    expect(parsed.agents).toEqual([
+      {
+        agent: "alpha",
+        provider: "openai",
+        model: "gpt-5",
+        tokens: 100,
+        inputTokens: 70,
+        outputTokens: 30,
+        toolCalls: 2,
+        llmCalls: 4,
+      },
+    ]);
+  });
+
+  it("decodes escaped label values", () => {
+    const parsed = parseMetrics(
+      String.raw`librefang_http_requests_total{path="/quoted\"path",method="GET",status="404"} 1`,
+    );
+
+    expect(parsed.requests[0]?.path).toBe('/quoted"path');
+  });
+
+  it("rejects fractional counters and filters zero-only or rollup agents", () => {
+    const parsed = parseMetrics(`
+librefang_tokens{agent="fractional",provider="openai",model="gpt"} 1.5
+librefang_tool_calls{agent="zero"} 0
+librefang_tokens{agent="namespace:rollup",provider="openai",model="gpt"} 9
+librefang_tokens_input{agent="active"} 3
+`);
+
+    expect(parsed.agents).toEqual([
+      {
+        agent: "active",
+        provider: "",
+        model: "",
+        tokens: 0,
+        inputTokens: 3,
+        outputTokens: 0,
+        toolCalls: 0,
+        llmCalls: 0,
+      },
+    ]);
+  });
+
+  it("parses unlabeled gauges and version labels", () => {
+    const parsed = parseMetrics(`
+librefang_uptime_seconds 42.5
+librefang_agents_active 2
+librefang_info{commit="abc",version="1.2.3"} 1
+`);
+
+    expect(parsed.system.uptime).toBe(42.5);
+    expect(parsed.system.agentsActive).toBe(2);
+    expect(parsed.system.version).toBe("1.2.3");
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/telemetryMetrics.ts
+++ b/crates/librefang-api/dashboard/src/pages/telemetryMetrics.ts
@@ -1,0 +1,213 @@
+export interface HttpMetric {
+  method: string;
+  path: string;
+  status: string;
+  count: number;
+}
+
+export interface AgentTokenMetric {
+  agent: string;
+  provider: string;
+  model: string;
+  tokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  toolCalls: number;
+  llmCalls: number;
+}
+
+interface SystemMetrics {
+  uptime: number;
+  agentsActive: number;
+  agentsTotal: number;
+  activeSessions: number;
+  costToday: number;
+  panics: number;
+  restarts: number;
+  version: string;
+}
+
+export interface ParsedMetrics {
+  requests: HttpMetric[];
+  agents: AgentTokenMetric[];
+  system: SystemMetrics;
+}
+
+interface PrometheusSample {
+  name: string;
+  labels: Map<string, string>;
+  value: string;
+}
+
+function parseLabels(source: string): Map<string, string> | null {
+  const labels = new Map<string, string>();
+  let index = 0;
+
+  while (index < source.length) {
+    while (source[index] === " " || source[index] === "\t") index += 1;
+    const keyMatch = source.slice(index).match(/^([a-zA-Z_][a-zA-Z0-9_]*)/);
+    if (!keyMatch) return null;
+    const key = keyMatch[1];
+    index += key.length;
+
+    while (source[index] === " " || source[index] === "\t") index += 1;
+    if (source[index] !== "=") return null;
+    index += 1;
+    while (source[index] === " " || source[index] === "\t") index += 1;
+    if (source[index] !== '"') return null;
+    index += 1;
+
+    let value = "";
+    let closed = false;
+    while (index < source.length) {
+      const char = source[index];
+      index += 1;
+      if (char === '"') {
+        closed = true;
+        break;
+      }
+      if (char === "\\") {
+        if (index >= source.length) return null;
+        const escaped = source[index];
+        index += 1;
+        if (escaped === "n") value += "\n";
+        else if (escaped === "\\" || escaped === '"') value += escaped;
+        else return null;
+      } else {
+        value += char;
+      }
+    }
+    if (!closed) return null;
+    labels.set(key, value);
+
+    while (source[index] === " " || source[index] === "\t") index += 1;
+    if (index === source.length) break;
+    if (source[index] !== ",") return null;
+    index += 1;
+  }
+
+  return labels;
+}
+
+function parseSample(line: string): PrometheusSample | null {
+  const match = line.match(
+    /^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{(.*)\})?\s+(\S+)(?:\s+\d+)?\s*$/,
+  );
+  if (!match) return null;
+  const labels = match[2] === undefined ? new Map<string, string>() : parseLabels(match[2]);
+  if (!labels) return null;
+  return { name: match[1], labels, value: match[3] };
+}
+
+function parseNonNegativeInteger(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function ensureAgentEntry(
+  map: Map<string, AgentTokenMetric>,
+  agent: string,
+): AgentTokenMetric {
+  let entry = map.get(agent);
+  if (!entry) {
+    entry = {
+      agent,
+      provider: "",
+      model: "",
+      tokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      toolCalls: 0,
+      llmCalls: 0,
+    };
+    map.set(agent, entry);
+  }
+  return entry;
+}
+
+function hasUsage(metric: AgentTokenMetric): boolean {
+  return (
+    metric.tokens > 0 ||
+    metric.inputTokens > 0 ||
+    metric.outputTokens > 0 ||
+    metric.toolCalls > 0 ||
+    metric.llmCalls > 0
+  );
+}
+
+export function parseMetrics(text: string): ParsedMetrics {
+  const requests: HttpMetric[] = [];
+  const agentMap = new Map<string, AgentTokenMetric>();
+  const gaugeMap = new Map<string, number>();
+  let version = "";
+
+  for (const line of text.split("\n")) {
+    if (line === "" || line.startsWith("#")) continue;
+    const sample = parseSample(line);
+    if (!sample) continue;
+
+    if (sample.labels.size === 0) {
+      const value = Number(sample.value);
+      if (Number.isFinite(value)) gaugeMap.set(sample.name, value);
+    }
+
+    if (sample.name === "librefang_http_requests_total") {
+      const method = sample.labels.get("method");
+      const path = sample.labels.get("path");
+      const status = sample.labels.get("status");
+      const count = parseNonNegativeInteger(sample.value);
+      if (method && path && status && count !== null) {
+        requests.push({ method, path, status, count });
+      }
+      continue;
+    }
+
+    const agent = sample.labels.get("agent");
+    if (agent) {
+      const value = parseNonNegativeInteger(sample.value);
+      if (value === null) continue;
+      const entry = ensureAgentEntry(agentMap, agent);
+      entry.provider = sample.labels.get("provider") ?? entry.provider;
+      entry.model = sample.labels.get("model") ?? entry.model;
+      switch (sample.name) {
+        case "librefang_tokens":
+          entry.tokens = value;
+          break;
+        case "librefang_tokens_input":
+          entry.inputTokens = value;
+          break;
+        case "librefang_tokens_output":
+          entry.outputTokens = value;
+          break;
+        case "librefang_tool_calls":
+          entry.toolCalls = value;
+          break;
+        case "librefang_llm_calls":
+          entry.llmCalls = value;
+          break;
+      }
+    }
+
+    if (!version && sample.name === "librefang_info") {
+      version = sample.labels.get("version") ?? "";
+    }
+  }
+
+  return {
+    requests,
+    agents: Array.from(agentMap.values()).filter(
+      (metric) => !metric.agent.includes(":") && hasUsage(metric),
+    ),
+    system: {
+      uptime: gaugeMap.get("librefang_uptime_seconds") ?? 0,
+      agentsActive: gaugeMap.get("librefang_agents_active") ?? 0,
+      agentsTotal: gaugeMap.get("librefang_agents_total") ?? 0,
+      activeSessions: gaugeMap.get("librefang_active_sessions") ?? 0,
+      costToday: gaugeMap.get("librefang_cost_usd_today") ?? 0,
+      panics: gaugeMap.get("librefang_panics_total") ?? 0,
+      restarts: gaugeMap.get("librefang_restarts_total") ?? 0,
+      version,
+    },
+  };
+}


### PR DESCRIPTION
## Substantive changes

- parse Prometheus label blocks by label name instead of fixed label order
- preserve provider/model identity regardless of agent metric line order
- reject fractional request and usage counts and filter zero-only agent rows
- decode supported Prometheus label escapes and tolerate extra labels
- replace nested error-rate presentation ternaries with explicit state branches
- name the raw metrics endpoint and truncation constants
- add focused parser regressions for reordered labels, escaped values, invalid counts, rollups, and gauges

## Verification

- `corepack pnpm exec vitest run src/pages/telemetryMetrics.test.ts` (4 tests)
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm test` (102 files, 1079 tests)
- `corepack pnpm build`
- `corepack pnpm test:i18n-parity` (expected existing failure only: 8 extra plural keys each in pl.json and uk.json)

## Out of scope

- exporting one shared metrics endpoint constant from `api.ts`; that file is occupied by open #7394
- changing the Prometheus exporter or usage-window semantics
- existing Polish and Ukrainian plural-key parity drift