### PR TITLE
fix(kernel): neutralize reviewer code fences

### DIFF
--- a/changelog.d/fixed/7525-reviewer-code-fence-neutralization.md
+++ b/changelog.d/fixed/7525-reviewer-code-fence-neutralization.md
@@ -1,0 +1,1 @@
+Neutralize every triple-backtick sequence in untrusted reviewer context, including longer backtick runs that previously rebuilt a valid code fence. (#7525) (@houko)

--- a/crates/librefang-kernel/src/kernel/reviewer_sanitize.rs
+++ b/crates/librefang-kernel/src/kernel/reviewer_sanitize.rs
@@ -14,6 +14,32 @@ pub(super) fn sanitize_reviewer_line(s: &str, max_chars: usize) -> String {
     librefang_runtime::prompt_builder::sanitize_for_prompt(s, max_chars)
 }
 
+/// Break every run of three or more backticks without deleting content.
+///
+/// A single non-overlapping `replace("```", "``")` is insufficient:
+/// four backticks become three. Inserting a visible space before every
+/// third backtick guarantees no output run can form a Markdown fence.
+fn neutralize_code_fences(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut backtick_run = 0;
+
+    for ch in s.chars() {
+        if ch == '`' {
+            if backtick_run == 2 {
+                out.push(' ');
+                backtick_run = 0;
+            }
+            out.push(ch);
+            backtick_run += 1;
+        } else {
+            backtick_run = 0;
+            out.push(ch);
+        }
+    }
+
+    out
+}
+
 /// Sanitize a multi-line block (trace summary, response summary) for
 /// embedding inside `<data>…</data>` markers in the reviewer prompt.
 ///
@@ -43,8 +69,7 @@ pub(super) fn sanitize_reviewer_block(s: &str, max_chars: usize) -> String {
     // Neutralize markers that could break out of the reviewer's data block
     // or forge an answer code fence. Replace rather than strip so the
     // content's shape (indentation, line structure) stays recognizable.
-    let out = out
-        .replace("```", "``")
+    let out = neutralize_code_fences(&out)
         .replace("<data>", "(data)")
         .replace("</data>", "(/data)");
     if out.chars().count() <= max_chars {
@@ -53,4 +78,31 @@ pub(super) fn sanitize_reviewer_block(s: &str, max_chars: usize) -> String {
     // UTF-8-safe truncation: keep chars, not bytes.
     let truncated: String = out.chars().take(max_chars.saturating_sub(14)).collect();
     format!("{truncated} …[truncated]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fence_neutralization_handles_every_run_length() {
+        for run_len in 3..=12 {
+            let input = "`".repeat(run_len);
+            let output = neutralize_code_fences(&input);
+
+            assert!(
+                !output.contains("```"),
+                "run of {run_len} backticks rebuilt a fence: {output:?}"
+            );
+            assert_eq!(output.chars().filter(|ch| *ch == '`').count(), run_len);
+        }
+    }
+
+    #[test]
+    fn reviewer_block_neutralizes_four_backtick_bypass() {
+        let output = sanitize_reviewer_block("before ````json after", 200);
+
+        assert!(!output.contains("```"));
+        assert_eq!(output, "before `` ``json after");
+    }
 }


### PR DESCRIPTION
## Changes

- Replace non-overlapping triple-backtick substitution with run-aware fence neutralization.
- Insert a visible separator before every third backtick while preserving every original backtick.
- Cover run lengths three through twelve and the reported four-backtick bypass.
- Add the required changelog fragment.

Audit finding: F-baeeec92de34337d.

## Verification

- `cargo test -p librefang-kernel --lib sanitize_reviewer` — 4 passed.
- `cargo test -p librefang-kernel --lib fence_neutralization` — 1 passed.
- `cargo test -p librefang-kernel --lib four_backtick_bypass` — 1 passed.
- `cargo clippy -p librefang-kernel --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/check-changelog-attribution.py`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- Data-marker neutralization, control-character handling, truncation limits, reviewer prompt structure, and JSON extraction strategies are unchanged.