### PR TITLE
fix(ci): pin AUR publishing trust boundary

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -196,7 +196,7 @@ When `AUR_SSH_PRIVATE_KEY` is absent the three jobs no-op with a notice — noth
 | Secret | Purpose | Format | Rotation |
 |---|---|---|---|
 | `AUR_SSH_PRIVATE_KEY` | SSH private key whose public half is registered on the AUR account that owns `librefang-bin`, `librefang-desktop-bin`, `librefang-docker`. Authenticates `git push ssh://aur@aur.archlinux.org/…`. | OpenSSH private key incl. BEGIN/END lines (multi-line; no base64) | When personnel changes or the key is compromised |
-| `AUR_KNOWN_HOSTS` | Optional. `known_hosts` line(s) pinning `aur.archlinux.org`. When absent the workflow fetches them with `ssh-keyscan` at runtime (trust-on-first-use). Set it to remove the TOFU window. | `ssh-keyscan aur.archlinux.org` output | When AUR rotates its host key |
+| `AUR_KNOWN_HOSTS` | Required whenever `AUR_SSH_PRIVATE_KEY` is configured. Pinned `known_hosts` line(s) for `aur.archlinux.org`; publishing fails closed when absent. Verify fingerprints through a trusted Arch-operated channel before storing the lines. | Verified `known_hosts` entries for `aur.archlinux.org` | When AUR rotates its host key |
 | `AUR_GIT_NAME` | Optional. Commit author name for AUR pushes. Defaults to `LibreFang Release Bot`. | plain string | n/a |
 | `AUR_GIT_EMAIL` | Optional. Commit author email for AUR pushes. Defaults to `release-bot@librefang.ai`. | email | n/a |
 
@@ -211,8 +211,9 @@ ssh-keygen -t ed25519 -C "librefang-aur-ci" -f aur_ci -N ""
 
 # 3. Paste the PRIVATE key (aur_ci, incl. BEGIN/END) into AUR_SSH_PRIVATE_KEY.
 
-# 4. (Optional) pin the host key instead of relying on ssh-keyscan:
-ssh-keyscan aur.archlinux.org   # paste into AUR_KNOWN_HOSTS
+# 4. Obtain aur.archlinux.org host keys, verify their fingerprints through a
+#    trusted Arch-operated channel, then paste the verified known_hosts lines
+#    into AUR_KNOWN_HOSTS. Do not trust unverified ssh-keyscan output.
 ```
 
 The AUR repositories (`ssh://aur@aur.archlinux.org/librefang-bin.git`, etc.) must exist and be owned by that account before the first push.

--- a/.github/actions/publish-aur/action.yml
+++ b/.github/actions/publish-aur/action.yml
@@ -16,10 +16,9 @@ inputs:
     required: true
   known-hosts:
     description: >
-      known_hosts entries for aur.archlinux.org. When empty they are fetched
-      with ssh-keyscan at runtime (trust-on-first-use).
-    required: false
-    default: ""
+      Pinned known_hosts entries for aur.archlinux.org. Publishing fails when
+      this input is empty; never acquire host keys on the credentialed runner.
+    required: true
   git-name:
     description: Commit author name for the AUR push.
     required: false
@@ -60,20 +59,19 @@ runs:
 
         ( umask 077; printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$KEY" )
 
-        if [[ -n "${AUR_KNOWN_HOSTS//[[:space:]]/}" ]]; then
-          printf '%s\n' "$AUR_KNOWN_HOSTS" > "$KNOWN"
-        else
-          ssh-keyscan -t rsa,ecdsa,ed25519 aur.archlinux.org > "$KNOWN" 2>/dev/null
+        if [[ -z "${AUR_KNOWN_HOSTS//[[:space:]]/}" ]]; then
+          echo "::error::AUR_KNOWN_HOSTS must pin aur.archlinux.org before publishing."
+          exit 1
         fi
-        [[ -s "$KNOWN" ]] || { echo "::error::empty known_hosts for aur.archlinux.org"; exit 1; }
+        ( umask 077; printf '%s\n' "$AUR_KNOWN_HOSTS" > "$KNOWN" )
 
         docker run --rm \
-          -v "$GITHUB_WORKSPACE":/repo \
+          -v "$GITHUB_WORKSPACE":/repo:ro \
           -v "$KEY":/keys/aur_key:ro \
           -v "$KNOWN":/keys/known_hosts:ro \
           -e RELEASE_TAG -e GITHUB_REPOSITORY -e GH_API_TOKEN \
           -e AUR_GIT_NAME -e AUR_GIT_EMAIL \
           -e AUR_KEY_FILE=/keys/aur_key \
           -e AUR_KNOWN_HOSTS_FILE=/keys/known_hosts \
-          archlinux:base-devel \
+          archlinux:base-devel@sha256:ee205c220399524a683cf495d411691b921baed8ab47cdc6d732efa782fae484 \
           bash /repo/packaging/aur/publish-to-aur.sh "$PACKAGE"

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -77,7 +77,7 @@ The automation is inert until a maintainer configures the secrets — when `AUR_
    - `ssh://aur@aur.archlinux.org/librefang-desktop-bin.git`
    - `ssh://aur@aur.archlinux.org/librefang-docker.git`
 
-2. Generate a dedicated CI keypair, register the public half on that AUR account, and add the secrets (`AUR_SSH_PRIVATE_KEY` and the optional `AUR_KNOWN_HOSTS` / `AUR_GIT_NAME` / `AUR_GIT_EMAIL`).
+2. Generate a dedicated CI keypair, register the public half on that AUR account, and add `AUR_SSH_PRIVATE_KEY` plus verified `AUR_KNOWN_HOSTS` entries. `AUR_GIT_NAME` and `AUR_GIT_EMAIL` remain optional.
    See `.github/SECRETS.md` for the exact commands and rotation policy.
 
 3. Validate end-to-end with `workflow_dispatch` on `release.yml` (`channel=current`, `tag=<an existing release tag>`) before the next real release.

--- a/scripts/tests/test_publish_aur_action_hardening.py
+++ b/scripts/tests/test_publish_aur_action_hardening.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression checks for the credentialed AUR publishing boundary."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION = ROOT / ".github/actions/publish-aur/action.yml"
+PINNED_IMAGE = (
+    "archlinux:base-devel@"
+    "sha256:ee205c220399524a683cf495d411691b921baed8ab47cdc6d732efa782fae484"
+)
+
+
+class PublishAurActionHardeningTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = ACTION.read_text(encoding="utf-8")
+
+    def test_host_keys_are_required_instead_of_acquired_on_runner(self) -> None:
+        self.assertNotIn("ssh-keyscan", self.action)
+        self.assertIn('if [[ -z "${AUR_KNOWN_HOSTS//[[:space:]]/}" ]]', self.action)
+        self.assertIn("AUR_KNOWN_HOSTS must pin aur.archlinux.org", self.action)
+
+    def test_credential_files_use_restrictive_permissions(self) -> None:
+        self.assertIn(
+            '( umask 077; printf \'%s\\n\' "$AUR_SSH_PRIVATE_KEY" > "$KEY" )',
+            self.action,
+        )
+        self.assertIn(
+            '( umask 077; printf \'%s\\n\' "$AUR_KNOWN_HOSTS" > "$KNOWN" )',
+            self.action,
+        )
+
+    def test_publish_container_has_read_only_source_and_pinned_identity(self) -> None:
+        self.assertIn('-v "$GITHUB_WORKSPACE":/repo:ro', self.action)
+        self.assertIn(PINNED_IMAGE, self.action)
+        self.assertNotIn("archlinux:base-devel \\", self.action)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes

- Fail closed when credentialed AUR publishing lacks verified `known_hosts` entries instead of trusting runtime `ssh-keyscan` output.
- Write host-key material with restrictive permissions and mount the source workspace read-only.
- Pin the credentialed Arch build container to OCI index digest `sha256:ee205c220399524a683cf495d411691b921baed8ab47cdc6d732efa782fae484`.
- Document the required host-key secret and add focused regression checks for the publishing boundary.

## Verification

- `python3 scripts/tests/test_publish_aur_action_hardening.py` (3 passed)
- Parsed the composite action YAML and checked its embedded Bash block with `bash -n`
- Confirmed all three release jobs pass `secrets.AUR_KNOWN_HOSTS`
- Confirmed the pinned OCI index contains a `linux/amd64` manifest
- `git diff --check`

## Out of scope

- Maintainers must provision and rotate verified `AUR_KNOWN_HOSTS` entries through repository secrets; this PR cannot inspect or mutate secret values.
- AUR package contents, release job topology, and GitHub token permissions are unchanged.
- The separate Arch repository publisher image remains outside this AUR action finding.