### PR TITLE
fix(api): reject rooted dashboard asset paths

### DIFF
--- a/crates/librefang-api/src/webchat.rs
+++ b/crates/librefang-api/src/webchat.rs
@@ -303,14 +303,11 @@ fn is_safe_asset_path(path: &str) -> bool {
     if path.contains('\0') {
         return false;
     }
-    // Reject Windows UNC / authority-style prefixes outright. `\\server\share`
-    // and `//server/share` carry no `..` segment, so the per-segment check
-    // below passes them — but `Path::join` REPLACES the base with an absolute
-    // or UNC path on Windows, so `home/dashboard`.join("\\server\share")
-    // resolves to `\\server\share`, escaping the dashboard directory entirely.
-    // A legitimate dashboard asset is always a relative sub-path, never an
-    // authority reference, so refuse the prefix on every platform.
-    if path.starts_with("\\\\") || path.starts_with("//") {
+    // A legitimate dashboard asset is always a relative sub-path. Reject any
+    // separator-prefixed value, including Unix absolute paths, Windows rooted
+    // paths, UNC paths, and authority-style paths. Otherwise a future caller
+    // could let `Path::join` replace the dashboard base instead of extending it.
+    if path.starts_with('/') || path.starts_with('\\') {
         return false;
     }
     // Split on BOTH forward slash and backslash. Backslash is a path
@@ -820,6 +817,14 @@ mod tests {
         assert_eq!(decoded, "../etc/passwd");
         assert!(!is_safe_asset_path(&decoded));
 
+        let decoded = percent_decode("%2Fetc%2Fpasswd");
+        assert_eq!(decoded, "/etc/passwd");
+        assert!(!is_safe_asset_path(&decoded));
+
+        let decoded = percent_decode("%5CWindows%5CSystem32");
+        assert_eq!(decoded, "\\Windows\\System32");
+        assert!(!is_safe_asset_path(&decoded));
+
         let decoded = percent_decode("%2e%2e%2fetc%2fpasswd");
         assert_eq!(decoded, "../etc/passwd");
         assert!(!is_safe_asset_path(&decoded));
@@ -841,13 +846,15 @@ mod tests {
     }
 
     #[test]
-    fn safe_asset_path_rejects_unc_and_authority_prefix() {
+    fn safe_asset_path_rejects_absolute_unc_and_authority_prefixes() {
         // Windows UNC (`\\server\share`) and protocol-relative authority
         // (`//server/share`) carry no `..` segment, so the per-segment guard
         // alone lets them through — but `Path::join` REPLACES the dashboard
         // base with the UNC/absolute path on Windows, escaping the directory.
         // The explicit leading-prefix reject closes that on every platform.
         for p in [
+            "/etc/passwd",
+            "\\Windows\\System32\\config\\SAM",
             "\\\\server\\share",
             "\\\\server\\share\\file.js",
             "//server/share",


### PR DESCRIPTION
## Changes

- Reject dashboard asset paths beginning with either path separator.
- Cover Unix absolute paths, Windows rooted paths, UNC paths, and authority-style paths with one self-contained guard.
- Add direct and URL-decoded regression cases.

## Verification

- Focused asset-path tests: 6 passed
- webchat_spa_fallback_test: 7 passed
- mise exec -- cargo clippy -p librefang-api --lib -- -D warnings
- mise exec -- cargo fmt --check
- git diff --check

## Out of scope

- Dashboard archive extraction and synchronization behavior are unchanged.
- SPA route allowlisting and asset resolution precedence are unchanged.