### PR TITLE
fix(kernel): preserve goal not-found status

### DIFF
--- a/changelog.d/fixed/7527-goal-not-found-status.md
+++ b/changelog.d/fixed/7527-goal-not-found-status.md
@@ -1,0 +1,1 @@
+Return a typed not-found error when goal updates target an absent store or missing goal while keeping malformed goal storage as an internal error. (#7527) (@houko)

--- a/crates/librefang-kernel/src/kernel/handles/goal_control.rs
+++ b/crates/librefang-kernel/src/kernel/handles/goal_control.rs
@@ -7,6 +7,60 @@ use librefang_runtime::kernel_handle;
 
 use super::super::{shared_memory_agent_id, LibreFangKernel};
 
+fn goal_not_found(goal_id: &str) -> kernel_handle::KernelOpError {
+    kernel_handle::KernelOpError::ResourceNotFound {
+        kind: "goal".to_string(),
+        id: goal_id.to_string(),
+    }
+}
+
+fn decode_goal_store(
+    current: Option<serde_json::Value>,
+    goal_id: &str,
+) -> Result<Vec<serde_json::Value>, kernel_handle::KernelOpError> {
+    match current {
+        Some(serde_json::Value::Array(goals)) => Ok(goals),
+        None => Err(goal_not_found(goal_id)),
+        Some(_) => Err(kernel_handle::KernelOpError::Internal(
+            "Malformed goal store: `__librefang_goals` must be a JSON array".to_string(),
+        )),
+    }
+}
+
+fn apply_goal_update(
+    mut goals: Vec<serde_json::Value>,
+    goal_id: &str,
+    status: Option<&str>,
+    progress: Option<u8>,
+) -> Result<(serde_json::Value, serde_json::Value), kernel_handle::KernelOpError> {
+    let mut updated_goal = None;
+    for goal in &mut goals {
+        if goal["id"].as_str() == Some(goal_id) {
+            if let Some(status) = status {
+                goal["status"] = serde_json::Value::String(status.to_string());
+            }
+            if let Some(progress) = progress {
+                goal["progress"] = serde_json::json!(progress);
+            }
+            goal["updated_at"] = serde_json::Value::String(chrono::Utc::now().to_rfc3339());
+            updated_goal = Some(goal.clone());
+            break;
+        }
+    }
+
+    let result = updated_goal.ok_or_else(|| goal_not_found(goal_id))?;
+    Ok((serde_json::Value::Array(goals), result))
+}
+
+fn map_goal_update_error(error: kernel_handle::KernelOpError) -> kernel_handle::KernelOpError {
+    match error {
+        kernel_handle::KernelOpError::Internal(_)
+        | kernel_handle::KernelOpError::InvalidInput(_)
+        | kernel_handle::KernelOpError::ResourceNotFound { .. } => error,
+        other => kernel_handle::KernelOpError::Internal(format!("Failed to save goals: {other}")),
+    }
+}
+
 impl kernel_handle::GoalControl for LibreFangKernel {
     fn goal_list_active(
         &self,
@@ -59,43 +113,60 @@ impl kernel_handle::GoalControl for LibreFangKernel {
         self.memory
             .substrate
             .structured_modify(shared_id, "__librefang_goals", |current| {
-                let mut goals: Vec<serde_json::Value> = match current {
-                    Some(serde_json::Value::Array(arr)) => arr,
-                    _ => {
-                        return Err(kernel_handle::KernelOpError::Internal(format!(
-                            "goal `{goal_id}` not found"
-                        )))
-                    }
-                };
-
-                let mut updated_goal = None;
-                for g in goals.iter_mut() {
-                    if g["id"].as_str() == Some(goal_id) {
-                        if let Some(s) = status {
-                            g["status"] = serde_json::Value::String(s.to_string());
-                        }
-                        if let Some(p) = progress {
-                            g["progress"] = serde_json::json!(p);
-                        }
-                        g["updated_at"] =
-                            serde_json::Value::String(chrono::Utc::now().to_rfc3339());
-                        updated_goal = Some(g.clone());
-                        break;
-                    }
-                }
-
-                let result = updated_goal.ok_or_else(|| {
-                    kernel_handle::KernelOpError::Internal(format!("goal `{goal_id}` not found"))
-                })?;
-
-                Ok((serde_json::Value::Array(goals), result))
+                let goals = decode_goal_store(current, goal_id)?;
+                apply_goal_update(goals, goal_id, status, progress)
             })
-            .map_err(|e| match e {
-                kernel_handle::KernelOpError::Internal(_)
-                | kernel_handle::KernelOpError::InvalidInput(_) => e,
-                other => {
-                    kernel_handle::KernelOpError::Internal(format!("Failed to save goals: {other}"))
-                }
-            })
+            .map_err(map_goal_update_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_goal_store_is_typed_not_found() {
+        let error = decode_goal_store(None, "goal-123").unwrap_err();
+
+        assert!(matches!(
+            error,
+            kernel_handle::KernelOpError::ResourceNotFound { ref kind, ref id }
+                if kind == "goal" && id == "goal-123"
+        ));
+    }
+
+    #[test]
+    fn malformed_goal_store_is_internal() {
+        let error =
+            decode_goal_store(Some(serde_json::json!({"id": "goal-123"})), "goal-123").unwrap_err();
+
+        assert!(matches!(
+            error,
+            kernel_handle::KernelOpError::Internal(ref message)
+                if message.contains("must be a JSON array")
+        ));
+    }
+
+    #[test]
+    fn missing_id_in_valid_goal_store_is_typed_not_found() {
+        let error =
+            apply_goal_update(Vec::new(), "goal-123", Some("completed"), Some(100)).unwrap_err();
+
+        assert!(matches!(
+            error,
+            kernel_handle::KernelOpError::ResourceNotFound { ref kind, ref id }
+                if kind == "goal" && id == "goal-123"
+        ));
+    }
+
+    #[test]
+    fn transaction_boundary_preserves_goal_not_found() {
+        let error = map_goal_update_error(goal_not_found("goal-123"));
+
+        assert!(matches!(
+            error,
+            kernel_handle::KernelOpError::ResourceNotFound { ref kind, ref id }
+                if kind == "goal" && id == "goal-123"
+        ));
     }
 }


### PR DESCRIPTION
## Changes\n\n- return ResourceNotFound when the goal store is absent or the requested goal ID is missing\n- keep malformed goal storage as an Internal error\n- preserve typed not-found errors across the structured transaction boundary\n- add focused coverage for all three error paths\n- add the required changelog fragment\n\n## Verification\n\n- CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7527-final cargo test -p librefang-kernel --lib goal_control::tests (4 passed)\n- CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7527-final cargo clippy -p librefang-kernel --lib -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n- python3 scripts/check-changelog-attribution.py\n- python3 scripts/check-changelog-attribution.py --all-unreleased\n\n## Out of scope\n\n- goal payload validation is unchanged\n- active-goal listing behavior is unchanged\n- API serialization of KernelOpError is unchanged