### PR TITLE
fix(dashboard): synchronize audit route state

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AuditPage.route.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.route.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AuditPage } from "./AuditPage";
+import { useAuditQuery } from "../lib/queries/audit";
+import { PushDrawer } from "../components/ui/PushDrawer";
+import { useDrawerStore } from "../lib/drawerStore";
+
+const routerState = vi.hoisted(() => ({
+  search: { user: "first" } as Record<string, unknown>,
+  navigate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useSearch: () => routerState.search,
+  useNavigate: () => routerState.navigate,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("../lib/queries/audit", () => ({
+  useAuditQuery: vi.fn(),
+}));
+
+vi.mock("../lib/queries/channels", () => ({
+  useChannels: () => ({ data: [] }),
+}));
+
+vi.mock("../lib/store", () => ({
+  useUIStore: (selector: (state: { addToast: ReturnType<typeof vi.fn> }) => unknown) =>
+    selector({ addToast: vi.fn() }),
+}));
+
+const useAuditQueryMock = useAuditQuery as unknown as ReturnType<typeof vi.fn>;
+
+describe("AuditPage route synchronization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDrawerStore.getState().close();
+    routerState.search = { user: "first" };
+    useAuditQueryMock.mockReturnValue({
+      data: { entries: [], count: 0 },
+      error: null,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("applies an in-place route search change without remounting", async () => {
+    const view = render(<AuditPage />);
+    expect(useAuditQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ user: "first", limit: 200 }),
+    );
+
+    routerState.search = { user: "second" };
+    view.rerender(<AuditPage />);
+
+    await waitFor(() =>
+      expect(useAuditQueryMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ user: "second", limit: 200 }),
+      ),
+    );
+  });
+
+  it("opens the custom-channel input when the current channel is blank", async () => {
+    routerState.search = {};
+    render(
+      <>
+        <AuditPage />
+        <PushDrawer />
+      </>,
+    );
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "audit.filters" }));
+    const [channelSelect] = await screen.findAllByLabelText("audit.f_channel");
+    await user.selectOptions(
+      channelSelect,
+      "__custom__",
+    );
+
+    expect(
+      screen.getAllByPlaceholderText("audit.f_channel_placeholder").length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/AuditPage.test.ts
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../lib/http/errors";
+import {
+  auditFiltersToParams,
+  filtersFromRouteSearch,
+  formatAuditExportError,
+  isCustomAuditChannel,
+  routeSearchIdentity,
+  scheduleObjectUrlRevoke,
+} from "./AuditPage";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("AuditPage state helpers", () => {
+  it("serializes only populated filter values", () => {
+    expect(
+      auditFiltersToParams({
+        user: "owner",
+        action: "",
+        channel: undefined,
+        limit: 200,
+      }).toString(),
+    ).toBe("user=owner&limit=200");
+  });
+
+  it("keeps explicit custom-channel mode open for a blank value", () => {
+    expect(isCustomAuditChannel(undefined, ["", "api"], true)).toBe(true);
+    expect(isCustomAuditChannel("webhook-a", ["", "api"], false)).toBe(true);
+    expect(isCustomAuditChannel("api", ["", "api"], false)).toBe(false);
+  });
+
+  it("derives filters and identity from every route update", () => {
+    expect(filtersFromRouteSearch({ user: "one" })).toEqual({
+      user: "one",
+      action: undefined,
+      agent: undefined,
+      channel: undefined,
+      from: undefined,
+      to: undefined,
+      limit: 200,
+    });
+    expect(routeSearchIdentity({ user: "one", seq: 1 })).not.toBe(
+      routeSearchIdentity({ user: "two", seq: 2 }),
+    );
+  });
+
+  it("formats structured and ordinary export failures", () => {
+    expect(formatAuditExportError(new ApiError(403, "FORBIDDEN", "Denied"))).toBe(
+      "403: Denied",
+    );
+    expect(formatAuditExportError(new Error("Network failed"))).toBe(
+      "Network failed",
+    );
+  });
+
+  it("revokes the previous object URL before replacing its timer", () => {
+    vi.useFakeTimers();
+    const revokeObjectURL = vi.fn();
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      URL,
+      "revokeObjectURL",
+    );
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    try {
+      scheduleObjectUrlRevoke("blob:first");
+      scheduleObjectUrlRevoke("blob:second");
+
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:first");
+      vi.advanceTimersByTime(1000);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:second");
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(URL, "revokeObjectURL", originalDescriptor);
+      } else {
+        Reflect.deleteProperty(URL, "revokeObjectURL");
+      }
+    }
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -4,7 +4,7 @@
 // rows, default 200) — for deeper history use the export button which hits
 // /api/audit/export with the same filter set.
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
@@ -85,17 +85,36 @@ function normaliseFilters(filters: AuditQueryFilters): AuditQueryFilters {
   };
 }
 
+export function auditFiltersToParams(filters: AuditQueryFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === undefined || value === null || value === "") continue;
+    params.set(key, String(value));
+  }
+  return params;
+}
+
 function buildExportUrl(
   filters: AuditQueryFilters,
   format: "csv" | "json",
 ): string {
-  const normalised = normaliseFilters(filters);
-  const params = new URLSearchParams({ format });
-  for (const [k, v] of Object.entries(normalised)) {
-    if (v === undefined || v === null || v === "") continue;
-    params.set(k, String(v));
-  }
+  const params = auditFiltersToParams(normaliseFilters(filters));
+  params.set("format", format);
   return `/api/audit/export?${params.toString()}`;
+}
+
+let pendingObjectUrl: string | null = null;
+let objectUrlRevokeTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function scheduleObjectUrlRevoke(objectUrl: string) {
+  if (objectUrlRevokeTimer !== null) clearTimeout(objectUrlRevokeTimer);
+  if (pendingObjectUrl !== null) URL.revokeObjectURL(pendingObjectUrl);
+  pendingObjectUrl = objectUrl;
+  objectUrlRevokeTimer = setTimeout(() => {
+    URL.revokeObjectURL(objectUrl);
+    if (pendingObjectUrl === objectUrl) pendingObjectUrl = null;
+    objectUrlRevokeTimer = null;
+  }, 1000);
 }
 
 // Authenticated download: dashboard auth is Bearer-in-header, but
@@ -133,7 +152,53 @@ async function downloadExport(
   a.click();
   a.remove();
   // Defer revoke so the browser has a chance to start the save dialog.
-  setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+  scheduleObjectUrlRevoke(objectUrl);
+}
+
+export function formatAuditExportError(error: unknown): string {
+  if (error instanceof ApiError) return `${error.status}: ${error.message}`;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export function isCustomAuditChannel(
+  channel: string | undefined,
+  knownChannels: string[],
+  explicitCustomMode: boolean,
+): boolean {
+  return (
+    explicitCustomMode ||
+    (!!channel && !knownChannels.includes(channel))
+  );
+}
+
+type AuditRouteSearch = {
+  user?: string;
+  action?: string;
+  agent?: string;
+  channel?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  seq?: number;
+};
+
+export function filtersFromRouteSearch(search: AuditRouteSearch): AuditQueryFilters {
+  return {
+    user: search.user,
+    action: search.action,
+    agent: search.agent,
+    channel: search.channel,
+    from: search.from,
+    to: search.to,
+    limit: search.limit ?? 200,
+  };
+}
+
+export function routeSearchIdentity(search: AuditRouteSearch): string {
+  const params = auditFiltersToParams(filtersFromRouteSearch(search));
+  if (search.seq !== undefined) params.set("seq", String(search.seq));
+  return params.toString();
 }
 
 // Action enum identifiers — these are the literal `AuditAction` variant
@@ -436,34 +501,31 @@ export function AuditPage() {
   // `?seq=N` deep-link to a specific entry's detail modal. The page
   // writes back to the URL whenever `active` changes so a bookmark /
   // shared link round-trips.
-  const search = useSearch({ from: "/audit" }) as {
-    user?: string;
-    action?: string;
-    agent?: string;
-    channel?: string;
-    from?: string;
-    to?: string;
-    limit?: number;
-    seq?: number;
-  };
-  const initialFilters: AuditQueryFilters = useMemo(
-    () => ({
-      user: search.user,
-      action: search.action,
-      agent: search.agent,
-      channel: search.channel,
-      from: search.from,
-      to: search.to,
-      limit: search.limit ?? 200,
-    }),
-    // Initial only — subsequent URL changes flow OUT (active → URL),
-    // not in. Reading `search` reactively here would create a loop with
-    // the sync effect below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+  const search = useSearch({ from: "/audit" }) as AuditRouteSearch;
+  const routeFilters = useMemo(
+    () =>
+      filtersFromRouteSearch({
+        user: search.user,
+        action: search.action,
+        agent: search.agent,
+        channel: search.channel,
+        from: search.from,
+        to: search.to,
+        limit: search.limit,
+      }),
+    [
+      search.user,
+      search.action,
+      search.agent,
+      search.channel,
+      search.from,
+      search.to,
+      search.limit,
+    ],
   );
-  const [draft, setDraft] = useState<AuditQueryFilters>(initialFilters);
-  const [active, setActive] = useState<AuditQueryFilters>(initialFilters);
+  const routeIdentity = routeSearchIdentity(search);
+  const [draft, setDraft] = useState<AuditQueryFilters>(routeFilters);
+  const [active, setActive] = useState<AuditQueryFilters>(routeFilters);
   const [exportError, setExportError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -471,12 +533,33 @@ export function AuditPage() {
   // the row map so the `?seq=` URL deep-link can pre-open it without
   // racing with the row click handler.
   const [detailEntry, setDetailEntry] = useState<AuditQueryEntry | null>(null);
+  const [channelCustomMode, setChannelCustomMode] = useState(false);
+  const syncingFromRouteRef = useRef(false);
+  const expectedRouteIdentityRef = useRef<string | null>(null);
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const addToast = useUIStore((s) => s.addToast);
   // Per-row detail-expansion. Keyed by `${seq}-${hash}` (same as row key).
   // We default to "clamped" for any row with shouldClampDetail(detail);
   // Show more flips it for that one row only.
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  // TanStack Router can update search params without remounting this page.
+  // Accept those external changes while ignoring the replace-navigation
+  // emitted by the active-filter sync effect below.
+  useEffect(() => {
+    if (expectedRouteIdentityRef.current === routeIdentity) {
+      expectedRouteIdentityRef.current = null;
+      syncingFromRouteRef.current = true;
+      return;
+    }
+    syncingFromRouteRef.current = true;
+    setDraft(routeFilters);
+    setActive(routeFilters);
+    setChannelCustomMode(false);
+    setDetailEntry((current) =>
+      current?.seq === search.seq ? current : null,
+    );
+  }, [routeFilters, routeIdentity, search.seq]);
   const toggleExpanded = (key: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -549,16 +632,20 @@ export function AuditPage() {
   // channel not in the seed). The Select snaps to "Custom…" and the
   // free-text input below stays visible.
   const channelIsCustom = useMemo(() => {
-    if (!draft.channel) return false;
-    return !channelOptions.some((o) => o.value === draft.channel);
-  }, [draft.channel, channelOptions]);
+    const knownChannels = channelOptions.map((option) => option.value);
+    return isCustomAuditChannel(
+      draft.channel,
+      knownChannels,
+      channelCustomMode,
+    );
+  }, [draft.channel, channelOptions, channelCustomMode]);
 
   const onChannelChange = (value: string) => {
     if (value === "__custom__") {
-      // Stay on whatever was typed; if blank, just open the input.
-      setDraft((d) => ({ ...d, channel: d.channel ?? "" }));
+      setChannelCustomMode(true);
       return;
     }
+    setChannelCustomMode(false);
     setDraft((d) => ({ ...d, channel: value || undefined }));
   };
 
@@ -569,6 +656,7 @@ export function AuditPage() {
 
   const onClearAll = () => {
     const reset: AuditQueryFilters = { limit: 200 };
+    setChannelCustomMode(false);
     setDraft(reset);
     setActive(reset);
   };
@@ -588,7 +676,11 @@ export function AuditPage() {
   // preserved so an open detail modal stays in the URL while the
   // filters change underneath.
   useEffect(() => {
-    const next: Record<string, string | number | undefined> = {
+    if (syncingFromRouteRef.current) {
+      syncingFromRouteRef.current = false;
+      return;
+    }
+    const next: AuditRouteSearch = {
       user: active.user || undefined,
       action: active.action || undefined,
       agent: active.agent || undefined,
@@ -600,6 +692,7 @@ export function AuditPage() {
       limit: active.limit && active.limit !== 200 ? active.limit : undefined,
       seq: detailEntry?.seq,
     };
+    expectedRouteIdentityRef.current = routeSearchIdentity(next);
     navigate({
       to: "/audit",
       // TanStack Router strips undefined keys, so omitted filters
@@ -607,23 +700,19 @@ export function AuditPage() {
       search: next as Record<string, unknown>,
       replace: true,
     });
-  }, [active, detailEntry?.seq, navigate]);
+  }, [active, detailEntry?.seq, navigate, routeIdentity]);
 
-  // `?seq=N` deep-link: when the page boots with a seq in the URL,
-  // wait for the row data and auto-open the matching detail modal.
-  // We only consult `search.seq` once (initial value) — subsequent
-  // URL writes from the modal-open/close path manage themselves.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const initialSeq = useMemo(() => search.seq, []);
+  // `?seq=N` deep-link: wait for the row data and open the matching
+  // detail modal. This stays reactive for in-place route navigation.
   useEffect(() => {
-    if (initialSeq == null || detailEntry) return;
+    if (search.seq == null || detailEntry?.seq === search.seq) return;
     // Defensive `?? []`: the backend returns `{count:0,limit:N}` without an
     // `entries` field on cold registries / pre-first-action, even though the
     // typed schema marks `entries` required. Prevents a render crash before
     // the first audit row exists.
-    const match = (query.data?.entries ?? []).find((e) => e.seq === initialSeq);
+    const match = (query.data?.entries ?? []).find((e) => e.seq === search.seq);
     if (match) setDetailEntry(match);
-  }, [initialSeq, query.data, detailEntry]);
+  }, [search.seq, query.data, detailEntry?.seq]);
 
   // Copy helpers + transient "Copied" affordance. The keyed state lets
   // multiple buttons in the modal each show their own check briefly
@@ -640,14 +729,10 @@ export function AuditPage() {
   };
 
   const buildPermalink = (entry: AuditQueryEntry): string => {
-    const params = new URLSearchParams();
-    if (active.user) params.set("user", active.user);
-    if (active.action) params.set("action", active.action);
-    if (active.agent) params.set("agent", active.agent);
-    if (active.channel) params.set("channel", active.channel);
-    if (active.from) params.set("from", active.from);
-    if (active.to) params.set("to", active.to);
-    if (active.limit && active.limit !== 200) params.set("limit", String(active.limit));
+    const params = auditFiltersToParams({
+      ...active,
+      limit: active.limit === 200 ? undefined : active.limit,
+    });
     params.set("seq", String(entry.seq));
     const qs = params.toString();
     // Use the dashboard's basepath; fall back to current location host so
@@ -663,6 +748,7 @@ export function AuditPage() {
   // and the draft (so the form, when expanded, reflects reality).
   const drillFilter = (key: keyof AuditQueryFilters, value: string) => {
     const next = { ...active, [key]: value };
+    if (key === "channel") setChannelCustomMode(false);
     setActive(next);
     setDraft(next);
   };
@@ -673,13 +759,7 @@ export function AuditPage() {
     try {
       await downloadExport(active, format);
     } catch (err) {
-      setExportError(
-        err instanceof ApiError
-          ? `${err.status}: ${err.message}`
-          : err instanceof Error
-            ? err.message
-            : String(err),
-      );
+      setExportError(formatAuditExportError(err));
     } finally {
       setExporting(false);
     }


### PR DESCRIPTION
## Substantive changes

- track explicit custom-channel mode so selecting Custom opens the blank free-text input
- synchronize external in-place route search and sequence changes without looping on page-owned replace navigation
- consolidate page-local audit filter serialization across exports and permalinks
- replace nested export-error formatting with explicit typed branches
- revoke superseded object URLs and replace their pending cleanup timers
- add focused helper and real page/drawer route-state regressions

Audit findings: F-9e7ddc5dd7ca71c2, F-31281af250a4cbcf, F-45a852ae7fe290ec, F-d9938d4b90d3cc02. Page-local portion of F-b460eef809f758ef.

## Verification

- `pnpm exec vitest run src/pages/AuditPage.test.ts src/pages/AuditPage.route.test.tsx` (7 tests)
- `pnpm test` (103 files, 1082 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:i18n-parity` (known baseline only: 8 extra plural keys each in pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- Moving the serializer into the API client is deferred because `api.ts` is occupied by open PR #7394; query request behavior remains unchanged.
- Audit APIs, authorization, and the existing Polish/Ukrainian parity baseline remain unchanged.