### PR TITLE
fix(channels): preserve journal durability

### DIFF
--- a/changelog.d/fixed/7560-message-journal-durability.md
+++ b/changelog.d/fixed/7560-message-journal-durability.md
@@ -1,0 +1,1 @@
+Sync channel journal appends before dispatch, use unique compaction staging files, and abort compaction when any snapshotted entry changes before atomic replacement. (#7560) (@houko)

--- a/changelog.d/fixed/message-journal-durability.md
+++ b/changelog.d/fixed/message-journal-durability.md
@@ -1,0 +1,1 @@
+Sync channel journal appends before dispatch and abort compaction when any snapshotted entry changes before the atomic replacement. (@houko)

--- a/changelog.d/fixed/message-journal-durability.md
+++ b/changelog.d/fixed/message-journal-durability.md
@@ -1,1 +1,0 @@
-Sync channel journal appends before dispatch and abort compaction when any snapshotted entry changes before the atomic replacement. (@houko)

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -59,7 +59,7 @@ pub fn parse_defer_marker(err: &str) -> Option<u64> {
 }
 
 /// A single journal entry.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JournalEntry {
     /// Platform-specific unique message ID.
     pub message_id: String,
@@ -573,21 +573,19 @@ impl MessageJournal {
     ///    holding it across `sync_all` serializes all channel traffic
     ///    behind the compactor regardless of which scheduler runs the I/O).
     /// 3. **Re-acquire lock for atomic rename** — before swapping
-    ///    `tmp.jsonl → journal.jsonl`, take the lock again and verify no
-    ///    new entries were appended to `pending` since the snapshot. If
-    ///    any are present, `record()` has already appended their lines to
-    ///    the live file; renaming our stale tmp over it would truncate
-    ///    those lines and lose just-journaled messages on the next crash
-    ///    (audit of #3967). When that happens, abort this compaction
-    ///    (the next tick retries) and clean up the tmp file.
+    ///    `tmp.jsonl → journal.jsonl`, take the lock again and verify the
+    ///    complete pending map still matches the snapshot. Any addition,
+    ///    removal, or status update was already appended to the live file;
+    ///    renaming our stale tmp over it would lose that transition on the
+    ///    next restart. When the map changed, abort this compaction (the
+    ///    next tick retries) and clean up the tmp file.
     pub async fn compact(&self) {
-        use std::collections::HashSet;
-        let (path, snapshot_ids, entries) = {
+        let (path, snapshot, entries) = {
             let inner = self.inner.lock().await;
             let path = inner.path.clone();
-            let snapshot_ids: HashSet<String> = inner.pending.keys().cloned().collect();
+            let snapshot = inner.pending.clone();
             let entries: Vec<JournalEntry> = inner.pending.values().cloned().collect();
-            (path, snapshot_ids, entries)
+            (path, snapshot, entries)
         };
         let tmp_path = path.with_extension(format!("jsonl.tmp.{}", std::process::id()));
         let remaining = entries.len();
@@ -625,21 +623,24 @@ impl MessageJournal {
         // Re-acquire the lock for the rename. `record()` holds this same
         // mutex across its disk-append spawn_blocking, so once we own it
         // again no append can interleave with our rename. We also detect
-        // any append that happened *during* the slow write window above
-        // and abort if so — otherwise the rename would overwrite those
-        // freshly-journaled lines on disk.
+        // any mutation that happened *during* the slow write window above
+        // and abort if so — otherwise the rename would overwrite newer
+        // lines on disk with the stale snapshot.
         let inner = self.inner.lock().await;
-        let raced: Vec<String> = inner
-            .pending
-            .keys()
-            .filter(|id| !snapshot_ids.contains(*id))
-            .cloned()
-            .collect();
-        if !raced.is_empty() {
+        if !Self::compaction_snapshot_is_current(&snapshot, &inner.pending) {
+            let changed = snapshot
+                .iter()
+                .filter(|(id, entry)| inner.pending.get(*id) != Some(*entry))
+                .count()
+                + inner
+                    .pending
+                    .keys()
+                    .filter(|id| !snapshot.contains_key(*id))
+                    .count();
             drop(inner);
             warn!(
-                appended = raced.len(),
-                "Journal compaction aborted: entries were appended during compact; will retry next cycle",
+                changed,
+                "Journal compaction aborted: entries changed during compact; will retry next cycle",
             );
             let cleanup = tmp_path.clone();
             let _ = tokio::task::spawn_blocking(move || std::fs::remove_file(cleanup)).await;
@@ -648,9 +649,11 @@ impl MessageJournal {
 
         let path_for_rename = path.clone();
         let tmp_for_rename = tmp_path.clone();
-        let rename_join =
-            tokio::task::spawn_blocking(move || std::fs::rename(&tmp_for_rename, &path_for_rename))
-                .await;
+        let rename_join = tokio::task::spawn_blocking(move || {
+            std::fs::rename(&tmp_for_rename, &path_for_rename)?;
+            Self::sync_parent_directory(&path_for_rename)
+        })
+        .await;
         drop(inner);
 
         match rename_join {
@@ -686,12 +689,44 @@ impl MessageJournal {
     /// Intended for use inside `tokio::task::spawn_blocking` so that the
     /// sync `OpenOptions::open` + `flush` calls do not stall the async runtime.
     fn write_line_to_path(path: &Path, line: &str) -> std::io::Result<()> {
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
+        let (mut file, created) = match std::fs::OpenOptions::new()
             .append(true)
-            .open(path)?;
+            .create_new(true)
+            .open(path)
+        {
+            Ok(file) => (file, true),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                (std::fs::OpenOptions::new().append(true).open(path)?, false)
+            }
+            Err(error) => return Err(error),
+        };
         writeln!(file, "{line}")?;
         file.flush()?;
+        file.sync_data()?;
+        if created {
+            Self::sync_parent_directory(path)?;
+        }
+        Ok(())
+    }
+
+    fn compaction_snapshot_is_current(
+        snapshot: &HashMap<String, JournalEntry>,
+        current: &HashMap<String, JournalEntry>,
+    ) -> bool {
+        snapshot == current
+    }
+
+    #[cfg(unix)]
+    fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        std::fs::File::open(parent)?.sync_all()
+    }
+
+    #[cfg(not(unix))]
+    fn sync_parent_directory(_path: &Path) -> std::io::Result<()> {
         Ok(())
     }
 }
@@ -741,6 +776,35 @@ mod tests {
 
         assert!(!journal.record(test_entry("msg-1")).await);
         assert!(journal.pending_entries().await.is_empty());
+    }
+
+    #[test]
+    fn compaction_snapshot_detects_every_pending_map_change() {
+        let mut snapshot = HashMap::new();
+        snapshot.insert("msg-1".to_string(), test_entry("msg-1"));
+        snapshot.insert("msg-2".to_string(), test_entry("msg-2"));
+
+        assert!(MessageJournal::compaction_snapshot_is_current(
+            &snapshot, &snapshot
+        ));
+
+        let mut removed = snapshot.clone();
+        removed.remove("msg-1");
+        assert!(!MessageJournal::compaction_snapshot_is_current(
+            &snapshot, &removed
+        ));
+
+        let mut updated = snapshot.clone();
+        updated.get_mut("msg-1").unwrap().status = JournalStatus::Processing;
+        assert!(!MessageJournal::compaction_snapshot_is_current(
+            &snapshot, &updated
+        ));
+
+        let mut appended = snapshot.clone();
+        appended.insert("msg-3".to_string(), test_entry("msg-3"));
+        assert!(!MessageJournal::compaction_snapshot_is_current(
+            &snapshot, &appended
+        ));
     }
 
     #[tokio::test]

--- a/crates/librefang-channels/src/message_journal.rs
+++ b/crates/librefang-channels/src/message_journal.rs
@@ -13,9 +13,12 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
+
+static NEXT_COMPACTION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Status of a journaled message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -587,7 +590,7 @@ impl MessageJournal {
             let entries: Vec<JournalEntry> = inner.pending.values().cloned().collect();
             (path, snapshot, entries)
         };
-        let tmp_path = path.with_extension(format!("jsonl.tmp.{}", std::process::id()));
+        let tmp_path = Self::compaction_temp_path(&path);
         let remaining = entries.len();
 
         let tmp_for_write = tmp_path.clone();
@@ -716,6 +719,11 @@ impl MessageJournal {
         snapshot == current
     }
 
+    fn compaction_temp_path(path: &Path) -> PathBuf {
+        let sequence = NEXT_COMPACTION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        path.with_extension(format!("jsonl.tmp.{}.{sequence}", std::process::id()))
+    }
+
     #[cfg(unix)]
     fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
         let parent = path
@@ -805,6 +813,17 @@ mod tests {
         assert!(!MessageJournal::compaction_snapshot_is_current(
             &snapshot, &appended
         ));
+    }
+
+    #[test]
+    fn concurrent_compactions_use_distinct_staging_paths() {
+        let path = Path::new("message_journal.jsonl");
+        let first = MessageJournal::compaction_temp_path(path);
+        let second = MessageJournal::compaction_temp_path(path);
+
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), path.parent());
+        assert_eq!(second.parent(), path.parent());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Changes

- sync every journal append before dispatch and sync the parent directory when creating or atomically replacing the journal
- compare the complete pending-entry snapshot before compaction replacement so additions, removals, and status changes cannot be lost
- give concurrent compactions unique staging paths
- add regression coverage for snapshot mutation detection and staging-path isolation

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p librefang-channels`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- no changes to journal retention or retry policy
