### PR TITLE
fix(api): report config reload outcomes

### DIFF
--- a/changelog.d/fixed/7556-config-reload-outcomes.md
+++ b/changelog.d/fixed/7556-config-reload-outcomes.md
@@ -1,0 +1,1 @@
+Report config reload outcomes truthfully in audit records and surface channel adapter restart failures to API and Dashboard users. (#7556) (@houko)

--- a/changelog.d/fixed/config-reload-outcomes.md
+++ b/changelog.d/fixed/config-reload-outcomes.md
@@ -1,1 +1,0 @@
-Report config reload and set outcomes truthfully in the audit trail, and surface channel bridge restart failures as partial reloads with a stable warning. (@houko)

--- a/changelog.d/fixed/config-reload-outcomes.md
+++ b/changelog.d/fixed/config-reload-outcomes.md
@@ -1,0 +1,1 @@
+Report config reload and set outcomes truthfully in the audit trail, and surface channel bridge restart failures as partial reloads with a stable warning. (@houko)

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2842,8 +2842,15 @@ export async function shutdownServer(): Promise<{ status: string }> {
   return post<{ status: string }>("/api/shutdown", {});
 }
 
-export async function reloadConfig(): Promise<{ status: string; restart_required?: boolean; restart_reasons?: string[] }> {
-  return post<{ status: string; restart_required?: boolean; restart_reasons?: string[] }>("/api/config/reload", {});
+export type ReloadConfigResult = {
+  status: string;
+  restart_required?: boolean;
+  restart_reasons?: string[];
+  warnings?: string[];
+};
+
+export async function reloadConfig(): Promise<ReloadConfigResult> {
+  return post<ReloadConfigResult>("/api/config/reload", {});
 }
 
 export interface HealthDetailResponse {

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -174,6 +174,7 @@ export type {
   UserBudgetPayload,
   ListSessionsResult,
   SidecarSaveResult,
+  ReloadConfigResult,
   // workflows — HITL operator-step (#4977)
   OperatorPause,
   OperatorActionVerb,

--- a/crates/librefang-api/dashboard/src/lib/mutations/config.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/config.ts
@@ -3,7 +3,11 @@ import {
   useQueryClient,
   type UseMutationOptions,
 } from "@tanstack/react-query";
-import { setConfigValue, reloadConfig } from "../http/client";
+import {
+  setConfigValue,
+  reloadConfig,
+  type ReloadConfigResult,
+} from "../http/client";
 import { configKeys, overviewKeys } from "../queries/keys";
 
 type SetConfigResult = {
@@ -62,12 +66,6 @@ export function useBatchSetConfigValues(
     },
   });
 }
-
-type ReloadConfigResult = {
-  status: string;
-  restart_required?: boolean;
-  restart_reasons?: string[];
-};
 
 export function useReloadConfig(
   options?: Partial<

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -582,7 +582,10 @@ export function ConfigPage({ category }: { category: string }) {
   const [pendingChanges, setPendingChanges] = useState<Record<string, unknown>>({});
   const [saveStatus, setSaveStatus] = useState<Record<string, { ok: boolean; msg: string }>>({});
   const [searchQuery, setSearchQuery] = useState("");
-  const [reloadStatus, setReloadStatus] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [reloadStatus, setReloadStatus] = useState<{
+    kind: "success" | "warning" | "error";
+    msg: string;
+  } | null>(null);
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const [showRawToml, setShowRawToml] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -850,11 +853,15 @@ export function ConfigPage({ category }: { category: string }) {
   );
 
   const reloadMutation = useReloadConfig({
-    onSuccess: () => {
-      setReloadStatus({ ok: true, msg: t("config.reload_success", "Config reloaded") });
+    onSuccess: (data) => {
+      const warning = data.warnings?.filter(Boolean).join(" ");
+      setReloadStatus({
+        kind: warning ? "warning" : "success",
+        msg: warning || t("config.reload_success", "Config reloaded"),
+      });
     },
     onError: (err: Error) => {
-      setReloadStatus({ ok: false, msg: err.message });
+      setReloadStatus({ kind: "error", msg: err.message });
     },
   });
 
@@ -960,7 +967,13 @@ export function ConfigPage({ category }: { category: string }) {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {reloadStatus && (
-            <span className={`text-xs font-semibold ${reloadStatus.ok ? "text-success" : "text-danger"}`}>
+            <span className={`text-xs font-semibold ${
+              reloadStatus.kind === "success"
+                ? "text-success"
+                : reloadStatus.kind === "warning"
+                  ? "text-warning"
+                  : "text-danger"
+            }`}>
               {reloadStatus.msg}
             </span>
           )}

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -854,10 +854,20 @@ export function ConfigPage({ category }: { category: string }) {
 
   const reloadMutation = useReloadConfig({
     onSuccess: (data) => {
-      const warning = data.warnings?.filter(Boolean).join(" ");
+      const details = [
+        ...(data.warnings ?? []),
+        ...(data.restart_required ? (data.restart_reasons ?? []) : []),
+      ].filter(Boolean);
+      const isPartial = data.status === "partial"
+        || data.restart_required === true
+        || details.length > 0;
       setReloadStatus({
-        kind: warning ? "warning" : "success",
-        msg: warning || t("config.reload_success", "Config reloaded"),
+        kind: isPartial ? "warning" : "success",
+        msg: details.length > 0
+          ? `${t("runtime.reload_success", { status: data.status })} — ${details.join(" ")}`
+          : isPartial
+            ? t("runtime.reload_success", { status: data.status })
+            : t("config.reload_success", "Config reloaded"),
       });
     },
     onError: (err: Error) => {

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
@@ -326,9 +326,37 @@ describe("RuntimePage", () => {
     });
 
     expect(
-      screen.getByText("Channel adapters could not be restarted; see server logs"),
+      screen.getByText(
+        "runtime.reload_success — Channel adapters could not be restarted; see server logs",
+      ),
     ).toBeInTheDocument();
-    expect(screen.queryByText("runtime.reload_success")).not.toBeInTheDocument();
+  });
+
+  it("surfaces restart-required reloads as warnings with their reasons", () => {
+    let onSuccess: ((data: {
+      status: string;
+      restart_required?: boolean;
+      restart_reasons?: string[];
+    }) => void) | undefined;
+    useReloadConfigMock.mockImplementation((options) => {
+      onSuccess = options?.onSuccess as typeof onSuccess;
+      return makeMutation();
+    });
+    renderPage();
+
+    act(() => {
+      onSuccess?.({
+        status: "partial",
+        restart_required: true,
+        restart_reasons: ["api_listen changed"],
+      });
+    });
+
+    const notice = screen.getByText(
+      "runtime.reload_success — api_listen changed",
+    );
+    expect(notice).toBeInTheDocument();
+    expect(notice).toHaveClass("text-warning");
   });
 
   it("invokes createBackup mutation when create backup button is clicked", () => {

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RuntimePage } from "./RuntimePage";
 import {
@@ -308,6 +308,27 @@ describe("RuntimePage", () => {
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: "runtime.reload_config" }));
     expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces config reload warnings instead of reporting plain success", () => {
+    let onSuccess: ((data: { status: string; warnings?: string[] }) => void) | undefined;
+    useReloadConfigMock.mockImplementation((options) => {
+      onSuccess = options?.onSuccess as typeof onSuccess;
+      return makeMutation();
+    });
+    renderPage();
+
+    act(() => {
+      onSuccess?.({
+        status: "partial",
+        warnings: ["Channel adapters could not be restarted; see server logs"],
+      });
+    });
+
+    expect(
+      screen.getByText("Channel adapters could not be restarted; see server logs"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("runtime.reload_success")).not.toBeInTheDocument();
   });
 
   it("invokes createBackup mutation when create backup button is clicked", () => {

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -1,7 +1,13 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useUIStore } from "../lib/store";
-import type { HealthCheck, AuditEntry, BackupItem, TaskQueueItem } from "../api";
+import type {
+  HealthCheck,
+  AuditEntry,
+  BackupItem,
+  TaskQueueItem,
+  ReloadConfigResult,
+} from "../api";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { isProviderAvailable } from "../lib/status";
@@ -97,10 +103,7 @@ export function RuntimePage() {
   const addToast = useUIStore((s) => s.addToast);
   const [showShutdownConfirm, setShowShutdownConfirm] = useState(false);
   const [backupConfirm, setBackupConfirm] = useState<BackupConfirmState | null>(null);
-  const [reloadResult, setReloadResult] = useState<{
-    status: string;
-    warnings?: string[];
-  } | null>(null);
+  const [reloadResult, setReloadResult] = useState<ReloadConfigResult | null>(null);
   const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -148,6 +151,17 @@ export function RuntimePage() {
   const hd = healthDetailQuery.data ?? null;
   const security = securityQuery.data ?? null;
   const status = snapshot?.status;
+  const reloadDetails = reloadResult
+    ? [
+        ...(reloadResult.warnings ?? []),
+        ...(reloadResult.restart_required ? (reloadResult.restart_reasons ?? []) : []),
+      ].filter(Boolean)
+    : [];
+  const reloadIsPartial = reloadResult !== null && (
+    reloadResult.status === "partial"
+    || reloadResult.restart_required === true
+    || reloadDetails.length > 0
+  );
 
   const uptimeStr = formatUptime(status?.uptime_seconds);
   const healthChecks = snapshot?.health?.checks ?? [];
@@ -806,10 +820,9 @@ export function RuntimePage() {
               </Button>
             </div>
             {reloadResult && (
-              <p className={`text-xs mt-3 ${reloadResult.warnings?.length ? "text-warning" : "text-success"}`}>
-                {reloadResult.warnings?.length
-                  ? reloadResult.warnings.join(" ")
-                  : t("runtime.reload_success", { status: reloadResult.status })}
+              <p className={`text-xs mt-3 ${reloadIsPartial ? "text-warning" : "text-success"}`}>
+                {t("runtime.reload_success", { status: reloadResult.status })}
+                {reloadDetails.length > 0 ? ` — ${reloadDetails.join(" ")}` : ""}
               </p>
             )}
             {reloadMutation.isError && <p className="text-xs text-error mt-3">{t("runtime.reload_error")}</p>}

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -97,7 +97,10 @@ export function RuntimePage() {
   const addToast = useUIStore((s) => s.addToast);
   const [showShutdownConfirm, setShowShutdownConfirm] = useState(false);
   const [backupConfirm, setBackupConfirm] = useState<BackupConfirmState | null>(null);
-  const [reloadResult, setReloadResult] = useState<string | null>(null);
+  const [reloadResult, setReloadResult] = useState<{
+    status: string;
+    warnings?: string[];
+  } | null>(null);
   const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -124,7 +127,7 @@ export function RuntimePage() {
   });
   const reloadMutation = useReloadConfig({
     onSuccess: (data) => {
-      setReloadResult(data.status);
+      setReloadResult(data);
       if (reloadTimeoutRef.current) {
         clearTimeout(reloadTimeoutRef.current);
       }
@@ -802,7 +805,13 @@ export function RuntimePage() {
                 {t("runtime.shutdown")}
               </Button>
             </div>
-            {reloadResult && <p className="text-xs text-success mt-3">{t("runtime.reload_success", { status: reloadResult })}</p>}
+            {reloadResult && (
+              <p className={`text-xs mt-3 ${reloadResult.warnings?.length ? "text-warning" : "text-success"}`}>
+                {reloadResult.warnings?.length
+                  ? reloadResult.warnings.join(" ")
+                  : t("runtime.reload_success", { status: reloadResult.status })}
+              </p>
+            )}
             {reloadMutation.isError && <p className="text-xs text-error mt-3">{t("runtime.reload_error")}</p>}
             {cleanupMutation.isSuccess && <p className="text-xs text-success mt-3">{t("runtime.sessions_deleted", { count: cleanupMutation.data?.sessions_deleted ?? 0 })}</p>}
             {shutdownMutation.isError && <p className="text-xs text-error mt-3">{t("runtime.shutdown_error")}</p>}

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -942,6 +942,20 @@ fn redacted_config_json(
 // ---------------------------------------------------------------------------
 // Config Reload endpoint
 // ---------------------------------------------------------------------------
+fn config_reload_status(
+    restart_required: bool,
+    has_changes: bool,
+    channel_reload_failed: bool,
+) -> &'static str {
+    if restart_required || channel_reload_failed {
+        "partial"
+    } else if has_changes {
+        "applied"
+    } else {
+        "no_changes"
+    }
+}
+
 /// POST /api/config/reload — Reload configuration from disk and apply hot-reloadable changes.
 ///
 /// Reads the config file, diffs against current config, validates the new config,
@@ -959,16 +973,7 @@ pub async fn config_reload(
     State(state): State<Arc<AppState>>,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
 ) -> impl IntoResponse {
-    // SECURITY: Record config reload in audit trail with caller attribution.
     let user_id = api_user.as_ref().map(|u| u.0.user_id);
-    state.kernel.audit().record_with_context(
-        "system",
-        librefang_kernel::audit::AuditAction::ConfigChange,
-        "config reload requested via API",
-        "pending",
-        user_id,
-        Some("api".to_string()),
-    );
     match state.kernel.reload_config().await {
         Ok(plan) => {
             // `api_key` / `api_key_hash` are classified as read-live in
@@ -986,6 +991,7 @@ pub async fn config_reload(
             // If channel config changed, the kernel already cleared the adapter
             // registry — but we also need to stop the old BridgeManager and
             // restart adapters from the new config.
+            let mut warnings = Vec::new();
             if plan.hot_actions.contains(&HotAction::ReloadChannels) {
                 match crate::channel_bridge::reload_channels_from_disk(&state).await {
                     Ok(names) => {
@@ -997,33 +1003,54 @@ pub async fn config_reload(
                     }
                     Err(e) => {
                         tracing::error!("Hot-reload: failed to restart channel bridge: {e}");
+                        warnings.push(
+                            "Channel adapters could not be restarted; see server logs".to_string(),
+                        );
                     }
                 }
             }
 
-            let status = if plan.restart_required {
-                "partial"
-            } else if plan.has_changes() {
-                "applied"
-            } else {
-                "no_changes"
-            };
+            let status = config_reload_status(
+                plan.restart_required,
+                plan.has_changes(),
+                !warnings.is_empty(),
+            );
+            state.kernel.audit().record_with_context(
+                "system",
+                librefang_kernel::audit::AuditAction::ConfigChange,
+                "config reload requested via API",
+                status,
+                user_id,
+                Some("api".to_string()),
+            );
 
+            let mut body = serde_json::json!({
+                "status": status,
+                "restart_required": plan.restart_required,
+                "restart_reasons": plan.restart_reasons,
+                "hot_actions_applied": plan.hot_actions.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>(),
+                "noop_changes": plan.noop_changes,
+            });
+            if !warnings.is_empty() {
+                body["warnings"] = serde_json::json!(warnings);
+            }
+
+            (StatusCode::OK, Json(body))
+        }
+        Err(e) => {
+            state.kernel.audit().record_with_context(
+                "system",
+                librefang_kernel::audit::AuditAction::ConfigChange,
+                "config reload requested via API",
+                "failed",
+                user_id,
+                Some("api".to_string()),
+            );
             (
-                StatusCode::OK,
-                Json(serde_json::json!({
-                    "status": status,
-                    "restart_required": plan.restart_required,
-                    "restart_reasons": plan.restart_reasons,
-                    "hot_actions_applied": plan.hot_actions.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>(),
-                    "noop_changes": plan.noop_changes,
-                })),
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"status": "error", "error": e})),
             )
         }
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"status": "error", "error": e})),
-        ),
     }
 }
 
@@ -1562,7 +1589,7 @@ pub async fn config_set(
         "system",
         librefang_kernel::audit::AuditAction::ConfigChange,
         format!("config set: {path}"),
-        "completed",
+        reload_status,
         user_id,
         Some("api".to_string()),
     );
@@ -1572,6 +1599,24 @@ pub async fn config_set(
         body["reload_error"] = serde_json::Value::String(err);
     }
     (StatusCode::OK, Json(body))
+}
+
+#[cfg(test)]
+mod config_reload_outcome_tests {
+    use super::config_reload_status;
+
+    #[test]
+    fn channel_restart_failure_forces_partial_reload_status() {
+        assert_eq!(config_reload_status(false, true, true), "partial");
+        assert_eq!(config_reload_status(false, false, true), "partial");
+    }
+
+    #[test]
+    fn reload_status_preserves_existing_success_states() {
+        assert_eq!(config_reload_status(true, true, false), "partial");
+        assert_eq!(config_reload_status(false, true, false), "applied");
+        assert_eq!(config_reload_status(false, false, false), "no_changes");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -670,6 +670,8 @@ async fn config_set_writes_allowlisted_path_to_tempdir_toml() {
         "expected 200 for allowlisted log_level write, got {status}: {}",
         String::from_utf8_lossy(&body)
     );
+    let response: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let response_status = response["status"].as_str().expect("status string");
 
     // Verify the write landed in the tempdir's config.toml — NOT the user's
     // real ~/.librefang/config.toml. (kernel.home_dir is the tempdir.)
@@ -680,6 +682,16 @@ async fn config_set_writes_allowlisted_path_to_tempdir_toml() {
 
     // And the in-memory kernel config reflects it (post-reload).
     assert_eq!(h.state.kernel.config_ref().log_level, "debug");
+
+    let audit = h
+        .state
+        .kernel
+        .audit()
+        .recent(20)
+        .into_iter()
+        .find(|entry| entry.detail == "config set: log_level")
+        .expect("config set audit entry");
+    assert_eq!(audit.outcome, response_status);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1005,6 +1017,21 @@ async fn config_reload_returns_no_changes_when_disk_matches_memory() {
         json.get("status").is_some(),
         "missing 'status' field: {json}"
     );
+    let expected_audit_outcome = if status == StatusCode::OK {
+        json["status"].as_str().expect("reload status")
+    } else {
+        "failed"
+    };
+    let audit = h
+        .state
+        .kernel
+        .audit()
+        .recent(20)
+        .into_iter()
+        .find(|entry| entry.detail == "config reload requested via API")
+        .expect("config reload audit entry");
+    assert_eq!(audit.outcome, expected_audit_outcome);
+    assert_ne!(audit.outcome, "pending");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1076,6 +1103,15 @@ async fn config_reload_with_invalid_toml_returns_error_and_preserves_live_config
         err_str.contains("invalid TOML") && err_str.contains("live config unchanged"),
         "error must be operator-actionable; got: {err_str}"
     );
+    let audit = h
+        .state
+        .kernel
+        .audit()
+        .recent(20)
+        .into_iter()
+        .find(|entry| entry.detail == "config reload requested via API")
+        .expect("failed config reload audit entry");
+    assert_eq!(audit.outcome, "failed");
 
     // Live config must be unchanged — the failed reload did not blow away
     // `default_model.model` (which is the symptom that broke the dashboard).


### PR DESCRIPTION
## Changes

- record one terminal config-reload audit outcome instead of leaving a permanent pending entry
- make config-set audit outcomes match applied, applied_partial, or saved_reload_failed responses
- mark channel adapter restart failures as partial reloads and return stable warnings while retaining details in server logs
- type reload responses in the Dashboard and surface both adapter failures and restart-required partial outcomes as warnings

## Verification

- `cargo fmt --all -- --check`
- `cargo test -q -p librefang-api --test config_routes_integration -- --test-threads=1` (46 passed)
- `cargo test -q -p librefang-api --lib -- --test-threads=1` (1006 passed)
- `cargo clippy -q -p librefang-api --all-targets -- -D warnings`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm test --run` (1080 passed)
- `mise exec -- pnpm build`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- rolling back kernel config when a channel adapter restart fails
- changing the config export payload or pairing URL redaction
- changing config persistence or validation rules