### PR TITLE
fix(kernel): atomically persist config migrations

### DIFF
--- a/changelog.d/fixed/7535-kernel-atomic-config-migration.md
+++ b/changelog.d/fixed/7535-kernel-atomic-config-migration.md
@@ -1,0 +1,1 @@
+Persist config migrations through durable atomic replacement while preserving symlinks and permissions. (#7535) (@houko)

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -25,9 +25,17 @@ fn atomic_write_config(path: &Path, content: &str) -> std::io::Result<()> {
         Ok(metadata) if metadata.file_type().is_symlink() => std::fs::canonicalize(path)?,
         _ => path.to_path_buf(),
     };
-    let original_permissions = std::fs::metadata(&target)
-        .ok()
-        .map(|metadata| metadata.permissions());
+    let original_permissions = match std::fs::metadata(&target) {
+        Ok(metadata) => {
+            // Atomic rename is governed by directory permissions and could
+            // otherwise replace an operator-owned read-only config that the
+            // previous direct-write path correctly refused to modify.
+            std::fs::OpenOptions::new().write(true).open(&target)?;
+            Some(metadata.permissions())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error),
+    };
     let file_name = target
         .file_name()
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename"))?;
@@ -794,6 +802,22 @@ mod tests {
             std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
             0o600
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_config_write_refuses_a_read_only_target() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "old = true\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+        let error = atomic_write_config(&path, "new = true\n").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "old = true\n");
     }
 
     #[test]

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -13,6 +13,66 @@ use tracing::info;
 /// Maximum include nesting depth.
 const MAX_INCLUDE_DEPTH: u32 = 10;
 
+fn atomic_write_config(path: &Path, content: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    // Preserve a configured symlink. Renaming over `path` itself would replace
+    // the link rather than atomically updating the operator-owned target.
+    let target = match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => std::fs::canonicalize(path)?,
+        _ => path.to_path_buf(),
+    };
+    let original_permissions = std::fs::metadata(&target)
+        .ok()
+        .map(|metadata| metadata.permissions());
+    let file_name = target
+        .file_name()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename"))?;
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut temp_name = file_name.to_os_string();
+    temp_name.push(format!(".{}.{seq}.{timestamp}.tmp", std::process::id()));
+    let temp_path = target.with_file_name(temp_name);
+
+    let write_result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+        if let Some(permissions) = original_permissions {
+            file.set_permissions(permissions)?;
+        }
+        file.write_all(content.as_bytes())?;
+        file.sync_all()
+    })();
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
+    if let Err(error) = std::fs::rename(&temp_path, &target) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
+    #[cfg(unix)]
+    {
+        let parent = target
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+
+    Ok(())
+}
+
 /// Load kernel configuration from a TOML file, with defaults.
 ///
 /// Returns `Err` when the config file exists but cannot be parsed as valid TOML
@@ -225,7 +285,7 @@ pub fn load_config(path: Option<&Path>) -> Result<KernelConfig, String> {
                                 let toml_str = toml::to_string_pretty(&config);
                                 match toml_str {
                                     Ok(s) => {
-                                        if let Err(e) = std::fs::write(&config_path, &s) {
+                                        if let Err(e) = atomic_write_config(&config_path, &s) {
                                             tracing::warn!(
                                                 error = %e,
                                                 path = %config_path.display(),
@@ -670,6 +730,70 @@ mod tests {
     fn test_load_config_missing_file() {
         let config = load_config(Some(Path::new("/nonexistent/config.toml"))).unwrap();
         assert_eq!(config.log_level, "info");
+    }
+
+    #[test]
+    fn atomic_config_write_never_exposes_partial_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let seed = "config_version = 2\n".to_string();
+        let payload_a = format!("marker = \"{}\"\n", "a".repeat(16 * 1024));
+        let payload_b = format!("marker = \"{}\"\n", "b".repeat(16 * 1024));
+        std::fs::write(&path, &seed).unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let writer = |payload: String| {
+            let path = path.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..30 {
+                    atomic_write_config(&path, &payload).unwrap();
+                }
+            })
+        };
+        let writer_a = writer(payload_a.clone());
+        let writer_b = writer(payload_b.clone());
+        barrier.wait();
+
+        for _ in 0..200 {
+            let observed = std::fs::read_to_string(&path).unwrap();
+            assert!(
+                observed == seed || observed == payload_a || observed == payload_b,
+                "observed partial config: {} bytes",
+                observed.len()
+            );
+        }
+        writer_a.join().unwrap();
+        writer_b.join().unwrap();
+
+        let final_content = std::fs::read_to_string(path).unwrap();
+        assert!(final_content == payload_a || final_content == payload_b);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_config_write_preserves_symlink_and_target_permissions() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("operator-config.toml");
+        let link = dir.path().join("config.toml");
+        std::fs::write(&target, "old = true\n").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+        symlink(&target, &link).unwrap();
+
+        atomic_write_config(&link, "new = true\n").unwrap();
+
+        assert!(std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new = true\n");
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- stage migrated config in a unique same-directory file and fsync before atomic rename
- clean failed staging writes and fsync the containing directory after publication on Unix
- preserve existing permissions and update symlink targets without replacing the operator symlink
- preserve the prior write-permission contract by refusing atomic replacement of a read-only config
- add concurrent-reader, symlink, permission-preservation, and read-only regressions

Audit finding: `F-05374b769b483ed6`

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7535-final cargo test -p librefang-kernel --lib config::` (40 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/.cargo-targets/pr7535-final cargo clippy -p librefang-kernel --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- config migration rules
- managed-mode write policy
- hot-reload writes
- cross-process lost-update coordination
