### PR TITLE
fix(ci): serialize PR review label updates

### DIFF
--- a/.github/workflows/pr-review-collector.yml
+++ b/.github/workflows/pr-review-collector.yml
@@ -20,10 +20,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-review-collector-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   collect:
     name: Capture review event
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Only the two states the applier acts on need a full collection
     # run; commented/dismissed/pending events are dropped here so we
     # don't churn artifacts.

--- a/.github/workflows/pr-review-collector.yml
+++ b/.github/workflows/pr-review-collector.yml
@@ -21,7 +21,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-review-collector-${{ github.event.pull_request.number }}
+  # Non-actionable submitted reviews still start this workflow before the job
+  # filter skips them. Give those runs a unique group so they cannot cancel an
+  # in-flight approved/changes-requested collector for the same PR.
+  group: pr-review-collector-${{ (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested') && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-review-state-applier.yml
+++ b/.github/workflows/pr-review-state-applier.yml
@@ -5,9 +5,8 @@ name: PR Review Sync (applier)
 # needs-changes labels.
 #
 # Runs in the default-branch context, so the GITHUB_TOKEN here gets
-# the workflow's declared permissions (issues: write, pull-requests:
-# write) — unlike the collector's pull_request_review token, which
-# GitHub forces read-only.
+# the job's declared permissions — unlike the collector's
+# pull_request_review token, which GitHub forces read-only.
 
 on:
   workflow_run:
@@ -16,23 +15,20 @@ on:
 
 permissions:
   contents: read
-  # Required by `actions/download-artifact` when fetching an artifact
-  # from a different workflow run (the collector). Without this the
-  # download step 403s — once a workflow declares `permissions:`,
-  # unspecified scopes default to `none`.
-  actions: read
-  issues: write
-  pull-requests: write
-
-concurrency:
-  group: pr-review-applier-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
 
 jobs:
-  apply:
-    name: Apply review-state labels
+  prepare:
+    name: Validate review-state payload
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      # Required by `actions/download-artifact` when fetching an artifact
+      # from a different workflow run (the collector).
+      actions: read
+      contents: read
+    outputs:
+      pr_number: ${{ steps.payload.outputs.pr_number }}
+      review_state: ${{ steps.payload.outputs.review_state }}
     # Skip if the collector failed (e.g. the review state filter
     # excluded it, jq missing, etc.). The artifact would also be
     # absent in that case.
@@ -46,7 +42,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./payload
 
-      - name: Apply labels
+      - name: Validate payload
+        id: payload
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -59,12 +56,46 @@ jobs:
             // Defensive: collector pre-filters but double-check here so
             // a stale or hand-crafted artifact can't drive label state.
             if (reviewState !== 'changes_requested' && reviewState !== 'approved') {
-              core.info(`Ignoring review_state=${reviewState}`);
-              return;
+              throw new Error(`Invalid review_state in payload: ${reviewState}`);
             }
             if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.setFailed(`Invalid pr_number in payload: ${prNumber}`);
-              return;
+              throw new Error(`Invalid pr_number in payload: ${prNumber}`);
+            }
+
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('review_state', reviewState);
+
+  apply:
+    name: Apply review-state labels
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    # `workflow_run.pull_requests` is empty for pull_request_review runs in
+    # practice. Resolve the PR from the trusted collector artifact first, then
+    # serialize the mutating job on that exact PR number.
+    concurrency:
+      group: pr-review-applier-${{ needs.prepare.outputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Apply labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          REVIEW_STATE: ${{ needs.prepare.outputs.review_state }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const reviewState = process.env.REVIEW_STATE;
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              throw new Error(`Invalid prepared pr_number: ${process.env.PR_NUMBER}`);
+            }
+            if (reviewState !== 'changes_requested' && reviewState !== 'approved') {
+              throw new Error(`Invalid prepared review_state: ${reviewState}`);
             }
 
             const READY = 'ready-for-review';

--- a/.github/workflows/pr-review-state-applier.yml
+++ b/.github/workflows/pr-review-state-applier.yml
@@ -24,10 +24,15 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: pr-review-applier-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   apply:
     name: Apply review-state labels
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Skip if the collector failed (e.g. the review state filter
     # excluded it, jq missing, etc.). The artifact would also be
     # absent in that case.
@@ -65,35 +70,24 @@ jobs:
             const READY = 'ready-for-review';
             const NEEDS = 'needs-changes';
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            const labels = pr.labels.map(l => l.name);
-
             async function addLabel(label) {
-              if (!labels.includes(label)) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                  labels: [label],
-                });
-              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [label],
+              });
             }
             async function removeLabel(label) {
-              if (labels.includes(label)) {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                  name: label,
-                }).catch(() => {});
-              }
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label,
+              }).catch((error) => {
+                if (error.status !== 404) throw error;
+              });
             }
-
-            const hasBlocker = labels.includes('has-conflicts') || labels.includes('ci-failed');
 
             if (reviewState === 'changes_requested') {
               await addLabel(NEEDS);
@@ -102,10 +96,22 @@ jobs:
             } else {
               // approved
               await removeLabel(NEEDS);
+              // Re-read immediately before the blocker decision. Other label
+              // workflows may have added a conflict or CI failure since this
+              // applier started.
+              const { data: freshPr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              const freshLabels = freshPr.labels.map(label => label.name);
+              const hasBlocker = freshLabels.includes('has-conflicts') ||
+                freshLabels.includes('ci-failed');
               if (!hasBlocker) {
                 await addLabel(READY);
                 core.info(`#${prNumber}: approved → -${NEEDS} +${READY}`);
               } else {
+                await removeLabel(READY);
                 core.info(`#${prNumber}: approved but has blockers, skipping ${READY}`);
               }
             }

--- a/.github/workflows/pr-review-state-applier.yml
+++ b/.github/workflows/pr-review-state-applier.yml
@@ -89,17 +89,53 @@ jobs:
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
-            const reviewState = process.env.REVIEW_STATE;
+            const payloadReviewState = process.env.REVIEW_STATE;
 
             if (!Number.isInteger(prNumber) || prNumber <= 0) {
               throw new Error(`Invalid prepared pr_number: ${process.env.PR_NUMBER}`);
             }
-            if (reviewState !== 'changes_requested' && reviewState !== 'approved') {
-              throw new Error(`Invalid prepared review_state: ${reviewState}`);
+            if (payloadReviewState !== 'changes_requested' && payloadReviewState !== 'approved') {
+              throw new Error(`Invalid prepared review_state: ${payloadReviewState}`);
             }
 
             const READY = 'ready-for-review';
             const NEEDS = 'needs-changes';
+
+            // `prepare` jobs from different workflow runs can finish out of
+            // event order. Concurrency serializes mutations, but it does not
+            // make an older payload that arrived late authoritative. Resolve
+            // the latest actionable review from GitHub immediately before
+            // writing labels so every queued job converges on current state.
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              },
+            );
+            const latestReview = reviews
+              .filter((review) => {
+                const state = review.state.toLowerCase();
+                return state === 'changes_requested' || state === 'approved';
+              })
+              .sort((left, right) => {
+                const timeDelta = Date.parse(left.submitted_at || '') -
+                  Date.parse(right.submitted_at || '');
+                return timeDelta || left.id - right.id;
+              })
+              .at(-1);
+            if (!latestReview) {
+              core.info(`#${prNumber}: no current actionable review; nothing to reconcile`);
+              return;
+            }
+            const reviewState = latestReview.state.toLowerCase();
+            if (reviewState !== payloadReviewState) {
+              core.info(
+                `#${prNumber}: stale payload ${payloadReviewState}; reconciling latest ${reviewState}`,
+              );
+            }
 
             async function addLabel(label) {
               await github.rest.issues.addLabels({

--- a/changelog.d/fixed/7546-pr-review-label-reconciliation.md
+++ b/changelog.d/fixed/7546-pr-review-label-reconciliation.md
@@ -1,0 +1,1 @@
+Serialize review-label mutations on the exact PR number from the validated collector payload, and prevent non-actionable reviews from cancelling actionable events. (#7546) (@houko)

--- a/scripts/tests/test_pr_review_label_workflows.py
+++ b/scripts/tests/test_pr_review_label_workflows.py
@@ -17,17 +17,28 @@ class PrReviewLabelWorkflowTests(unittest.TestCase):
         cls.applier = APPLIER.read_text(encoding="utf-8")
 
     def test_collector_keeps_only_latest_review_per_pr(self) -> None:
-        self.assertIn("group: pr-review-collector-${{ github.event.pull_request.number }}", self.collector)
+        self.assertIn("github.event.pull_request.number || github.run_id", self.collector)
+        self.assertIn("github.event.review.state == 'approved'", self.collector)
+        self.assertIn("github.event.review.state == 'changes_requested'", self.collector)
         self.assertIn("cancel-in-progress: true", self.collector)
 
     def test_applier_serializes_each_pr_without_interrupting_mutations(self) -> None:
-        self.assertIn("github.event.workflow_run.pull_requests[0].number", self.applier)
-        self.assertIn("github.event.workflow_run.head_sha", self.applier)
+        self.assertIn("pr_number: ${{ steps.payload.outputs.pr_number }}", self.applier)
+        self.assertIn("group: pr-review-applier-${{ needs.prepare.outputs.pr_number }}", self.applier)
+        self.assertNotIn("github.event.workflow_run.pull_requests", self.applier)
+        self.assertNotIn("github.event.workflow_run.head_sha", self.applier)
         self.assertIn("cancel-in-progress: false", self.applier)
 
     def test_both_jobs_are_bounded(self) -> None:
         self.assertEqual(self.collector.count("timeout-minutes: 5"), 1)
-        self.assertEqual(self.applier.count("timeout-minutes: 5"), 1)
+        self.assertEqual(self.applier.count("timeout-minutes: 5"), 2)
+
+    def test_payload_is_validated_before_the_mutating_job(self) -> None:
+        self.assertIn("id: payload", self.applier)
+        self.assertIn("core.setOutput('pr_number', String(prNumber))", self.applier)
+        self.assertIn("core.setOutput('review_state', reviewState)", self.applier)
+        self.assertIn("PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}", self.applier)
+        self.assertIn("REVIEW_STATE: ${{ needs.prepare.outputs.review_state }}", self.applier)
 
     def test_removal_only_ignores_missing_labels(self) -> None:
         self.assertNotIn(".catch(() => {})", self.applier)

--- a/scripts/tests/test_pr_review_label_workflows.py
+++ b/scripts/tests/test_pr_review_label_workflows.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression checks for the collector/applier review-label pipeline."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COLLECTOR = ROOT / ".github/workflows/pr-review-collector.yml"
+APPLIER = ROOT / ".github/workflows/pr-review-state-applier.yml"
+
+
+class PrReviewLabelWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.collector = COLLECTOR.read_text(encoding="utf-8")
+        cls.applier = APPLIER.read_text(encoding="utf-8")
+
+    def test_collector_keeps_only_latest_review_per_pr(self) -> None:
+        self.assertIn("group: pr-review-collector-${{ github.event.pull_request.number }}", self.collector)
+        self.assertIn("cancel-in-progress: true", self.collector)
+
+    def test_applier_serializes_each_pr_without_interrupting_mutations(self) -> None:
+        self.assertIn("github.event.workflow_run.pull_requests[0].number", self.applier)
+        self.assertIn("github.event.workflow_run.head_sha", self.applier)
+        self.assertIn("cancel-in-progress: false", self.applier)
+
+    def test_both_jobs_are_bounded(self) -> None:
+        self.assertEqual(self.collector.count("timeout-minutes: 5"), 1)
+        self.assertEqual(self.applier.count("timeout-minutes: 5"), 1)
+
+    def test_removal_only_ignores_missing_labels(self) -> None:
+        self.assertNotIn(".catch(() => {})", self.applier)
+        self.assertIn("if (error.status !== 404) throw error", self.applier)
+
+    def test_approval_uses_fresh_blockers(self) -> None:
+        self.assertIn("const { data: freshPr }", self.applier)
+        self.assertIn("freshLabels.includes('has-conflicts')", self.applier)
+        self.assertIn("await removeLabel(READY)", self.applier)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_pr_review_label_workflows.py
+++ b/scripts/tests/test_pr_review_label_workflows.py
@@ -49,6 +49,14 @@ class PrReviewLabelWorkflowTests(unittest.TestCase):
         self.assertIn("freshLabels.includes('has-conflicts')", self.applier)
         self.assertIn("await removeLabel(READY)", self.applier)
 
+    def test_applier_reconciles_latest_review_instead_of_payload_order(self) -> None:
+        self.assertIn("github.rest.pulls.listReviews", self.applier)
+        self.assertIn("const latestReview = reviews", self.applier)
+        self.assertIn("Date.parse(left.submitted_at || '')", self.applier)
+        self.assertIn("const reviewState = latestReview.state.toLowerCase()", self.applier)
+        self.assertIn("stale payload ${payloadReviewState}", self.applier)
+        self.assertNotIn("const reviewState = process.env.REVIEW_STATE", self.applier)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Changes

- Keep only the latest actionable collector per PR without letting non-actionable reviews cancel it.
- Validate the collector artifact before exposing the exact PR number to the mutating job.
- Serialize applier mutations per PR and re-fetch current reviews before writing labels, so out-of-order prepare jobs converge on the latest actionable review.
- Propagate label-removal failures except expected 404 responses.
- Re-fetch blocker labels immediately before adding `ready-for-review`, and remove readiness when an approval lands while blockers exist.
- Bound both workflows at five minutes and add focused pipeline regressions.

## Verification

- `python3 scripts/tests/test_pr_review_label_workflows.py` — 7 passed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-review-collector.yml"); YAML.load_file(".github/workflows/pr-review-state-applier.yml")'`
- Collector `run` block extracted from YAML and checked with `bash -n`
- Applier `github-script` block extracted from YAML, wrapped as an async function, and checked with `node --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check origin/main...HEAD`

## Out of scope

- Review eligibility and the existing latest-actionable-review label policy are unchanged.
- Review dismissal handling remains unchanged because the collector only consumes submitted actionable reviews.
- Conflict and CI labels remain owned by the PR status workflow.
- `actionlint` was unavailable locally; GitHub Actions CI remains the authoritative workflow validation gate.