### PR TITLE
fix(dashboard): surface network query failures

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/NetworkPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/NetworkPage.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NetworkPage } from "./NetworkPage";
+import {
+  useNetworkStatus,
+  usePeers,
+  useTrustedPeers,
+} from "../lib/queries/network";
+import { useUIStore } from "../lib/store";
+
+vi.mock("../lib/queries/network", () => ({
+  useNetworkStatus: vi.fn(),
+  usePeers: vi.fn(),
+  useTrustedPeers: vi.fn(),
+}));
+
+vi.mock("../lib/store", () => ({
+  useUIStore: vi.fn(),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  const t = (key: string) => key;
+  return {
+    ...actual,
+    useTranslation: () => ({ t }),
+  };
+});
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+const mock = <T,>(fn: T) => fn as unknown as ReturnType<typeof vi.fn>;
+const useNetworkStatusMock = mock(useNetworkStatus);
+const usePeersMock = mock(usePeers);
+const useTrustedPeersMock = mock(useTrustedPeers);
+const useUIStoreMock = mock(useUIStore);
+
+const addToast = vi.fn();
+const refetchStatus = vi.fn().mockResolvedValue(undefined);
+const refetchPeers = vi.fn().mockResolvedValue(undefined);
+const refetchTrusted = vi.fn().mockResolvedValue(undefined);
+
+function query<T>(data: T, overrides: Record<string, unknown> = {}) {
+  return {
+    data,
+    error: null,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function setQueries(
+  status: Record<string, unknown> = {
+    online: true,
+    node_id: "node-1",
+    protocol_version: "1",
+    identity_fingerprint: "fingerprint-123",
+    pinned_peers: 0,
+  },
+) {
+  useNetworkStatusMock.mockReturnValue(
+    query(status, { refetch: refetchStatus }),
+  );
+  usePeersMock.mockReturnValue(query([], { refetch: refetchPeers }));
+  useTrustedPeersMock.mockReturnValue(
+    query([], { refetch: refetchTrusted }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setQueries();
+  useUIStoreMock.mockImplementation(
+    (selector: (state: { addToast: typeof addToast }) => unknown) =>
+      selector({ addToast }),
+  );
+});
+
+describe("NetworkPage", () => {
+  it("renders an error state instead of empty success content when any query fails", () => {
+    usePeersMock.mockReturnValue(
+      query(undefined, {
+        error: new Error("network unavailable"),
+        isError: true,
+        refetch: refetchPeers,
+      }),
+    );
+
+    render(<NetworkPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("common.error");
+    expect(screen.queryByText("network.no_peers")).not.toBeInTheDocument();
+    expect(screen.queryByText("network.no_trusted_peers")).not.toBeInTheDocument();
+  });
+
+  it("retries all three network queries from the error state", () => {
+    useNetworkStatusMock.mockReturnValue(
+      query(undefined, {
+        error: new Error("network unavailable"),
+        isError: true,
+        refetch: refetchStatus,
+      }),
+    );
+    render(<NetworkPage />);
+
+    fireEvent.click(
+      within(screen.getByRole("alert")).getByRole("button", {
+        name: "common.refresh",
+      }),
+    );
+
+    expect(refetchStatus).toHaveBeenCalledTimes(1);
+    expect(refetchPeers).toHaveBeenCalledTimes(1);
+    expect(refetchTrusted).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a fingerprint when the online node has one", () => {
+    render(<NetworkPage />);
+
+    expect(screen.getByText("fingerprint-123")).toBeInTheDocument();
+    expect(screen.queryByText("network.identity_missing")).not.toBeInTheDocument();
+  });
+
+  it("renders the missing-identity warning for an online node", () => {
+    setQueries({ online: true, identity_fingerprint: null, pinned_peers: 0 });
+    render(<NetworkPage />);
+
+    expect(screen.getByText("network.identity_missing")).toBeInTheDocument();
+    expect(screen.queryByText("network.ofp_disabled")).not.toBeInTheDocument();
+  });
+
+  it("renders the disabled message for an offline node", () => {
+    setQueries({ online: false, identity_fingerprint: null, pinned_peers: 0 });
+    render(<NetworkPage />);
+
+    expect(screen.getByText("network.ofp_disabled")).toBeInTheDocument();
+    expect(screen.queryByText("network.identity_missing")).not.toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { EmptyState } from "../components/ui/EmptyState";
+import { ErrorState } from "../components/ui/ErrorState";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { StaggerList } from "../components/ui/StaggerList";
 import {
@@ -27,6 +28,38 @@ import {
 
 const NETWORK_ICON = <Network className="h-4 w-4" />;
 
+function FingerprintStatus({
+  fingerprint,
+  online,
+}: {
+  fingerprint?: string | null;
+  online?: boolean;
+}) {
+  const { t } = useTranslation();
+  if (fingerprint) {
+    return (
+      <p
+        className="text-xs font-mono mt-2 break-all"
+        title={t("network.identity_fingerprint_hint")}
+      >
+        {fingerprint}
+      </p>
+    );
+  }
+  if (online) {
+    return (
+      <p className="text-xs text-warning mt-2">
+        {t("network.identity_missing")}
+      </p>
+    );
+  }
+  return (
+    <p className="text-xs text-text-dim mt-2">
+      {t("network.ofp_disabled")}
+    </p>
+  );
+}
+
 export function NetworkPage() {
   const { t } = useTranslation();
 
@@ -39,16 +72,20 @@ export function NetworkPage() {
   const trustedPeers = trustedQuery.data ?? [];
   const addToast = useUIStore((s) => s.addToast);
   const isLoading = statusQuery.isPending || peersQuery.isPending || trustedQuery.isPending;
+  const isError = statusQuery.isError || peersQuery.isError || trustedQuery.isError;
+  const refetchStatus = statusQuery.refetch;
+  const refetchPeers = peersQuery.refetch;
+  const refetchTrusted = trustedQuery.refetch;
 
   const handleRefresh = useCallback(() => {
     Promise.all([
-      statusQuery.refetch(),
-      peersQuery.refetch(),
-      trustedQuery.refetch(),
+      refetchStatus(),
+      refetchPeers(),
+      refetchTrusted(),
     ]).catch((e) => {
       addToast(toastErr(e, t("common.error")), "error");
     });
-  }, [statusQuery, peersQuery, trustedQuery, addToast, t]);
+  }, [refetchStatus, refetchPeers, refetchTrusted, addToast, t]);
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -62,7 +99,9 @@ export function NetworkPage() {
         helpText={t("network.help")}
       />
 
-      {isLoading ? (
+      {isError ? (
+        <ErrorState onRetry={handleRefresh} />
+      ) : isLoading ? (
         <div className="grid gap-4 md:grid-cols-3">
           <CardSkeleton />
           <CardSkeleton />
@@ -143,22 +182,10 @@ export function NetworkPage() {
                 />
               </div>
             </div>
-            {status?.identity_fingerprint ? (
-              <p
-                className="text-xs font-mono mt-2 break-all"
-                title={t("network.identity_fingerprint_hint")}
-              >
-                {status.identity_fingerprint}
-              </p>
-            ) : status?.online ? (
-              <p className="text-xs text-warning mt-2">
-                {t("network.identity_missing")}
-              </p>
-            ) : (
-              <p className="text-xs text-text-dim mt-2">
-                {t("network.ofp_disabled")}
-              </p>
-            )}
+            <FingerprintStatus
+              fingerprint={status?.identity_fingerprint}
+              online={status?.online}
+            />
             <p className="text-[10px] text-text-dim mt-2">
               {t("network.pinned_peers_count", {
                 count: status?.pinned_peers ?? 0,


### PR DESCRIPTION
## Changes

- render a retryable error state when any network status, peer, or trusted-peer query fails instead of showing empty success content
- retry all three network queries from the shared error state
- replace nested fingerprint presentation with explicit fingerprint, missing-identity, and disabled branches
- depend on stable query refetch functions rather than whole changing query result objects
- add NetworkPage regressions for partial query failure, retry fan-out, and all fingerprint states

Audit findings:
- F-a3ed9767ed67d158
- F-617fa12c6eedb3ba
- F-59816e2f18e29ed8

## Verification

- `mise exec -- pnpm exec vitest run src/pages/NetworkPage.test.tsx` (5 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (102 files, 1,080 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- network APIs, peer polling cadence, and trust semantics remain unchanged
- retry continues to use the existing TanStack refetch contract and global toast formatting
- existing Polish and Ukrainian locale parity drift remains for a separate change