### PR TITLE
fix(dashboard): validate media render inputs

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -3120,7 +3120,8 @@
     "status_submitted": "submitted",
     "status_completed": "completed",
     "status_failed": "failed",
-    "image_too_large": "Image too large to display"
+    "image_too_large": "Image too large to display",
+    "image_unavailable": "Image unavailable"
   },
   "auth": {
     "title": "API Key Required",

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -3119,7 +3119,8 @@
     "status_submitted": "submitted",
     "status_completed": "completed",
     "status_failed": "failed",
-    "image_too_large": "Image too large to display"
+    "image_too_large": "Image too large to display",
+    "image_unavailable": "Image unavailable"
   },
   "auth": {
     "title": "API Key Required",

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -3119,7 +3119,8 @@
     "status_submitted": "제출됨",
     "status_completed": "완료됨",
     "status_failed": "실패",
-    "image_too_large": "이미지가 너무 커서 표시할 수 없습니다."
+    "image_too_large": "이미지가 너무 커서 표시할 수 없습니다.",
+    "image_unavailable": "이미지를 사용할 수 없습니다."
   },
   "auth": {
     "title": "API 키 필요",

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -3120,7 +3120,8 @@
     "status_submitted": "제출됨",
     "status_completed": "완료됨",
     "status_failed": "실패",
-    "image_too_large": "이미지가 너무 커서 표시할 수 없습니다."
+    "image_too_large": "이미지가 너무 커서 표시할 수 없습니다.",
+    "image_unavailable": "이미지를 사용할 수 없습니다."
   },
   "auth": {
     "title": "API 키 필요",

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -3121,7 +3121,8 @@
     "status_submitted": "zgłoszone",
     "status_completed": "ukończone",
     "status_failed": "nieudane",
-    "image_too_large": "Obraz jest zbyt duży, aby go wyświetlić"
+    "image_too_large": "Obraz jest zbyt duży, aby go wyświetlić",
+    "image_unavailable": "Obraz jest niedostępny"
   },
   "auth": {
     "title": "Wymagany klucz API",

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -3122,7 +3122,8 @@
     "status_submitted": "zgłoszone",
     "status_completed": "ukończone",
     "status_failed": "nieudane",
-    "image_too_large": "Obraz jest zbyt duży, aby go wyświetlić"
+    "image_too_large": "Obraz jest zbyt duży, aby go wyświetlić",
+    "image_unavailable": "Obraz jest niedostępny"
   },
   "auth": {
     "title": "Wymagany klucz API",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -3122,7 +3122,8 @@
     "status_submitted": "надіслано",
     "status_completed": "завершено",
     "status_failed": "помилка",
-    "image_too_large": "Зображення завелике для показу"
+    "image_too_large": "Зображення завелике для показу",
+    "image_unavailable": "Зображення недоступне"
   },
   "auth": {
     "title": "Потрібен API-ключ",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -3121,7 +3121,8 @@
     "status_submitted": "надіслано",
     "status_completed": "завершено",
     "status_failed": "помилка",
-    "image_too_large": "Зображення завелике для показу"
+    "image_too_large": "Зображення завелике для показу",
+    "image_unavailable": "Зображення недоступне"
   },
   "auth": {
     "title": "Потрібен API-ключ",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -3085,7 +3085,8 @@
     "status_submitted": "已提交",
     "status_completed": "已完成",
     "status_failed": "失败",
-    "image_too_large": "图片过大，无法显示"
+    "image_too_large": "图片过大，无法显示",
+    "image_unavailable": "图片不可用"
   },
   "auth": {
     "title": "需要 API Key",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -3086,7 +3086,8 @@
     "status_submitted": "已提交",
     "status_completed": "已完成",
     "status_failed": "失败",
-    "image_too_large": "图片过大，无法显示"
+    "image_too_large": "图片过大，无法显示",
+    "image_unavailable": "图片不可用"
   },
   "auth": {
     "title": "需要 API Key",

--- a/crates/librefang-api/dashboard/src/pages/MediaPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MediaPage.test.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaPage, normalizeSpeechSpeed } from "./MediaPage";
+import { useMediaProviders, useVideoTask } from "../lib/queries/media";
+import {
+  useGenerateImage,
+  useGenerateMusic,
+  useSubmitVideo,
+  useSynthesizeSpeech,
+} from "../lib/mutations/media";
+import { useUIStore } from "../lib/store";
+
+vi.mock("../lib/queries/media", () => ({
+  useMediaProviders: vi.fn(),
+  useVideoTask: vi.fn(),
+}));
+
+vi.mock("../lib/mutations/media", () => ({
+  useGenerateImage: vi.fn(),
+  useGenerateMusic: vi.fn(),
+  useSubmitVideo: vi.fn(),
+  useSynthesizeSpeech: vi.fn(),
+}));
+
+vi.mock("../lib/store", () => ({
+  useUIStore: vi.fn(),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) =>
+        String(options?.defaultValue ?? key),
+    }),
+  };
+});
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+const mock = <T,>(fn: T) => fn as unknown as ReturnType<typeof vi.fn>;
+const useMediaProvidersMock = mock(useMediaProviders);
+const useVideoTaskMock = mock(useVideoTask);
+const useGenerateImageMock = mock(useGenerateImage);
+const useGenerateMusicMock = mock(useGenerateMusic);
+const useSubmitVideoMock = mock(useSubmitVideo);
+const useSynthesizeSpeechMock = mock(useSynthesizeSpeech);
+const useUIStoreMock = mock(useUIStore);
+
+const imageMutate = vi.fn();
+const speechMutate = vi.fn();
+const addToast = vi.fn();
+
+function mutation(mutate = vi.fn()) {
+  return { mutate, isPending: false };
+}
+
+function finishImageGeneration(images: { data_base64: string; url?: string }[]) {
+  const options = imageMutate.mock.calls[0][1];
+  act(() => {
+    options.onSuccess({
+      images,
+      model: "image-model",
+      provider: "image-provider",
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useMediaProvidersMock.mockReturnValue({
+    data: [
+      {
+        name: "configured-provider",
+        configured: true,
+        capabilities: [
+          "image_generation",
+          "text_to_speech",
+          "video_generation",
+          "music_generation",
+        ],
+      },
+    ],
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useVideoTaskMock.mockReturnValue({
+    data: undefined,
+    error: null,
+    isError: false,
+  });
+  useGenerateImageMock.mockReturnValue(mutation(imageMutate));
+  useSynthesizeSpeechMock.mockReturnValue(mutation(speechMutate));
+  useSubmitVideoMock.mockReturnValue(mutation());
+  useGenerateMusicMock.mockReturnValue(mutation());
+  useUIStoreMock.mockImplementation((selector: (state: { addToast: typeof addToast }) => unknown) =>
+    selector({ addToast }),
+  );
+});
+
+describe("MediaPage image results", () => {
+  it("uses a sanitized URL for both the image and its link", () => {
+    render(<MediaPage />);
+    fireEvent.change(screen.getByPlaceholderText("media.image_prompt_placeholder"), {
+      target: { value: "a sunrise" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "media.generate" }));
+    finishImageGeneration([{ data_base64: "", url: "https://example.com/image.png" }]);
+
+    const image = screen.getByRole("img", { name: "generated {{index}}" });
+    expect(image).toHaveAttribute("src", "https://example.com/image.png");
+    expect(image.closest("a")).toHaveAttribute("href", "https://example.com/image.png");
+  });
+
+  it("never assigns an unsafe result URL to an image or link", () => {
+    render(<MediaPage />);
+    fireEvent.change(screen.getByPlaceholderText("media.image_prompt_placeholder"), {
+      target: { value: "a sunrise" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "media.generate" }));
+    finishImageGeneration([{ data_base64: "", url: "javascript:alert(1)" }]);
+
+    expect(screen.queryByRole("img", { name: "generated {{index}}" })).not.toBeInTheDocument();
+    expect(document.querySelector('[href="javascript:alert(1)"]')).not.toBeInTheDocument();
+    expect(screen.getByText("Image unavailable")).toBeInTheDocument();
+  });
+
+  it("renders an explicit unavailable state for an empty image payload", () => {
+    render(<MediaPage />);
+    fireEvent.change(screen.getByPlaceholderText("media.image_prompt_placeholder"), {
+      target: { value: "a sunrise" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "media.generate" }));
+    finishImageGeneration([{ data_base64: "" }]);
+
+    expect(screen.getByText("Image unavailable")).toBeInTheDocument();
+    expect(document.querySelector('img[src="data:image/png;base64,"]')).not.toBeInTheDocument();
+  });
+
+  it("does not construct a data URL for an oversized image payload", () => {
+    render(<MediaPage />);
+    fireEvent.change(screen.getByPlaceholderText("media.image_prompt_placeholder"), {
+      target: { value: "a sunrise" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "media.generate" }));
+    finishImageGeneration([{ data_base64: "a".repeat(2 * 1024 * 1024 + 1) }]);
+
+    expect(screen.getByText("Image too large to display")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "generated {{index}}" })).not.toBeInTheDocument();
+  });
+});
+
+describe("MediaPage speech speed", () => {
+  it("normalizes finite values into the API range and omits non-finite values", () => {
+    expect(normalizeSpeechSpeed(0)).toBe(0.25);
+    expect(normalizeSpeechSpeed(2.5)).toBe(2.5);
+    expect(normalizeSpeechSpeed(9)).toBe(4);
+    expect(normalizeSpeechSpeed(Number.NaN)).toBeUndefined();
+    expect(normalizeSpeechSpeed(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("submits the normalized speed", () => {
+    const { container } = render(<MediaPage />);
+    fireEvent.click(screen.getByRole("tab", { name: "media.tab_speech" }));
+    fireEvent.change(screen.getByPlaceholderText("media.speech_text_placeholder"), {
+      target: { value: "hello" },
+    });
+    const speedInput = container.querySelector('input[type="number"]');
+    expect(speedInput).not.toBeNull();
+    fireEvent.change(speedInput!, { target: { value: "10" } });
+    fireEvent.submit(screen.getByRole("button", { name: "media.synthesize" }).closest("form")!);
+
+    expect(speechMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ speed: 4 }),
+      expect.any(Object),
+    );
+  });
+});
+
+describe("MediaPage video errors", () => {
+  it("does not cross-suppress query and provider-status errors with the same text", () => {
+    useVideoTaskMock.mockReturnValue({
+      data: { status: "failed", error: "generation failed" },
+      error: new Error("generation failed"),
+      isError: true,
+    });
+    render(<MediaPage />);
+    fireEvent.click(screen.getByRole("tab", { name: "media.tab_video" }));
+
+    expect(addToast).toHaveBeenCalledTimes(2);
+    expect(addToast).toHaveBeenNthCalledWith(1, "generation failed", "error");
+    expect(addToast).toHaveBeenNthCalledWith(2, "generation failed", "error");
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
@@ -60,6 +60,11 @@ const textareaClass =
 
 const MAX_BASE64_LENGTH = 2 * 1024 * 1024;
 
+export function normalizeSpeechSpeed(speed: number): number | undefined {
+  if (!Number.isFinite(speed)) return undefined;
+  return Math.min(Math.max(speed, 0.25), 4);
+}
+
 export function MediaPage() {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
@@ -345,40 +350,74 @@ function ImagePanel({
             <p className="text-xs text-text-dim mb-3 italic">{t("media.revised_prompt")}: {result.revised_prompt}</p>
           )}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {result.images.map((img, i) => {
-              const imageSrc = img.url && (isAuthenticatedImagePath(img.url) ? img.url : safeUrl(img.url));
-              if (imageSrc) {
-                return (
-                  <AuthenticatedImage
-                    key={i}
-                    src={imageSrc}
-                    alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })}
-                    className="w-full h-auto"
-                    linkProps={{
-                      target: "_blank",
-                      rel: "noopener noreferrer",
-                      className: "block rounded-xl overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors",
-                    }}
-                  />
-                );
-              }
-              return (
-                <div key={i} className="block rounded-xl overflow-hidden border border-border-subtle">
-                  {img.data_base64 && img.data_base64.length > MAX_BASE64_LENGTH ? (
-                  <div className="flex items-center gap-2 p-3 text-xs text-warning">
-                    <AlertCircle className="w-4 h-4 shrink-0" />
-                    <span>{t("media.image_too_large", { defaultValue: "Image too large to display" })}</span>
-                  </div>
-                  ) : (
-                    <img src={`data:image/png;base64,${img.data_base64}`} alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })} className="w-full h-auto" />
-                  )}
-                </div>
-              );
-            })}
+            {result.images.map((img, i) => (
+              <GeneratedImage
+                key={i}
+                url={img.url}
+                dataBase64={img.data_base64}
+                alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })}
+              />
+            ))}
           </div>
         </ResultBlock>
       )}
     </form>
+  );
+}
+
+function GeneratedImage({
+  url,
+  dataBase64,
+  alt,
+}: {
+  url?: string;
+  dataBase64?: string;
+  alt: string;
+}) {
+  const { t } = useTranslation();
+  // Authenticated API paths are fetched with credentials by AuthenticatedImage; everything else must survive URL sanitization first.
+  const imageSrc = url ? (isAuthenticatedImagePath(url) ? url : safeUrl(url)) : null;
+  const base64 = dataBase64?.trim();
+  const containerClass =
+    "block rounded-xl overflow-hidden border border-border-subtle";
+
+  if (imageSrc) {
+    return (
+      <AuthenticatedImage
+        src={imageSrc}
+        alt={alt}
+        className="w-full h-auto"
+        linkProps={{
+          target: "_blank",
+          rel: "noopener noreferrer",
+          className: `${containerClass} hover:border-brand/40 transition-colors`,
+        }}
+      />
+    );
+  }
+
+  if (!base64) {
+    return (
+      <div className={`${containerClass} flex items-center gap-2 p-3 text-xs text-text-dim`}>
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span>{t("media.image_unavailable", { defaultValue: "Image unavailable" })}</span>
+      </div>
+    );
+  }
+
+  if (base64.length > MAX_BASE64_LENGTH) {
+    return (
+      <div className={`${containerClass} flex items-center gap-2 p-3 text-xs text-warning`}>
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span>{t("media.image_too_large", { defaultValue: "Image too large to display" })}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={containerClass}>
+      <img src={`data:image/png;base64,${base64}`} alt={alt} className="w-full h-auto" />
+    </div>
   );
 }
 
@@ -414,7 +453,7 @@ function SpeechPanel({
             model: model || undefined,
             voice: voice || undefined,
             format: format || undefined,
-            speed: speed ?? undefined,
+            speed: normalizeSpeechSpeed(speed),
           },
           {
             onSuccess: (data) => {
@@ -509,7 +548,8 @@ function VideoPanel({
   const [taskId, setTaskId] = useState<string | null>(null);
   const [taskProvider, setTaskProvider] = useState<string | null>(null);
   const completionToastShown = useRef<string | null>(null);
-  const errorToastShown = useRef<string | null>(null);
+  const queryErrorToastShown = useRef<string | null>(null);
+  const statusErrorToastShown = useRef<string | null>(null);
 
   const submit = useSubmitVideo();
   const videoTaskQuery = useVideoTask(
@@ -527,8 +567,8 @@ function VideoPanel({
   useEffect(() => {
     if (!videoTaskQuery.isError) return;
     const message = videoTaskQuery.error instanceof Error ? videoTaskQuery.error.message : t("common.error");
-    if (errorToastShown.current === message) return;
-    errorToastShown.current = message;
+    if (queryErrorToastShown.current === message) return;
+    queryErrorToastShown.current = message;
     onToast(message, "error");
   }, [videoTaskQuery.error, videoTaskQuery.isError, onToast, t]);
 
@@ -541,8 +581,8 @@ function VideoPanel({
       return;
     }
     if (statusError) {
-      if (errorToastShown.current === statusError) return;
-      errorToastShown.current = statusError;
+      if (statusErrorToastShown.current === statusError) return;
+      statusErrorToastShown.current = statusError;
       onToast(statusError, "error");
     }
   }, [onToast, statusError, statusState, t, taskId]);
@@ -570,7 +610,8 @@ function VideoPanel({
               setTaskId(data.task_id);
               setTaskProvider(data.provider);
               completionToastShown.current = null;
-              errorToastShown.current = null;
+              queryErrorToastShown.current = null;
+              statusErrorToastShown.current = null;
               onToast(t("media.video_submitted"), "success");
             },
             onError: (err: unknown) => onToast((err instanceof Error ? err.message : String(err)) || t("common.error"), "error"),

--- a/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
@@ -58,6 +58,11 @@ const textareaClass =
 
 const MAX_BASE64_LENGTH = 2 * 1024 * 1024;
 
+export function normalizeSpeechSpeed(speed: number): number | undefined {
+  if (!Number.isFinite(speed)) return undefined;
+  return Math.min(Math.max(speed, 0.25), 4);
+}
+
 export function MediaPage() {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
@@ -344,29 +349,70 @@ function ImagePanel({
           )}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {result.images.map((img, i) => (
-              <a
+              <GeneratedImage
                 key={i}
-                href={safeUrl(img.url) || undefined}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-xl overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors"
-              >
-                {img.url ? (
-                  <img src={img.url} alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })} className="w-full h-auto" />
-                ) : img.data_base64 && img.data_base64.length > MAX_BASE64_LENGTH ? (
-                  <div className="flex items-center gap-2 p-3 text-xs text-warning">
-                    <AlertCircle className="w-4 h-4 shrink-0" />
-                    <span>{t("media.image_too_large", { defaultValue: "Image too large to display" })}</span>
-                  </div>
-                ) : (
-                  <img src={`data:image/png;base64,${img.data_base64}`} alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })} className="w-full h-auto" />
-                )}
-              </a>
+                url={img.url}
+                dataBase64={img.data_base64}
+                alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })}
+              />
             ))}
           </div>
         </ResultBlock>
       )}
     </form>
+  );
+}
+
+function GeneratedImage({
+  url,
+  dataBase64,
+  alt,
+}: {
+  url?: string;
+  dataBase64?: string;
+  alt: string;
+}) {
+  const { t } = useTranslation();
+  const sanitizedUrl = safeUrl(url);
+  const base64 = dataBase64?.trim();
+  const containerClass =
+    "block rounded-xl overflow-hidden border border-border-subtle";
+
+  if (sanitizedUrl) {
+    return (
+      <a
+        href={sanitizedUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${containerClass} hover:border-brand/40 transition-colors`}
+      >
+        <img src={sanitizedUrl} alt={alt} className="w-full h-auto" />
+      </a>
+    );
+  }
+
+  if (!base64) {
+    return (
+      <div className={`${containerClass} flex items-center gap-2 p-3 text-xs text-text-dim`}>
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span>{t("media.image_unavailable", { defaultValue: "Image unavailable" })}</span>
+      </div>
+    );
+  }
+
+  if (base64.length > MAX_BASE64_LENGTH) {
+    return (
+      <div className={`${containerClass} flex items-center gap-2 p-3 text-xs text-warning`}>
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span>{t("media.image_too_large", { defaultValue: "Image too large to display" })}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={containerClass}>
+      <img src={`data:image/png;base64,${base64}`} alt={alt} className="w-full h-auto" />
+    </div>
   );
 }
 
@@ -402,7 +448,7 @@ function SpeechPanel({
             model: model || undefined,
             voice: voice || undefined,
             format: format || undefined,
-            speed: speed ?? undefined,
+            speed: normalizeSpeechSpeed(speed),
           },
           {
             onSuccess: (data) => {
@@ -497,7 +543,8 @@ function VideoPanel({
   const [taskId, setTaskId] = useState<string | null>(null);
   const [taskProvider, setTaskProvider] = useState<string | null>(null);
   const completionToastShown = useRef<string | null>(null);
-  const errorToastShown = useRef<string | null>(null);
+  const queryErrorToastShown = useRef<string | null>(null);
+  const statusErrorToastShown = useRef<string | null>(null);
 
   const submit = useSubmitVideo();
   const videoTaskQuery = useVideoTask(
@@ -516,8 +563,8 @@ function VideoPanel({
   useEffect(() => {
     if (!videoTaskQuery.isError) return;
     const message = videoTaskQuery.error instanceof Error ? videoTaskQuery.error.message : t("common.error");
-    if (errorToastShown.current === message) return;
-    errorToastShown.current = message;
+    if (queryErrorToastShown.current === message) return;
+    queryErrorToastShown.current = message;
     onToast(message, "error");
   }, [videoTaskQuery.error, videoTaskQuery.isError, onToast, t]);
 
@@ -530,8 +577,8 @@ function VideoPanel({
       return;
     }
     if (statusError) {
-      if (errorToastShown.current === statusError) return;
-      errorToastShown.current = statusError;
+      if (statusErrorToastShown.current === statusError) return;
+      statusErrorToastShown.current = statusError;
       onToast(statusError, "error");
     }
   }, [onToast, statusError, statusState, t, taskId]);
@@ -559,7 +606,8 @@ function VideoPanel({
               setTaskId(data.task_id);
               setTaskProvider(data.provider);
               completionToastShown.current = null;
-              errorToastShown.current = null;
+              queryErrorToastShown.current = null;
+              statusErrorToastShown.current = null;
               onToast(t("media.video_submitted"), "success");
             },
             onError: (err: unknown) => onToast((err instanceof Error ? err.message : String(err)) || t("common.error"), "error"),


### PR DESCRIPTION
## Changes

- sanitize generated image URLs once and reuse the validated value for both image sources and download links
- replace the nested image-result branches with explicit URL, unavailable, oversized, and base64 states
- add localized unavailable-image feedback across all maintained dashboard locales
- normalize speech speed to the supported 0.25–4 range and omit non-finite values
- isolate video query-error and provider-status toast deduplication so one source cannot suppress the other
- add MediaPage regressions for safe image rendering, empty and oversized payloads, speed normalization, and independent video errors

Audit findings:
- F-b11912057fa99163
- F-814cf949afa2529e
- F-f4d6799dde674803
- F-8a34b0ba35cf4893
- F-ed6cb175d08bd1c9

## Verification

- `mise exec -- pnpm exec vitest run src/pages/MediaPage.test.tsx` (7 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (102 files, 1,082 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- speech, image, and video backend contracts remain unchanged
- audio and video media-player URL policy is unchanged
- existing Polish and Ukrainian locale parity drift remains for a separate change