### PR TITLE
fix(api): classify cron mutation errors

### DIFF
--- a/changelog.d/fixed/cron-mutation-error-status.md
+++ b/changelog.d/fixed/cron-mutation-error-status.md
@@ -1,0 +1,1 @@
+Distinguish absent cron jobs, malformed update fields, and internal scheduler failures so delete and update endpoints no longer hide failures behind successful or not-found responses. (@houko)

--- a/crates/librefang-api/src/routes/workflows/cron.rs
+++ b/crates/librefang-api/src/routes/workflows/cron.rs
@@ -86,6 +86,46 @@ pub async fn create_cron_job(
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum CronJobErrorClass<'a> {
+    NotFound,
+    BadRequest(&'a str),
+    Internal,
+}
+
+fn classify_cron_job_error<'a>(
+    error: &'a librefang_types::error::LibreFangError,
+    job_id: librefang_types::scheduler::CronJobId,
+) -> CronJobErrorClass<'a> {
+    use librefang_types::error::LibreFangError;
+
+    match error {
+        LibreFangError::ResourceNotFound { kind, id }
+            if kind.eq_ignore_ascii_case("cron job") && id == &job_id.to_string() =>
+        {
+            CronJobErrorClass::NotFound
+        }
+        LibreFangError::Internal(message) if message == &format!("Cron job {job_id} not found") => {
+            CronJobErrorClass::NotFound
+        }
+        LibreFangError::InvalidInput(message) => CronJobErrorClass::BadRequest(message),
+        LibreFangError::Internal(message)
+            if [
+                "Invalid agent_id:",
+                "Invalid schedule:",
+                "Invalid action:",
+                "Invalid delivery:",
+                "Invalid delivery_targets:",
+            ]
+            .iter()
+            .any(|prefix| message.starts_with(prefix)) =>
+        {
+            CronJobErrorClass::BadRequest(message)
+        }
+        _ => CronJobErrorClass::Internal,
+    }
+}
+
 /// DELETE /api/cron/jobs/{id} — Delete a cron job.
 ///
 /// Idempotent (RFC 9110 §9.2.2): deleting a cron job that is already gone
@@ -125,7 +165,7 @@ pub async fn delete_cron_job(
                 Json(serde_json::json!({"status": "deleted", "job_id": id})),
             )
         }
-        Err(_) => {
+        Err(error) if classify_cron_job_error(&error, job_id) == CronJobErrorClass::NotFound => {
             // Idempotent DELETE — the cron job is already gone (replayed
             // request, double-click, or removed by another deleter). Treat
             // as success so clients don't have to special-case 404.
@@ -133,6 +173,10 @@ pub async fn delete_cron_job(
                 StatusCode::OK,
                 Json(serde_json::json!({"status": "already-deleted", "job_id": id})),
             )
+        }
+        Err(error) => {
+            tracing::error!(%job_id, error = %error, "Failed to remove cron job");
+            ApiErrorResponse::internal("Failed to delete cron job").into_json_tuple()
         }
     }
 }
@@ -162,15 +206,18 @@ pub async fn update_cron_job(
                         Json(serde_json::to_value(&job).unwrap_or_default()),
                     )
                 }
-                // SSRF / shape rejections from `validate_cron_delivery*`
-                // surface as `InvalidInput` and must map to 400, not the
-                // catch-all 404 (#4732). 404 here would silently mask a
-                // refused webhook host as "schedule not found", letting
-                // attacker-controlled clients confuse the failure mode.
-                Err(librefang_types::error::LibreFangError::InvalidInput(msg)) => {
-                    ApiErrorResponse::bad_request(msg).into_json_tuple()
-                }
-                Err(e) => ApiErrorResponse::not_found(format!("{e}")).into_json_tuple(),
+                Err(error) => match classify_cron_job_error(&error, job_id) {
+                    CronJobErrorClass::NotFound => {
+                        ApiErrorResponse::not_found("Cron job not found").into_json_tuple()
+                    }
+                    CronJobErrorClass::BadRequest(message) => {
+                        ApiErrorResponse::bad_request(message).into_json_tuple()
+                    }
+                    CronJobErrorClass::Internal => {
+                        tracing::error!(%job_id, error = %error, "Failed to update cron job");
+                        ApiErrorResponse::internal("Failed to update cron job").into_json_tuple()
+                    }
+                },
             }
         }
         Err(_) => ApiErrorResponse::bad_request("Invalid job ID").into_json_tuple(),
@@ -278,5 +325,65 @@ pub async fn cron_job_status(
             }
         }
         Err(_) => ApiErrorResponse::bad_request("Invalid job ID").into_json_tuple(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use librefang_types::error::LibreFangError;
+
+    #[test]
+    fn cron_job_error_classification_is_narrow() {
+        let job_id = librefang_types::scheduler::CronJobId::new();
+        let missing = LibreFangError::Internal(format!("Cron job {job_id} not found"));
+        assert_eq!(
+            classify_cron_job_error(&missing, job_id),
+            CronJobErrorClass::NotFound
+        );
+
+        let other_id = librefang_types::scheduler::CronJobId::new();
+        assert_eq!(
+            classify_cron_job_error(&missing, other_id),
+            CronJobErrorClass::Internal,
+            "a failure for a different job must not become idempotent success"
+        );
+
+        let storage = LibreFangError::Internal("scheduler storage unavailable".to_string());
+        assert_eq!(
+            classify_cron_job_error(&storage, job_id),
+            CronJobErrorClass::Internal
+        );
+    }
+
+    #[test]
+    fn cron_job_update_parse_errors_are_bad_requests() {
+        let job_id = librefang_types::scheduler::CronJobId::new();
+        for message in [
+            "Invalid agent_id: malformed UUID",
+            "Invalid schedule: missing field",
+            "Invalid action: unknown variant",
+            "Invalid delivery: unknown variant",
+            "Invalid delivery_targets: expected array",
+        ] {
+            let error = LibreFangError::Internal(message.to_string());
+            assert_eq!(
+                classify_cron_job_error(&error, job_id),
+                CronJobErrorClass::BadRequest(message)
+            );
+        }
+    }
+
+    #[test]
+    fn typed_cron_not_found_is_supported() {
+        let job_id = librefang_types::scheduler::CronJobId::new();
+        let missing = LibreFangError::ResourceNotFound {
+            kind: "Cron job".to_string(),
+            id: job_id.to_string(),
+        };
+        assert_eq!(
+            classify_cron_job_error(&missing, job_id),
+            CronJobErrorClass::NotFound
+        );
     }
 }

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -905,6 +905,19 @@ async fn cron_job_toggle_unknown_uuid_returns_404() {
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_unknown_uuid_returns_404() {
+    let h = boot().await;
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/cron/jobs/00000000-0000-0000-0000-000000000000",
+        Some(serde_json::json!({"enabled": false})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+}
+
 // ---------------------------------------------------------------------------
 // /api/workflow-templates
 // ---------------------------------------------------------------------------
@@ -1200,6 +1213,20 @@ async fn seed_cron_job(h: &Harness) -> String {
         .add_job(job, false)
         .expect("seed cron add_job");
     id.0.to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_rejects_malformed_agent_id_as_bad_request() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        &format!("/api/cron/jobs/{id}"),
+        Some(serde_json::json!({"agent_id": "not-a-uuid"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Changes
- keep cron DELETE idempotent only for the exact absent-job error
- map malformed update fields to 400 and absent jobs to 404
- log unexpected scheduler failures while returning a stable 500 response
- accept the shared typed ResourceNotFound shape for a future kernel migration

## Verification
- `cargo test -q -p librefang-api --lib routes::workflows::cron::tests` (3 passed)
- `cargo test -q -p librefang-api --test workflows_routes_integration` (71 passed)
- `cargo clippy -q -p librefang-api --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`
- commit hook changelog validation

## Out of scope
- changing kernel cron error variants while open #7102 owns the scheduler file
- changing persistence rollback semantics or toggle endpoint classification