### PR TITLE
fix(api): preserve Unicode lowercase expansions

### DIFF
--- a/crates/librefang-api/src/stream_dedup.rs
+++ b/crates/librefang-api/src/stream_dedup.rs
@@ -86,7 +86,7 @@ fn normalize(text: &str) -> String {
                 last_was_space = true;
             }
         } else {
-            result.push(ch.to_lowercase().next().unwrap_or(ch));
+            result.extend(ch.to_lowercase());
             last_was_space = false;
         }
     }
@@ -156,5 +156,6 @@ mod tests {
         assert_eq!(normalize("Hello  World"), "hello world");
         assert_eq!(normalize("  spaced  out  "), "spaced out");
         assert_eq!(normalize("UPPER case"), "upper case");
+        assert_eq!(normalize("İSTANBUL"), "i\u{307}stanbul");
     }
 }


### PR DESCRIPTION
## Changes

- Append every scalar produced by Unicode lowercase conversion during stream dedup normalization.
- Preserve multi-scalar mappings such as capital I-with-dot to i plus combining dot.
- Add a focused normalization regression.

## Verification

- Focused stream dedup tests: 7 passed
- mise exec -- cargo test -p librefang-api --lib: 1000 passed; one unrelated MCP vault cleanup test failed in parallel and passed on an exact isolated rerun
- mise exec -- cargo clippy -p librefang-api --lib -- -D warnings
- mise exec -- cargo fmt --check
- git diff --check

## Out of scope

- Dedup window sizing and minimum-length policy are unchanged.
- Whitespace normalization and exact-match behavior are unchanged.