### PR TITLE
fix(dashboard): harden security settings

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2025,6 +2025,8 @@
     "totp_recovery_title": "Recovery Codes (save these somewhere safe):",
     "totp_recovery_reveal": "Reveal codes",
     "totp_recovery_hide": "Hide codes",
+    "totp_secret_reveal": "Reveal secret",
+    "totp_secret_hide": "Hide secret",
     "totp_reset_placeholder": "Current TOTP or recovery code",
     "totp_verify_reset": "Verify & Reset",
     "totp_revoke_placeholder": "TOTP or recovery code",
@@ -2093,6 +2095,7 @@
     "export_config_btn": "Export Config",
     "export_config_desc": "Download your current configuration as a TOML file.",
     "export_config_title": "Export Configuration",
+    "export_config_failed": "Could not export config.",
     "totp_qr_alt": "TOTP QR Code"
   },
   "config": {

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -2025,6 +2025,8 @@
     "totp_recovery_title": "복구 코드(안전한 곳에 저장하세요):",
     "totp_recovery_reveal": "코드 공개",
     "totp_recovery_hide": "코드 숨기기",
+    "totp_secret_reveal": "비밀 키 공개",
+    "totp_secret_hide": "비밀 키 숨기기",
     "totp_reset_placeholder": "현재 TOTP 또는 복구 코드",
     "totp_verify_reset": "확인 및 재설정",
     "totp_revoke_placeholder": "TOTP 또는 복구 코드",
@@ -2093,6 +2095,7 @@
     "export_config_btn": "구성 내보내기",
     "export_config_desc": "현재 구성을 TOML 파일로 다운로드합니다.",
     "export_config_title": "구성 내보내기",
+    "export_config_failed": "구성을 내보낼 수 없습니다.",
     "totp_qr_alt": "TOTP QR 코드"
   },
   "config": {

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -2027,6 +2027,8 @@
     "totp_recovery_title": "Kody odzyskiwania (zapisz je w bezpiecznym miejscu):",
     "totp_recovery_reveal": "Pokaż kody",
     "totp_recovery_hide": "Ukryj kody",
+    "totp_secret_reveal": "Pokaż sekret",
+    "totp_secret_hide": "Ukryj sekret",
     "totp_reset_placeholder": "Bieżący kod TOTP lub kod odzyskiwania",
     "totp_verify_reset": "Zweryfikuj i zresetuj",
     "totp_revoke_placeholder": "Kod TOTP lub kod odzyskiwania",
@@ -2095,6 +2097,7 @@
     "export_config_btn": "Eksportuj konfigurację",
     "export_config_desc": "Pobierz bieżącą konfigurację jako plik TOML.",
     "export_config_title": "Eksportuj konfigurację",
+    "export_config_failed": "Nie udało się wyeksportować konfiguracji.",
     "totp_qr_alt": "Kod QR TOTP"
   },
   "config": {

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -2027,6 +2027,8 @@
     "totp_recovery_title": "Коди відновлення (збережіть їх у безпечному місці):",
     "totp_recovery_reveal": "Показати коди",
     "totp_recovery_hide": "Приховати коди",
+    "totp_secret_reveal": "Показати секрет",
+    "totp_secret_hide": "Приховати секрет",
     "totp_reset_placeholder": "Поточний TOTP або код відновлення",
     "totp_verify_reset": "Перевірити та скинути",
     "totp_revoke_placeholder": "TOTP або код відновлення",
@@ -2095,6 +2097,7 @@
     "export_config_btn": "Експортувати конфігурацію",
     "export_config_desc": "Завантажити поточну конфігурацію як TOML-файл.",
     "export_config_title": "Експортувати конфігурацію",
+    "export_config_failed": "Не вдалося експортувати конфігурацію.",
     "totp_qr_alt": "QR-код TOTP"
   },
   "config": {

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1991,6 +1991,8 @@
     "totp_recovery_title": "恢复码（请保存到安全的地方）：",
     "totp_recovery_reveal": "显示恢复码",
     "totp_recovery_hide": "隐藏恢复码",
+    "totp_secret_reveal": "显示密钥",
+    "totp_secret_hide": "隐藏密钥",
     "totp_reset_placeholder": "当前 TOTP 或恢复码",
     "totp_verify_reset": "验证并重置",
     "totp_revoke_placeholder": "TOTP 或恢复码",
@@ -2059,6 +2061,7 @@
     "export_config_btn": "导出配置",
     "export_config_desc": "将当前配置下载为 TOML 文件。",
     "export_config_title": "导出配置",
+    "export_config_failed": "无法导出配置。",
     "totp_qr_alt": "TOTP 二维码"
   },
   "config": {

--- a/crates/librefang-api/dashboard/src/pages/SettingsPage.totp.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SettingsPage.totp.test.tsx
@@ -2,13 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { SettingsPage } from "./SettingsPage";
+import { SettingsPage, getTotpActionState } from "./SettingsPage";
 import { useTotpStatus } from "../lib/queries/approvals";
+import { usePasskeys } from "../lib/queries/passkeys";
 import {
   useTotpSetup,
   useTotpConfirm,
   useTotpRevoke,
 } from "../lib/mutations/approvals";
+import {
+  useRegisterPasskey,
+  useRevokePasskey,
+} from "../lib/mutations/passkeys";
+import { getRawConfigToml, isPasskeySupported } from "../api";
+import { ApiError } from "../lib/http/client";
 
 // Tests for #3853 — TOTP second-factor surface in SettingsPage. The
 // TotpSection lives inside SettingsPage and was completely uncovered.
@@ -24,6 +31,24 @@ vi.mock("../lib/mutations/approvals", () => ({
   useTotpConfirm: vi.fn(),
   useTotpRevoke: vi.fn(),
 }));
+
+vi.mock("../lib/queries/passkeys", () => ({
+  usePasskeys: vi.fn(),
+}));
+
+vi.mock("../lib/mutations/passkeys", () => ({
+  useRegisterPasskey: vi.fn(),
+  useRevokePasskey: vi.fn(),
+}));
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    getRawConfigToml: vi.fn(),
+    isPasskeySupported: vi.fn(),
+  };
+});
 
 vi.mock("react-i18next", async () => {
   const actual = await vi.importActual<typeof import("react-i18next")>(
@@ -42,6 +67,11 @@ const useTotpStatusMock = useTotpStatus as unknown as ReturnType<typeof vi.fn>;
 const useTotpSetupMock = useTotpSetup as unknown as ReturnType<typeof vi.fn>;
 const useTotpConfirmMock = useTotpConfirm as unknown as ReturnType<typeof vi.fn>;
 const useTotpRevokeMock = useTotpRevoke as unknown as ReturnType<typeof vi.fn>;
+const usePasskeysMock = usePasskeys as unknown as ReturnType<typeof vi.fn>;
+const useRegisterPasskeyMock = useRegisterPasskey as unknown as ReturnType<typeof vi.fn>;
+const useRevokePasskeyMock = useRevokePasskey as unknown as ReturnType<typeof vi.fn>;
+const getRawConfigTomlMock = getRawConfigToml as unknown as ReturnType<typeof vi.fn>;
+const isPasskeySupportedMock = isPasskeySupported as unknown as ReturnType<typeof vi.fn>;
 
 interface MutationStub {
   mutateAsync: ReturnType<typeof vi.fn>;
@@ -66,13 +96,23 @@ function renderPage(): void {
   );
 }
 
-describe("SettingsPage TOTP section (#3853)", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    useTotpSetupMock.mockReturnValue(makeMutation());
-    useTotpConfirmMock.mockReturnValue(makeMutation());
-    useTotpRevokeMock.mockReturnValue(makeMutation());
+beforeEach(() => {
+  vi.clearAllMocks();
+  useTotpSetupMock.mockReturnValue(makeMutation());
+  useTotpConfirmMock.mockReturnValue(makeMutation());
+  useTotpRevokeMock.mockReturnValue(makeMutation());
+  usePasskeysMock.mockReturnValue({
+    data: [],
+    isError: false,
+    error: null,
   });
+  useRegisterPasskeyMock.mockReturnValue(makeMutation());
+  useRevokePasskeyMock.mockReturnValue(makeMutation());
+  isPasskeySupportedMock.mockReturnValue(false);
+  getRawConfigTomlMock.mockResolvedValue("[kernel]\nlog_level = \"info\"\n");
+});
+
+describe("SettingsPage TOTP section (#3853)", () => {
 
   it("shows the 'Not enrolled' badge and a Set up TOTP button when not enrolled", () => {
     useTotpStatusMock.mockReturnValue({
@@ -175,6 +215,13 @@ describe("SettingsPage TOTP section (#3853)", () => {
       expect(screen.getByAltText("TOTP QR Code")).toBeInTheDocument();
     });
     expect(screen.getByText("ABCDEFGHIJKLMNOP")).toBeInTheDocument();
+    const secret = screen.getByText("ABCDEFGHIJKLMNOP");
+    expect(secret).toHaveClass("blur-sm", "select-none");
+    expect(secret).toHaveAttribute("aria-hidden", "true");
+    await user.click(screen.getByRole("button", { name: "Reveal secret" }));
+    expect(secret).not.toHaveClass("blur-sm");
+    expect(secret).toHaveClass("select-all");
+    expect(secret).toHaveAttribute("aria-hidden", "false");
     expect(screen.getByText("aaaa-1111")).toBeInTheDocument();
     expect(screen.getByText("bbbb-2222")).toBeInTheDocument();
     expect(
@@ -222,6 +269,36 @@ describe("SettingsPage TOTP section (#3853)", () => {
     expect(
       await screen.findByText(/TOTP confirmed/i),
     ).toBeInTheDocument();
+  });
+
+  it("renders duplicate recovery-code values with distinct React keys", async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    useTotpStatusMock.mockReturnValue({
+      data: {
+        enrolled: false,
+        confirmed: false,
+        enforced: false,
+        remaining_recovery_codes: 0,
+      },
+    });
+    useTotpSetupMock.mockReturnValue(
+      makeMutation(async () => ({
+        otpauth_uri: "otpauth://x",
+        secret: "SECRET",
+        qr_code: null,
+        recovery_codes: ["same-code", "same-code"],
+      })),
+    );
+
+    renderPage();
+    await user.click(screen.getByRole("button", { name: "Set up TOTP" }));
+
+    expect(await screen.findAllByText("same-code")).toHaveLength(2);
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
+      "same key",
+    );
+    consoleError.mockRestore();
   });
 
   it("revoke flow requires a code before calling useTotpRevoke", async () => {
@@ -323,5 +400,55 @@ describe("SettingsPage TOTP section (#3853)", () => {
       screen.getByRole("button", { name: "Verify & Reset" }),
     );
     expect(setupMutation.mutateAsync).toHaveBeenCalledWith("654321");
+  });
+});
+
+describe("SettingsPage security helpers", () => {
+  it("selects each TOTP action branch without nested render conditions", () => {
+    expect(getTotpActionState(true, true, true)).toBe("setup");
+    expect(getTotpActionState(false, true, true)).toBe("reset");
+    expect(getTotpActionState(false, false, true)).toBe("revoke");
+    expect(getTotpActionState(false, false, false)).toBe("default");
+  });
+
+  it("uses the structured passkey-disabled error contract", () => {
+    isPasskeySupportedMock.mockReturnValue(true);
+    usePasskeysMock.mockReturnValue({
+      data: undefined,
+      isError: true,
+      error: new ApiError(503, "passkey_disabled", "localized message"),
+    });
+    useTotpStatusMock.mockReturnValue({ data: undefined });
+
+    renderPage();
+
+    expect(
+      screen.getByText(/Passkey login is not enabled on this server/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add passkey" })).not.toBeInTheDocument();
+  });
+
+  it("downloads config through the authenticated API client", async () => {
+    const user = userEvent.setup();
+    const createObjectUrl = vi.fn(() => "blob:config-export");
+    const revokeObjectUrl = vi.fn();
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: createObjectUrl,
+      revokeObjectURL: revokeObjectUrl,
+    });
+    useTotpStatusMock.mockReturnValue({ data: undefined });
+
+    renderPage();
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(getRawConfigTomlMock).toHaveBeenCalledTimes(1);
+    expect(createObjectUrl).toHaveBeenCalledWith(expect.any(Blob));
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:config-export");
+    vi.unstubAllGlobals();
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SettingsPage.tsx
@@ -20,12 +20,26 @@ import {
   useRegisterPasskey,
   useRevokePasskey,
 } from "../lib/mutations/passkeys";
-import { isPasskeySupported } from "../api";
+import { getRawConfigToml, isPasskeySupported } from "../api";
+import { ApiError } from "../lib/http/client";
 
 interface SegmentOption<T extends string> {
   value: T;
   icon: React.ElementType;
   label: string;
+}
+
+export type TotpActionState = "setup" | "reset" | "revoke" | "default";
+
+export function getTotpActionState(
+  hasSetupData: boolean,
+  showResetPrompt: boolean,
+  showRevokePrompt: boolean,
+): TotpActionState {
+  if (hasSetupData) return "setup";
+  if (showResetPrompt) return "reset";
+  if (showRevokePrompt) return "revoke";
+  return "default";
 }
 
 function SegmentControl<T extends string>({
@@ -203,8 +217,9 @@ function PasskeysSection() {
   // panel as informational rather than broken.
   const disabledServerSide =
     passkeysQuery.isError &&
-    passkeysQuery.error instanceof Error &&
-    passkeysQuery.error.message.toLowerCase().includes("not enabled");
+    passkeysQuery.error instanceof ApiError &&
+    (passkeysQuery.error.code === "passkey_disabled" ||
+      passkeysQuery.error.status === 503);
   const busy = registerPasskey.isPending || revokePasskey.isPending;
 
   const dateFmt = (secs: number) =>
@@ -411,6 +426,7 @@ function TotpSection() {
   const [showResetCode, setShowResetCode] = useState(false);
   const [showRevokeCode, setShowRevokeCode] = useState(false);
   const [showConfirmCode, setShowConfirmCode] = useState(false);
+  const [showSecret, setShowSecret] = useState(false);
   const [revealRecovery, setRevealRecovery] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -423,6 +439,11 @@ function TotpSection() {
   const status = statusQuery.data;
   const loading =
     setupTotp.isPending || confirmTotp.isPending || revokeTotp.isPending;
+  const actionState = getTotpActionState(
+    setupData !== null,
+    showResetPrompt,
+    showRevokePrompt,
+  );
 
   async function handleSetup(currentCode?: string) {
     if (loading) return;
@@ -433,6 +454,7 @@ function TotpSection() {
       setSetupData({ otpauth_uri: data.otpauth_uri, secret: data.secret, qr_code: data.qr_code, recovery_codes: data.recovery_codes });
       setShowResetPrompt(false);
       setResetCode("");
+      setShowSecret(false);
       setRevealRecovery(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : t("settings.totp_setup_failed", "Setup failed"));
@@ -527,7 +549,7 @@ function TotpSection() {
         )}
 
         <div className="py-4">
-          {showResetPrompt && !setupData ? (
+          {actionState === "reset" && (
             <div className="flex flex-col sm:flex-row sm:items-center gap-2">
               <div className="relative w-full sm:w-48">
                 <input
@@ -557,7 +579,8 @@ function TotpSection() {
                 {t("common.cancel", "Cancel")}
               </Button>
             </div>
-          ) : showRevokePrompt && !setupData ? (
+          )}
+          {actionState === "revoke" && (
             <div className="flex flex-col sm:flex-row sm:items-center gap-2">
               <div className="relative w-full sm:w-48">
                 <input
@@ -587,7 +610,8 @@ function TotpSection() {
                 {t("common.cancel", "Cancel")}
               </Button>
             </div>
-          ) : !setupData ? (
+          )}
+          {actionState === "default" && (
             <div className="flex gap-2">
               <Button variant="secondary" size="sm" onClick={initiateSetup} isLoading={loading}>
                 {status?.confirmed
@@ -604,7 +628,8 @@ function TotpSection() {
                 </Button>
               )}
             </div>
-          ) : (
+          )}
+          {actionState === "setup" && setupData && (
             <div className="flex flex-col gap-3">
               <p className="text-sm text-text-dim">
                 {t("settings.totp_scan", "Scan the QR code or enter the secret in your authenticator app:")}
@@ -614,9 +639,28 @@ function TotpSection() {
                   <img src={setupData.qr_code} alt={t("settings.totp_qr_alt", "TOTP QR Code")} className="w-40 h-40 sm:w-48 sm:h-48" />
                 </div>
               )}
-              <code className="block text-sm font-mono bg-main border border-border-subtle rounded-lg px-3 py-2 break-all select-all">
-                {setupData.secret}
-              </code>
+              <div className="flex items-center gap-2">
+                <code
+                  aria-hidden={!showSecret}
+                  className={`block flex-1 text-sm font-mono bg-main border border-border-subtle rounded-lg px-3 py-2 break-all transition-[filter] duration-150 ${
+                    showSecret ? "select-all" : "blur-sm select-none"
+                  }`}
+                >
+                  {setupData.secret}
+                </code>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-pressed={showSecret}
+                  onClick={() => setShowSecret((visible) => !visible)}
+                >
+                  {showSecret ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  {showSecret
+                    ? t("settings.totp_secret_hide", "Hide secret")
+                    : t("settings.totp_secret_reveal", "Reveal secret")}
+                </Button>
+              </div>
               {setupData.recovery_codes.length > 0 && (
                 <div className="mt-2">
                   <div className="flex items-center justify-between mb-1">
@@ -653,9 +697,9 @@ function TotpSection() {
                     }`}
                     aria-hidden={!revealRecovery}
                   >
-                    {setupData.recovery_codes.map((code) => (
+                    {setupData.recovery_codes.map((code, index) => (
                       <code
-                        key={code}
+                        key={`${index}-${code}`}
                         className={`text-sm font-mono text-center ${revealRecovery ? "select-all" : "select-none"}`}
                       >
                         {code}
@@ -712,6 +756,33 @@ function TotpSection() {
 
 function ConfigBackupSection() {
   const { t } = useTranslation();
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleExport() {
+    if (exporting) return;
+    setExporting(true);
+    setError(null);
+    try {
+      const toml = await getRawConfigToml();
+      const objectUrl = URL.createObjectURL(
+        new Blob([toml], { type: "application/toml" }),
+      );
+      const link = document.createElement("a");
+      link.href = objectUrl;
+      link.download = "librefang-config.toml";
+      link.click();
+      URL.revokeObjectURL(objectUrl);
+    } catch (exportError) {
+      setError(
+        exportError instanceof Error
+          ? exportError.message
+          : t("settings.export_config_failed", "Could not export config."),
+      );
+    } finally {
+      setExporting(false);
+    }
+  }
 
   return (
     <div className="rounded-2xl border border-border-subtle bg-surface">
@@ -730,15 +801,20 @@ function ConfigBackupSection() {
             "Download a backup of your current config.toml settings file"
           )}
         >
-          <a
-            href="/api/config/export"
-            download="librefang-config.toml"
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            isLoading={exporting}
+            disabled={exporting}
+            onClick={handleExport}
             className="inline-flex items-center justify-center gap-2 rounded-xl font-bold transition-all duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-[0.96] active:duration-100 focus:outline-none focus:ring-2 focus:ring-brand/30 focus:ring-offset-1 border border-border-subtle bg-surface text-text-main hover:bg-main/50 hover:border-brand/20 shadow-sm px-3 py-1.5 text-xs"
           >
             <Download className="w-3.5 h-3.5 mr-1.5" />
             {t("settings.export_config_btn", "Download")}
-          </a>
+          </Button>
         </SettingRow>
+        {error && <p className="pb-3 text-sm text-danger">{error}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Changes

- replace nested TOTP action rendering with an explicit reset, revoke, default, or setup state
- mask newly issued TOTP secrets by default and add a localized reveal control
- use index-prefixed recovery-code keys so duplicate values remain renderable
- identify server-disabled passkeys through structured `ApiError` status/code fields instead of message text
- download config through the authenticated API client and surface export failures inline
- add regressions for every TOTP action state, secret visibility, duplicate codes, structured passkey errors, and authenticated export

Audit findings:
- F-ed58f2a0a8adf8f7
- F-b9af7858a13a9089
- F-0ca5097e0d61d777
- F-d8c4253170ea06bc
- F-302aeb32e17a4fa1

## Verification

- `mise exec -- pnpm exec vitest run src/pages/SettingsPage.totp.test.tsx src/lib/__tests__/en-locale-coverage.test.ts` (2 files, 18 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (101 files, 1,079 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- TOTP and passkey backend contracts remain unchanged
- config export keeps the canonical same-origin API client contract; remote-daemon routing is not introduced
- existing Polish and Ukrainian locale parity drift remains for a separate change