### PR TITLE
fix(extensions): preserve missing error status

### DIFF
--- a/changelog.d/fixed/7516-extension-missing-error-status.md
+++ b/changelog.d/fixed/7516-extension-missing-error-status.md
@@ -1,0 +1,1 @@
+Keep missing extension resources as distinct typed errors so API clients receive accurate 404 responses without losing the original failure text. (#7516) (@houko)

--- a/crates/librefang-api/src/routes/skills/extensions.rs
+++ b/crates/librefang-api/src/routes/skills/extensions.rs
@@ -154,12 +154,7 @@ pub async fn install_extension(
         Ok(r) => r,
         Err(e) => {
             let err_str = e.to_string();
-            let status = match e {
-                librefang_types::integration::IntegrationError::NotFound(_) => {
-                    StatusCode::NOT_FOUND
-                }
-                _ => StatusCode::INTERNAL_SERVER_ERROR,
-            };
+            let status = extension_install_error_status(&e);
             // 404 echoes the "not found" message (caller-useful); the
             // 500 catch-all scrubs (audit: rusqlite-errors-leak) and
             // logs the full error for operators.
@@ -271,6 +266,19 @@ pub async fn uninstall_extension(
     )
 }
 
+fn extension_install_error_status(
+    error: &librefang_types::integration::IntegrationError,
+) -> StatusCode {
+    match error {
+        librefang_types::integration::IntegrationError::NotFound(_)
+        | librefang_types::integration::IntegrationError::NotInstalled(_)
+        | librefang_types::integration::IntegrationError::CredentialNotFound(_) => {
+            StatusCode::NOT_FOUND
+        }
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
 fn extension_reload_error(
     action: &str,
     target: &str,
@@ -285,6 +293,29 @@ fn extension_reload_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_extension_resources_return_not_found() {
+        use librefang_types::integration::IntegrationError;
+
+        let errors = [
+            IntegrationError::NotFound("github".to_string()),
+            IntegrationError::NotInstalled("github".to_string()),
+            IntegrationError::CredentialNotFound("GITHUB_TOKEN".to_string()),
+        ];
+
+        for error in errors {
+            assert_eq!(
+                extension_install_error_status(&error),
+                StatusCode::NOT_FOUND
+            );
+        }
+
+        assert_eq!(
+            extension_install_error_status(&IntegrationError::Vault("locked".to_string())),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
 
     #[test]
     fn extension_reload_errors_return_scrubbed_server_error() {

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -85,9 +85,9 @@ impl From<ExtensionError> for librefang_types::integration::IntegrationError {
     fn from(err: ExtensionError) -> Self {
         use librefang_types::integration::IntegrationError as IE;
         match err {
-            ExtensionError::NotFound(s)
-            | ExtensionError::NotInstalled(s)
-            | ExtensionError::CredentialNotFound(s) => IE::NotFound(s),
+            ExtensionError::NotFound(s) => IE::NotFound(s),
+            ExtensionError::NotInstalled(s) => IE::NotInstalled(s),
+            ExtensionError::CredentialNotFound(s) => IE::CredentialNotFound(s),
             ExtensionError::AlreadyInstalled(s) => IE::AlreadyInstalled(s),
             ExtensionError::Vault(s) => IE::Vault(s),
             // `VaultLocked` / `VaultKeyMismatch` are still vault failures at
@@ -114,8 +114,8 @@ mod tests {
         assert!(err.to_string().contains("vault"));
     }
 
-    /// The `From<ExtensionError>` bridge must preserve the `NotFound`
-    /// discriminant the API layer keys its 404 response off, fold the vault
+    /// The `From<ExtensionError>` bridge must preserve the missing-resource
+    /// discriminants the API layer keys its 404 response off, fold the vault
     /// family into `IntegrationError::Vault`, and collapse everything else
     /// into `Other` while keeping the original `Display` message.
     #[test]
@@ -126,10 +126,12 @@ mod tests {
         assert!(matches!(mapped, IE::NotFound(ref s) if s == "github"));
 
         let mapped: IE = ExtensionError::NotInstalled("github".to_string()).into();
-        assert!(matches!(mapped, IE::NotFound(ref s) if s == "github"));
+        assert!(matches!(&mapped, IE::NotInstalled(s) if s == "github"));
+        assert_eq!(mapped.to_string(), "MCP server not configured: github");
 
         let mapped: IE = ExtensionError::CredentialNotFound("GITHUB_TOKEN".to_string()).into();
-        assert!(matches!(mapped, IE::NotFound(ref s) if s == "GITHUB_TOKEN"));
+        assert!(matches!(&mapped, IE::CredentialNotFound(s) if s == "GITHUB_TOKEN"));
+        assert_eq!(mapped.to_string(), "Credential not found: GITHUB_TOKEN");
 
         let mapped: IE = ExtensionError::AlreadyInstalled("slack".to_string()).into();
         assert!(matches!(mapped, IE::AlreadyInstalled(ref s) if s == "slack"));

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -77,15 +77,17 @@ pub type ExtensionResult<T> = Result<T, ExtensionError>;
 /// `IntegrationError` directly without ever touching this crate.
 ///
 /// The mapping preserves the discriminant the API layer keys HTTP status
-/// codes off (`NotFound` → 404; everything else → 500). Variants that don't
-/// have a direct counterpart collapse into `IntegrationError::Other`, whose
-/// `Display` carries the original `ExtensionError` message so operator-facing
-/// responses are unchanged.
+/// codes off (missing resources → 404; everything else → 500). Variants that
+/// don't have a direct counterpart collapse into `IntegrationError::Other`,
+/// whose `Display` carries the original `ExtensionError` message so
+/// operator-facing responses are unchanged.
 impl From<ExtensionError> for librefang_types::integration::IntegrationError {
     fn from(err: ExtensionError) -> Self {
         use librefang_types::integration::IntegrationError as IE;
         match err {
-            ExtensionError::NotFound(s) => IE::NotFound(s),
+            ExtensionError::NotFound(s)
+            | ExtensionError::NotInstalled(s)
+            | ExtensionError::CredentialNotFound(s) => IE::NotFound(s),
             ExtensionError::AlreadyInstalled(s) => IE::AlreadyInstalled(s),
             ExtensionError::Vault(s) => IE::Vault(s),
             // `VaultLocked` / `VaultKeyMismatch` are still vault failures at
@@ -122,6 +124,12 @@ mod tests {
 
         let mapped: IE = ExtensionError::NotFound("github".to_string()).into();
         assert!(matches!(mapped, IE::NotFound(ref s) if s == "github"));
+
+        let mapped: IE = ExtensionError::NotInstalled("github".to_string()).into();
+        assert!(matches!(mapped, IE::NotFound(ref s) if s == "github"));
+
+        let mapped: IE = ExtensionError::CredentialNotFound("GITHUB_TOKEN".to_string()).into();
+        assert!(matches!(mapped, IE::NotFound(ref s) if s == "GITHUB_TOKEN"));
 
         let mapped: IE = ExtensionError::AlreadyInstalled("slack".to_string()).into();
         assert!(matches!(mapped, IE::AlreadyInstalled(ref s) if s == "slack"));

--- a/crates/librefang-types/src/integration.rs
+++ b/crates/librefang-types/src/integration.rs
@@ -12,8 +12,8 @@
 //! (the conversion impls live in `librefang-extensions`).
 //!
 //! The variants intentionally preserve the discriminants the API layer maps
-//! to HTTP status codes (`NotFound` → 404; everything else → 500), so the
-//! switch from `ExtensionError` does not silently change response shapes.
+//! to HTTP status codes (missing resources → 404; everything else → 500), so
+//! the switch from `ExtensionError` does not silently change response shapes.
 
 use crate::config::McpServerConfigEntry;
 use crate::mcp::McpStatus;
@@ -64,6 +64,14 @@ pub enum IntegrationError {
     #[error("MCP catalog entry not found: {0}")]
     NotFound(String),
 
+    /// The requested MCP server was not configured.
+    #[error("MCP server not configured: {0}")]
+    NotInstalled(String),
+
+    /// A required credential was not present in the configured sources.
+    #[error("Credential not found: {0}")]
+    CredentialNotFound(String),
+
     /// An MCP server with this id / name is already configured.
     #[error("MCP server already configured: {0}")]
     AlreadyInstalled(String),
@@ -96,6 +104,14 @@ mod tests {
         assert_eq!(
             IntegrationError::NotFound("github".into()).to_string(),
             "MCP catalog entry not found: github"
+        );
+        assert_eq!(
+            IntegrationError::NotInstalled("github".into()).to_string(),
+            "MCP server not configured: github"
+        );
+        assert_eq!(
+            IntegrationError::CredentialNotFound("GITHUB_TOKEN".into()).to_string(),
+            "Credential not found: GITHUB_TOKEN"
         );
         assert_eq!(
             IntegrationError::AlreadyInstalled("slack".into()).to_string(),


### PR DESCRIPTION
## Changes

- preserve `NotFound`, `NotInstalled`, and `CredentialNotFound` as distinct shared integration errors
- map all three missing-resource variants to HTTP 404 without changing their operator-facing text
- add shared-type, bridge, and API-status regression coverage
- add the required changelog fragment

Audit finding: `F-5ed431ba4f828858`.

## Verification

- `mise exec -- cargo test -p librefang-types --lib integration::tests -- --nocapture`
- `mise exec -- cargo test -p librefang-extensions --lib extension_error_maps_to_integration_error -- --nocapture`
- `mise exec -- cargo test -p librefang-api --lib missing_extension_resources_return_not_found -- --nocapture`
- `mise exec -- cargo clippy -p librefang-types -p librefang-extensions -p librefang-api --lib -- -D warnings`
- `mise exec -- cargo fmt --check`
- `git diff --check`
- `python3 scripts/check-changelog-attribution.py --base origin/main --head HEAD`

## Out of scope

- vault, installation-conflict, and generic failure mappings are unchanged
- API response-body scrubbing for internal errors is unchanged
