### PR TITLE
fix(channels): honor embedded SDK fallback precedence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ dependencies = [
  "chrono",
  "criterion",
  "dashmap",
+ "fs2",
  "futures",
  "image",
  "include_dir",

--- a/changelog.d/fixed/7564-embedded-sdk-fallback.md
+++ b/changelog.d/fixed/7564-embedded-sdk-fallback.md
@@ -1,0 +1,1 @@
+Keep operator PYTHONPATH entries ahead of the embedded sidecar SDK fallback and serialize torn-tree recovery across concurrent extractors. (#7564) (@houko)

--- a/changelog.d/fixed/embedded-sdk-fallback.md
+++ b/changelog.d/fixed/embedded-sdk-fallback.md
@@ -1,0 +1,1 @@
+Keep operator PYTHONPATH entries ahead of the embedded sidecar SDK fallback and preserve a concurrently completed extraction during torn-tree recovery. (@houko)

--- a/changelog.d/fixed/embedded-sdk-fallback.md
+++ b/changelog.d/fixed/embedded-sdk-fallback.md
@@ -1,1 +1,0 @@
-Keep operator PYTHONPATH entries ahead of the embedded sidecar SDK fallback and preserve a concurrently completed extraction during torn-tree recovery. (@houko)

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -57,6 +57,9 @@ rustls = { workspace = true }
 # behaviour. Same crate the dashboard SPA bundle uses
 # (`librefang-api` dep, version pinned at the workspace level).
 include_dir = "0.7"
+# Serializes extraction of one embedded SDK hash across daemon processes.
+# The lock is advisory and released automatically when the file handle drops.
+fs2 = "0.4"
 # Content hash of the embedded SDK tree — drives the
 # `<home>/sidecar-python/<hash>/` directory name so a daemon upgrade
 # extracts to a fresh subdirectory. The wider `librefang-channels`

--- a/crates/librefang-channels/src/embedded_sdk.rs
+++ b/crates/librefang-channels/src/embedded_sdk.rs
@@ -26,8 +26,8 @@
 //!   Their workflow is unchanged.
 //! - Otherwise (the new-user case — no SDK installed anywhere), we
 //!   lazily extract the embedded tree once to `<home>/sidecar-python/
-//!   <content_hash>/` and prepend that directory to the child's
-//!   `PYTHONPATH`.
+//!   <content_hash>/` and append that directory as a fallback on the
+//!   child's `PYTHONPATH`.
 //!
 //! Skipping the inject when a real install exists is what keeps
 //! developers' editable installs authoritative — the embedded copy
@@ -175,6 +175,12 @@ pub(crate) fn ensure_extracted(home_dir: &Path) -> std::io::Result<PathBuf> {
     // recovery is best-effort: if a racing process removes it first,
     // the NotFound is swallowed.
     if target.exists() {
+        // Another extractor may have completed after the first marker check.
+        // Never remove a tree that became authoritative while this caller was
+        // waiting to inspect the target.
+        if marker.exists() {
+            return Ok(target);
+        }
         if let Err(e) = std::fs::remove_dir_all(&target) {
             if e.kind() != std::io::ErrorKind::NotFound {
                 return Err(e);
@@ -343,10 +349,10 @@ const PYTHONPATH_SEP: &str = ":";
 /// `existing_pythonpath` is the value already in the merged env about
 /// to be passed to the child — either operator-explicit
 /// `[sidecar_channels.env]` or inherited from the daemon's own env.
-/// When set, our extracted dir is **prepended** so the user's
-/// PYTHONPATH still wins for any module they're explicitly overriding;
-/// our entry only provides resolution for names that nobody else
-/// claimed.
+/// When set, the user's entries stay first and our extracted directory is
+/// appended as a fallback. Explicit operator modules therefore remain
+/// authoritative while names absent from those paths resolve from the
+/// embedded package.
 pub fn pythonpath_with_embedded(
     command: &str,
     home_dir: &Path,
@@ -375,7 +381,7 @@ pub fn pythonpath_with_embedded(
     let entry = extracted.to_string_lossy().into_owned();
     let composed = match existing_pythonpath {
         Some(existing) if !existing.is_empty() => {
-            format!("{entry}{PYTHONPATH_SEP}{existing}")
+            format!("{existing}{PYTHONPATH_SEP}{entry}")
         }
         _ => entry,
     };
@@ -536,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn pythonpath_composition_prepends_extracted_dir() {
+    fn pythonpath_composition_keeps_operator_entries_first() {
         // Drives the no-real-sdk branch via an interpreter path whose
         // basename matches the Python detector (`python3`) but whose
         // file does NOT exist, so `has_real_sdk_installed` reliably
@@ -552,13 +558,13 @@ mod tests {
         let composed = result.expect("should compose when sdk absent");
         let sep = PYTHONPATH_SEP;
         assert!(
-            composed.ends_with(&format!("{sep}/operator/explicit/path")),
-            "operator PYTHONPATH must be preserved at the tail: got {composed}"
+            composed.starts_with(&format!("/operator/explicit/path{sep}")),
+            "operator PYTHONPATH must remain authoritative: got {composed}"
         );
         let extract_target = tmp.path().join("sidecar-python").join(embedded_hash());
         assert!(
-            composed.starts_with(&extract_target.to_string_lossy().to_string()),
-            "extracted dir must be prepended: got {composed}"
+            composed.ends_with(&extract_target.to_string_lossy().to_string()),
+            "extracted dir must remain a fallback: got {composed}"
         );
     }
 

--- a/crates/librefang-channels/src/embedded_sdk.rs
+++ b/crates/librefang-channels/src/embedded_sdk.rs
@@ -55,13 +55,13 @@
 //! ## Concurrency
 //!
 //! Two sidecars (e.g. telegram and discord) spawning at once both
-//! enter `ensure_extracted`. The function is idempotent (the marker
-//! file gates re-extraction) and uses `rename`-into-place from a
-//! per-pid temporary to make the visible final directory atomic with
-//! respect to other readers / racing processes. The `OnceLock`
-//! around the content hash avoids re-hashing 1MB of embedded files
-//! on every spawn.
+//! enter `ensure_extracted`. An advisory file lock serializes work for
+//! one content hash across threads and daemon processes. The marker is
+//! re-checked after locking, then extraction uses `rename`-into-place
+//! from a per-process temporary. The `OnceLock` around the content hash
+//! avoids re-hashing 1MB of embedded files on every spawn.
 
+use fs2::FileExt;
 use include_dir::{include_dir, Dir, DirEntry};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -148,7 +148,7 @@ fn collect_files<'a>(dir: &'a Dir<'a>, out: &mut Vec<(PathBuf, &'a [u8])>) {
     }
 }
 
-/// Idempotent extract. Returns the directory that should be prepended
+/// Idempotent extract. Returns the directory that should be appended
 /// to `PYTHONPATH` (i.e. the directory that has `librefang/` as an
 /// immediate child).
 ///
@@ -167,25 +167,30 @@ pub(crate) fn ensure_extracted(home_dir: &Path) -> std::io::Result<PathBuf> {
 
     std::fs::create_dir_all(&root)?;
 
+    // The lock lives beside the hash directory so it remains valid while a
+    // torn target is removed and replaced. File locks are released by the OS
+    // on process exit, so a crashed extractor cannot leave a stale owner.
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(root.join(format!("{hash}.lock")))?;
+    lock_file.lock_exclusive()?;
+
+    // Another extractor may have completed while this caller waited for the
+    // lock. Only the lock owner may inspect or replace a torn target.
+    if marker.exists() {
+        return Ok(target);
+    }
+
     // Torn previous run? An existing `target` directory without the
     // `.complete` marker means a prior extract was killed before it
     // could finish — its tree may be partial, byte-corrupt, or stale.
     // POSIX `rename` of a directory onto a non-empty directory is
     // ENOTEMPTY, so we have to clear it before staging. Concurrent
-    // recovery is best-effort: if a racing process removes it first,
-    // the NotFound is swallowed.
+    // recovery is serialized by the per-hash lock above.
     if target.exists() {
-        // Another extractor may have completed after the first marker check.
-        // Never remove a tree that became authoritative while this caller was
-        // waiting to inspect the target.
-        if marker.exists() {
-            return Ok(target);
-        }
-        if let Err(e) = std::fs::remove_dir_all(&target) {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                return Err(e);
-            }
-        }
+        std::fs::remove_dir_all(&target)?;
     }
 
     // Extract into a sibling pid-tagged staging dir, then atomically
@@ -509,6 +514,33 @@ mod tests {
         let out = ensure_extracted(tmp.path()).expect("recovers");
         assert!(out.join(".complete").exists());
         assert!(out.join("librefang/__init__.py").exists());
+    }
+
+    #[test]
+    fn concurrent_extractors_serialize_torn_tree_recovery() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("sidecar-python").join(embedded_hash());
+        std::fs::create_dir_all(target.join("librefang")).unwrap();
+        std::fs::write(target.join("librefang/garbage.py"), b"truncated").unwrap();
+
+        let home = Arc::new(tmp.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(8));
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let home = Arc::clone(&home);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                ensure_extracted(&home)
+            }));
+        }
+
+        for thread in threads {
+            assert_eq!(thread.join().unwrap().unwrap(), target);
+        }
+        assert!(target.join(".complete").exists());
+        assert!(target.join("librefang/__init__.py").exists());
+        assert!(!target.join("librefang/garbage.py").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- preserve the configured and packaged Python SDK precedence before using the embedded fallback
- extract embedded SDK bundles under a per-content advisory lock across threads and processes
- re-check the completion marker inside the lock and replace torn extraction targets safely
- cover concurrent recovery from an incomplete extraction

## Verification

- `cargo fmt --all -- --check`
- `cargo test -q -p librefang-channels --lib` (555 passed)
- `cargo clippy -q -p librefang-channels --all-targets -- -D warnings`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check origin/main...HEAD`

## Out of scope

- changing the Python sidecar protocol or adapter behavior
- changing bundled SDK contents
- changing fallback selection after a valid external SDK is found