### PR TITLE
fix(dashboard/memory): bound KV row output

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/Memory/components/AgentKvRows.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/Memory/components/AgentKvRows.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentKvPair } from "../../../api";
+import { KV_TITLE_TRUNCATE, KV_VALUE_TRUNCATE } from "../constants";
+import { AgentKvRows } from "./AgentKvRows";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+function renderRows(kvQuery: Partial<UseQueryResult<AgentKvPair[]>>) {
+  return render(
+    <table>
+      <tbody>
+        <AgentKvRows kvQuery={kvQuery as UseQueryResult<AgentKvPair[]>} />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("AgentKvRows", () => {
+  it("shows generic copy instead of exposing a raw query error", () => {
+    renderRows({ isError: true, error: new Error("internal path: /srv/private.db") });
+
+    expect(screen.getByText("common.error")).toBeInTheDocument();
+    expect(screen.queryByText(/private\.db/)).not.toBeInTheDocument();
+  });
+
+  it("caps both cell and hover previews with the same ellipsis semantics", () => {
+    const value = "x".repeat(KV_TITLE_TRUNCATE + 100);
+    renderRows({
+      isError: false,
+      isLoading: false,
+      data: [
+        {
+          key: "long-value",
+          value,
+          source: "test",
+        },
+      ],
+    });
+
+    const valueCell = screen.getByTitle(`${"x".repeat(KV_TITLE_TRUNCATE)}…`);
+    expect(valueCell).toHaveTextContent(`${"x".repeat(KV_VALUE_TRUNCATE)}…`);
+    expect(valueCell).not.toHaveAttribute("title", value);
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/Memory/components/AgentKvRows.tsx
+++ b/crates/librefang-api/dashboard/src/pages/Memory/components/AgentKvRows.tsx
@@ -10,6 +10,10 @@ interface Props {
   kvQuery: UseQueryResult<AgentKvPair[]>;
 }
 
+function truncateWithEllipsis(value: string, limit: number): string {
+  return value.length > limit ? `${value.slice(0, limit)}…` : value;
+}
+
 // Receives the per-agent KV query result from the surrounding tab — a single
 // `useQueries` observer batches every agent's lookup so this row component
 // stays presentational (no per-row hook subscription, no N+1 churn).
@@ -29,7 +33,7 @@ export function AgentKvRows({ kvQuery }: Props) {
     return (
       <tr>
         <td colSpan={4} className="px-3 py-2 text-xs text-error">
-          {kvQuery.error instanceof Error ? kvQuery.error.message : t("common.error")}
+          {t("common.error")}
         </td>
       </tr>
     );
@@ -50,14 +54,8 @@ export function AgentKvRows({ kvQuery }: Props) {
     <>
       {pairs.map((pair: AgentKvPair) => {
         const formatted = formatKvValue(pair.value);
-        const truncated =
-          formatted.length > KV_VALUE_TRUNCATE
-            ? formatted.slice(0, KV_VALUE_TRUNCATE) + "…"
-            : formatted;
-        const titlePreview =
-          formatted.length > KV_TITLE_TRUNCATE
-            ? formatted.slice(0, KV_TITLE_TRUNCATE) + "…"
-            : formatted;
+        const truncated = truncateWithEllipsis(formatted, KV_VALUE_TRUNCATE);
+        const titlePreview = truncateWithEllipsis(formatted, KV_TITLE_TRUNCATE);
         return (
           <tr key={pair.key} className="border-t border-border-subtle/40">
             <td className="px-3 py-2 text-xs font-mono break-all">{pair.key}</td>


### PR DESCRIPTION
## Substantive changes

- Replace raw per-agent KV query errors with fixed localized UI copy.
- Centralize visible-cell and hover-preview truncation semantics.
- Add focused coverage for error redaction and both preview bounds.

## Verification

- `mise exec -- pnpm test --run src/pages/Memory/components/AgentKvRows.test.tsx` (2 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm exec eslint src/pages/Memory/components/AgentKvRows.tsx src/pages/Memory/components/AgentKvRows.test.tsx src/pages/Memory/constants.ts`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm test --run` (102 files, 1077 tests passed)
- `mise exec -- pnpm build`
- `mise exec -- pnpm test:i18n-parity` (known baseline only: Polish and Ukrainian each retain the same eight extra plural keys; Korean and Chinese match English)

## Out-of-scope follow-ups

- The inaccurate full-tooltip promise in `Memory/constants.ts` remains pending because open #7472 owns that file. Re-audit the preview contract on its post-merge source instead of stacking a conflicting edit.
- Other Memory page audit findings remain separate component-level clusters in the handoff inventory.