### PR TITLE
fix(ci): serialize worker deployments

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -11,10 +11,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-workers-production
+  cancel-in-progress: false
+
 jobs:
   deploy-worker:
     name: Deploy Main Worker
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -23,10 +28,12 @@ jobs:
 
       - name: Test Worker
         working-directory: deploy/worker
+        shell: bash
         run: npm test
 
       - name: Deploy Worker
         working-directory: deploy/worker
+        shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -35,6 +42,7 @@ jobs:
   deploy-github-stats:
     name: Deploy GitHub Stats Worker
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -43,6 +51,7 @@ jobs:
 
       - name: Deploy GitHub Stats Worker
         working-directory: web/workers/github-stats-worker
+        shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/scripts/tests/test_deploy_worker_workflow.py
+++ b/scripts/tests/test_deploy_worker_workflow.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Regression checks for production worker deployment serialization."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/deploy-worker.yml"
+
+
+class DeployWorkerWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_production_deployments_are_serial_and_not_interrupted(self) -> None:
+        self.assertIn("group: deploy-workers-production", self.workflow)
+        self.assertIn("cancel-in-progress: false", self.workflow)
+
+    def test_both_jobs_have_bounded_runtime(self) -> None:
+        self.assertEqual(self.workflow.count("timeout-minutes: 15"), 2)
+
+    def test_deploy_tooling_is_exact_and_shell_is_explicit(self) -> None:
+        self.assertEqual(self.workflow.count("npx -y wrangler@4.121.0 deploy"), 2)
+        self.assertEqual(self.workflow.count("shell: bash"), 3)
+        self.assertNotIn("wrangler@4 deploy", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes

- Serialize production worker workflow runs without cancelling an in-flight deployment.
- Coalesce rapid pushes through GitHub concurrency so the latest pending revision deploys after the active run finishes.
- Bound both worker jobs to 15 minutes and declare Bash explicitly on every run step.
- Add focused regressions for concurrency, timeouts, exact Wrangler pinning, and shell contracts.

## Verification

- `python3 scripts/tests/test_deploy_worker_workflow.py` (3 passed)
- Parsed workflow YAML and checked every embedded run block with `bash -n`
- `git diff --check`

## Out of scope

- Per-directory job gating remains a separate workflow-contract decision because `workflow_dispatch` currently deploys both workers together.
- Wrangler was already pinned to `4.121.0` by merged #6972 and remains unchanged.
- Worker code, Cloudflare configuration, secrets, and deployment targets are unchanged.