### PR TITLE
fix(runtime): preserve text after Unicode directives

### DIFF
--- a/changelog.d/fixed/reply-directive-unicode-skip.md
+++ b/changelog.d/fixed/reply-directive-unicode-skip.md
@@ -1,0 +1,1 @@
+Preserve text following reply directives whose message IDs contain multi-byte Unicode characters. (@houko)

--- a/crates/librefang-runtime/src/reply_directives.rs
+++ b/crates/librefang-runtime/src/reply_directives.rs
@@ -73,13 +73,14 @@ impl StreamingDirectiveAccumulator {
                     // Look for closing ]]
                     if let Some(end) = after_open.find("]]") {
                         let tag_content = &after_open[..end];
-                        let tag_len = 2 + end + 2; // [[ + content + ]]
+                        let tag_byte_len = 2 + end + 2; // [[ + content + ]]
+                        let tag_char_len = remaining[..tag_byte_len].chars().count();
 
                         // Parse the directive
                         self.parse_tag(tag_content);
 
                         // Advance past the full tag
-                        for _ in 0..tag_len {
+                        for _ in 0..tag_char_len {
                             chars.next();
                         }
                         continue;
@@ -145,6 +146,14 @@ mod tests {
         let (text, dirs) = parse_directives("[[reply:msg_123]] Hello!");
         assert_eq!(text, "Hello!");
         assert_eq!(dirs.reply_to.as_deref(), Some("msg_123"));
+    }
+
+    #[test]
+    fn test_reply_directive_with_unicode_id_preserves_following_text() {
+        let (text, dirs) = parse_directives("[[reply:café]]Visible");
+
+        assert_eq!(text, "Visible");
+        assert_eq!(dirs.reply_to.as_deref(), Some("café"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Advance the streaming reply-directive parser by Unicode scalar count instead of a UTF-8 byte count.
- Preserve visible text immediately following reply IDs that contain multi-byte characters.
- Add a regression for a non-ASCII reply ID followed directly by visible text.

## Verification

- `cargo test -q -p librefang-runtime --lib reply_directives::tests` (13 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Changing directive syntax or unknown-directive handling.
- Replacing the existing character iterator with a byte-index parser.