### PR TITLE
fix(ci): surface inactive issue API failures

### DIFF
--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -8,15 +8,22 @@ on:
 permissions:
   issues: write
 
+concurrency:
+  group: issue-inactive
+  cancel-in-progress: false
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Remind inactive assigned issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          REPO="${{ github.repository }}"
+          set -euo pipefail
+
           CUTOFF=$(date -u -d '14 days ago' +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -v-14d +%Y-%m-%dT00:00:00Z)
 
           # Find assigned issues with no activity for 14 days
@@ -24,7 +31,7 @@ jobs:
             "repos/$REPO/issues?state=open&per_page=100&since=2000-01-01T00:00:00Z" --jq '
             [flatten[] | select(.assignees | length > 0) | select(.pull_request == null) |
             {number, title, updated_at, assignee: .assignees[0].login}]
-          ' 2>/dev/null | jq -c '.[]' | while read -r line; do
+          ' | jq -c '.[]' | while read -r line; do
             NUMBER=$(echo "$line" | jq -r '.number')
             UPDATED=$(echo "$line" | jq -r '.updated_at')
             ASSIGNEE=$(echo "$line" | jq -r '.assignee')

--- a/scripts/tests/test_issue_inactive_workflow.py
+++ b/scripts/tests/test_issue_inactive_workflow.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Regression checks for inactive-issue reconciliation."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/issue-inactive.yml"
+
+
+class IssueInactiveWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_api_failures_are_visible_and_fatal(self) -> None:
+        self.assertIn("set -euo pipefail", self.workflow)
+        self.assertIn("gh api --paginate --slurp", self.workflow)
+        self.assertNotIn("' 2>/dev/null | jq", self.workflow)
+
+    def test_repository_context_is_routed_through_environment(self) -> None:
+        self.assertIn("REPO: ${{ github.repository }}", self.workflow)
+        self.assertNotIn('REPO="${{ github.repository }}"', self.workflow)
+
+    def test_scheduled_reconciliation_is_bounded_and_serial(self) -> None:
+        self.assertIn("group: issue-inactive", self.workflow)
+        self.assertIn("cancel-in-progress: false", self.workflow)
+        self.assertIn("timeout-minutes: 15", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes

- Stop suppressing inactive-issue API errors and enable strict pipeline failure propagation.
- Route repository context through the step environment instead of interpolating it into shell source.
- Serialize scheduled/manual reconciliation and cap the job at 15 minutes.
- Add focused regression checks for pagination, error visibility, context routing, concurrency, and timeout policy.

## Verification

- `python3 scripts/tests/test_issue_inactive_workflow.py` (3 passed)
- Parsed the workflow YAML and checked the embedded Bash block with `bash -n`
- `git diff --check origin/main...HEAD`

## Out of scope

- The existing 14-day inactivity threshold and reminder wording are unchanged.
- Pagination was already fixed by merged #6959 and is retained here.
- This workflow still comments once per matching assigned issue; broader notification policy is unchanged.