### PR TITLE
fix(extensions): finish failed reconnect state

### DIFF
--- a/changelog.d/fixed/7514-extension-reconnect-state.md
+++ b/changelog.d/fixed/7514-extension-reconnect-state.md
@@ -1,0 +1,1 @@
+Finish every failed MCP reconnect transition so health status no longer remains stuck in an in-progress state after connection or configuration errors. (#7514) (@houko)

--- a/crates/librefang-extensions/src/health.rs
+++ b/crates/librefang-extensions/src/health.rs
@@ -68,6 +68,7 @@ impl McpHealth {
         self.status = McpStatus::Error(error.clone());
         self.last_error = Some(error);
         self.consecutive_failures += 1;
+        self.reconnecting = false;
         self.connected_since = None;
     }
 
@@ -268,6 +269,22 @@ mod tests {
             monitor.mark_reconnecting("test");
         }
         assert!(!monitor.should_reconnect("test"));
+    }
+
+    #[test]
+    fn reconnect_failure_clears_in_progress_state_without_resetting_attempts() {
+        let monitor = HealthMonitor::new(HealthMonitorConfig::default());
+        monitor.register("test");
+        monitor.report_error("test", "initial failure".to_string());
+        monitor.mark_reconnecting("test");
+
+        monitor.report_error("test", "reconnect failed".to_string());
+
+        let health = monitor.get_health("test").unwrap();
+        assert!(!health.reconnecting);
+        assert_eq!(health.reconnect_attempts, 1);
+        assert_eq!(health.consecutive_failures, 2);
+        assert!(matches!(health.status, McpStatus::Error(_)));
     }
 
     #[test]

--- a/crates/librefang-kernel/src/kernel/mcp_setup.rs
+++ b/crates/librefang-kernel/src/kernel/mcp_setup.rs
@@ -547,10 +547,12 @@ impl LibreFangKernel {
         let transport_entry = match &server_config.transport {
             Some(t) => t,
             None => {
-                return Err(format!(
+                let error = format!(
                     "MCP server '{}' has no transport configured",
                     server_config.name
-                ));
+                );
+                self.mcp.mcp_health.report_error(id, error.clone());
+                return Err(error);
             }
         };
         let transport = match transport_entry {


### PR DESCRIPTION
## Changes

- clear the MCP health reconnecting flag whenever a reconnect attempt reports an error
- retain the reconnect-attempt counter so retry limits continue to work
- report a missing transport configuration through the health monitor before reconnect returns
- cover the failed-reconnect state transition with a focused regression test

Audit finding: F-34415b2a3d228a94.

## Verification

- CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7514-final cargo test -p librefang-extensions --lib health::tests -- --nocapture (8 passed)
- CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7514-final cargo clippy -p librefang-extensions -p librefang-kernel --lib -- -D warnings
- cargo fmt --check
- git diff --check
- python3 scripts/check-changelog-attribution.py --base origin/main --head HEAD
- python3 scripts/check-changelog-attribution.py --all-unreleased

## Out of scope

- reconnect scheduling and backoff values are unchanged
- maximum-attempt policy and health-check cadence are unchanged
- successful MCP connection lifecycle is unchanged