### PR TITLE
fix(dashboard): synchronize permission simulator

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/PermissionSimulatorPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PermissionSimulatorPage.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PermissionSimulatorPage,
+  normalizeRole,
+} from "./PermissionSimulatorPage";
+import { useUsers } from "../lib/queries/users";
+import { useEffectivePermissions } from "../lib/queries/authz";
+import { ApiError } from "../lib/http/client";
+
+vi.mock("../lib/queries/users", () => ({
+  useUsers: vi.fn(),
+}));
+
+vi.mock("../lib/queries/authz", () => ({
+  useEffectivePermissions: vi.fn(),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, fallback?: string) => fallback ?? key,
+    }),
+  };
+});
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+const mock = <T,>(fn: T) => fn as unknown as ReturnType<typeof vi.fn>;
+const useUsersMock = mock(useUsers);
+const useEffectivePermissionsMock = mock(useEffectivePermissions);
+
+const alice = { name: "alice", role: "admin" };
+const bob = { name: "bob", role: "viewer" };
+
+function setUsers(users: Array<{ name: string; role: string }>) {
+  useUsersMock.mockReturnValue({ data: users });
+}
+
+function setEffective(overrides: Record<string, unknown> = {}) {
+  useEffectivePermissionsMock.mockReturnValue({
+    data: undefined,
+    error: null,
+    isError: false,
+    isLoading: true,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setUsers([alice, bob]);
+  setEffective();
+});
+
+describe("PermissionSimulatorPage", () => {
+  it("recognizes missing users through the structured 404 status", () => {
+    setEffective({
+      error: new ApiError(404, "user_missing", "localized response"),
+      isError: true,
+      isLoading: false,
+    });
+    render(<PermissionSimulatorPage />);
+
+    expect(screen.getByText("User not found")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Could not load effective permissions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not classify free-text 404 messages as structured not-found errors", () => {
+    setEffective({
+      error: new Error("404 user not found"),
+      isError: true,
+      isLoading: false,
+    });
+    render(<PermissionSimulatorPage />);
+
+    expect(screen.getByText("Could not load effective permissions")).toBeInTheDocument();
+    expect(screen.queryByText("User not found")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the user role for unknown API role values", () => {
+    expect(normalizeRole("viewer")).toBe("viewer");
+    expect(normalizeRole("owner")).toBe("owner");
+    expect(normalizeRole("future-role")).toBe("user");
+    expect(normalizeRole(undefined)).toBe("user");
+  });
+
+  it("synchronizes selection when the chosen user disappears", async () => {
+    const view = render(<PermissionSimulatorPage />);
+    const select = screen.getByLabelText("User") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "bob" } });
+    await waitFor(() => expect(select.value).toBe("bob"));
+
+    setUsers([alice]);
+    view.rerender(<PermissionSimulatorPage />);
+    await waitFor(() => expect(select.value).toBe("alice"));
+
+    setUsers([alice, bob]);
+    view.rerender(<PermissionSimulatorPage />);
+    expect(select.value).toBe("alice");
+    const lastCall = useEffectivePermissionsMock.mock.calls[
+      useEffectivePermissionsMock.mock.calls.length - 1
+    ];
+    expect(lastCall?.[0]).toBe("alice");
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/PermissionSimulatorPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PermissionSimulatorPage.tsx
@@ -7,7 +7,7 @@
 // drift from the runtime gate path. Admins reading this page compose
 // the result mentally; the gate path stays the source of truth.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Shield,
@@ -31,6 +31,7 @@ import type {
   EffectiveToolCategories,
   EffectiveToolPolicy,
 } from "../lib/http/client";
+import { ApiError } from "../lib/http/client";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
@@ -45,6 +46,10 @@ import { Skeleton } from "../components/ui/Skeleton";
 // than the per-user-policy slices below.
 const ROLE_ORDER = ["viewer", "user", "admin", "owner"] as const;
 type Role = (typeof ROLE_ORDER)[number];
+
+export function normalizeRole(role: string | undefined): Role {
+  return ROLE_ORDER.includes(role as Role) ? (role as Role) : "user";
+}
 
 type Translate = (key: string, fallback: string) => string;
 
@@ -140,7 +145,12 @@ export function PermissionSimulatorPage() {
     () => users.find(u => u.name === selectedName) ?? users[0],
     [users, selectedName],
   );
-  const role = (selected?.role as Role) ?? "user";
+  const role = normalizeRole(selected?.role);
+
+  useEffect(() => {
+    const nextName = selected?.name ?? "";
+    if (selectedName !== nextName) setSelectedName(nextName);
+  }, [selected?.name, selectedName]);
 
   const effectiveQuery = useEffectivePermissions(selected?.name ?? "");
   const effective = effectiveQuery.data;
@@ -151,7 +161,8 @@ export function PermissionSimulatorPage() {
   // user list.
   const notFound =
     effectiveQuery.isError &&
-    /404|not found/i.test(String(effectiveQuery.error));
+    effectiveQuery.error instanceof ApiError &&
+    effectiveQuery.error.status === 404;
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Changes

- classify missing users through structured `ApiError` 404 status instead of regex-matching error text
- validate API role strings against the supported role order and fall back safely to `user`
- synchronize the selected user name when the selected record disappears, preventing a later refetch from silently restoring stale selection
- add regressions for structured versus free-text 404s, unknown roles, and remove/reappear selection behavior

Audit findings:
- F-a0fd75b21b17d9da
- F-8d20dea5e509c4d0
- F-21834c15c8f7129c

## Verification

- `mise exec -- pnpm exec vitest run src/pages/PermissionSimulatorPage.test.tsx` (4 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test` (102 files, 1,079 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: eight extra plural keys in each of pl.json and uk.json; ko.json and zh.json pass)

## Out of scope

- authz APIs, role hierarchy, and effective-permission calculation remain unchanged
- unknown future roles intentionally degrade to the current `user` safety baseline
- existing Polish and Ukrainian locale parity drift remains for a separate change