### PR TITLE
fix(ci): serialize umbrella auto-close runs

### DIFF
--- a/.github/workflows/close-umbrella-on-last-pr.yml
+++ b/.github/workflows/close-umbrella-on-last-pr.yml
@@ -47,6 +47,10 @@ permissions:
   issues: write
   pull-requests: read
 
+concurrency:
+  group: umbrella-autoclose
+  cancel-in-progress: false
+
 jobs:
   maybe-close-umbrella:
     if: github.event.pull_request.merged == true

--- a/changelog.d/fixed/umbrella-autoclose-concurrency.md
+++ b/changelog.d/fixed/umbrella-autoclose-concurrency.md
@@ -1,0 +1,1 @@
+Serialize umbrella auto-close workflow runs so simultaneous PR merges cannot post duplicate comments or race the same issue close. (@houko)

--- a/scripts/tests/test_close_umbrella_workflow.py
+++ b/scripts/tests/test_close_umbrella_workflow.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Regression checks for umbrella auto-close mutation serialization."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "close-umbrella-on-last-pr.yml"
+
+
+class CloseUmbrellaWorkflowTests(unittest.TestCase):
+    def test_mutating_runs_are_serialized_without_cancellation(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        match = re.search(
+            r"(?m)^concurrency:\n"
+            r"  group: (?P<group>[^\n]+)\n"
+            r"  cancel-in-progress: (?P<cancel>[^\n]+)$",
+            text,
+        )
+
+        self.assertIsNotNone(match, "workflow must declare top-level concurrency")
+        assert match is not None
+        self.assertEqual(match.group("group"), "umbrella-autoclose")
+        self.assertEqual(match.group("cancel"), "false")
+        self.assertLess(
+            match.start(),
+            text.index("\njobs:\n"),
+            "concurrency must serialize complete workflow runs, not one step",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- serialize complete umbrella auto-close workflow runs under one repository-level concurrency group
- let an active issue mutation finish instead of cancelling it when another PR merges
- add a regression that pins top-level placement, the stable group, and non-cancelling behavior

## Verification

- `python3 scripts/tests/test_close_umbrella_workflow.py`
- workflow YAML parsed with Ruby `YAML.load_file`
- embedded GitHub Script passed `node --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check`

## Out of scope

- no changes to umbrella eligibility or reference parsing
- no changes to dry-run/live policy
- no retries or timeout-policy changes

Audit finding: `F-c6f91bbc4fdf82ad`.