### PR TITLE
fix(runtime): handle empty shell bleed commands

### DIFF
--- a/changelog.d/fixed/7571-shell-bleed-empty-command.md
+++ b/changelog.d/fixed/7571-shell-bleed-empty-command.md
@@ -1,0 +1,1 @@
+Return no shell-bleed warnings for empty or whitespace-only commands instead of panicking while extracting a script path. (#7571) (@houko)

--- a/changelog.d/fixed/shell-bleed-empty-command.md
+++ b/changelog.d/fixed/shell-bleed-empty-command.md
@@ -1,0 +1,1 @@
+Return no shell-bleed warnings for empty or whitespace-only commands instead of panicking while extracting a script path. (@houko)

--- a/changelog.d/fixed/shell-bleed-empty-command.md
+++ b/changelog.d/fixed/shell-bleed-empty-command.md
@@ -1,1 +1,0 @@
-Return no shell-bleed warnings for empty or whitespace-only commands instead of panicking while extracting a script path. (@houko)

--- a/crates/librefang-runtime/src/shell_bleed.rs
+++ b/crates/librefang-runtime/src/shell_bleed.rs
@@ -76,9 +76,7 @@ const SCRIPT_EXTENSIONS: &[&str] = &[".py", ".sh", ".bash", ".rb", ".pl", ".js",
 /// - `bash -c ./run.sh`
 /// - `node app.js`
 fn extract_script_path(command: &str) -> Option<String> {
-    let parts: Vec<&str> = command.split_whitespace().collect();
-    for part in &parts[1..] {
-        // skip the command itself
+    for part in command.split_whitespace().skip(1) {
         // Skip flags
         if part.starts_with('-') {
             continue;
@@ -331,6 +329,13 @@ mod tests {
     fn test_scan_non_script_command() {
         let warnings = scan_script_for_shell_bleed("ls -la", None);
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_scan_empty_commands() {
+        for command in ["", " \t\n"] {
+            assert!(scan_script_for_shell_bleed(command, None).is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Iterate script arguments with `skip(1)` instead of slicing a possibly empty vector.
- Return no warnings for empty and whitespace-only shell command strings.
- Avoid allocating an intermediate argument vector during script-path extraction.

## Verification

- `cargo test -q -p librefang-runtime --lib shell_bleed::tests` (10 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Changing shell-bleed variable detection or warning policy.
- Parsing quoted shell arguments.