### PR TITLE
fix(dashboard/memory): clarify agent rail controls

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/Memory/AgentRail.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/Memory/AgentRail.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentRail } from "./AgentRail";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}));
+
+const baseProps = {
+  agents: [{ id: "agent-123456", name: "Planner" }],
+  autoDream: undefined,
+  recordsByAgentId: new Map([["agent-123456", 3]]),
+  kvCountByAgentId: new Map([["agent-123456", 4]]),
+  totalRecords: 7,
+  totalKv: 8,
+  selectedAgentId: undefined,
+  onSelect: vi.fn(),
+};
+
+describe("AgentRail", () => {
+  it("gives the agent filter a persistent accessible name", () => {
+    render(<AgentRail {...baseProps} />);
+
+    const filter = screen.getByRole("textbox", { name: "Filter agents" });
+    expect(filter).toHaveAttribute("placeholder", "Filter agents");
+
+    fireEvent.change(filter, { target: { value: "plan" } });
+    expect(screen.getByRole("button", { name: "Clear search" })).toBeInTheDocument();
+  });
+
+  it("formats aggregate and per-agent memory counts consistently", () => {
+    render(<AgentRail {...baseProps} />);
+
+    expect(screen.getByText("7 mem · 8 KV")).toBeInTheDocument();
+    expect(screen.getByText("3 mem · 4 KV")).toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/Memory/AgentRail.tsx
+++ b/crates/librefang-api/dashboard/src/pages/Memory/AgentRail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Database, Moon, Search, X } from "lucide-react";
 import type { AgentItem, AutoDreamStatus } from "../../api";
@@ -31,6 +31,9 @@ export function AgentRail({
 }: Props) {
   const { t } = useTranslation();
   const [filter, setFilter] = useState("");
+  const filterLabel = t("memory.rail_filter_placeholder", { defaultValue: "Filter agents" });
+  const formatSubtitle = (records: number, kv: number) =>
+    `${records} ${t("memory.rail_records_short", { defaultValue: "mem" })} · ${kv} ${t("memory.rail_kv_short", { defaultValue: "KV" })}`;
 
   const dreamByAgentId = useMemo(() => {
     const m = new Map<string, boolean>();
@@ -62,14 +65,15 @@ export function AgentRail({
         <input
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          placeholder={t("memory.rail_filter_placeholder", { defaultValue: "Filter agents" })}
+          placeholder={filterLabel}
+          aria-label={filterLabel}
           className="w-full rounded-lg border border-border-subtle bg-main pl-8 pr-7 py-1.5 text-xs outline-none focus:border-brand"
         />
         {filter && (
           <button
             onClick={() => setFilter("")}
             className="absolute right-2 top-1/2 -translate-y-1/2 text-text-dim hover:text-text-main"
-          aria-label={t("common.clear_search", { defaultValue: "Clear search" })}
+            aria-label={t("common.clear_search", { defaultValue: "Clear search" })}
           >
             <X className="w-3 h-3" />
           </button>
@@ -81,7 +85,7 @@ export function AgentRail({
         <AgentRailRow
           icon={<Database className="w-3.5 h-3.5" />}
           name={t("memory.rail_all_agents", { defaultValue: "All agents" })}
-          subtitle={`${totalRecords} ${t("memory.rail_records_short", { defaultValue: "mem" })} · ${totalKv} ${t("memory.rail_kv_short", { defaultValue: "KV" })}`}
+          subtitle={formatSubtitle(totalRecords, totalKv)}
           selected={selectedAgentId === undefined}
           onClick={() => onSelect(undefined)}
         />
@@ -107,7 +111,7 @@ export function AgentRail({
                 }
                 name={agent.name}
                 idHint={agent.id.slice(0, 6)}
-                subtitle={`${records} ${t("memory.rail_records_short", { defaultValue: "mem" })} · ${kv} ${t("memory.rail_kv_short", { defaultValue: "KV" })}`}
+                subtitle={formatSubtitle(records, kv)}
                 selected={selectedAgentId === agent.id}
                 onClick={() => onSelect(agent.id)}
               />
@@ -120,7 +124,7 @@ export function AgentRail({
 }
 
 interface RowProps {
-  icon: React.ReactNode;
+  icon: ReactNode;
   name: string;
   idHint?: string;
   subtitle: string;


### PR DESCRIPTION
## Substantive changes

- Give the agent-filter input a persistent localized accessible name.
- Centralize aggregate and per-agent memory/KV subtitle formatting.
- Import `ReactNode` explicitly instead of relying on the ambient React namespace.
- Add focused coverage for accessible filter controls and consistent count labels.

## Verification

- `mise exec -- pnpm test --run src/pages/Memory/AgentRail.test.tsx` (2 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm exec eslint src/pages/Memory/AgentRail.tsx src/pages/Memory/AgentRail.test.tsx`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test --run` (102 files, 1077 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: Polish and Ukrainian each retain the same eight extra plural keys; Korean and Chinese match English)

## Out-of-scope follow-ups

- Other Memory page audit findings are separate component-level clusters and remain in the audit handoff inventory.