### PR TITLE
fix(dashboard): bound service worker cache

### DIFF
--- a/crates/librefang-api/dashboard/public/sw.js
+++ b/crates/librefang-api/dashboard/public/sw.js
@@ -1,24 +1,50 @@
 const CACHE_NAME = "librefang-v1";
 const PRECACHE = ["/dashboard/"];
+const MAX_CACHE_ENTRIES = 200;
+
+async function trimCache(cache) {
+  const keys = await cache.keys();
+  const excess = keys.length - MAX_CACHE_ENTRIES;
+  if (excess <= 0) return;
+  await Promise.all(keys.slice(0, excess).map((request) => cache.delete(request)));
+}
+
+async function precache() {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    await Promise.allSettled(
+      PRECACHE.map(async (url) => {
+        const response = await fetch(url, { cache: "reload" });
+        if (response.ok) await cache.put(url, response);
+      }),
+    );
+  } catch (error) {
+    console.warn("Service worker precache failed", error);
+  }
+}
 
 self.addEventListener("install", (e) => {
-  e.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE))
-  );
-  self.skipWaiting();
+  e.waitUntil(precache());
+});
+
+// Let an explicit update prompt activate a waiting worker. Do not take over
+// open tabs automatically while they may still reference the prior build.
+self.addEventListener("message", (e) => {
+  if (e.data?.type === "SKIP_WAITING") self.skipWaiting();
 });
 
 self.addEventListener("activate", (e) => {
   e.waitUntil(
-    caches.keys().then((names) =>
-      Promise.all(
+    caches.keys().then(async (names) => {
+      await Promise.all(
         names
           .filter((n) => n !== CACHE_NAME)
-          .map((n) => caches.delete(n))
-      )
-    )
+          .map((n) => caches.delete(n)),
+      );
+      const cache = await caches.open(CACHE_NAME);
+      await trimCache(cache);
+    }),
   );
-  self.clients.claim();
 });
 
 self.addEventListener("fetch", (e) => {
@@ -38,12 +64,18 @@ self.addEventListener("fetch", (e) => {
     caches.open(CACHE_NAME).then(async (cache) => {
       const cached = await cache.match(e.request);
       const fetched = fetch(e.request)
-        .then((resp) => {
-          if (resp.ok) cache.put(e.request, resp.clone());
+        .then(async (resp) => {
+          if (resp.ok) {
+            await cache.put(e.request, resp.clone());
+            await trimCache(cache);
+          }
           return resp;
-        })
-        .catch(() => cached);
-      return cached || fetched;
-    })
+        });
+      if (cached) {
+        e.waitUntil(fetched.catch(() => undefined));
+        return cached;
+      }
+      return fetched.catch(() => Response.error());
+    }),
   );
 });

--- a/crates/librefang-api/dashboard/src/lib/serviceWorker.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/serviceWorker.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+type WorkerHandler = (event: Record<string, unknown>) => void;
+
+class MemoryCache {
+  entries = new Map<unknown, Response>();
+
+  async match(request: unknown): Promise<Response | undefined> {
+    return this.entries.get(request);
+  }
+
+  async put(request: unknown, response: Response): Promise<void> {
+    this.entries.set(request, response);
+  }
+
+  async keys(): Promise<unknown[]> {
+    return [...this.entries.keys()];
+  }
+
+  async delete(request: unknown): Promise<boolean> {
+    return this.entries.delete(request);
+  }
+}
+
+function loadWorker(fetchMock: typeof fetch, cache = new MemoryCache()) {
+  const handlers = new Map<string, WorkerHandler>();
+  const skipWaiting = vi.fn();
+  const worker = {
+    addEventListener: (type: string, handler: WorkerHandler) => handlers.set(type, handler),
+    skipWaiting,
+  };
+  const caches = {
+    open: vi.fn(async () => cache),
+    keys: vi.fn(async () => ["librefang-v0", "librefang-v1"]),
+    delete: vi.fn(async () => true),
+  };
+  const source = readFileSync(join(__dirname, "../../public/sw.js"), "utf8");
+  runInNewContext(source, {
+    self: worker,
+    caches,
+    fetch: fetchMock,
+    Response,
+    URL,
+    console,
+  });
+  return { cache, caches, handlers, skipWaiting };
+}
+
+describe("dashboard service worker", () => {
+  it("returns an error Response when both cache and network miss", async () => {
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    const { handlers } = loadWorker(fetchMock);
+    let responsePromise: Promise<Response> | undefined;
+    handlers.get("fetch")?.({
+      request: { url: "https://example.test/dashboard/missing.js", method: "GET" },
+      respondWith: (promise: Promise<Response>) => { responsePromise = promise; },
+      waitUntil: vi.fn(),
+    });
+    const response = await responsePromise;
+    expect(response).toBeInstanceOf(Response);
+    expect(response?.type).toBe("error");
+  });
+
+  it("keeps a cached response while refreshing it in the event lifetime", async () => {
+    const request = { url: "https://example.test/dashboard/app.js", method: "GET" };
+    const cached = new Response("cached");
+    const fresh = new Response("fresh");
+    const cache = new MemoryCache();
+    cache.entries.set(request, cached);
+    const { handlers } = loadWorker(vi.fn(async () => fresh) as unknown as typeof fetch, cache);
+    let responsePromise: Promise<Response> | undefined;
+    let refreshPromise: Promise<unknown> | undefined;
+    handlers.get("fetch")?.({
+      request,
+      respondWith: (promise: Promise<Response>) => { responsePromise = promise; },
+      waitUntil: (promise: Promise<unknown>) => { refreshPromise = promise; },
+    });
+    expect(await responsePromise).toBe(cached);
+    await refreshPromise;
+    expect(await cache.entries.get(request)?.text()).toBe("fresh");
+  });
+
+  it("bounds the runtime cache after a successful network response", async () => {
+    const cache = new MemoryCache();
+    for (let i = 0; i < 205; i++) cache.entries.set(`old-${i}`, new Response(String(i)));
+    const request = { url: "https://example.test/dashboard/new.js", method: "GET" };
+    const { handlers } = loadWorker(vi.fn(async () => new Response("new")) as unknown as typeof fetch, cache);
+    let responsePromise: Promise<Response> | undefined;
+    handlers.get("fetch")?.({
+      request,
+      respondWith: (promise: Promise<Response>) => { responsePromise = promise; },
+      waitUntil: vi.fn(),
+    });
+    await responsePromise;
+    expect(cache.entries.size).toBe(200);
+    expect(cache.entries.has(request)).toBe(true);
+  });
+
+  it("settles a failed precache and waits for explicit activation", async () => {
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    const { handlers, skipWaiting } = loadWorker(fetchMock);
+    let installPromise: Promise<unknown> | undefined;
+    handlers.get("install")?.({
+      waitUntil: (promise: Promise<unknown>) => { installPromise = promise; },
+    });
+    await expect(installPromise).resolves.toBeUndefined();
+    expect(skipWaiting).not.toHaveBeenCalled();
+    handlers.get("message")?.({ data: { type: "SKIP_WAITING" } });
+    expect(skipWaiting).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- return a valid error `Response` when both runtime cache and network miss
- precache entries independently so one fetch failure does not reject worker installation
- bound the runtime cache to 200 entries and keep background refresh work in the fetch event lifetime
- wait for explicit `SKIP_WAITING` activation instead of forcing a new worker onto open tabs
- execute the actual public worker script in focused lifecycle regressions

## Verification

- `mise exec -- pnpm exec vitest run src/lib/serviceWorker.test.ts` (4 passed)
- `mise exec -- pnpm test` (102 files, 1079 tests passed)
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm build`
- `git diff --check`

## Out of scope

- The dashboard does not yet expose an update prompt that sends `SKIP_WAITING`; normal browser worker activation remains available.
- The stable cache namespace remains unchanged; bounded stale-while-revalidate updates entries without requiring a manual version bump.
- `pnpm test:i18n-parity` still reports only the pre-existing eight extra Polish and Ukrainian plural keys present on `main`.