### PR TITLE
fix(api): redact ntfy URL credentials

### DIFF
--- a/changelog.d/fixed/7567-config-ntfy-url-redaction.md
+++ b/changelog.d/fixed/7567-config-ntfy-url-redaction.md
@@ -1,0 +1,1 @@
+Redact embedded Basic Auth credentials from `pairing.ntfy_url` in the config read API while preserving the endpoint host, path, topic, and non-credential `@` characters. (#7567) (@houko)

--- a/changelog.d/fixed/config-ntfy-url-redaction.md
+++ b/changelog.d/fixed/config-ntfy-url-redaction.md
@@ -1,1 +1,0 @@
-Redact embedded Basic Auth credentials from `pairing.ntfy_url` in the config read API while preserving the endpoint host and path. (@houko)

--- a/changelog.d/fixed/config-ntfy-url-redaction.md
+++ b/changelog.d/fixed/config-ntfy-url-redaction.md
@@ -1,0 +1,1 @@
+Redact embedded Basic Auth credentials from `pairing.ntfy_url` in the config read API while preserving the endpoint host and path. (@houko)

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -565,7 +565,11 @@ fn redacted_config_json(
         "token_expiry_secs": config.pairing.token_expiry_secs,
         "public_base_url": config.pairing.public_base_url,
         "push_provider": config.pairing.push_provider,
-        "ntfy_url": config.pairing.ntfy_url,
+        "ntfy_url": config
+            .pairing
+            .ntfy_url
+            .as_deref()
+            .map(redact_url_credentials),
         "ntfy_topic": config.pairing.ntfy_topic,
     });
 
@@ -1744,6 +1748,22 @@ mod config_read_write_parity_tests {
                  variant name"
             );
         }
+    }
+
+    #[test]
+    fn pairing_ntfy_url_hides_embedded_credentials() {
+        let mut config = KernelConfig::default();
+        config.pairing.ntfy_url =
+            Some("https://notify-user:notify-password@ntfy.example.test/topic".to_string());
+
+        let payload = super::redacted_config_json(&config, &BudgetConfig::default());
+        let rendered = lookup(&payload, "pairing.ntfy_url")
+            .and_then(|value| value.as_str())
+            .expect("configured ntfy URL remains visible in redacted form");
+
+        assert_eq!(rendered, "https://***@ntfy.example.test/topic");
+        assert!(!rendered.contains("notify-user"));
+        assert!(!rendered.contains("notify-password"));
     }
 
     /// The specific paths the #6596 report listed as writable-but-unreadable, pinned by name so a regression names the issue rather than surfacing as one entry in the bulk diff above.

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -1766,6 +1766,24 @@ mod config_read_write_parity_tests {
         assert!(!rendered.contains("notify-password"));
     }
 
+    #[test]
+    fn pairing_ntfy_url_preserves_at_signs_outside_the_authority() {
+        for url in [
+            "https://ntfy.example.test/topic@tenant",
+            "https://ntfy.example.test/topic?contact=ops@example.test",
+        ] {
+            let mut config = KernelConfig::default();
+            config.pairing.ntfy_url = Some(url.to_string());
+
+            let payload = super::redacted_config_json(&config, &BudgetConfig::default());
+            let rendered = lookup(&payload, "pairing.ntfy_url")
+                .and_then(|value| value.as_str())
+                .expect("configured ntfy URL remains visible");
+
+            assert_eq!(rendered, url);
+        }
+    }
+
     /// The specific paths the #6596 report listed as writable-but-unreadable, pinned by name so a regression names the issue rather than surfacing as one entry in the bulk diff above.
     #[test]
     fn reported_missing_paths_are_present() {

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -1771,6 +1771,7 @@ mod config_read_write_parity_tests {
         for url in [
             "https://ntfy.example.test/topic@tenant",
             "https://ntfy.example.test/topic?contact=ops@example.test",
+            "https://ntfy.example.test/topic#owner@tenant",
         ] {
             let mut config = KernelConfig::default();
             config.pairing.ntfy_url = Some(url.to_string());

--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -288,7 +288,11 @@ fn llm_health_snapshot(state: &AppState) -> LlmHealthSnapshot {
 fn redact_url_credentials(url: &str) -> String {
     if let Some(scheme_end) = url.find("://") {
         let after_scheme = &url[scheme_end + 3..];
-        if let Some(at_pos) = after_scheme.find('@') {
+        let authority_end = after_scheme
+            .find(|character: char| matches!(character, '/' | '?' | '#'))
+            .unwrap_or(after_scheme.len());
+        let authority = &after_scheme[..authority_end];
+        if let Some(at_pos) = authority.rfind('@') {
             let host_and_rest = &after_scheme[at_pos..]; // includes '@'
             return format!("{}://***{}", &url[..scheme_end], host_and_rest);
         }

--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -282,9 +282,9 @@ fn llm_health_snapshot(state: &AppState) -> LlmHealthSnapshot {
 
 /// Strip embedded `user:pass@` credentials from a URL, keeping host/port.
 ///
-/// Used for telemetry / OTLP endpoints that may legitimately contain a
-/// basic-auth tuple in the URL. Returns the input unchanged when no `@`
-/// follows the scheme — i.e. when there is nothing to redact.
+/// Used for configured endpoints, including pairing and OTLP, that may
+/// legitimately contain a basic-auth tuple in the URL. Returns the input
+/// unchanged when the authority has no `@` delimiter.
 fn redact_url_credentials(url: &str) -> String {
     if let Some(scheme_end) = url.find("://") {
         let after_scheme = &url[scheme_end + 3..];

--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -289,7 +289,7 @@ fn redact_url_credentials(url: &str) -> String {
     if let Some(scheme_end) = url.find("://") {
         let after_scheme = &url[scheme_end + 3..];
         let authority_end = after_scheme
-            .find(|character: char| matches!(character, '/' | '?' | '#'))
+            .find(['/', '?', '#'])
             .unwrap_or(after_scheme.len());
         let authority = &after_scheme[..authority_end];
         if let Some(at_pos) = authority.rfind('@') {


### PR DESCRIPTION
## Changes

- strip embedded `user:password@` credentials from `pairing.ntfy_url` in `GET /api/config`
- preserve the configured scheme, host, port, path, and topic for operator visibility
- cover both username and password non-disclosure in the redacted response builder

## Verification

- `cargo test -q -p librefang-api --lib pairing_ntfy_url_hides_embedded_credentials`
- `cargo test -q -p librefang-api --test config_routes_integration` (46 passed)
- `cargo clippy -q -p librefang-api --all-targets -- -D warnings`
- `git diff --check`
- changelog commit hook

## Out of scope

- changing the Owner-only raw config export contract
- URL validation for ntfy endpoints
- credential storage migration into the vault