### PR TITLE
fix(runtime): align Bedrock fixture authentication

### DIFF
--- a/changelog.d/fixed/7500-bedrock-fixture-auth.md
+++ b/changelog.d/fixed/7500-bedrock-fixture-auth.md
@@ -1,0 +1,1 @@
+Align the pinned Bedrock provider fixture with the bearer-token credential used by the runtime driver. (#7500) (@houko)

--- a/crates/librefang-runtime/tests/fixtures/registry/providers/bedrock.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/providers/bedrock.toml
@@ -4,7 +4,7 @@
 [provider]
 id = "bedrock"
 display_name = "AWS Bedrock"
-api_key_env = "AWS_ACCESS_KEY_ID"
+api_key_env = "AWS_BEARER_TOKEN_BEDROCK"
 base_url = "https://bedrock-runtime.us-east-1.amazonaws.com"
 key_required = true
 

--- a/crates/librefang-runtime/tests/registry_provider_fixture_contract.rs
+++ b/crates/librefang-runtime/tests/registry_provider_fixture_contract.rs
@@ -1,0 +1,14 @@
+use librefang_types::model_catalog::ModelCatalogFile;
+
+#[test]
+fn bedrock_fixture_uses_the_driver_bearer_token_environment_variable() {
+    let source = include_str!("fixtures/registry/providers/bedrock.toml");
+    let catalog = toml::from_str::<ModelCatalogFile>(source)
+        .expect("Bedrock provider fixture must parse as a model catalog");
+    let provider = catalog
+        .provider
+        .expect("Bedrock provider fixture must declare provider metadata");
+
+    assert_eq!(provider.id, "bedrock");
+    assert_eq!(provider.api_key_env, "AWS_BEARER_TOKEN_BEDROCK");
+}


### PR DESCRIPTION
## Changes

- Align the pinned Bedrock provider fixture with the LLM driver bearer-token environment variable.
- Add a regression that parses the fixture and checks its provider authentication contract.
- Add the required PR-attributed changelog fragment.

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7500-final cargo test -p librefang-runtime --test registry_provider_fixture_contract` (1 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7500-final cargo clippy -p librefang-runtime --test registry_provider_fixture_contract -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- Re-fetched `pull/7500/head` and `origin/main`; both were ancestors of the pushed head.

## Out of scope

- Bedrock driver behavior and embedding SigV4 authentication are unchanged.
- Provider documentation and other registry fixtures remain unchanged.
