### PR TITLE
fix(dashboard): validate user budget inputs

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -3652,7 +3652,7 @@
     },
     "errors": {
       "non_negative": "{{field}} must be a finite, non-negative number",
-      "threshold_range": "alert_threshold must be in 0.0..=1.0"
+      "threshold_range": "alert_threshold must be greater than 0 and at most 1"
     },
     "toast": {
       "saved": "Spend cap saved"

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -3652,7 +3652,7 @@
     },
     "errors": {
       "non_negative": "{{field}}는 음수가 아닌 유한한 숫자여야 합니다.",
-      "threshold_range": "alert_threshold는 0.0..=1.0이어야 합니다."
+      "threshold_range": "alert_threshold는 0보다 크고 1 이하여야 합니다."
     },
     "toast": {
       "saved": "지출 한도가 저장되었습니다."

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -3658,7 +3658,7 @@
     },
     "errors": {
       "non_negative": "{{field}} musi być skończoną, nieujemną liczbą",
-      "threshold_range": "alert_threshold musi mieścić się w przedziale 0.0..=1.0"
+      "threshold_range": "alert_threshold musi być większy od 0 i nie większy niż 1"
     },
     "toast": {
       "saved": "Zapisano limit wydatków"

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -3658,7 +3658,7 @@
     },
     "errors": {
       "non_negative": "{{field}} має бути скінченним невід'ємним числом",
-      "threshold_range": "alert_threshold має бути в межах 0.0..=1.0"
+      "threshold_range": "alert_threshold має бути більше 0 і не більше 1"
     },
     "toast": {
       "saved": "Ліміт витрат збережено"

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -3652,7 +3652,7 @@
     },
     "errors": {
       "non_negative": "{{field}} 必须是有限的非负数",
-      "threshold_range": "alert_threshold 必须在 0.0..=1.0 范围内"
+      "threshold_range": "alert_threshold 必须大于 0 且不大于 1"
     },
     "toast": {
       "saved": "支出上限已保存"

--- a/crates/librefang-api/dashboard/src/pages/UserBudgetPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UserBudgetPage.test.tsx
@@ -8,7 +8,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { UserBudgetPage } from "./UserBudgetPage";
+import {
+  UserBudgetPage,
+  isBudgetFormDirty,
+  parseBudgetNumber,
+} from "./UserBudgetPage";
 import { useUserBudget } from "../lib/queries/userBudget";
 import {
   useUpdateUserBudget,
@@ -73,11 +77,11 @@ const HAPPY_DATA = {
   monthly: { spend: 12.345, limit: 100.0, pct: 0.12345 },
 };
 
-function renderPage(): void {
+function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 0 } },
   });
-  render(
+  return render(
     <QueryClientProvider client={queryClient}>
       <UserBudgetPage />
     </QueryClientProvider>,
@@ -198,9 +202,102 @@ describe("UserBudgetPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Save/ }));
 
     expect(
-      await screen.findByText("alert_threshold must be in 0.0..=1.0"),
+      await screen.findByText("alert_threshold must be greater than 0 and at most 1"),
     ).toBeInTheDocument();
     expect(updateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("rejects a zero alert_threshold without firing the mutation", async () => {
+    useUserBudgetMock.mockReturnValue({
+      data: HAPPY_DATA,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    const inputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    fireEvent.change(inputs[3], { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save/ }));
+
+    expect(
+      await screen.findByText("alert_threshold must be greater than 0 and at most 1"),
+    ).toBeInTheDocument();
+    expect(updateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("treats equivalent numeric strings as unchanged", () => {
+    useUserBudgetMock.mockReturnValue({
+      data: HAPPY_DATA,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    const inputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: "1.00" } });
+
+    expect(screen.getByRole("button", { name: /Save/ })).toBeDisabled();
+    expect(
+      isBudgetFormDirty(
+        {
+          max_hourly_usd: "1.00",
+          max_daily_usd: "10",
+          max_monthly_usd: "100",
+          alert_threshold: "0.80",
+        },
+        {
+          max_hourly_usd: "1",
+          max_daily_usd: "10.0",
+          max_monthly_usd: "100",
+          alert_threshold: ".8",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("reseeds after every save even when wall-clock timestamps collide", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    useUserBudgetMock.mockReturnValue({
+      data: HAPPY_DATA,
+      isLoading: false,
+      error: null,
+    });
+    updateMutateAsync
+      .mockImplementationOnce(async () => {
+        useUserBudgetMock.mockReturnValue({
+          data: {
+            ...HAPPY_DATA,
+            hourly: { ...HAPPY_DATA.hourly, limit: 2.25 },
+          },
+          isLoading: false,
+          error: null,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        useUserBudgetMock.mockReturnValue({
+          data: {
+            ...HAPPY_DATA,
+            hourly: { ...HAPPY_DATA.hourly, limit: 3.25 },
+          },
+          isLoading: false,
+          error: null,
+        });
+      });
+    renderPage();
+
+    let hourly = screen.getAllByRole("spinbutton")[0] as HTMLInputElement;
+    fireEvent.change(hourly, { target: { value: "2.5" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save/ }));
+    await waitFor(() => expect(hourly.value).toBe("2.25"));
+
+    fireEvent.change(hourly, { target: { value: "3.5" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save/ }));
+    await waitFor(() => {
+      hourly = screen.getAllByRole("spinbutton")[0] as HTMLInputElement;
+      expect(hourly.value).toBe("3.25");
+    });
+    expect(updateMutateAsync).toHaveBeenCalledTimes(2);
+    dateNow.mockRestore();
   });
 
   it("calls useDeleteUserBudget with the user name when Clear cap is clicked", async () => {
@@ -230,5 +327,14 @@ describe("UserBudgetPage", () => {
     renderPage();
 
     expect(screen.getByText("alert breach")).toBeInTheDocument();
+  });
+
+  it("parses only complete finite decimal strings", () => {
+    expect(parseBudgetNumber(" 12.50 ")).toBe(12.5);
+    expect(parseBudgetNumber(".75")).toBe(0.75);
+    expect(parseBudgetNumber("12abc")).toBeNull();
+    expect(parseBudgetNumber("1e3")).toBeNull();
+    expect(parseBudgetNumber("Infinity")).toBeNull();
+    expect(parseBudgetNumber("   ")).toBeNull();
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/UserBudgetPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/UserBudgetPage.tsx
@@ -40,6 +40,31 @@ interface FormState {
   alert_threshold: string;
 }
 
+const BUDGET_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+export function parseBudgetNumber(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!BUDGET_NUMBER_PATTERN.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : null;
+}
+
+function budgetValuesEqual(left: string, right: string): boolean {
+  const leftValue = parseBudgetNumber(left);
+  const rightValue = parseBudgetNumber(right);
+  return leftValue !== null && rightValue !== null && leftValue === rightValue;
+}
+
+export function isBudgetFormDirty(
+  form: FormState,
+  serverForm: FormState | null,
+): boolean {
+  if (!serverForm) return false;
+  return (Object.keys(form) as Array<keyof FormState>).some(
+    (key) => !budgetValuesEqual(form[key], serverForm[key]),
+  );
+}
+
 const ZERO_FORM: FormState = {
   max_hourly_usd: "0",
   max_daily_usd: "0",
@@ -65,17 +90,17 @@ export function UserBudgetPage() {
   // Bumped after a successful save / clear so the next `query.data`
   // delivery is allowed to reseed (so the form reflects the normalized
   // server state, not the raw input we just sent).
-  const [lastSavedAt, setLastSavedAt] = useState(0);
-  const lastSeededSavedAt = useRef(0);
+  const [saveRevision, setSaveRevision] = useState(0);
+  const lastSeededSaveRevision = useRef(0);
 
   // Seed once on first successful load; reseed only after a save we
-  // initiated (tracked via `lastSavedAt`). All other refetches —
+  // initiated (tracked via `saveRevision`). All other refetches —
   // window-focus revalidations, sibling-mutation invalidations — leave
   // the form alone so the operator's edits survive.
   useEffect(() => {
     if (!query.data) return;
     const justSaved =
-      lastSavedAt > 0 && lastSavedAt !== lastSeededSavedAt.current;
+      saveRevision > 0 && saveRevision !== lastSeededSaveRevision.current;
     if (hasSeeded.current && !justSaved) return;
     setForm({
       max_hourly_usd: String(query.data.hourly.limit),
@@ -84,8 +109,8 @@ export function UserBudgetPage() {
       alert_threshold: String(query.data.alert_threshold),
     });
     hasSeeded.current = true;
-    lastSeededSavedAt.current = lastSavedAt;
-  }, [query.data, lastSavedAt]);
+    lastSeededSaveRevision.current = saveRevision;
+  }, [query.data, saveRevision]);
 
   // Server-truth snapshot for the dirty flag. Stringified so a refetch
   // that returns identical numbers doesn't flicker the Save button.
@@ -97,12 +122,7 @@ export function UserBudgetPage() {
         alert_threshold: String(query.data.alert_threshold),
       }
     : null;
-  const dirty =
-    serverForm !== null &&
-    (form.max_hourly_usd !== serverForm.max_hourly_usd ||
-      form.max_daily_usd !== serverForm.max_daily_usd ||
-      form.max_monthly_usd !== serverForm.max_monthly_usd ||
-      form.alert_threshold !== serverForm.alert_threshold);
+  const dirty = isBudgetFormDirty(form, serverForm);
 
   const isLoading = query.isLoading;
   const fetchError = query.error;
@@ -121,15 +141,15 @@ export function UserBudgetPage() {
     e.preventDefault();
     setError(null);
 
-    const payload = {
-      max_hourly_usd: parseFloat(form.max_hourly_usd),
-      max_daily_usd: parseFloat(form.max_daily_usd),
-      max_monthly_usd: parseFloat(form.max_monthly_usd),
-      alert_threshold: parseFloat(form.alert_threshold),
+    const parsed = {
+      max_hourly_usd: parseBudgetNumber(form.max_hourly_usd),
+      max_daily_usd: parseBudgetNumber(form.max_daily_usd),
+      max_monthly_usd: parseBudgetNumber(form.max_monthly_usd),
+      alert_threshold: parseBudgetNumber(form.alert_threshold),
     };
 
-    for (const [k, v] of Object.entries(payload)) {
-      if (Number.isNaN(v) || !Number.isFinite(v) || v < 0) {
+    for (const [k, v] of Object.entries(parsed)) {
+      if (v === null || v < 0) {
         setError(
           t(
             "userBudget.errors.non_negative",
@@ -140,11 +160,12 @@ export function UserBudgetPage() {
         return;
       }
     }
-    if (payload.alert_threshold > 1) {
+    const payload = parsed as Record<keyof FormState, number>;
+    if (payload.alert_threshold <= 0 || payload.alert_threshold > 1) {
       setError(
         t(
           "userBudget.errors.threshold_range",
-          "alert_threshold must be in 0.0..=1.0",
+          "alert_threshold must be greater than 0 and at most 1",
         ),
       );
       return;
@@ -153,7 +174,7 @@ export function UserBudgetPage() {
     try {
       await updateMut.mutateAsync({ name, payload });
       // Allow the next `query.data` delivery to reseed the form.
-      setLastSavedAt(Date.now());
+      setSaveRevision((revision) => revision + 1);
       addToast(t("userBudget.toast.saved", "Spend cap saved"), "success");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -167,7 +188,7 @@ export function UserBudgetPage() {
       setForm(ZERO_FORM);
       // Clearing is also a save; trip the reseed gate so refetched
       // (now-zeroed) limits replace ZERO_FORM cleanly.
-      setLastSavedAt(Date.now());
+      setSaveRevision((revision) => revision + 1);
       addToast(t("userBudget.toast.saved", "Spend cap saved"), "success");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Changes

- replace wall-clock save timestamps with a monotonic revision so every successful save or clear can reseed normalized server state
- parse budget fields with a complete finite-decimal grammar instead of permissive `parseFloat`
- require alert thresholds to be greater than zero and at most one, with updated localized feedback
- compare form and server values numerically so equivalent strings such as `1`, `1.0`, and `1.00` are not marked dirty
- add regressions for timestamp collisions, malformed numeric strings, zero thresholds, and semantic dirty state

Audit findings:
- F-d57243a430f7376a
- F-dcd88ca8abb3eca2
- F-3494b9a084d1a19a
- F-93ef8c920d2315f9

## Verification

- `mise exec -- pnpm exec vitest run src/pages/UserBudgetPage.test.tsx src/lib/__tests__/en-locale-coverage.test.ts` (2 files, 17 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (101 files, 1,079 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- user-budget API payloads and backend enforcement remain unchanged
- zero continues to mean unlimited for hourly, daily, and monthly cap fields only
- existing Polish and Ukrainian locale parity drift remains for a separate change