### PR TITLE
fix(api): inherit Argon2 workspace features

### DIFF
--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -65,7 +65,7 @@ dirs = { workspace = true }
 jsonwebtoken = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
-argon2 = "0.5"
+argon2 = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 zeroize = { workspace = true }


### PR DESCRIPTION
## Changes

- Inherit the workspace Argon2 dependency in librefang-api.
- Make the API crate directly enable the workspace rand feature instead of relying on feature unification through librefang-extensions.

## Verification

- mise exec -- cargo check -p librefang-api --lib
- mise exec -- cargo tree -p librefang-api -e features -i argon2@0.5.3 (confirmed the API crate directly enables argon2/rand)
- mise exec -- cargo clippy -p librefang-api --lib -- -D warnings
- mise exec -- cargo fmt --check
- git diff --check

## Out of scope

- The workspace Argon2 version and feature set are unchanged.
- Password hashing and authentication behavior are unchanged.
- Cargo.lock is unchanged.