### PR TITLE
fix(kernel): preserve retryable approvals

### DIFF
--- a/changelog.d/fixed/7524-approval-self-handle-preflight.md
+++ b/changelog.d/fixed/7524-approval-self-handle-preflight.md
@@ -1,0 +1,1 @@
+Keep deferred approvals pending when the kernel self-handle needed to resume them is unavailable so the decision remains retryable. (#7524) (@houko)

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1,7 +1,7 @@
 //! Execution approval manager — gates dangerous operations behind human approval.
 
 use chrono::Utc;
-use dashmap::DashMap;
+use dashmap::{mapref::entry::Entry, DashMap};
 use librefang_types::approval::{
     ApprovalAuditEntry, ApprovalDecision, ApprovalEvent, ApprovalPolicy, ApprovalRequest,
     ApprovalResponse, RiskLevel, SecondFactor, TimeoutFallback,
@@ -1064,6 +1064,51 @@ impl ApprovalManager {
         totp_verified: bool,
         user_id: Option<&str>,
     ) -> Result<(ApprovalResponse, Option<DeferredToolExecution>), String> {
+        let (response, deferred) = self.resolve_inner(
+            request_id,
+            decision,
+            decided_by,
+            totp_verified,
+            user_id,
+            || Ok(()),
+        )?;
+        Ok((response, deferred.map(|(deferred, ())| deferred)))
+    }
+
+    /// Resolve a request after acquiring the resource required to resume deferred work.
+    ///
+    /// `preflight` runs only for a pending request with a deferred payload. It runs
+    /// while that pending entry is still locked and before it is removed, so a
+    /// failed preflight leaves the approval retryable. The acquired resource is
+    /// returned alongside the deferred payload.
+    pub(crate) fn resolve_with_deferred_preflight<T>(
+        &self,
+        request_id: Uuid,
+        decision: ApprovalDecision,
+        decided_by: Option<String>,
+        totp_verified: bool,
+        user_id: Option<&str>,
+        preflight: impl FnOnce() -> Result<T, String>,
+    ) -> Result<(ApprovalResponse, Option<(DeferredToolExecution, T)>), String> {
+        self.resolve_inner(
+            request_id,
+            decision,
+            decided_by,
+            totp_verified,
+            user_id,
+            preflight,
+        )
+    }
+
+    fn resolve_inner<T>(
+        &self,
+        request_id: Uuid,
+        decision: ApprovalDecision,
+        decided_by: Option<String>,
+        totp_verified: bool,
+        user_id: Option<&str>,
+        preflight: impl FnOnce() -> Result<T, String>,
+    ) -> Result<(ApprovalResponse, Option<(DeferredToolExecution, T)>), String> {
         // Read policy once and hold the snapshot for both the gate check and
         // the grace-period recording below, avoiding a hot-reload race between
         // two separate lock acquisitions.
@@ -1085,8 +1130,14 @@ impl ApprovalManager {
             }
         }
 
-        match self.pending.remove(&request_id) {
-            Some((_, pending)) => {
+        match self.pending.entry(request_id) {
+            Entry::Occupied(entry) => {
+                let deferred_resource = if entry.get().deferred.is_some() {
+                    Some(preflight()?)
+                } else {
+                    None
+                };
+                let pending = entry.remove();
                 // Remove from persistent store now that it is resolved (issue #3611).
                 self.db_delete_pending(request_id);
 
@@ -1153,9 +1204,9 @@ impl ApprovalManager {
                 if let Some(sender) = pending.sender {
                     let _ = sender.send(decision);
                 }
-                Ok((response, pending.deferred))
+                Ok((response, pending.deferred.zip(deferred_resource)))
             }
-            None => {
+            Entry::Vacant(_) => {
                 // Not pending. Distinguish "already resolved" (→ 409 at the api boundary) from "never existed / long expired" (→ 404).
                 // Check the in-memory `recent` ring first for the fast path, then fall back to the durable audit log so the answer stays stable after `recent` evicts the entry or the daemon restarts (issue #6492 Bug 3).
                 let recent = Self::lock_state(&self.recent, "recent");

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -433,18 +433,6 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         ),
         kernel_handle::KernelOpError,
     > {
-        // Resolving removes the pending request and records its terminal
-        // decision. Acquire the handle needed to resume deferred work first,
-        // so a malformed kernel cannot terminalize an approval and then lose
-        // the approved tool with no retry path.
-        let kernel = self
-            .self_handle
-            .get()
-            .and_then(|weak| weak.upgrade())
-            .ok_or_else(|| {
-                kernel_handle::KernelOpError::Internal("Kernel self-handle unavailable".to_string())
-            })?;
-
         // #3541 follow-up: classify the missing-id case as
         // `KernelOpError::AgentNotFound` / `Internal` so the API
         // boundary surfaces 404 via the typed mapping. The underlying
@@ -452,10 +440,22 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         // is left to a separate ApprovalManager refactor); the substring
         // check is scoped to the manager's exact "not found or expired"
         // wording. All other error wordings flow through `Internal`.
-        let (response, deferred) = self
+        let (response, deferred_with_kernel) = self
             .governance
             .approval_manager
-            .resolve(request_id, decision, decided_by, totp_verified, user_id)
+            .resolve_with_deferred_preflight(
+                request_id,
+                decision,
+                decided_by,
+                totp_verified,
+                user_id,
+                || {
+                    self.self_handle
+                        .get()
+                        .and_then(|weak| weak.upgrade())
+                        .ok_or_else(|| "Kernel self-handle unavailable".to_string())
+                },
+            )
             .map_err(|msg| {
                 if msg.starts_with("Already ") {
                     // Double-resolve of an already-terminal approval ("Already {decision} by {who}") is a state conflict, not a malformed request: map to `Conflict` (409) so a client can tell "someone already handled this" apart from a bad request (400) or a never-existed id (404).
@@ -474,7 +474,7 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
 
         // Deferred approval execution resumes in the background so API callers do
         // not block on slow tools.
-        if let Some(ref def) = deferred {
+        let deferred = deferred_with_kernel.map(|(def, kernel)| {
             let decision_clone = response.decision.clone();
             let deferred_clone = def.clone();
             spawn_logged("approval_resolution", async move {
@@ -482,7 +482,8 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
                     .handle_approval_resolution(request_id, decision_clone, deferred_clone)
                     .await;
             });
-        }
+            def
+        });
 
         Ok((response, deferred))
     }
@@ -595,6 +596,64 @@ mod tests {
                 .is_some(),
             "failed preflight must leave approval retryable"
         );
+
+        kernel.shutdown();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_self_handle_does_not_block_manual_approval() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = KernelConfig {
+            home_dir: tmp.path().to_path_buf(),
+            data_dir: tmp.path().join("data"),
+            ..KernelConfig::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+        assert!(kernel.self_handle.get().is_none());
+
+        let request_id = uuid::Uuid::new_v4();
+        let request = ApprovalRequest {
+            id: request_id,
+            agent_id: AgentId::new().to_string(),
+            tool_name: "shell_exec".to_string(),
+            description: "run command".to_string(),
+            action_summary: "run command".to_string(),
+            risk_level: RiskLevel::High,
+            requested_at: chrono::Utc::now(),
+            timeout_secs: 60,
+            sender_id: None,
+            channel: None,
+            chat_id: None,
+            route_to: Vec::new(),
+            escalation_count: 0,
+            session_id: None,
+            tool_use_id: None,
+        };
+        kernel
+            .governance
+            .approval_manager
+            .submit_manual_request(request)
+            .expect("submit approval");
+
+        let (response, deferred) = kernel_handle::ApprovalGate::resolve_tool_approval(
+            &kernel,
+            request_id,
+            ApprovalDecision::Denied,
+            Some("test".to_string()),
+            false,
+            None,
+        )
+        .await
+        .expect("manual approval does not need deferred resume state");
+
+        assert_eq!(response.decision, ApprovalDecision::Denied);
+        assert!(deferred.is_none());
+        assert!(kernel
+            .governance
+            .approval_manager
+            .get_pending(request_id)
+            .is_none());
 
         kernel.shutdown();
     }

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -2,8 +2,6 @@
 //! Holds the synchronous "does this tool require approval?" predicates and the async request/submit/resolve flow used by the agent loop.
 //! Hand-tagged agents (curated trusted packages) auto-approve on the context-carrying non-blocking path unless per-user policy demanded human approval (RBAC M3, #3054).
 
-use std::sync::Arc;
-
 use tracing::{debug, info};
 
 use librefang_runtime::kernel_handle;
@@ -435,6 +433,18 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         ),
         kernel_handle::KernelOpError,
     > {
+        // Resolving removes the pending request and records its terminal
+        // decision. Acquire the handle needed to resume deferred work first,
+        // so a malformed kernel cannot terminalize an approval and then lose
+        // the approved tool with no retry path.
+        let kernel = self
+            .self_handle
+            .get()
+            .and_then(|weak| weak.upgrade())
+            .ok_or_else(|| {
+                kernel_handle::KernelOpError::Internal("Kernel self-handle unavailable".to_string())
+            })?;
+
         // #3541 follow-up: classify the missing-id case as
         // `KernelOpError::AgentNotFound` / `Internal` so the API
         // boundary surfaces 404 via the typed mapping. The underlying
@@ -466,13 +476,6 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         // not block on slow tools.
         if let Some(ref def) = deferred {
             let decision_clone = response.decision.clone();
-            let kernel = Arc::clone(
-                self.self_handle
-                    .get()
-                    .and_then(|w| w.upgrade())
-                    .as_ref()
-                    .ok_or_else(|| "Kernel self-handle unavailable".to_string())?,
-            );
             let deferred_clone = def.clone();
             spawn_logged("approval_resolution", async move {
                 kernel
@@ -506,5 +509,93 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
             }
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use librefang_types::approval::{ApprovalDecision, ApprovalRequest, RiskLevel};
+    use librefang_types::config::KernelConfig;
+    use librefang_types::tool::DeferredToolExecution;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_self_handle_leaves_deferred_approval_pending() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = KernelConfig {
+            home_dir: tmp.path().to_path_buf(),
+            data_dir: tmp.path().join("data"),
+            ..KernelConfig::default()
+        };
+        std::fs::create_dir_all(&config.data_dir).unwrap();
+        let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+        assert!(kernel.self_handle.get().is_none());
+
+        let request_id = uuid::Uuid::new_v4();
+        let request = ApprovalRequest {
+            id: request_id,
+            agent_id: AgentId::new().to_string(),
+            tool_name: "shell_exec".to_string(),
+            description: "run command".to_string(),
+            action_summary: "run command".to_string(),
+            risk_level: RiskLevel::High,
+            requested_at: chrono::Utc::now(),
+            timeout_secs: 60,
+            sender_id: None,
+            channel: None,
+            chat_id: None,
+            route_to: Vec::new(),
+            escalation_count: 0,
+            session_id: None,
+            tool_use_id: Some("tool-use-test".to_string()),
+        };
+        let deferred = DeferredToolExecution {
+            agent_id: request.agent_id.clone(),
+            tool_use_id: "tool-use-test".to_string(),
+            tool_name: request.tool_name.clone(),
+            input: serde_json::json!({}),
+            allowed_tools: None,
+            allowed_env_vars: None,
+            exec_policy: None,
+            sender_id: None,
+            channel: None,
+            chat_id: None,
+            account_id: None,
+            workspace_root: None,
+            force_human: false,
+            session_id: None,
+        };
+        kernel
+            .governance
+            .approval_manager
+            .submit_request(request, deferred)
+            .expect("submit approval");
+
+        let error = kernel_handle::ApprovalGate::resolve_tool_approval(
+            &kernel,
+            request_id,
+            ApprovalDecision::Approved,
+            Some("test".to_string()),
+            false,
+            None,
+        )
+        .await
+        .expect_err("missing self-handle must fail before resolution");
+
+        assert!(matches!(
+            error,
+            kernel_handle::KernelOpError::Internal(ref message)
+                if message == "Kernel self-handle unavailable"
+        ));
+        assert!(
+            kernel
+                .governance
+                .approval_manager
+                .get_pending(request_id)
+                .is_some(),
+            "failed preflight must leave approval retryable"
+        );
+
+        kernel.shutdown();
     }
 }


### PR DESCRIPTION
## Changes

- Acquire the kernel self-handle only for approvals that carry deferred tool execution.
- Run that preflight while the pending entry is locked and before removal, so failure leaves the decision retryable under concurrent resolution.
- Return the acquired handle with the deferred payload and use it for background resolution.
- Preserve normal resolution for manual and blocking approvals that do not need deferred resume state.
- Add regressions for both deferred and manual approvals, plus a changelog fragment.

## Verification

- `cargo test -p librefang-kernel --lib missing_self_handle` (2 passed)
- `cargo test -p librefang-kernel --lib approval::tests::` (100 passed)
- `cargo clippy -p librefang-kernel --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/check-changelog-attribution.py`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- The existing string-based `ApprovalManager::resolve` error API remains unchanged.