### PR TITLE
fix(api): continue Accept version scans

### DIFF
--- a/crates/librefang-api/src/versioning.rs
+++ b/crates/librefang-api/src/versioning.rs
@@ -92,7 +92,9 @@ pub fn requested_version_from_accept_header(accept: &str) -> Option<&str> {
     for part in accept.split(',') {
         let media_type = part.trim().split(';').next().unwrap_or("").trim();
         if let Some(rest) = media_type.strip_prefix(VENDOR_PREFIX) {
-            let (version, suffix) = rest.rsplit_once('+')?;
+            let Some((version, suffix)) = rest.rsplit_once('+') else {
+                continue;
+            };
             if suffix == "json" && !version.is_empty() {
                 return Some(version);
             }
@@ -217,6 +219,16 @@ mod tests {
         assert_eq!(
             requested_version_from_accept_header("application/vnd.librefang.v1"),
             None
+        );
+    }
+
+    #[test]
+    fn test_requested_version_from_accept_header_skips_malformed_vendor_type() {
+        assert_eq!(
+            requested_version_from_accept_header(
+                "application/vnd.librefang.v1, application/vnd.librefang.v1+json"
+            ),
+            Some("v1")
         );
     }
 


### PR DESCRIPTION
## Changes

- Continue scanning comma-separated Accept values when a vendor media type lacks a + suffix.
- Preserve selection of a later valid LibreFang JSON vendor media type.
- Add a focused regression for malformed-first, valid-second Accept values.

## Verification

- Focused versioning tests: 2 passed
- mise exec -- cargo test -p librefang-api --lib: 1001 passed; one unrelated MCP vault cleanup test failed in parallel and passed on an exact isolated rerun
- mise exec -- cargo clippy -p librefang-api --lib -- -D warnings
- mise exec -- cargo fmt --check
- git diff --check

## Out of scope

- Supported API versions and media-type syntax are unchanged.
- URL-path version precedence and fallback behavior are unchanged.