### PR TITLE
fix(extensions): propagate client build errors

### DIFF
--- a/crates/librefang-extensions/src/http_client.rs
+++ b/crates/librefang-extensions/src/http_client.rs
@@ -26,8 +26,26 @@ pub fn client_builder() -> ClientBuilder {
         .redirect(reqwest::redirect::Policy::limited(5))
 }
 
-pub fn new_client() -> reqwest::Client {
-    client_builder()
-        .build()
-        .expect("HTTP client with bundled CA roots should always build")
+pub fn new_client() -> Result<reqwest::Client, reqwest::Error> {
+    build_client(client_builder())
+}
+
+fn build_client(builder: ClientBuilder) -> Result<reqwest::Client, reqwest::Error> {
+    builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_build_errors_are_returned() {
+        let builder = ClientBuilder::new().user_agent("invalid\nuser-agent");
+        assert!(build_client(builder).is_err());
+    }
+
+    #[test]
+    fn shared_client_builds_with_bundled_roots() {
+        assert!(new_client().is_ok());
+    }
 }

--- a/crates/librefang-extensions/src/oauth.rs
+++ b/crates/librefang-extensions/src/oauth.rs
@@ -282,7 +282,8 @@ pub async fn run_pkce_flow(oauth: &OAuthTemplate, client_id: &str) -> ExtensionR
     debug!("Received authorization code, exchanging for tokens...");
 
     // Exchange code for tokens
-    let client = crate::http_client::new_client();
+    let client = crate::http_client::new_client()
+        .map_err(|e| ExtensionError::OAuth(format!("Failed to build HTTP client: {e}")))?;
     let mut params = HashMap::new();
     params.insert("grant_type", "authorization_code");
     params.insert("code", &code);


### PR DESCRIPTION
## Changes

- return `reqwest::Error` from the shared extension HTTP client constructor instead of panicking
- translate OAuth client-construction failures into the existing handled OAuth error path
- cover both a deliberately invalid builder and the normal bundled-root configuration

Audit finding: `F-4a06d65229e74306`.

## Verification

- `mise exec -- cargo test -p librefang-extensions --lib http_client::tests` (2 passed)
- `mise exec -- cargo clippy -p librefang-extensions --lib -- -D warnings`
- `mise exec -- cargo fmt --check`
- `git diff --check`

## Out of scope

- TLS root selection and default protocol configuration are unchanged
- connection, read, and redirect policies are unchanged
- OAuth request and token-exchange behavior are unchanged