### PR TITLE
fix(dashboard): validate locale parity input

### DIFF
--- a/changelog.d/fixed/7497-dashboard-i18n-parity-script.md
+++ b/changelog.d/fixed/7497-dashboard-i18n-parity-script.md
@@ -1,0 +1,1 @@
+Validate dashboard locale files and preserve array structure when checking translation-key parity. (#7497) (@houko)

--- a/crates/librefang-api/dashboard/scripts/i18n-parity.mjs
+++ b/crates/librefang-api/dashboard/scripts/i18n-parity.mjs
@@ -16,22 +16,26 @@ const here = dirname(fileURLToPath(import.meta.url));
 const LOCALES_DIR = join(here, "..", "src", "locales");
 const REFERENCE = "en.json";
 
-export function flatten(node, prefix = "") {
-  if (!prefix && (node === null || typeof node !== "object" || Array.isArray(node))) {
-    throw new TypeError("Locale root must be a JSON object");
-  }
+function flattenValue(node, prefix) {
   if (Array.isArray(node)) {
-    if (node.length === 0) return [prefix];
-    return node.flatMap((value, index) => flatten(value, `${prefix}.${index}`));
+    if (node.length === 0) return [`${prefix}[]`];
+    return node.flatMap((value, index) => flattenValue(value, `${prefix}[${index}]`));
   }
   if (node === null || typeof node !== "object") {
     return [prefix];
   }
   const out = [];
-  for (const [k, v] of Object.entries(node)) {
-    out.push(...flatten(v, prefix ? `${prefix}.${k}` : k));
+  for (const [key, value] of Object.entries(node)) {
+    out.push(...flattenValue(value, prefix ? `${prefix}.${key}` : key));
   }
   return out;
+}
+
+export function flatten(node) {
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    throw new TypeError("Locale root must be a JSON object");
+  }
+  return flattenValue(node, "");
 }
 
 export function loadFlat(file, localesDir = LOCALES_DIR) {

--- a/crates/librefang-api/dashboard/scripts/i18n-parity.mjs
+++ b/crates/librefang-api/dashboard/scripts/i18n-parity.mjs
@@ -9,15 +9,22 @@
 // Exit code: 0 on parity, 1 on drift.
 
 import { readFileSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const LOCALES_DIR = join(here, "..", "src", "locales");
 const REFERENCE = "en.json";
 
-function flatten(node, prefix = "") {
-  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+export function flatten(node, prefix = "") {
+  if (!prefix && (node === null || typeof node !== "object" || Array.isArray(node))) {
+    throw new TypeError("Locale root must be a JSON object");
+  }
+  if (Array.isArray(node)) {
+    if (node.length === 0) return [prefix];
+    return node.flatMap((value, index) => flatten(value, `${prefix}.${index}`));
+  }
+  if (node === null || typeof node !== "object") {
     return [prefix];
   }
   const out = [];
@@ -27,35 +34,53 @@ function flatten(node, prefix = "") {
   return out;
 }
 
-function loadFlat(file) {
-  return new Set(flatten(JSON.parse(readFileSync(join(LOCALES_DIR, file), "utf8"))));
-}
-
-const reference = loadFlat(REFERENCE);
-const others = readdirSync(LOCALES_DIR).filter(
-  (f) => f.endsWith(".json") && f !== REFERENCE,
-);
-
-let drift = false;
-for (const file of others) {
-  const locale = loadFlat(file);
-  const missing = [...reference].filter((k) => !locale.has(k)).sort();
-  const extra = [...locale].filter((k) => !reference.has(k)).sort();
-  if (missing.length === 0 && extra.length === 0) {
-    console.log(`OK   ${file} (${locale.size} keys, parity with ${REFERENCE})`);
-    continue;
+export function loadFlat(file, localesDir = LOCALES_DIR) {
+  try {
+    const text = readFileSync(join(localesDir, file), "utf8");
+    return new Set(flatten(JSON.parse(text)));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load locale ${file}: ${detail}`, { cause: error });
   }
-  drift = true;
-  console.error(`FAIL ${file}`);
-  if (missing.length) console.error(`  missing (${missing.length}):`, missing);
-  if (extra.length) console.error(`  extra (${extra.length}):`, extra);
 }
 
-if (drift) {
-  console.error(
-    "\nLocale drift detected. Add the missing translations to the affected locale, " +
-      "and remove any extra (dead) keys. See issue #3557 for context.",
+export function runParity() {
+  const reference = loadFlat(REFERENCE);
+  const others = readdirSync(LOCALES_DIR).filter(
+    (f) => f.endsWith(".json") && f !== REFERENCE,
   );
-  process.exit(1);
+
+  let drift = false;
+  for (const file of others) {
+    const locale = loadFlat(file);
+    const missing = [...reference].filter((k) => !locale.has(k)).sort();
+    const extra = [...locale].filter((k) => !reference.has(k)).sort();
+    if (missing.length === 0 && extra.length === 0) {
+      console.log(`OK   ${file} (${locale.size} keys, parity with ${REFERENCE})`);
+      continue;
+    }
+    drift = true;
+    console.error(`FAIL ${file}`);
+    if (missing.length) console.error(`  missing (${missing.length}):`, missing);
+    if (extra.length) console.error(`  extra (${extra.length}):`, extra);
+  }
+
+  if (drift) {
+    console.error(
+      "\nLocale drift detected. Add the missing translations to the affected locale, " +
+        "and remove any extra (dead) keys. See issue #3557 for context.",
+    );
+    return 1;
+  }
+  console.log("\nAll locales in parity with en.json.");
+  return 0;
 }
-console.log("\nAll locales in parity with en.json.");
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = runParity();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/crates/librefang-api/dashboard/src/lib/__tests__/i18n-parity-script.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/__tests__/i18n-parity-script.test.ts
@@ -15,10 +15,16 @@ const parity = await import(/* @vite-ignore */ modulePath) as ParityScript;
 describe("i18n parity script", () => {
   it("walks arrays by index instead of collapsing their shape", () => {
     expect(parity.flatten({ messages: ["first", { label: "second" }] })).toEqual([
-      "messages.0",
-      "messages.1.label",
+      "messages[0]",
+      "messages[1].label",
     ]);
-    expect(parity.flatten({ messages: [] })).toEqual(["messages"]);
+    expect(parity.flatten({ messages: [] })).toEqual(["messages[]"]);
+    expect(parity.flatten({ messages: ["first"] })).not.toEqual(
+      parity.flatten({ messages: { "0": "first" } }),
+    );
+    expect(parity.flatten({ messages: [] })).not.toEqual(
+      parity.flatten({ messages: "first" }),
+    );
   });
 
   it("rejects malformed locale roots", () => {

--- a/crates/librefang-api/dashboard/src/lib/__tests__/i18n-parity-script.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/__tests__/i18n-parity-script.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const modulePath = "../../../scripts/i18n-parity.mjs";
+
+interface ParityScript {
+  flatten: (node: unknown) => string[];
+  loadFlat: (file: string, localesDir?: string) => Set<string>;
+}
+
+const parity = await import(/* @vite-ignore */ modulePath) as ParityScript;
+
+describe("i18n parity script", () => {
+  it("walks arrays by index instead of collapsing their shape", () => {
+    expect(parity.flatten({ messages: ["first", { label: "second" }] })).toEqual([
+      "messages.0",
+      "messages.1.label",
+    ]);
+    expect(parity.flatten({ messages: [] })).toEqual(["messages"]);
+  });
+
+  it("rejects malformed locale roots", () => {
+    expect(() => parity.flatten([])).toThrow("Locale root must be a JSON object");
+    expect(() => parity.flatten("translation")).toThrow("Locale root must be a JSON object");
+    expect(() => parity.flatten(null)).toThrow("Locale root must be a JSON object");
+  });
+
+  it("adds file context to read and JSON parse failures", () => {
+    const dir = mkdtempSync(join(tmpdir(), "librefang-i18n-parity-"));
+    writeFileSync(join(dir, "broken.json"), "{not-json", "utf8");
+    expect(() => parity.loadFlat("broken.json", dir)).toThrow("Failed to load locale broken.json");
+    expect(() => parity.loadFlat("missing.json", dir)).toThrow("Failed to load locale missing.json");
+  });
+});


### PR DESCRIPTION
## Changes

- Flatten locale arrays with explicit indexed paths while keeping empty arrays distinct from scalar values.
- Keep array indices distinct from numeric object keys so malformed locale shapes cannot collide.
- Reject malformed non-object locale roots and wrap read or JSON parse failures with the affected filename.
- Add importable script helpers, focused regressions, and a changelog fragment.

## Verification

- mise exec -- pnpm --dir crates/librefang-api/dashboard lint
- mise exec -- pnpm --dir crates/librefang-api/dashboard typecheck
- mise exec -- pnpm --dir crates/librefang-api/dashboard test (102 files, 1078 tests)
- mise exec -- pnpm --dir crates/librefang-api/dashboard build
- python3 scripts/check-changelog-attribution.py --base origin/main --head HEAD
- git diff --check origin/main...HEAD

## Out of scope

- Locale content and the CLDR-aware parity policy are unchanged.
- Locale-directory discovery remains rooted beside the checked-in script.
- Existing Polish and Ukrainian plural-key drift remains unchanged.