### PR TITLE
fix(dashboard): bound MCP auth polling

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.test.tsx
@@ -1,8 +1,19 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { McpServersPage } from "./McpServersPage";
+import { Plug } from "lucide-react";
+import {
+  AUTH_POLL_MAX_ATTEMPTS,
+  AuthBadge,
+  McpServersPage,
+  authPollTermination,
+  computeAuthLabel,
+  resolveLucideIcon,
+  serverIdOf,
+  serverIdentityOf,
+  shouldShowAuthBanner,
+} from "./McpServersPage";
 import { useMcpServers, useMcpCatalog, useMcpHealth } from "../lib/queries/mcp";
 import {
   useAddMcpServer,
@@ -14,6 +25,7 @@ import {
   useRevokeMcpAuth,
 } from "../lib/mutations/mcp";
 import type { McpServerConfigured, McpServersResponse } from "../api";
+import { useUIStore } from "../lib/store";
 
 // ---------------------------------------------------------------------------
 // Mocks (#3853 — McpServersPage MCP server management page).
@@ -28,6 +40,10 @@ vi.mock("../lib/queries/mcp", () => ({
     servers: () => ({ queryKey: ["mcp", "servers"] }),
     catalog: () => ({ queryKey: ["mcp", "catalog"] }),
     health: () => ({ queryKey: ["mcp", "health"] }),
+    authStatus: (serverId: string) => ({
+      queryKey: ["mcp", "auth", serverId],
+      queryFn: vi.fn(),
+    }),
   },
 }));
 
@@ -58,6 +74,40 @@ vi.mock("react-i18next", async () => {
             key,
     }),
   };
+});
+
+describe("McpServersPage helpers", () => {
+  it("uses one server identity contract for empty ids", () => {
+    const server = makeServer({ id: "", name: "fallback-name" });
+    expect(serverIdOf(server)).toBe("fallback-name");
+    expect(serverIdentityOf(server)).toBe("fallback-name");
+  });
+
+  it("maps auth labels and attention banners to backend states", () => {
+    expect(computeAuthLabel("authorized", 0)).toBe("oauth");
+    expect(computeAuthLabel("not_required", 1)).toBe("token");
+    expect(computeAuthLabel("not_required", 0)).toBe("none");
+    expect(computeAuthLabel("needs_auth", 0)).toBe("needs_auth");
+    expect(shouldShowAuthBanner("authorized")).toBe(false);
+    expect(shouldShowAuthBanner("not_required")).toBe(false);
+    expect(shouldShowAuthBanner("needs_auth")).toBe(true);
+  });
+
+  it("terminates auth polling for final states, popup close, and timeout", () => {
+    expect(authPollTermination("authorized", true, 1)).toBe("authorized");
+    expect(authPollTermination("error", false, 1)).toBe("error");
+    expect(authPollTermination("pending_auth", true, 1)).toBe("popup_closed");
+    expect(
+      authPollTermination("pending_auth", false, AUTH_POLL_MAX_ATTEMPTS),
+    ).toBe("timeout");
+    expect(authPollTermination("pending_auth", false, 1)).toBeNull();
+  });
+
+  it("resolves missing lucide exports to a stable fallback", () => {
+    const ExampleIcon = () => null;
+    expect(resolveLucideIcon("example-icon", { ExampleIcon })).toBe(ExampleIcon);
+    expect(resolveLucideIcon("missing-icon", {})).toBe(Plug);
+  });
 });
 
 vi.mock("@tanstack/react-router", () => ({
@@ -188,6 +238,7 @@ beforeEach(() => {
 describe("McpServersPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useUIStore.setState({ toasts: [] });
     setMutationDefaults();
 
     // Catalog and health queries are always idle in these unit tests.
@@ -250,5 +301,55 @@ describe("McpServersPage", () => {
     expect(
       screen.getByRole("button", { name: "mcp.reload" }),
     ).toBeInTheDocument();
+  });
+
+  it("stops OAuth polling when the authorization popup closes", async () => {
+    vi.useFakeTimers();
+    const popup = {
+      closed: false,
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    } as unknown as Window;
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup);
+    const startAuth = vi.fn().mockResolvedValue({ auth_url: "https://idp.test" });
+    useStartMcpAuthMock.mockReturnValue({
+      mutateAsync: startAuth,
+      isPending: false,
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const fetchQuery = vi.spyOn(queryClient, "fetchQuery");
+    fetchQuery.mockResolvedValue({ auth: { state: "pending_auth" } } as never);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthBadge
+          server={makeServer({ auth_state: { state: "needs_auth" } })}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "mcp.auth_authorize" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(startAuth).toHaveBeenCalledWith("test-server-1");
+
+    Object.defineProperty(popup, "closed", { value: true, configurable: true });
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchQuery).toHaveBeenCalledTimes(1);
+    expect(useUIStore.getState().toasts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: "mcp.auth_failed", type: "error" }),
+      ]),
+    );
+    openSpy.mockRestore();
+    vi.useRealTimers();
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -39,23 +39,38 @@ import { TaintPolicyEditor } from "../components/TaintPolicyEditor";
 // Lazy-load individual lucide icons by name — avoids pulling the full
 // ~1500-icon registry that `lucide-react/dynamic` bundles.
 type IconName = string;
-const lazyIconCache = new Map<string, React.LazyExoticComponent<React.ComponentType<{ className?: string }>>>();
+type IconComponent = React.ComponentType<{ className?: string }>;
+const lazyIconCache = new Map<string, React.LazyExoticComponent<IconComponent>>();
+
+export function resolveLucideIcon(
+  name: string,
+  iconModule: Record<string, unknown>,
+): IconComponent {
+  const pascal = name
+    .split("-")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join("");
+  return (iconModule[pascal] as IconComponent | undefined) ?? Plug;
+}
+
 function getLazyIcon(name: string) {
   if (!lazyIconCache.has(name)) {
     lazyIconCache.set(
       name,
-      lazy(() =>
-        import("lucide-react").then((mod) => {
-          // Convert kebab-case icon name to PascalCase component name
-          const pascal = name
-            .split("-")
-            .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-            .join("");
-          const Component = (mod as Record<string, unknown>)[pascal] as React.ComponentType<{ className?: string }> | undefined;
-          if (!Component) throw new Error(`lucide icon not found: ${pascal}`);
-          return { default: Component };
-        }),
-      ),
+      lazy(async () => {
+        try {
+          const iconModule = await import("lucide-react");
+          return {
+            default: resolveLucideIcon(
+              name,
+              iconModule as unknown as Record<string, unknown>,
+            ),
+          };
+        } catch (error) {
+          console.warn("CatalogIcon: lucide module failed to load.", error);
+          return { default: Plug };
+        }
+      }),
     );
   }
   return lazyIconCache.get(name)!;
@@ -139,12 +154,48 @@ const defaultForm: ServerFormState = {
 
 // Prefer the backend-assigned id, fall back to the user-facing name.
 // Every URL operation (update / delete / auth / reconnect) should use this.
-function serverIdOf(server: McpServerConfigured): string {
-  return server.id ?? server.name;
+export function serverIdOf(server: McpServerConfigured): string {
+  return server.id || server.name;
 }
 
-function serverIdentityOf(server: Pick<McpServerConfigured, "id" | "name"> | Pick<McpServerConnected, "name">): string {
-  return "id" in server && server.id ? server.id : server.name;
+export function serverIdentityOf(server: Pick<McpServerConfigured, "id" | "name"> | Pick<McpServerConnected, "name">): string {
+  return "id" in server ? server.id || server.name : server.name;
+}
+
+const AUTH_POLL_INTERVAL_MS = 2000;
+export const AUTH_POLL_MAX_ATTEMPTS = 150;
+
+export type AuthPollTermination =
+  | "authorized"
+  | "error"
+  | "popup_closed"
+  | "timeout"
+  | null;
+
+export function authPollTermination(
+  authState: string | undefined,
+  popupClosed: boolean,
+  attempts: number,
+): AuthPollTermination {
+  if (authState === "authorized") return "authorized";
+  if (authState === "error") return "error";
+  if (popupClosed) return "popup_closed";
+  if (attempts >= AUTH_POLL_MAX_ATTEMPTS) return "timeout";
+  return null;
+}
+
+export function computeAuthLabel(authState: string, envCount: number): string {
+  if (authState === "authorized") return "oauth";
+  if (authState === "not_required") return envCount > 0 ? "token" : "none";
+  return authState;
+}
+
+export function shouldShowAuthBanner(authState: string | undefined): boolean {
+  return (
+    authState !== undefined &&
+    authState !== "authorized" &&
+    authState !== "not_required"
+  );
 }
 
 function formToPayload(form: ServerFormState): McpServerConfigured {
@@ -354,7 +405,7 @@ function TransportIcon({ type }: { type: TransportType }) {
 
 // ── Auth Badge ──────────────────────────────────────────────────────
 
-function AuthBadge({
+export function AuthBadge({
   server,
   onAuthSuccess,
 }: {
@@ -367,33 +418,71 @@ function AuthBadge({
   const authState = server.auth_state?.state ?? "not_required";
   const [polling, setPolling] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const authWindowRef = useRef<Window | null>(null);
+  const pollAttemptsRef = useRef(0);
+  const pollInFlightRef = useRef(false);
   const startAuthMutation = useStartMcpAuth();
   const revokeAuthMutation = useRevokeMcpAuth();
   const serverIdentity = serverIdentityOf(server);
 
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) clearInterval(pollRef.current);
+    pollRef.current = null;
+    pollInFlightRef.current = false;
+    setPolling(false);
+  }, []);
+
   useEffect(() => {
     if (polling) {
       pollRef.current = setInterval(async () => {
+        const popupClosed = authWindowRef.current?.closed === true;
+        if (pollInFlightRef.current) return;
+        pollInFlightRef.current = true;
+        pollAttemptsRef.current += 1;
         try {
           const status = await queryClient.fetchQuery(mcpQueries.authStatus(serverIdentity));
-          if (status.auth.state === "authorized") {
-            setPolling(false);
+          const termination = authPollTermination(
+            status.auth.state,
+            popupClosed,
+            pollAttemptsRef.current,
+          );
+          if (termination === "authorized") {
+            stopPolling();
             queryClient.invalidateQueries({ queryKey: mcpQueries.servers().queryKey });
             queryClient.invalidateQueries({ queryKey: mcpQueries.health().queryKey });
             onAuthSuccess?.();
-          } else if (status.auth.state === "error") {
-            setPolling(false);
+          } else if (termination === "error") {
+            stopPolling();
             addToast(status.auth.message || t("mcp.auth_failed"), "error");
+          } else if (termination === "popup_closed") {
+            authWindowRef.current = null;
+            stopPolling();
+            addToast(t("mcp.auth_failed"), "error");
+          } else if (termination === "timeout") {
+            stopPolling();
+            addToast(`${t("mcp.auth_failed")}: ${t("runtime.timeout")}`, "error");
           }
         } catch {
           // ignore transient errors during polling
+          if (popupClosed) {
+            authWindowRef.current = null;
+            stopPolling();
+            addToast(t("mcp.auth_failed"), "error");
+          } else if (pollAttemptsRef.current >= AUTH_POLL_MAX_ATTEMPTS) {
+            stopPolling();
+            addToast(`${t("mcp.auth_failed")}: ${t("runtime.timeout")}`, "error");
+          }
+        } finally {
+          pollInFlightRef.current = false;
         }
-      }, 2000);
+      }, AUTH_POLL_INTERVAL_MS);
     }
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
+      pollRef.current = null;
+      pollInFlightRef.current = false;
     };
-  }, [authState, polling, serverIdentity, onAuthSuccess, addToast, queryClient, t]);
+  }, [polling, serverIdentity, onAuthSuccess, addToast, queryClient, stopPolling, t]);
 
   const handleStartAuth = useCallback(async () => {
     // We deliberately do NOT pass `noopener` here.  Per the HTML spec
@@ -411,6 +500,8 @@ function AuthBadge({
     // a credential issue here — the OAuth provider already learns
     // the dashboard origin from `redirect_uri`.
     const authWindow = window.open("about:blank", "_blank");
+    authWindowRef.current = authWindow;
+    pollAttemptsRef.current = 0;
     try {
       const result = await startAuthMutation.mutateAsync(serverIdentity);
       if (authWindow && !authWindow.closed) {
@@ -429,6 +520,7 @@ function AuthBadge({
       if (authWindow && !authWindow.closed) {
         authWindow.close();
       }
+      authWindowRef.current = null;
       addToast(errorMessage(e, t("mcp.auth_start_failed")), "error");
     }
   }, [serverIdentity, startAuthMutation, addToast, t]);
@@ -525,14 +617,7 @@ function ServerCard({
   const transportType = useMemo(() => getTransportType(server), [server]);
   const transportDetail = useMemo(() => getTransportDetail(server), [server]);
   const authState = server.auth_state?.state ?? "not_required";
-  const authLabel =
-    authState === "authorized"
-      ? "oauth"
-      : authState === "not_required"
-        ? (server.env ?? []).length > 0
-          ? "token"
-          : "none"
-        : authState;
+  const authLabel = computeAuthLabel(authState, (server.env ?? []).length);
 
   return (
     <Card
@@ -799,8 +884,8 @@ function ServerDetailBody({
 
         {tab === "config" && (
           <div className="flex flex-col gap-4">
-            {/* OAuth banner if non-ok */}
-            {server.auth_state && server.auth_state.state !== "ok" && server.auth_state.state !== "not_required" && (
+            {/* OAuth banner if authorization needs attention. */}
+            {server.auth_state && shouldShowAuthBanner(server.auth_state.state) && (
               <div className="rounded-lg border border-warning/30 bg-warning/5 p-3 text-[12px] text-warning">
                 <p className="font-bold mb-1">{server.auth_state.state}</p>
                 {server.auth_state.message && (


### PR DESCRIPTION
## Changes

- recognize the backend-authorized state in the config attention banner
- retain the OAuth popup handle and stop polling on authorization, error, popup closure, or 150 attempts
- perform the final status fetch before treating a closed popup as failure so successful self-closing callbacks still win
- prevent overlapping auth-status requests and surface polling timeout feedback
- resolve missing or failed lazy lucide icons to a stable Plug fallback instead of caching a rejected React.lazy
- share one empty-id fallback contract and extract explicit auth-label branches
- add helper and component regressions for auth states, polling termination, popup closure, icon fallback, and server identity

Audit findings:
- F-7a8e33e6fc562c7d
- F-0a7722441adacd0a
- F-de7041b9e0d1e4ae
- F-20ad7a5c1b82a3c9
- F-daf700b9962dfece

## Verification

- `mise exec -- pnpm exec vitest run src/pages/McpServersPage.test.tsx` (9 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (101 files, 1,080 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- MCP OAuth endpoints, PKCE behavior, and server auth-state contracts remain unchanged
- catalog icon names remain backend-provided and unknown names intentionally render the fallback
- existing Polish and Ukrainian locale parity drift remains for a separate change