### PR TITLE
fix(api): backfill partial sidecar defaults

### DIFF
--- a/changelog.d/fixed/sidecar-partial-defaults.md
+++ b/changelog.d/fixed/sidecar-partial-defaults.md
@@ -1,0 +1,1 @@
+Repair missing sidecar command or argument defaults independently when saving a partially hand-edited channel configuration. (@houko)

--- a/crates/librefang-api/src/routes/sidecar_toml.rs
+++ b/crates/librefang-api/src/routes/sidecar_toml.rs
@@ -39,8 +39,11 @@ pub fn upsert_sidecar_block(
     // a venv binary (`command = "/opt/venv/bin/python"`) or pass extra
     // flags (`args = [..., "--debug"]`) don't lose those edits every
     // time someone clicks Save in the dashboard.
-    fn write_command_and_args_defaults(block: &mut Table, command: &str, args: &[&str]) {
+    fn write_command_default(block: &mut Table, command: &str) {
         block["command"] = value(command);
+    }
+
+    fn write_args_default(block: &mut Table, args: &[&str]) {
         let mut args_arr = Array::new();
         for a in args {
             args_arr.push(*a);
@@ -48,16 +51,23 @@ pub fn upsert_sidecar_block(
         block["args"] = value(args_arr);
     }
 
-    fn command_or_args_present(block: &Table) -> bool {
-        let cmd_present = block
+    fn command_present(block: &Table) -> bool {
+        block
             .get("command")
             .and_then(|i| i.as_str())
-            .is_some_and(|s| !s.is_empty());
-        let args_present = block
+            .is_some_and(|s| !s.is_empty())
+    }
+
+    fn args_present(block: &Table) -> bool {
+        block
             .get("args")
             .and_then(|i| i.as_array())
-            .is_some_and(|a| !a.is_empty());
-        cmd_present || args_present
+            .is_some_and(|a| !a.is_empty())
+    }
+
+    fn write_command_and_args_defaults(block: &mut Table, command: &str, args: &[&str]) {
+        write_command_default(block, command);
+        write_args_default(block, args);
     }
 
     // Helper: apply the keys the dashboard configure form owns. `name`
@@ -123,11 +133,14 @@ pub fn upsert_sidecar_block(
             .unwrap_or("");
         if existing_name == name {
             let existing = aot.get_mut(i).expect("indexed");
-            // Backfill catalog defaults only if the operator never set
-            // `command`/`args` (e.g. block was hand-written as a stub).
-            // Otherwise preserve their hand-edits.
-            if !command_or_args_present(existing) {
-                write_command_and_args_defaults(existing, command, args);
+            // Backfill each missing catalog field independently. A partial
+            // hand-edit must not suppress the default for its required
+            // sibling, while a non-empty operator value remains untouched.
+            if !command_present(existing) {
+                write_command_default(existing, command);
+            }
+            if !args_present(existing) {
+                write_args_default(existing, args);
             }
             write_form_managed(existing, name, channel_type, env, managed_env_keys);
             replaced = true;

--- a/crates/librefang-api/tests/sidecar_toml_test.rs
+++ b/crates/librefang-api/tests/sidecar_toml_test.rs
@@ -253,6 +253,63 @@ fn backfills_command_and_args_when_existing_block_is_a_stub() {
 }
 
 #[test]
+fn backfills_args_without_overwriting_operator_command() {
+    let tmp = NamedTempFile::new().unwrap();
+    fs::write(
+        tmp.path(),
+        "[[sidecar_channels]]\n\
+         name = \"telegram\"\n\
+         channel_type = \"telegram\"\n\
+         command = \"/opt/venv/bin/python\"\n",
+    )
+    .unwrap();
+
+    upsert_sidecar_block(
+        tmp.path(),
+        "telegram",
+        "telegram",
+        "python3",
+        &["-m", "librefang.sidecar.adapters.telegram"],
+        &pairs(&[]),
+        &[],
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(tmp.path()).unwrap();
+    assert!(content.contains("command = \"/opt/venv/bin/python\""));
+    assert!(content.contains("args = [\"-m\", \"librefang.sidecar.adapters.telegram\"]"));
+}
+
+#[test]
+fn backfills_command_without_overwriting_operator_args() {
+    let tmp = NamedTempFile::new().unwrap();
+    fs::write(
+        tmp.path(),
+        "[[sidecar_channels]]\n\
+         name = \"telegram\"\n\
+         channel_type = \"telegram\"\n\
+         args = [\"-m\", \"custom.adapter\", \"--debug\"]\n",
+    )
+    .unwrap();
+
+    upsert_sidecar_block(
+        tmp.path(),
+        "telegram",
+        "telegram",
+        "python3",
+        &["-m", "librefang.sidecar.adapters.telegram"],
+        &pairs(&[]),
+        &[],
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(tmp.path()).unwrap();
+    assert!(content.contains("command = \"python3\""));
+    assert!(content.contains("args = [\"-m\", \"custom.adapter\", \"--debug\"]"));
+    assert!(!content.contains("librefang.sidecar.adapters.telegram"));
+}
+
+#[test]
 fn preserves_non_schema_env_keys_on_replace() {
     // Operators sometimes hand-edit the `[sidecar_channels.env]` table
     // with operational vars the schema doesn't know about — `PYTHONPATH`


### PR DESCRIPTION
## Changes
- detect sidecar command and argument presence independently
- preserve a non-empty operator override while restoring its missing required sibling from the catalog
- add regressions for command-only and args-only channel blocks

## Verification
- `cargo test -p librefang-api --test sidecar_toml_test` (13 passed)
- `cargo test -q -p librefang-api --lib routes::sidecar_toml::tests` (4 passed)
- `cargo clippy -q -p librefang-api --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`
- commit hook changelog validation

## Out of scope
- serializing concurrent sidecar config read-modify-write operations
- changing catalog defaults or operator-owned supervision fields