### PR TITLE
fix(runtime): restore MCP fixture setup instructions

### DIFF
--- a/changelog.d/fixed/7499-mcp-fixture-setup-scope.md
+++ b/changelog.d/fixed/7499-mcp-fixture-setup-scope.md
@@ -1,0 +1,1 @@
+Restore setup instructions in the pinned MCP registry fixtures by keeping them at the catalog root. (#7499) (@houko)

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/aws.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/aws.toml
@@ -5,6 +5,12 @@ category = "cloud"
 icon = "lucide:cloud"
 tags = ["cloud", "amazon", "infrastructure", "s3", "ec2", "lambda", "devops"]
 
+setup_instructions = """
+1. Go to the AWS IAM Console (https://console.aws.amazon.com/iam/) and create or select an IAM user with programmatic access.
+2. Generate an access key pair and note down the Access Key ID and Secret Access Key.
+3. Paste both credentials and your preferred AWS region (default: us-east-1) into the fields above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -34,13 +40,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to the AWS IAM Console (https://console.aws.amazon.com/iam/) and create or select an IAM user with programmatic access.
-2. Generate an access key pair and note down the Access Key ID and Secret Access Key.
-3. Paste both credentials and your preferred AWS region (default: us-east-1) into the fields above.
-"""
-
 
 [i18n.zh]
 name = "AWS"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/azure-mcp.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/azure-mcp.toml
@@ -5,6 +5,12 @@ category = "cloud"
 icon = "lucide:diamond"
 tags = ["cloud", "microsoft", "infrastructure", "azure", "devops", "enterprise"]
 
+setup_instructions = """
+1. In the Azure Portal, register an application under Azure Active Directory > App registrations and note the Client ID and Tenant ID.
+2. Create a client secret under Certificates & Secrets for the registered application.
+3. Assign the appropriate RBAC roles to the application on your subscription, then paste all four values into the fields above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -41,13 +47,6 @@ get_url = "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/Applicat
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. In the Azure Portal, register an application under Azure Active Directory > App registrations and note the Client ID and Tenant ID.
-2. Create a client secret under Certificates & Secrets for the registered application.
-3. Assign the appropriate RBAC roles to the application on your subscription, then paste all four values into the fields above.
-"""
-
 
 [i18n.zh]
 name = "Microsoft Azure"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/bitbucket.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/bitbucket.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "lucide:package"
 tags = ["git", "vcs", "code", "pull-requests", "ci", "atlassian"]
 
+setup_instructions = """
+1. Go to Bitbucket > Personal Settings > App passwords (https://bitbucket.org/account/settings/app-passwords/).
+2. Create an app password with 'Repositories: Read/Write' and 'Pull requests: Read/Write' permissions.
+3. Enter your Bitbucket username and paste the app password into the fields above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -27,13 +33,6 @@ get_url = "https://bitbucket.org/account/settings/app-passwords/"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to Bitbucket > Personal Settings > App passwords (https://bitbucket.org/account/settings/app-passwords/).
-2. Create an app password with 'Repositories: Read/Write' and 'Pull requests: Read/Write' permissions.
-3. Enter your Bitbucket username and paste the app password into the fields above.
-"""
-
 
 [i18n.zh]
 name = "Bitbucket"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/brave-search.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/brave-search.toml
@@ -5,6 +5,12 @@ category = "ai"
 icon = "lucide:shield"
 tags = ["search", "web", "brave", "api", "information-retrieval"]
 
+setup_instructions = """
+1. Go to https://brave.com/search/api/ and sign up for a Brave Search API plan (free tier available).
+2. Generate an API key from your Brave Search API dashboard.
+3. Paste the API key into the BRAVE_API_KEY field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://brave.com/search/api/"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://brave.com/search/api/ and sign up for a Brave Search API plan (free tier available).
-2. Generate an API key from your Brave Search API dashboard.
-3. Paste the API key into the BRAVE_API_KEY field above.
-"""
-
 
 [i18n.zh]
 name = "Brave Search"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/discord-mcp.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/discord-mcp.toml
@@ -5,6 +5,12 @@ category = "communication"
 icon = "lucide:gamepad-2"
 tags = ["chat", "messaging", "community", "gaming", "voice"]
 
+setup_instructions = """
+1. Go to the Discord Developer Portal (https://discord.com/developers/applications) and create a new application.
+2. Navigate to the 'Bot' section, click 'Add Bot', and copy the bot token.
+3. Invite the bot to your server using the OAuth2 URL generator with the required permissions, then paste the token into the DISCORD_BOT_TOKEN field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://discord.com/developers/applications"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to the Discord Developer Portal (https://discord.com/developers/applications) and create a new application.
-2. Navigate to the 'Bot' section, click 'Add Bot', and copy the bot token.
-3. Invite the bot to your server using the OAuth2 URL generator with the required permissions, then paste the token into the DISCORD_BOT_TOKEN field above.
-"""
-
 
 [i18n.zh]
 name = "Discord"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/dropbox.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/dropbox.toml
@@ -5,6 +5,12 @@ category = "productivity"
 icon = "lucide:package"
 tags = ["files", "storage", "cloud-storage", "sync", "sharing"]
 
+setup_instructions = """
+1. Go to the Dropbox App Console (https://www.dropbox.com/developers/apps) and create a new app or select an existing one.
+2. Under the 'OAuth 2' section, generate an access token with the required permissions.
+3. Paste the access token into the DROPBOX_ACCESS_TOKEN field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://www.dropbox.com/developers/apps"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to the Dropbox App Console (https://www.dropbox.com/developers/apps) and create a new app or select an existing one.
-2. Under the 'OAuth 2' section, generate an access token with the required permissions.
-3. Paste the access token into the DROPBOX_ACCESS_TOKEN field above.
-"""
-
 
 [i18n.zh]
 name = "Dropbox"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/elasticsearch.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/elasticsearch.toml
@@ -5,6 +5,12 @@ category = "data"
 icon = "lucide:search"
 tags = ["search", "database", "indexing", "analytics", "full-text"]
 
+setup_instructions = """
+1. Obtain your Elasticsearch cluster URL from your Elastic Cloud dashboard or self-hosted instance configuration.
+2. Create an API key in Kibana (Stack Management > API Keys) with appropriate index permissions.
+3. Paste the cluster URL and API key into the fields above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -27,13 +33,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Obtain your Elasticsearch cluster URL from your Elastic Cloud dashboard or self-hosted instance configuration.
-2. Create an API key in Kibana (Stack Management > API Keys) with appropriate index permissions.
-3. Paste the cluster URL and API key into the fields above.
-"""
-
 
 [i18n.zh]
 name = "Elasticsearch"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/exa-search.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/exa-search.toml
@@ -5,6 +5,12 @@ category = "ai"
 icon = "lucide:search"
 tags = ["search", "web", "ai", "neural", "semantic", "information-retrieval"]
 
+setup_instructions = """
+1. Go to https://dashboard.exa.ai/ and create an account or sign in.
+2. Navigate to API Keys (https://dashboard.exa.ai/api-keys) and generate a new key.
+3. Paste the API key into the EXA_API_KEY field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://dashboard.exa.ai/api-keys"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://dashboard.exa.ai/ and create an account or sign in.
-2. Navigate to API Keys (https://dashboard.exa.ai/api-keys) and generate a new key.
-3. Paste the API key into the EXA_API_KEY field above.
-"""
-
 
 [i18n.zh]
 name = "Exa Search"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/fetch.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/fetch.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "🌐"
 tags = ["web", "fetch", "scraping", "markdown", "http"]
 
+setup_instructions = """
+No API key required. Fetches any publicly accessible URL and returns the content as Markdown.
+
+For JavaScript-rendered pages (SPAs), use the Puppeteer integration instead.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -13,13 +19,6 @@ args = ["-y", "@modelcontextprotocol/server-fetch@latest"]
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-No API key required. Fetches any publicly accessible URL and returns the content as Markdown.
-
-For JavaScript-rendered pages (SPAs), use the Puppeteer integration instead.
-"""
-
 
 [i18n.zh]
 name = "Web Fetch"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/filesystem.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/filesystem.toml
@@ -5,15 +5,6 @@ category = "devtools"
 icon = "📁"
 tags = ["files", "local", "read", "write", "search"]
 
-[transport]
-type = "stdio"
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-filesystem@latest", "$HOME"]
-
-[health_check]
-interval_secs = 60
-unhealthy_threshold = 3
-
 setup_instructions = """
 Exposes your home directory to agents by default.
 
@@ -32,6 +23,14 @@ args = ["-y", "@modelcontextprotocol/server-filesystem@latest", "/path/to/expose
 Requires Node.js / npx.
 """
 
+[transport]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem@latest", "$HOME"]
+
+[health_check]
+interval_secs = 60
+unhealthy_threshold = 3
 
 [i18n.zh]
 name = "Filesystem"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/gcp-mcp.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/gcp-mcp.toml
@@ -5,6 +5,12 @@ category = "cloud"
 icon = "lucide:globe"
 tags = ["cloud", "google", "infrastructure", "gce", "gcs", "bigquery", "devops"]
 
+setup_instructions = """
+1. Go to the GCP Console > IAM & Admin > Service Accounts (https://console.cloud.google.com/iam-admin/serviceaccounts) and create a new service account with the necessary roles.
+2. Generate a JSON key file for the service account and save it to a secure location on your filesystem.
+3. Enter the absolute path to the JSON key file in the GOOGLE_APPLICATION_CREDENTIALS field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://console.cloud.google.com/iam-admin/serviceaccounts"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to the GCP Console > IAM & Admin > Service Accounts (https://console.cloud.google.com/iam-admin/serviceaccounts) and create a new service account with the necessary roles.
-2. Generate a JSON key file for the service account and save it to a secure location on your filesystem.
-3. Enter the absolute path to the JSON key file in the GOOGLE_APPLICATION_CREDENTIALS field above.
-"""
-
 
 [i18n.zh]
 name = "Google Cloud Platform"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/git.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/git.toml
@@ -5,15 +5,6 @@ category = "devtools"
 icon = "🌿"
 tags = ["git", "version-control", "commits", "diff", "history", "blame"]
 
-[transport]
-type = "stdio"
-command = "uvx"
-args = ["mcp-server-git", "--repository", "."]
-
-[health_check]
-interval_secs = 60
-unhealthy_threshold = 3
-
 setup_instructions = """
 Requires `uv` (Python package manager):
 - macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
@@ -32,6 +23,14 @@ args = ["mcp-server-git", "--repository", "/path/to/your/repo"]
 ```
 """
 
+[transport]
+type = "stdio"
+command = "uvx"
+args = ["mcp-server-git", "--repository", "."]
+
+[health_check]
+interval_secs = 60
+unhealthy_threshold = 3
 
 [i18n.zh]
 name = "Git"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/github.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/github.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "lucide:github"
 tags = ["git", "vcs", "code", "issues", "pull-requests", "ci"]
 
+setup_instructions = """
+1. Go to https://github.com/settings/tokens and create a Personal Access Token (classic or fine-grained) with 'repo' and 'read:org' scopes.
+2. Paste the token into the GITHUB_PERSONAL_ACCESS_TOKEN field above.
+3. Alternatively, use the OAuth flow to authorize LibreFang directly with your GitHub account.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -26,13 +32,6 @@ token_url = "https://github.com/login/oauth/access_token"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://github.com/settings/tokens and create a Personal Access Token (classic or fine-grained) with 'repo' and 'read:org' scopes.
-2. Paste the token into the GITHUB_PERSONAL_ACCESS_TOKEN field above.
-3. Alternatively, use the OAuth flow to authorize LibreFang directly with your GitHub account.
-"""
-
 
 [i18n.zh]
 name = "GitHub"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/gitlab.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/gitlab.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "lucide:flame"
 tags = ["git", "vcs", "code", "merge-requests", "ci", "devops"]
 
+setup_instructions = """
+1. Navigate to GitLab > User Settings > Access Tokens (https://gitlab.com/-/user_settings/personal_access_tokens).
+2. Create a new personal access token with the 'api' scope and an appropriate expiration date.
+3. Paste the token into the GITLAB_PERSONAL_ACCESS_TOKEN field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://gitlab.com/-/user_settings/personal_access_tokens"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Navigate to GitLab > User Settings > Access Tokens (https://gitlab.com/-/user_settings/personal_access_tokens).
-2. Create a new personal access token with the 'api' scope and an appropriate expiration date.
-3. Paste the token into the GITLAB_PERSONAL_ACCESS_TOKEN field above.
-"""
-
 
 [i18n.zh]
 name = "GitLab"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/gmail.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/gmail.toml
@@ -5,6 +5,12 @@ category = "productivity"
 icon = "lucide:mail"
 tags = ["email", "google", "messaging", "inbox", "communication"]
 
+setup_instructions = """
+1. Click 'Connect' to initiate the OAuth flow with your Google account.
+2. Grant LibreFang permission to read and modify your Gmail messages when prompted.
+3. The connection will be established automatically after authorization.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -19,13 +25,6 @@ token_url = "https://oauth2.googleapis.com/token"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Click 'Connect' to initiate the OAuth flow with your Google account.
-2. Grant LibreFang permission to read and modify your Gmail messages when prompted.
-3. The connection will be established automatically after authorization.
-"""
-
 
 [i18n.zh]
 name = "Gmail"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/google-calendar.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/google-calendar.toml
@@ -5,6 +5,12 @@ category = "productivity"
 icon = "lucide:calendar"
 tags = ["calendar", "scheduling", "google", "events", "meetings"]
 
+setup_instructions = """
+1. Click 'Connect' to initiate the OAuth flow with your Google account.
+2. Grant LibreFang access to your Google Calendar when prompted.
+3. The connection will be established automatically after authorization.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -19,13 +25,6 @@ token_url = "https://oauth2.googleapis.com/token"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Click 'Connect' to initiate the OAuth flow with your Google account.
-2. Grant LibreFang access to your Google Calendar when prompted.
-3. The connection will be established automatically after authorization.
-"""
-
 
 [i18n.zh]
 name = "Google Calendar"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/google-drive.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/google-drive.toml
@@ -5,6 +5,12 @@ category = "productivity"
 icon = "lucide:folder"
 tags = ["files", "storage", "google", "documents", "cloud-storage"]
 
+setup_instructions = """
+1. Click 'Connect' to initiate the OAuth flow with your Google account.
+2. Grant LibreFang read-only access to your Google Drive files when prompted.
+3. The connection will be established automatically after authorization.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -19,13 +25,6 @@ token_url = "https://oauth2.googleapis.com/token"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Click 'Connect' to initiate the OAuth flow with your Google account.
-2. Grant LibreFang read-only access to your Google Drive files when prompted.
-3. The connection will be established automatically after authorization.
-"""
-
 
 [i18n.zh]
 name = "Google Drive"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/google-maps.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/google-maps.toml
@@ -5,6 +5,15 @@ category = "data"
 icon = "🗺️"
 tags = ["maps", "geocoding", "directions", "places", "google", "location"]
 
+setup_instructions = """
+1. Go to https://console.cloud.google.com
+2. Enable: Geocoding API, Directions API, Places API, Distance Matrix API
+3. Create credentials → API Key
+4. Paste the key into the field above
+
+Free tier includes $200/month credit (~40,000 geocoding requests).
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,16 +29,6 @@ get_url = "https://console.cloud.google.com/apis/credentials"
 [health_check]
 interval_secs = 120
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://console.cloud.google.com
-2. Enable: Geocoding API, Directions API, Places API, Distance Matrix API
-3. Create credentials → API Key
-4. Paste the key into the field above
-
-Free tier includes $200/month credit (~40,000 geocoding requests).
-"""
-
 
 [i18n.zh]
 name = "Google Maps"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/jira.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/jira.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "lucide:clipboard-list"
 tags = ["project-management", "issues", "agile", "atlassian", "tracking"]
 
+setup_instructions = """
+1. Go to https://id.atlassian.com/manage-profile/security/api-tokens and create a new API token.
+2. Enter your Jira Cloud instance URL (e.g., https://yourcompany.atlassian.net) and the email linked to your Atlassian account.
+3. Paste the API token into the JIRA_API_TOKEN field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -34,13 +40,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://id.atlassian.com/manage-profile/security/api-tokens and create a new API token.
-2. Enter your Jira Cloud instance URL (e.g., https://yourcompany.atlassian.net) and the email linked to your Atlassian account.
-3. Paste the API token into the JIRA_API_TOKEN field above.
-"""
-
 
 [i18n.zh]
 name = "Jira"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/linear.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/linear.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "lucide:ruler"
 tags = ["project-management", "issues", "agile", "tracking", "sprint"]
 
+setup_instructions = """
+1. Open Linear and go to Settings > API (https://linear.app/settings/api).
+2. Click 'Create key' to generate a new personal API key.
+3. Paste the key into the LINEAR_API_KEY field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://linear.app/settings/api"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Open Linear and go to Settings > API (https://linear.app/settings/api).
-2. Click 'Create key' to generate a new personal API key.
-3. Paste the key into the LINEAR_API_KEY field above.
-"""
-
 
 [i18n.zh]
 name = "Linear"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/memory.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/memory.toml
@@ -5,15 +5,6 @@ category = "ai"
 icon = "🧠"
 tags = ["memory", "knowledge-graph", "persistence", "facts", "entities"]
 
-[transport]
-type = "stdio"
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-memory@latest"]
-
-[health_check]
-interval_secs = 60
-unhealthy_threshold = 3
-
 setup_instructions = """
 No API key required. Stores a knowledge graph locally in JSON format.
 
@@ -31,6 +22,14 @@ args = ["-y", "@modelcontextprotocol/server-memory@latest"]
 ```
 """
 
+[transport]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-memory@latest"]
+
+[health_check]
+interval_secs = 60
+unhealthy_threshold = 3
 
 [i18n.zh]
 name = "Memory (知识图谱)"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/mongodb.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/mongodb.toml
@@ -5,6 +5,12 @@ category = "data"
 icon = "lucide:leaf"
 tags = ["database", "nosql", "document", "mongo", "queries"]
 
+setup_instructions = """
+1. Obtain your MongoDB connection URI from MongoDB Atlas (Clusters > Connect > Drivers) or your self-hosted instance.
+2. Ensure the database user has the necessary read/write permissions for the collections you want to access.
+3. Paste the full connection URI into the MONGODB_URI field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Obtain your MongoDB connection URI from MongoDB Atlas (Clusters > Connect > Drivers) or your self-hosted instance.
-2. Ensure the database user has the necessary read/write permissions for the collections you want to access.
-3. Paste the full connection URI into the MONGODB_URI field above.
-"""
-
 
 [i18n.zh]
 name = "MongoDB"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/notion.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/notion.toml
@@ -5,6 +5,12 @@ category = "productivity"
 icon = "lucide:file-text"
 tags = ["notes", "wiki", "knowledge-base", "documentation", "databases"]
 
+setup_instructions = """
+1. Go to https://www.notion.so/my-integrations and click 'New integration'.
+2. Give it a name, select your workspace, and grant the required capabilities (Read/Update/Insert content).
+3. Copy the Internal Integration Token and paste it into the NOTION_API_KEY field above. Then share relevant pages with the integration in Notion.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://www.notion.so/my-integrations"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://www.notion.so/my-integrations and click 'New integration'.
-2. Give it a name, select your workspace, and grant the required capabilities (Read/Update/Insert content).
-3. Copy the Internal Integration Token and paste it into the NOTION_API_KEY field above. Then share relevant pages with the integration in Notion.
-"""
-
 
 [i18n.zh]
 name = "Notion"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/postgresql.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/postgresql.toml
@@ -5,6 +5,12 @@ category = "data"
 icon = "lucide:database"
 tags = ["database", "sql", "relational", "postgres", "queries"]
 
+setup_instructions = """
+1. Obtain your PostgreSQL connection string in the format: postgresql://user:password@host:5432/dbname.
+2. Ensure the database user has the necessary read/write permissions for the tables you want to access.
+3. Paste the full connection string into the POSTGRES_CONNECTION_STRING field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Obtain your PostgreSQL connection string in the format: postgresql://user:password@host:5432/dbname.
-2. Ensure the database user has the necessary read/write permissions for the tables you want to access.
-3. Paste the full connection string into the POSTGRES_CONNECTION_STRING field above.
-"""
-
 
 [i18n.zh]
 name = "PostgreSQL"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/puppeteer.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/puppeteer.toml
@@ -13,15 +13,6 @@ tags = [
   "chrome",
 ]
 
-[transport]
-type = "stdio"
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-puppeteer@latest"]
-
-[health_check]
-interval_secs = 60
-unhealthy_threshold = 3
-
 setup_instructions = """
 Requires Chrome or Chromium to be installed:
 - macOS: `brew install --cask google-chrome`
@@ -31,6 +22,14 @@ Requires Chrome or Chromium to be installed:
 No API key required.
 """
 
+[transport]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-puppeteer@latest"]
+
+[health_check]
+interval_secs = 60
+unhealthy_threshold = 3
 
 [i18n.zh]
 name = "Puppeteer"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/redis.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/redis.toml
@@ -5,6 +5,12 @@ category = "data"
 icon = "lucide:circle"
 tags = ["database", "cache", "key-value", "in-memory", "nosql"]
 
+setup_instructions = """
+1. Obtain your Redis connection URL from your Redis hosting provider or local instance (e.g., redis://localhost:6379/0).
+2. If authentication is required, include the password in the URL: redis://user:password@host:6379/0.
+3. Paste the full connection URL into the REDIS_URL field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Obtain your Redis connection URL from your Redis hosting provider or local instance (e.g., redis://localhost:6379/0).
-2. If authentication is required, include the password in the URL: redis://user:password@host:6379/0.
-3. Paste the full connection URL into the REDIS_URL field above.
-"""
-
 
 [i18n.zh]
 name = "Redis"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/sentry.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/sentry.toml
@@ -5,6 +5,12 @@ category = "devtools"
 icon = "lucide:bug"
 tags = ["monitoring", "errors", "debugging", "observability", "apm"]
 
+setup_instructions = """
+1. Go to Sentry > Settings > Auth Tokens (https://sentry.io/settings/account/api/auth-tokens/) and create a new token with 'project:read' and 'event:read' scopes.
+2. Find your organization slug in Sentry > Settings > General Settings.
+3. Paste the auth token and organization slug into the fields above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -27,13 +33,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to Sentry > Settings > Auth Tokens (https://sentry.io/settings/account/api/auth-tokens/) and create a new token with 'project:read' and 'event:read' scopes.
-2. Find your organization slug in Sentry > Settings > General Settings.
-3. Paste the auth token and organization slug into the fields above.
-"""
-
 
 [i18n.zh]
 name = "Sentry"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/sequential-thinking.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/sequential-thinking.toml
@@ -5,6 +5,13 @@ category = "ai"
 icon = "🔗"
 tags = ["reasoning", "thinking", "chain-of-thought", "planning", "logic"]
 
+setup_instructions = """
+No API key required.
+
+Useful for complex reasoning tasks: multi-step math, logic puzzles, planning, debugging.
+The agent can revise earlier steps as it learns more during the thought chain.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -13,14 +20,6 @@ args = ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-No API key required.
-
-Useful for complex reasoning tasks: multi-step math, logic puzzles, planning, debugging.
-The agent can revise earlier steps as it learns more during the thought chain.
-"""
-
 
 [i18n.zh]
 name = "Sequential Thinking"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/slack.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/slack.toml
@@ -5,6 +5,12 @@ category = "communication"
 icon = "lucide:message-circle"
 tags = ["chat", "messaging", "team", "channels", "collaboration"]
 
+setup_instructions = """
+1. Go to https://api.slack.com/apps and create a new Slack app (or use an existing one). Add the 'channels:read', 'chat:write', and 'users:read' bot token scopes.
+2. Install the app to your workspace and copy the Bot User OAuth Token (starts with xoxb-).
+3. Paste the bot token and your workspace Team ID into the fields above, or use the OAuth flow to authorize directly.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -33,13 +39,6 @@ token_url = "https://slack.com/api/oauth.v2.access"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Go to https://api.slack.com/apps and create a new Slack app (or use an existing one). Add the 'channels:read', 'chat:write', and 'users:read' bot token scopes.
-2. Install the app to your workspace and copy the Bot User OAuth Token (starts with xoxb-).
-3. Paste the bot token and your workspace Team ID into the fields above, or use the OAuth flow to authorize directly.
-"""
-
 
 [i18n.zh]
 name = "Slack"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/sqlite-mcp.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/sqlite-mcp.toml
@@ -5,6 +5,12 @@ category = "data"
 icon = "lucide:save"
 tags = ["database", "sql", "relational", "sqlite", "local", "embedded"]
 
+setup_instructions = """
+1. Locate the SQLite database file you want to connect to on your local filesystem.
+2. Enter the absolute path to the database file in the SQLITE_DB_PATH field above.
+3. Ensure the file has appropriate read/write permissions for the LibreFang process.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = ""
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Locate the SQLite database file you want to connect to on your local filesystem.
-2. Enter the absolute path to the database file in the SQLITE_DB_PATH field above.
-3. Ensure the file has appropriate read/write permissions for the LibreFang process.
-"""
-
 
 [i18n.zh]
 name = "SQLite"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/teams-mcp.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/teams-mcp.toml
@@ -5,6 +5,12 @@ category = "communication"
 icon = "lucide:users"
 tags = ["chat", "messaging", "microsoft", "enterprise", "collaboration"]
 
+setup_instructions = """
+1. Click 'Connect' to initiate the OAuth flow with your Microsoft account.
+2. Sign in with your Microsoft 365 account and grant LibreFang permission to read teams and read/write chats.
+3. The connection will be established automatically after authorization.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -19,13 +25,6 @@ token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Click 'Connect' to initiate the OAuth flow with your Microsoft account.
-2. Sign in with your Microsoft 365 account and grant LibreFang permission to read teams and read/write chats.
-3. The connection will be established automatically after authorization.
-"""
-
 
 [i18n.zh]
 name = "Microsoft Teams"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/time.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/time.toml
@@ -5,15 +5,6 @@ category = "productivity"
 icon = "🕐"
 tags = ["time", "timezone", "clock", "datetime", "conversion"]
 
-[transport]
-type = "stdio"
-command = "uvx"
-args = ["mcp-server-time", "--local-timezone", "UTC"]
-
-[health_check]
-interval_secs = 60
-unhealthy_threshold = 3
-
 setup_instructions = """
 No API key required. Requires `uv`:
 - macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
@@ -33,6 +24,14 @@ args = ["mcp-server-time", "--local-timezone", "Asia/Shanghai"]
 Supports all IANA timezone names (e.g. `America/New_York`, `Europe/London`, `Asia/Tokyo`).
 """
 
+[transport]
+type = "stdio"
+command = "uvx"
+args = ["mcp-server-time", "--local-timezone", "UTC"]
+
+[health_check]
+interval_secs = 60
+unhealthy_threshold = 3
 
 [i18n.zh]
 name = "时间 & 时区"

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/todoist.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/todoist.toml
@@ -5,6 +5,12 @@ category = "productivity"
 icon = "lucide:check-circle"
 tags = ["tasks", "todo", "project-management", "productivity", "gtd"]
 
+setup_instructions = """
+1. Open Todoist and go to Settings > Integrations > Developer (https://todoist.com/prefs/integrations).
+2. Copy your API token from the 'API token' section.
+3. Paste the token into the TODOIST_API_KEY field above.
+"""
+
 [transport]
 type = "stdio"
 command = "npx"
@@ -20,13 +26,6 @@ get_url = "https://todoist.com/prefs/integrations"
 [health_check]
 interval_secs = 60
 unhealthy_threshold = 3
-
-setup_instructions = """
-1. Open Todoist and go to Settings > Integrations > Developer (https://todoist.com/prefs/integrations).
-2. Copy your API token from the 'API token' section.
-3. Paste the token into the TODOIST_API_KEY field above.
-"""
-
 
 [i18n.zh]
 name = "Todoist"

--- a/crates/librefang-runtime/tests/registry_mcp_fixture_contract.rs
+++ b/crates/librefang-runtime/tests/registry_mcp_fixture_contract.rs
@@ -1,0 +1,30 @@
+use librefang_types::mcp::McpCatalogEntry;
+use std::path::PathBuf;
+
+#[test]
+fn every_mcp_fixture_keeps_setup_instructions_at_the_catalog_root() {
+    let fixture_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/registry/mcp");
+    let mut fixture_paths = std::fs::read_dir(&fixture_dir)
+        .expect("MCP fixture directory must exist")
+        .map(|entry| {
+            entry
+                .expect("fixture directory entry must be readable")
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|ext| ext == "toml"))
+        .collect::<Vec<_>>();
+    fixture_paths.sort();
+
+    assert!(!fixture_paths.is_empty(), "MCP fixture directory is empty");
+    for path in fixture_paths {
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        let entry = toml::from_str::<McpCatalogEntry>(&source)
+            .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()));
+        assert!(
+            !entry.setup_instructions.trim().is_empty(),
+            "{} lost top-level setup_instructions (check TOML table ordering)",
+            path.display(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Move `setup_instructions` ahead of child TOML tables in every pinned MCP registry fixture so it remains on the catalog root.
- Add a regression contract that parses every MCP fixture as `McpCatalogEntry` and requires non-empty root-level setup instructions.
- Synchronize the branch with the latest `main`.

## Verification

- `cargo test -p librefang-runtime --test registry_mcp_fixture_contract`
- `cargo clippy -p librefang-runtime --test registry_mcp_fixture_contract -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Out of scope

- No runtime MCP parser or catalog schema changes.
