### PR TITLE
fix(memory): resolve channel bindings atomically

### DIFF
--- a/changelog.d/fixed/7533-channel-binding-resolve-snapshot.md
+++ b/changelog.d/fixed/7533-channel-binding-resolve-snapshot.md
@@ -1,0 +1,1 @@
+Resolve conversation overrides and channel instance defaults in one SQLite snapshot so concurrent resets or rebinds cannot produce a mixed dispatch decision. (#7533) (@houko)

--- a/crates/librefang-memory/src/channel_binding_store.rs
+++ b/crates/librefang-memory/src/channel_binding_store.rs
@@ -206,10 +206,21 @@ impl ChannelBindingStore {
         instance: &str,
         conversation_id: &str,
     ) -> LibreFangResult<Option<String>> {
-        if let Some(agent) = self.conversation_binding(instance, conversation_id)? {
-            return Ok(Some(agent));
-        }
-        self.instance_default(instance)
+        // Keep both precedence levels in one statement. Separate helper calls
+        // would use independent pooled connections and could observe two
+        // different commits during a concurrent reset or instance rebind.
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        c.query_row(
+            "SELECT COALESCE(
+                (SELECT agent_name FROM conversation_bindings
+                 WHERE instance_name = ?1 AND conversation_id = ?2),
+                (SELECT agent_name FROM channel_instance_defaults
+                 WHERE instance_name = ?1)
+             )",
+            rusqlite::params![instance, conversation_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .map_err(|e| LibreFangError::memory_msg(format!("channel binding resolve failed: {e}")))
     }
 }
 


### PR DESCRIPTION
## Changes

- resolve conversation overrides and instance defaults in one SQLite statement
- preserve override-first precedence through COALESCE subqueries
- ensure each dispatch decision observes one database snapshot during concurrent reset or rebind operations
- add the required attributed changelog fragment

## Verification

    cargo test -p librefang-memory --lib channel_binding_store::tests
    cargo clippy -p librefang-memory --lib -- -D warnings
    cargo fmt --all -- --check
    git diff --check
    python3 scripts/check-changelog-attribution.py
    python3 scripts/check-changelog-attribution.py --all-unreleased

## Out of scope

- binding mutation transactions
- agent-name validation
- legacy dispatch fallback behavior
- binding schema changes