### PR TITLE
fix(runtime): surface catalog scan failures

### DIFF
--- a/changelog.d/fixed/7529-catalog-scan-errors.md
+++ b/changelog.d/fixed/7529-catalog-scan-errors.md
@@ -1,0 +1,1 @@
+Report provider catalog scan, read, and parse failures while counting only successfully parsed catalog files in sync results. (#7529) (@houko)

--- a/crates/librefang-runtime/src/catalog_sync.rs
+++ b/crates/librefang-runtime/src/catalog_sync.rs
@@ -99,18 +99,51 @@ pub async fn sync_catalog_to(
     let mut models_count = 0usize;
 
     if repo_providers.is_dir() {
-        if let Ok(entries) = std::fs::read_dir(&repo_providers) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "toml") {
-                    file_count += 1;
-                    if let Ok(content) = std::fs::read_to_string(&path) {
-                        if let Ok(file) = toml::from_str::<ProviderCatalogFile>(&content) {
-                            models_count += file.models.len();
+        match std::fs::read_dir(&repo_providers) {
+            Ok(entries) => {
+                for entry in entries {
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(error) => {
+                            tracing::warn!(%error, "failed to inspect provider catalog entry");
+                            continue;
                         }
+                    };
+                    let path = entry.path();
+                    if path.extension().is_none_or(|e| e != "toml") {
+                        continue;
                     }
+                    let content = match std::fs::read_to_string(&path) {
+                        Ok(content) => content,
+                        Err(error) => {
+                            tracing::warn!(
+                                path = %path.display(),
+                                %error,
+                                "failed to read provider catalog"
+                            );
+                            continue;
+                        }
+                    };
+                    let file = match toml::from_str::<ProviderCatalogFile>(&content) {
+                        Ok(file) => file,
+                        Err(error) => {
+                            tracing::warn!(
+                                path = %path.display(),
+                                %error,
+                                "failed to parse provider catalog"
+                            );
+                            continue;
+                        }
+                    };
+                    file_count += 1;
+                    models_count += file.models.len();
                 }
             }
+            Err(error) => tracing::warn!(
+                path = %repo_providers.display(),
+                %error,
+                "failed to scan provider catalogs"
+            ),
         }
     } else {
         tracing::warn!(
@@ -243,6 +276,22 @@ supports_streaming = true
             result.models_count >= 1,
             "its models must reach the catalog; got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn malformed_provider_is_not_reported_as_downloaded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let providers = tmp.path().join("registry").join("providers");
+        std::fs::create_dir_all(&providers).expect("create providers dir");
+        std::fs::write(providers.join("broken.toml"), "[[models]")
+            .expect("write malformed provider catalog");
+
+        let result = sync_catalog_to(tmp.path(), "", None, false)
+            .await
+            .expect("catalog rebuild should skip malformed provider files");
+
+        assert_eq!(result.files_downloaded, 0);
+        assert_eq!(result.models_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- warn with the affected path and error when provider catalogs cannot be read or parsed
- report only successfully parsed provider files in `files_downloaded`
- surface provider-directory and directory-entry scan failures instead of silently flattening them
- add a regression proving malformed catalogs are not counted as downloaded

## Verification

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7529-final cargo test -p librefang-runtime --lib malformed_provider_is_not_reported_as_downloaded`
- `CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7529-final cargo clippy -p librefang-runtime --lib -- -D warnings`
- `python3 scripts/check-changelog-attribution.py`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- registry fetch and fallback policy
- catalog schema changes
- last-sync timestamp persistence
- recursive provider discovery