### PR TITLE
fix(dashboard/memory): correct formatter boundaries

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/Memory/formatters.test.ts
+++ b/crates/librefang-api/dashboard/src/pages/Memory/formatters.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatHours, formatKvValue, formatRelativeMs } from "./formatters";
+
+describe("formatRelativeMs", () => {
+  const never = () => "never";
+  const justNow = () => "localized just now";
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto", style: "narrow" });
+
+  it("uses localized callbacks for sentinel and near-current timestamps", () => {
+    const neverSpy = vi.fn(never);
+    const justNowSpy = vi.fn(justNow);
+
+    expect(formatRelativeMs(undefined, 1_000, "en", neverSpy, justNowSpy)).toBe("never");
+    expect(formatRelativeMs(1_001, 1_000, "en", neverSpy, justNowSpy)).toBe(
+      "localized just now",
+    );
+    expect(neverSpy).toHaveBeenCalledOnce();
+    expect(justNowSpy).toHaveBeenCalledOnce();
+  });
+
+  it("rolls rounded minute values into hours instead of emitting 60 minutes", () => {
+    const delta = 59.6 * 60_000;
+
+    expect(formatRelativeMs(1_000 + delta, 1_000, "en", never, justNow)).toBe(
+      rtf.format(1, "hour"),
+    );
+    expect(formatRelativeMs(1_000, 1_000 + delta, "en", never, justNow)).toBe(
+      rtf.format(-1, "hour"),
+    );
+  });
+
+  it("rolls rounded hour values into days", () => {
+    const delta = 23.96 * 3_600_000;
+
+    expect(formatRelativeMs(1_000 + delta, 1_000, "en", never, justNow)).toBe(
+      rtf.format(1, "day"),
+    );
+  });
+});
+
+describe("formatHours", () => {
+  const units = { minute: "m", hour: "h", day: "d", week: "w" };
+
+  it("treats tiny floating-point residuals as whole units", () => {
+    expect(formatHours(2 + 5e-10, units)).toBe("2h");
+    expect(formatHours(48 + 5e-10, units)).toBe("2d");
+    expect(formatHours(168 + 5e-10, units)).toBe("1w");
+  });
+
+  it("retains meaningful fractional units", () => {
+    expect(formatHours(1.25, units)).toBe("1.3h");
+    expect(formatHours(36, units)).toBe("1.5d");
+    expect(formatHours(252, units)).toBe("1.5w");
+  });
+});
+
+describe("formatKvValue", () => {
+  it("serializes values without applying presentation truncation", () => {
+    const value = "x".repeat(500);
+
+    expect(formatKvValue(value)).toBe(value);
+    expect(formatKvValue({ nested: true })).toBe('{"nested":true}');
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/Memory/formatters.ts
+++ b/crates/librefang-api/dashboard/src/pages/Memory/formatters.ts
@@ -20,7 +20,7 @@ export function formatRelativeMs(
   now: number,
   locale: string,
   tNever: () => string,
-  tJustNow?: () => string,
+  tJustNow: () => string,
 ): string {
   if (ts === undefined || ts === 0) return tNever();
   const diff = ts - now;
@@ -28,17 +28,26 @@ export function formatRelativeMs(
   // Anything within ~30s reads as "just now" rather than "in 0 minutes" /
   // "this minute" — Intl.RelativeTimeFormat with numeric:"auto" produces
   // locale-dependent and frequently awkward strings at the zero-crossing.
-  if (absSeconds < 30) return tJustNow ? tJustNow() : "just now";
-  const absMinutes = Math.abs(diff) / 60_000;
+  if (absSeconds < 30) return tJustNow();
   const rtf = getRelativeTimeFormat(locale);
-  if (absMinutes < 60) {
-    return rtf.format(Math.round(diff / 60_000), "minute");
+  const direction = Math.sign(diff);
+  const roundedMinutes = Math.round(absSeconds / 60);
+  if (roundedMinutes < 60) {
+    return rtf.format(direction * roundedMinutes, "minute");
   }
-  const absHours = absMinutes / 60;
-  if (absHours < 24) {
-    return rtf.format(parseFloat((diff / 3_600_000).toFixed(1)), "hour");
+  const roundedHours = Math.round((absSeconds / 3_600) * 10) / 10;
+  if (roundedHours < 24) {
+    return rtf.format(direction * roundedHours, "hour");
   }
-  return rtf.format(parseFloat((diff / 86_400_000).toFixed(1)), "day");
+  const roundedDays = Math.round((absSeconds / 86_400) * 10) / 10;
+  return rtf.format(direction * roundedDays, "day");
+}
+
+function formatUnitValue(value: number): string {
+  const nearestInteger = Math.round(value);
+  return Math.abs(value - nearestInteger) < 1e-9
+    ? nearestInteger.toFixed(0)
+    : value.toFixed(1);
 }
 
 // Human-readable duration for effective_min_hours. Switches between minutes,
@@ -48,15 +57,15 @@ export function formatHours(
   unit: { minute: string; hour: string; day: string; week: string },
 ): string {
   if (hours < 1) return `${(hours * 60).toFixed(0)}${unit.minute}`;
-  if (hours < 24) return `${hours % 1 === 0 ? hours.toFixed(0) : hours.toFixed(1)}${unit.hour}`;
+  if (hours < 24) return `${formatUnitValue(hours)}${unit.hour}`;
   const days = hours / 24;
-  if (days < 7) return `${days % 1 === 0 ? days.toFixed(0) : days.toFixed(1)}${unit.day}`;
+  if (days < 7) return `${formatUnitValue(days)}${unit.day}`;
   const weeks = days / 7;
-  return `${weeks % 1 === 0 ? weeks.toFixed(0) : weeks.toFixed(1)}${unit.week}`;
+  return `${formatUnitValue(weeks)}${unit.week}`;
 }
 
-// Truncate long KV values for table rendering. Full value remains in the
-// title attribute on hover (capped separately via KV_TITLE_TRUNCATE).
+// Serialize KV values to display strings. AgentKvRows applies its separate
+// table-cell and title-preview truncation limits after calling this helper.
 export function formatKvValue(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "string") return value;


### PR DESCRIPTION
## Substantive changes

- Roll rounded relative-minute values into hours so labels never emit 60 minutes.
- Roll rounded relative-hour values into days so labels never emit 24 hours.
- Require the localized near-current label callback instead of falling back to English.
- Format mathematically whole hour, day, and week values with floating-point tolerance.
- Correct the KV formatter documentation to reflect that truncation belongs to the render site.
- Add focused unit coverage for boundary rollover, localization callbacks, floating-point residuals, and KV serialization.

## Verification

- `mise exec -- pnpm test --run src/pages/Memory/formatters.test.ts` (6 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm exec eslint src/pages/Memory/formatters.ts src/pages/Memory/formatters.test.ts`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test --run` (102 files, 1081 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: Polish and Ukrainian each retain the same eight extra plural keys; Korean and Chinese match English)

## Out-of-scope follow-ups

- Other Memory page audit findings are separate component-level clusters and remain in the audit handoff inventory.