### PR TITLE
fix(rl-export): bound total request time

### DIFF
--- a/crates/librefang-rl-export/src/lib.rs
+++ b/crates/librefang-rl-export/src/lib.rs
@@ -54,15 +54,33 @@ mod wandb;
 
 pub use error::ExportError;
 
+use std::time::Duration;
+
 use chrono::{DateTime, Utc};
+
+/// Total wall-clock budget for one upstream request attempt.
+///
+/// The shared HTTP builder already bounds connection setup and individual
+/// response reads. A total timeout is still required here because an upstream
+/// can otherwise keep a request alive indefinitely by sending data slowly.
+const EXPORT_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 fn build_export_http_client_with(
     builder: reqwest::ClientBuilder,
     resolution: &ssrf::ResolvedEgress,
 ) -> Result<reqwest::Client, ExportError> {
+    build_export_http_client_with_timeout(builder, resolution, EXPORT_REQUEST_TIMEOUT)
+}
+
+fn build_export_http_client_with_timeout(
+    builder: reqwest::ClientBuilder,
+    resolution: &ssrf::ResolvedEgress,
+    request_timeout: Duration,
+) -> Result<reqwest::Client, ExportError> {
     let mut builder = builder
         .no_proxy()
-        .redirect(reqwest::redirect::Policy::none());
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(request_timeout);
     if let Some(hostname) = &resolution.hostname {
         builder = builder.resolve_to_addrs(hostname, &resolution.addresses);
     }
@@ -463,6 +481,34 @@ mod tests {
         assert_eq!(response.status(), reqwest::StatusCode::NO_CONTENT);
         assert_eq!(target.received_requests().await.unwrap().len(), 1);
         assert!(proxy.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_client_bounds_total_request_time() {
+        let target = MockServer::start().await;
+        Mock::given(path("/slow"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(1)))
+            .mount(&target)
+            .await;
+
+        let resolution = ssrf::ResolvedEgress {
+            hostname: None,
+            addresses: Vec::new(),
+        };
+        let client = build_export_http_client_with_timeout(
+            reqwest::Client::builder(),
+            &resolution,
+            Duration::from_millis(25),
+        )
+        .expect("export client should build");
+
+        let error = client
+            .get(format!("{}/slow", target.uri()))
+            .send()
+            .await
+            .expect_err("slow response must exceed the total request budget");
+
+        assert!(error.is_timeout(), "expected timeout, got {error}");
     }
 
     /// `*_env` indirection: an empty env-var name fails fast with


### PR DESCRIPTION
## Summary

- add a 300-second total wall-clock timeout to RL export HTTP requests
- preserve the existing connect/read timeouts, direct routing, redirect policy, and DNS pinning
- test that a delayed upstream is terminated by the total request budget

## Verification

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-rl-export` (63 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo clippy -p librefang-rl-export --all-targets -- -D warnings`
- after rebasing onto current `origin/main`: `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-rl-export --lib export_client_bounds_total_request_time`

## Out of scope

- retry attempt count and backoff policy are unchanged
- upload payload size and cloning behavior are separate audit findings