### PR TITLE
fix(dashboard): enforce approved dependency builds

### DIFF
--- a/changelog.d/fixed/7498-dashboard-strict-dependency-builds.md
+++ b/changelog.d/fixed/7498-dashboard-strict-dependency-builds.md
@@ -1,0 +1,1 @@
+Restore strict dashboard dependency build enforcement so installs fail when scripts are not explicitly approved. (#7498) (@houko)

--- a/crates/librefang-api/dashboard/.npmrc
+++ b/crates/librefang-api/dashboard/.npmrc
@@ -1,4 +1,3 @@
-# Downgrade ERR_PNPM_IGNORED_BUILDS to a warning. Modern esbuild ships its
-# native binary via the platform-specific optional dependency, so the
-# postinstall build script is not required for vite builds to succeed.
-strict-dep-builds=false
+# Fail installation when a dependency build script is not explicitly approved
+# by pnpm-workspace.yaml's onlyBuiltDependencies allowlist.
+strict-dep-builds=true


### PR DESCRIPTION
## Summary

- restore pnpm strict dependency-build enforcement for the dashboard
- require dependency build scripts to appear in the `pnpm-workspace.yaml` allowlist
- add the required changelog fragment
- merge the latest `main`

## Verification

- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm test` (101 files, 1075 tests passed)
- `mise exec -- pnpm build`
- pnpm 10.33.0 clean-install fixture with `esbuild` approved: passed
- the same clean-install fixture without `onlyBuiltDependencies`: failed with `ERR_PNPM_IGNORED_BUILDS`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check origin/main...HEAD`

## Out of scope

- The approved dependency list remains limited to `esbuild`.
- Dependency upgrades and existing default-branch audit findings are unchanged.