### PR TITLE
perf(api): index per-agent audit observability

### DIFF
--- a/crates/librefang-api/src/routes/agents/observability.rs
+++ b/crates/librefang-api/src/routes/agents/observability.rs
@@ -307,7 +307,7 @@ pub async fn agent_metrics(
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
@@ -315,7 +315,8 @@ pub async fn agent_metrics(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
-            );
+            )
+                .into_response();
         }
     };
 
@@ -325,14 +326,16 @@ pub async fn agent_metrics(
             return (
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
-            );
+            )
+                .into_response();
         }
     };
     if !super::super::can_access_agent(&state, agent_id, api_user.as_ref()) {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
-        );
+        )
+            .into_response();
     }
 
     // Session-level token/tool stats from the scheduler (in-memory, windowed).
@@ -361,18 +364,11 @@ pub async fn agent_metrics(
         .map(|s| s.messages.len() as u64)
         .unwrap_or(0);
 
-    // Error count from the audit log (count entries with non-"ok" outcome for this agent).
-    // NOTE: This scans the most recent 100k audit entries. Agents with errors beyond
-    // this window will have under-reported error counts. A dedicated per-agent error
-    // counter or index would eliminate this limitation.
     let agent_id_str = agent_id.to_string();
-    let error_count: u64 = state
-        .kernel
-        .audit()
-        .recent(100_000)
-        .iter()
-        .filter(|e| e.agent_id == agent_id_str && e.outcome != "ok" && e.outcome != "success")
-        .count() as u64;
+    let error_count = match state.kernel.audit().count_agent_errors(&agent_id_str) {
+        Ok(count) => count,
+        Err(error) => return ApiErrorResponse::internal_scrub(error).into_response(),
+    };
 
     // Uptime since the agent was created.
     let uptime_secs = (chrono::Utc::now() - entry.created_at).num_seconds().max(0) as u64;
@@ -418,6 +414,7 @@ pub async fn agent_metrics(
             "avg_response_time_ms": avg_response_time_ms,
         })),
     )
+        .into_response()
 }
 
 /// GET /api/agents/{id}/logs — Returns structured execution logs for an agent.
@@ -448,7 +445,7 @@ pub async fn agent_logs(
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
     Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
@@ -456,7 +453,8 @@ pub async fn agent_logs(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
-            );
+            )
+                .into_response();
         }
     };
 
@@ -465,7 +463,8 @@ pub async fn agent_logs(
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
-        );
+        )
+            .into_response();
     }
 
     let max_entries: usize = params
@@ -487,21 +486,18 @@ pub async fn agent_logs(
 
     let agent_id_str = agent_id.to_string();
 
-    // Filter audit log entries belonging to this agent.
-    let entries: Vec<serde_json::Value> = state
-        .kernel
-        .audit()
-        .recent(100_000)
+    let outcome = (!level_filter.is_empty()).then_some(level_filter.as_str());
+    let audit_entries =
+        match state
+            .kernel
+            .audit()
+            .recent_for_agent(&agent_id_str, outcome, offset, max_entries)
+        {
+            Ok(entries) => entries,
+            Err(error) => return ApiErrorResponse::internal_scrub(error).into_response(),
+        };
+    let entries: Vec<serde_json::Value> = audit_entries
         .iter()
-        .filter(|e| e.agent_id == agent_id_str)
-        .filter(|e| {
-            if level_filter.is_empty() {
-                return true;
-            }
-            e.outcome.eq_ignore_ascii_case(&level_filter)
-        })
-        .skip(offset)
-        .take(max_entries)
         .map(|e| {
             serde_json::json!({
                 "seq": e.seq,
@@ -522,4 +518,5 @@ pub async fn agent_logs(
             "logs": entries,
         })),
     )
+        .into_response()
 }

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -1199,6 +1199,123 @@ impl AuditLog {
         entries[start..].to_vec()
     }
 
+    /// Counts every retained non-success outcome for one agent.
+    ///
+    /// Persistent logs use the `audit_entries(agent_id, timestamp)` index
+    /// instead of cloning and scanning the bounded in-memory window. An
+    /// in-memory-only log has no durable history, so its retained entries are
+    /// the authoritative source.
+    pub fn count_agent_errors(&self, agent_id: &str) -> Result<u64, String> {
+        let Some(pool) = self.db.as_ref() else {
+            let entries = lock_audit_recover(&self.entries, "entries");
+            return Ok(entries
+                .iter()
+                .filter(|entry| {
+                    entry.agent_id == agent_id
+                        && entry.outcome != "ok"
+                        && entry.outcome != "success"
+                })
+                .count() as u64);
+        };
+
+        let db = pool
+            .get()
+            .map_err(|error| format!("failed to acquire audit database connection: {error}"))?;
+        let count: i64 = db
+            .query_row(
+                "SELECT COUNT(*) FROM audit_entries \
+                 WHERE agent_id = ?1 AND outcome != 'ok' AND outcome != 'success'",
+                [agent_id],
+                |row| row.get(0),
+            )
+            .map_err(|error| format!("failed to count agent audit errors: {error}"))?;
+        u64::try_from(count).map_err(|_| "agent audit error count was negative".to_string())
+    }
+
+    /// Returns one newest-first page of audit entries for an agent.
+    ///
+    /// Persistent logs are filtered and paginated in SQLite. Schema v41's
+    /// `(agent_id, timestamp)` index makes the work proportional to the
+    /// requested agent page rather than the global audit population.
+    pub fn recent_for_agent(
+        &self,
+        agent_id: &str,
+        outcome: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<AuditEntry>, String> {
+        let Some(pool) = self.db.as_ref() else {
+            let entries = lock_audit_recover(&self.entries, "entries");
+            return Ok(entries
+                .iter()
+                .rev()
+                .filter(|entry| entry.agent_id == agent_id)
+                .filter(|entry| {
+                    outcome.is_none_or(|value| entry.outcome.eq_ignore_ascii_case(value))
+                })
+                .skip(offset)
+                .take(limit)
+                .cloned()
+                .collect());
+        };
+
+        let db = pool
+            .get()
+            .map_err(|error| format!("failed to acquire audit database connection: {error}"))?;
+        let offset = i64::try_from(offset)
+            .map_err(|_| "agent audit offset exceeds SQLite range".to_string())?;
+        let limit = i64::try_from(limit)
+            .map_err(|_| "agent audit limit exceeds SQLite range".to_string())?;
+        let sql = if outcome.is_some() {
+            "SELECT seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash \
+             FROM audit_entries WHERE agent_id = ?1 AND outcome = ?2 COLLATE NOCASE \
+             ORDER BY timestamp DESC, seq DESC LIMIT ?3 OFFSET ?4"
+        } else {
+            "SELECT seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash \
+             FROM audit_entries WHERE agent_id = ?1 \
+             ORDER BY timestamp DESC, seq DESC LIMIT ?2 OFFSET ?3"
+        };
+        let mut stmt = db
+            .prepare(sql)
+            .map_err(|error| format!("failed to prepare agent audit query: {error}"))?;
+        let decode = |row: &rusqlite::Row<'_>| {
+            let action_str: String = row.get(3)?;
+            let action = action_str.parse::<AuditAction>().map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    3,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            })?;
+            let seq_raw: i64 = row.get(0)?;
+            let seq = u64::try_from(seq_raw)
+                .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, seq_raw))?;
+            let user_id_str: Option<String> = row.get(6)?;
+            Ok(AuditEntry {
+                seq,
+                timestamp: row.get(1)?,
+                agent_id: row.get(2)?,
+                action,
+                detail: row.get(4)?,
+                outcome: row.get(5)?,
+                user_id: user_id_str.as_deref().and_then(|value| value.parse().ok()),
+                channel: row.get(7)?,
+                prev_hash: row.get(8)?,
+                hash: row.get(9)?,
+            })
+        };
+        let rows = match outcome {
+            Some(outcome) => {
+                stmt.query_map(rusqlite::params![agent_id, outcome, limit, offset], decode)
+            }
+            None => stmt.query_map(rusqlite::params![agent_id, limit, offset], decode),
+        }
+        .map_err(|error| format!("failed to query agent audit entries: {error}"))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|error| format!("failed to decode agent audit entry: {error}"))
+    }
+
     /// Returns every entry with `seq > cursor`, in insertion order.
     ///
     /// Intended for cursor-based streaming consumers — e.g. the

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -192,6 +192,61 @@ fn test_record_with_context_persists_user_and_channel() {
 }
 
 #[test]
+fn agent_queries_use_complete_persisted_history_and_page_newest_first() {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(SqliteConnectionManager::memory())
+        .unwrap();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            );
+            CREATE INDEX idx_audit_agent_timestamp
+                ON audit_entries(agent_id, timestamp);",
+        )
+        .unwrap();
+    }
+
+    let log = AuditLog::with_db(pool);
+    log.record("agent-a", AuditAction::AgentSpawn, "first", "ok");
+    log.record("agent-b", AuditAction::AgentSpawn, "other", "error");
+    log.record("agent-a", AuditAction::ToolInvoke, "second", "ERROR");
+    log.record("agent-a", AuditAction::ShellExec, "third", "failed");
+    log.record("agent-a", AuditAction::AgentMessage, "fourth", "success");
+
+    // Simulate a bounded in-memory window that no longer contains the rows.
+    // Persistent queries must still use the complete indexed ledger.
+    lock_audit_recover(&log.entries, "entries").clear();
+
+    assert_eq!(log.count_agent_errors("agent-a").unwrap(), 2);
+    assert_eq!(log.count_agent_errors("agent-b").unwrap(), 1);
+
+    let page = log.recent_for_agent("agent-a", None, 1, 2).unwrap();
+    assert_eq!(
+        page.iter()
+            .map(|entry| entry.detail.as_str())
+            .collect::<Vec<_>>(),
+        ["third", "second"]
+    );
+    let filtered = log
+        .recent_for_agent("agent-a", Some("error"), 0, 10)
+        .unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].detail, "second");
+}
+
+#[test]
 fn malformed_persisted_row_fails_integrity_verification() {
     let pool = Pool::builder()
         .max_size(1)


### PR DESCRIPTION
## Summary

- add audit-layer queries for complete per-agent error counts and newest-first log pages
- use the existing `audit_entries(agent_id, timestamp)` index instead of cloning and scanning up to 100,000 global entries per request
- surface database failures as scrubbed 500 responses instead of silently returning incomplete observability data
- cover persisted-history lookup, agent isolation, outcome filtering, pagination, and ordering

## Verification

- `cargo test -p librefang-runtime-audit` (42 passed)
- `cargo test -p librefang-api --lib test_agent_metrics_returns` (2 passed)
- `cargo test -p librefang-api --lib test_agent_logs_filters_level_by_exact_match` (1 passed)
- `cargo clippy -p librefang-runtime-audit --all-targets -- -D warnings`
- `cargo clippy -p librefang-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Out of scope

- no audit retention-policy changes
- no dashboard changes
- in-memory-only audit logs still query their bounded retained window because they have no durable historical ledger

Audit finding: `F-c986a3e47f557296`.