### PR TITLE
fix(channels): encapsulate thread ownership keys

### DIFF
--- a/changelog.d/fixed/7563-thread-key-encapsulation.md
+++ b/changelog.d/fixed/7563-thread-key-encapsulation.md
@@ -1,0 +1,1 @@
+Require thread-ownership keys to pass through the validating constructor and normalizing scope builders while retaining read-only component accessors. (#7563) (@houko)

--- a/changelog.d/fixed/thread-key-encapsulation.md
+++ b/changelog.d/fixed/thread-key-encapsulation.md
@@ -1,1 +1,0 @@
-Require thread-ownership keys to pass through the validating constructor and normalizing scope builders while retaining read-only component accessors. (@houko)

--- a/changelog.d/fixed/thread-key-encapsulation.md
+++ b/changelog.d/fixed/thread-key-encapsulation.md
@@ -1,0 +1,1 @@
+Require thread-ownership keys to pass through the validating constructor and normalizing scope builders while retaining read-only component accessors. (@houko)

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -11856,12 +11856,12 @@ mod tests {
     fn build_thread_key_falls_back_to_chat_id_without_topic() {
         let mut msg = group_thread_message("topic-1", false);
         let k = build_thread_key(&msg).expect("key");
-        assert_eq!(k.thread, "topic-1");
-        assert_eq!(k.chat_id.as_deref(), Some("u1"));
+        assert_eq!(k.thread(), "topic-1");
+        assert_eq!(k.chat_id(), Some("u1"));
         // A topic-less group still gets a stable claim keyed by chat id.
         msg.thread_id = None;
         let k2 = build_thread_key(&msg).expect("key");
-        assert_eq!(k2.thread, "u1");
+        assert_eq!(k2.thread(), "u1");
     }
 
     #[test]
@@ -11872,8 +11872,8 @@ mod tests {
         msg.metadata
             .insert(SENDER_USER_ID_KEY.into(), serde_json::json!("peer-9"));
         let k = build_thread_key(&msg).expect("key");
-        assert_eq!(k.account_id.as_deref(), Some("acct-1"));
-        assert_eq!(k.peer_id.as_deref(), Some("peer-9"));
+        assert_eq!(k.account_id(), Some("acct-1"));
+        assert_eq!(k.peer_id(), Some("peer-9"));
     }
 
     #[tokio::test]

--- a/crates/librefang-channels/src/thread_ownership.rs
+++ b/crates/librefang-channels/src/thread_ownership.rs
@@ -35,21 +35,21 @@ pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ThreadKey {
     /// Adapter-qualified channel slug (e.g. `"slack"`, `"discord"`).
-    pub channel: String,
+    pub(crate) channel: String,
     /// Bot account this message reached, when the adapter is multi-tenant (e.g. one Slack workspace id, one Telegram bot token slug).
     /// Two accounts on the same channel-type never share a claim.
-    pub account_id: Option<String>,
+    pub(crate) account_id: Option<String>,
     /// Chat / group / DM container id.
     /// Distinguishes two chats that reuse the same platform-side `thread` id (rare but possible for forum topics).
-    pub chat_id: Option<String>,
+    pub(crate) chat_id: Option<String>,
     /// Platform thread identifier (Slack `thread_ts`, Discord thread ID, a forum-topic id, …).
     /// Callers without a forum topic pass the `chat_id` here so a topic-less group still gets a stable claim.
     /// Empty string is invalid; callers should not invoke the registry without a real thread.
-    pub thread: String,
+    pub(crate) thread: String,
     /// Conversational partner (the individual sender).
     /// Scoping the claim to a peer lets two users in the same thread talk to two different agents without contaminating each other.
     /// `None` => thread-wide claim.
-    pub peer_id: Option<String>,
+    pub(crate) peer_id: Option<String>,
 }
 
 impl ThreadKey {
@@ -88,6 +88,31 @@ impl ThreadKey {
     pub fn with_peer_id(mut self, peer_id: Option<&str>) -> Self {
         self.peer_id = normalize_opt(peer_id);
         self
+    }
+
+    /// Canonical channel slug.
+    pub fn channel(&self) -> &str {
+        &self.channel
+    }
+
+    /// Normalized bot-account scope, when present.
+    pub fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
+
+    /// Normalized chat-container scope, when present.
+    pub fn chat_id(&self) -> Option<&str> {
+        self.chat_id.as_deref()
+    }
+
+    /// Canonical platform thread identifier.
+    pub fn thread(&self) -> &str {
+        &self.thread
+    }
+
+    /// Normalized conversational-peer scope, when present.
+    pub fn peer_id(&self) -> Option<&str> {
+        self.peer_id.as_deref()
     }
 }
 
@@ -475,6 +500,21 @@ mod tests {
             .with_chat_id(Some(""))
             .with_peer_id(None);
         assert_eq!(bare, blanked);
+    }
+
+    #[test]
+    fn construction_normalizes_every_exposed_key_component() {
+        let key = ThreadKey::new("  slack  ", "  T1  ")
+            .unwrap()
+            .with_account_id(Some("  account  "))
+            .with_chat_id(Some("  chat  "))
+            .with_peer_id(Some("  peer  "));
+
+        assert_eq!(key.channel(), "slack");
+        assert_eq!(key.account_id(), Some("account"));
+        assert_eq!(key.chat_id(), Some("chat"));
+        assert_eq!(key.thread(), "T1");
+        assert_eq!(key.peer_id(), Some("peer"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/thread_ownership.rs
+++ b/crates/librefang-channels/src/thread_ownership.rs
@@ -35,21 +35,21 @@ pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ThreadKey {
     /// Adapter-qualified channel slug (e.g. `"slack"`, `"discord"`).
-    pub(crate) channel: String,
+    channel: String,
     /// Bot account this message reached, when the adapter is multi-tenant (e.g. one Slack workspace id, one Telegram bot token slug).
     /// Two accounts on the same channel-type never share a claim.
-    pub(crate) account_id: Option<String>,
+    account_id: Option<String>,
     /// Chat / group / DM container id.
     /// Distinguishes two chats that reuse the same platform-side `thread` id (rare but possible for forum topics).
-    pub(crate) chat_id: Option<String>,
+    chat_id: Option<String>,
     /// Platform thread identifier (Slack `thread_ts`, Discord thread ID, a forum-topic id, …).
     /// Callers without a forum topic pass the `chat_id` here so a topic-less group still gets a stable claim.
     /// Empty string is invalid; callers should not invoke the registry without a real thread.
-    pub(crate) thread: String,
+    thread: String,
     /// Conversational partner (the individual sender).
     /// Scoping the claim to a peer lets two users in the same thread talk to two different agents without contaminating each other.
     /// `None` => thread-wide claim.
-    pub(crate) peer_id: Option<String>,
+    peer_id: Option<String>,
 }
 
 impl ThreadKey {


### PR DESCRIPTION
## Changes

- make `ThreadKey` fields private so callers cannot bypass ownership-key construction
- retain explicit accessors for channel, account, conversation, and thread components
- update bridge tests to use the public construction and accessor contract
- normalize the changelog fragment and attribution

## Verification

- `cargo fmt --all -- --check`
- `cargo test -q -p librefang-channels --lib` (556 passed)
- `cargo clippy -q -p librefang-channels --all-targets -- -D warnings`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check origin/main...HEAD`

## Out of scope

- changing thread-key serialization or comparison semantics
- changing ownership routing policy
- changing channel bridge message behavior