### PR TITLE
fix(dashboard): preserve collapsed goal trees

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/GoalsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/GoalsPage.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { GoalsPage } from "./GoalsPage";
+import {
+  GoalsPage,
+  buildGoalRows,
+  goalStatusBadgeVariant,
+  progressForGoalStatus,
+  runIndependentBatch,
+} from "./GoalsPage";
 import { useGoals, useGoalTemplates, useGoalRun } from "../lib/queries/goals";
 import {
   useCreateGoal,
@@ -211,7 +217,7 @@ describe("GoalsPage", () => {
 
     fireEvent.click(screen.getByText("goals.use_template"));
 
-    // runBatch awaits sequentially; flush microtasks.
+    // Flush the allSettled batch.
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -357,19 +363,17 @@ describe("GoalsPage", () => {
     expect(screen.queryByText("goals.delete_confirm")).not.toBeInTheDocument();
   });
 
-  it("renders both parent and child goals in the tree", () => {
+  it("hides collapsed descendants and reveals them when expanded", () => {
     useGoalsMock.mockReturnValue(makeQuery([PARENT_GOAL, CHILD_GOAL]));
     useGoalTemplatesMock.mockReturnValue(makeQuery<GoalTemplate[]>([]));
     renderPage();
 
     expect(screen.getByText("Parent goal")).toBeInTheDocument();
-    expect(screen.getByText("Child goal")).toBeInTheDocument();
-    // Parent has an expandable chevron because a child references it.
-    // Clicking it must not throw — exercises the expand toggle.
-    const headerRoot = screen.getByText("goals.goal_tree").closest("div")!;
-    const buttons = within(headerRoot.parentElement!).getAllByRole("button");
-    expect(buttons.length).toBeGreaterThan(0);
-    fireEvent.click(buttons[0]);
+    expect(screen.queryByText("Child goal")).not.toBeInTheDocument();
+
+    const parentRow = screen.getByText("Parent goal").closest("div.rounded-xl");
+    expect(parentRow).toBeTruthy();
+    fireEvent.click(within(parentRow as HTMLElement).getAllByRole("button")[0]);
     expect(screen.getByText("Child goal")).toBeInTheDocument();
   });
 
@@ -393,5 +397,51 @@ describe("GoalsPage", () => {
       id: "g-parent",
       data: expect.objectContaining({ title: "Renamed parent" }),
     });
+  });
+});
+
+describe("GoalsPage helpers", () => {
+  it("builds only visible tree rows with child depth", () => {
+    expect(buildGoalRows([PARENT_GOAL, CHILD_GOAL], {})).toEqual([
+      { goal: PARENT_GOAL, depth: 0, hasChildren: true },
+    ]);
+    expect(
+      buildGoalRows([PARENT_GOAL, CHILD_GOAL], { "g-parent": true }),
+    ).toEqual([
+      { goal: PARENT_GOAL, depth: 0, hasChildren: true },
+      { goal: CHILD_GOAL, depth: 1, hasChildren: false },
+    ]);
+  });
+
+  it("starts independent batch actions before waiting for settlement", async () => {
+    let releaseFirst: () => void = () => undefined;
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const failure = new Error("second failed");
+    const action = vi.fn((item: number) =>
+      item === 1 ? first : Promise.reject(failure),
+    );
+
+    const pending = runIndependentBatch([1, 2], action);
+    expect(action).toHaveBeenCalledTimes(2);
+    releaseFirst();
+
+    await expect(pending).resolves.toEqual({
+      total: 2,
+      succeeded: 1,
+      failed: 1,
+      errors: [failure],
+    });
+  });
+
+  it("derives progress and badge variants without nested status branches", () => {
+    expect(progressForGoalStatus("completed", 12)).toBe(100);
+    expect(progressForGoalStatus("in_progress", 12)).toBe(50);
+    expect(progressForGoalStatus("in_progress", 80)).toBe(80);
+    expect(progressForGoalStatus("pending", 80)).toBe(0);
+    expect(goalStatusBadgeVariant("completed")).toBe("success");
+    expect(goalStatusBadgeVariant("in_progress")).toBe("warning");
+    expect(goalStatusBadgeVariant("pending")).toBe("default");
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
@@ -29,6 +29,100 @@ const TEMPLATE_ICONS: Record<string, React.ComponentType<{ className?: string }>
   alert: AlertTriangle,
 };
 
+type GoalRow = { goal: GoalItem; depth: number; hasChildren: boolean };
+
+export function buildGoalRows(
+  goals: GoalItem[],
+  expandedById: Record<string, boolean>,
+): GoalRow[] {
+  const roots: GoalItem[] = [];
+  const childrenByParent = new Map<string, GoalItem[]>();
+  const goalsById = new Map(goals.map((goal) => [goal.id, goal]));
+  for (const goal of goals) {
+    if (goal.parent_id && goalsById.has(goal.parent_id)) {
+      const children = childrenByParent.get(goal.parent_id) ?? [];
+      children.push(goal);
+      childrenByParent.set(goal.parent_id, children);
+    } else {
+      roots.push(goal);
+    }
+  }
+
+  const rows: GoalRow[] = [];
+  const visited = new Set<string>();
+  function walk(goal: GoalItem, depth: number) {
+    if (visited.has(goal.id)) return;
+    visited.add(goal.id);
+    const children = childrenByParent.get(goal.id) ?? [];
+    rows.push({ goal, depth, hasChildren: children.length > 0 });
+    if (expandedById[goal.id]) {
+      for (const child of children) walk(child, depth + 1);
+    }
+  }
+  for (const root of roots) walk(root, 0);
+  return rows;
+}
+
+export async function runIndependentBatch<T>(
+  items: readonly T[],
+  action: (item: T) => Promise<unknown>,
+) {
+  const settled = await Promise.allSettled(items.map((item) => action(item)));
+  const errors = settled.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  return {
+    total: items.length,
+    succeeded: items.length - errors.length,
+    failed: errors.length,
+    errors,
+  };
+}
+
+async function runSequentialBatch<T>(
+  items: readonly T[],
+  action: (item: T) => Promise<unknown>,
+) {
+  let succeeded = 0;
+  const errors: unknown[] = [];
+  for (const item of items) {
+    try {
+      await action(item);
+      succeeded += 1;
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+  return {
+    total: items.length,
+    succeeded,
+    failed: items.length - succeeded,
+    errors,
+  };
+}
+
+export function progressForGoalStatus(status: string, current: number): number {
+  if (status === "completed") return 100;
+  if (status === "in_progress") return Math.max(current, 50);
+  return 0;
+}
+
+export function goalStatusBadgeVariant(status: string) {
+  if (status === "completed") return "success";
+  if (status === "in_progress") return "warning";
+  return "default";
+}
+
+function GoalStatusIcon({ status }: { status: string }) {
+  if (status === "completed") {
+    return <CheckCircle2 className="h-4 w-4 text-success" />;
+  }
+  if (status === "in_progress") {
+    return <Play className="h-4 w-4 text-warning" />;
+  }
+  return <Clock className="h-4 w-4 text-text-dim/40" />;
+}
+
 /**
  * Start / stop the autonomous long-horizon run for a single goal (#5744).
  * Only meaningful when the goal has an agent assigned — without one there is
@@ -117,10 +211,11 @@ export function GoalsPage() {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
   const [expandedById, setExpandedById] = useState<Record<string, boolean>>({});
-  const [createDraft, setCreateDraft] = useState({ title: "", description: "", status: "pending" as "pending" | "in_progress" | "completed", progress: 0, parent_id: "", agent_id: "" });
+  const [createDraft, setCreateDraft] = useState({ title: "", description: "", status: "pending" as "pending" | "in_progress" | "completed", progress: 0 });
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState({ title: "", description: "", status: "pending" as "pending" | "in_progress" | "completed", progress: 0 });
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
 
   const goalsQuery = useGoals();
   const templatesQuery = useGoalTemplates();
@@ -132,39 +227,13 @@ export function GoalsPage() {
   const goals = useMemo(() => goalsQuery.data ?? [], [goalsQuery.data]);
   const templates = templatesQuery.data ?? [];
 
-  const runBatch = async <T,>(items: readonly T[], action: (item: T) => Promise<unknown>) => {
-    let succeeded = 0;
-    const errors: unknown[] = [];
-    for (const item of items) {
-      try {
-        await action(item);
-        succeeded += 1;
-      } catch (err) {
-        errors.push(err);
-      }
-    }
-
-    return {
-      total: items.length,
-      succeeded,
-      failed: items.length - succeeded,
-      errors,
-    };
-  };
-
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!createDraft.title.trim()) return;
     try {
-      // Drop blank parent_id / agent_id instead of posting `""` (#6562): the form seeds both as empty strings, and an empty parent_id used to fail the backend's parent-existence check with "Parent goal '' not found".
-      const { parent_id, agent_id, ...rest } = createDraft;
-      await createMutation.mutateAsync({
-        ...rest,
-        ...(parent_id.trim() ? { parent_id: parent_id.trim() } : {}),
-        ...(agent_id.trim() ? { agent_id: agent_id.trim() } : {}),
-      });
+      await createMutation.mutateAsync(createDraft);
       addToast(t("common.success"), "success");
-      setCreateDraft({ title: "", description: "", status: "pending", progress: 0, parent_id: "", agent_id: "" });
+      setCreateDraft({ title: "", description: "", status: "pending", progress: 0 });
     } catch (err) {
       addToast(toastErr(err, t("common.error")), "error");
     }
@@ -173,7 +242,9 @@ export function GoalsPage() {
   const handleApplyTemplate = async (tpl: GoalTemplate) => {
     setApplyingTemplate(tpl.id);
     try {
-      const result = await runBatch(tpl.goals, (goal) => createMutation.mutateAsync(goal));
+      const result = await runIndependentBatch(tpl.goals, (goal) =>
+        createMutation.mutateAsync(goal),
+      );
       if (result.failed === 0) {
         addToast(`${t("common.success")} (${result.succeeded}/${result.total})`, "success");
       } else {
@@ -235,7 +306,7 @@ export function GoalsPage() {
     const status = nextStatus(current);
     try {
       const goal = goals.find(g => g.id === id);
-      const progress = status === "completed" ? 100 : status === "in_progress" ? Math.max(goal?.progress ?? 0, 50) : 0;
+      const progress = progressForGoalStatus(status, goal?.progress ?? 0);
       await updateMutation.mutateAsync({ id, data: { status, progress } });
     } catch (err) {
       addToast(toastErr(err, t("common.error")), "error");
@@ -244,7 +315,11 @@ export function GoalsPage() {
 
   const handleClearAll = async () => {
     try {
-      const result = await runBatch(goals, (goal) => deleteMutation.mutateAsync(goal.id));
+      // Goal deletion cascades to descendants, so these requests must remain
+      // ordered rather than sharing the independent template-create batch.
+      const result = await runSequentialBatch(goals, (goal) =>
+        deleteMutation.mutateAsync(goal.id),
+      );
       if (result.failed === 0) {
         addToast(`${t("common.success")} (${result.succeeded}/${result.total})`, "success");
         setShowClearConfirm(false);
@@ -263,30 +338,10 @@ export function GoalsPage() {
     }
   };
 
-  const rows = useMemo(() => {
-    const roots: GoalItem[] = [];
-    const childrenByParent = new Map<string, GoalItem[]>();
-    const goalsById = new Map(goals.map(goal => [goal.id, goal]));
-    for (const goal of goals) {
-      if (goal.parent_id && goalsById.has(goal.parent_id)) {
-        const list = childrenByParent.get(goal.parent_id) ?? [];
-        list.push(goal);
-        childrenByParent.set(goal.parent_id, list);
-      } else roots.push(goal);
-    }
-    const result: { goal: GoalItem; depth: number; hasChildren: boolean }[] = [];
-    const visited = new Set<string>();
-    function walk(goal: GoalItem, depth: number) {
-      if (visited.has(goal.id)) return;
-      visited.add(goal.id);
-      const children = childrenByParent.get(goal.id) ?? [];
-      result.push({ goal, depth, hasChildren: children.length > 0 });
-      if (expandedById[goal.id]) for (const child of children) walk(child, depth + 1);
-    }
-    for (const root of roots) walk(root, 0);
-    for (const goal of goals) walk(goal, 0);
-    return result;
-  }, [expandedById, goals]);
+  const rows = useMemo(
+    () => buildGoalRows(goals, expandedById),
+    [expandedById, goals],
+  );
 
   const stats = useMemo(() => ({
     total: goals.length,
@@ -295,8 +350,6 @@ export function GoalsPage() {
     pending: goals.filter(g => g.status === "pending").length,
     pct: goals.length > 0 ? Math.round((goals.filter(g => g.status === "completed").length / goals.length) * 100) : 0,
   }), [goals]);
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
-
   const inputClass = "rounded-xl border border-border-subtle bg-main px-4 py-2 text-sm focus:border-brand outline-none transition-colors";
 
   const statusLabel = (status: string) => {
@@ -449,11 +502,6 @@ export function GoalsPage() {
                 {rows.map(r => {
                   const status = r.goal.status || "pending";
                   const progress = r.goal.progress ?? 0;
-                  const statusIcon = status === "completed"
-                    ? <CheckCircle2 className="h-4 w-4 text-success" />
-                    : status === "in_progress"
-                      ? <Play className="h-4 w-4 text-warning" />
-                      : <Clock className="h-4 w-4 text-text-dim/40" />;
                   return (
                     <div key={r.goal.id} className="rounded-xl bg-main/40 border border-border-subtle hover:border-brand/30 transition-colors" style={{ marginLeft: `${r.depth * 16}px` }}>
                       {editingId === r.goal.id ? (
@@ -497,12 +545,12 @@ export function GoalsPage() {
                                 className="shrink-0 hover:scale-110 transition-transform"
                                 title={t("goals.toggle_reset")}
                               >
-                                {statusIcon}
+                                <GoalStatusIcon status={status} />
                               </button>
                               <span className={`text-sm font-bold truncate ${status === "completed" ? "line-through text-text-dim" : ""}`}>
                                 {r.goal.title}
                               </span>
-                              <Badge variant={status === "completed" ? "success" : status === "in_progress" ? "warning" : "default"} className="shrink-0">
+                              <Badge variant={goalStatusBadgeVariant(status)} className="shrink-0">
                                 {statusLabel(status)}
                               </Badge>
                             </div>


### PR DESCRIPTION
## Changes

- keep descendants out of the rendered goal tree until their parent is expanded
- run independent template goal creation concurrently while retaining ordered cascade-capable deletes
- move clear-confirmation state with the other page state
- remove unused parent and agent fields from the create draft
- replace nested status icon, badge, and progress branches with named helpers
- add regressions for collapsed tree rows, batch concurrency, and status presentation

Audit findings:
- F-d18c2ce2a909e125
- F-f1e6479e4cd25306
- F-f5bbb84cef870aa0
- F-acc2a946df8bf4b8
- F-287c2caf23981230
- F-698ed3da599438f1
- F-3febf7394dc6020e

## Verification

- `mise exec -- pnpm exec vitest run src/pages/GoalsPage.test.tsx` (17 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (101 files, 1,078 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- goal API validation and cascade-delete semantics remain unchanged
- create-form parent and agent assignment remain unavailable
- existing Polish and Ukrainian locale parity drift remains for a separate change