### PR TITLE
fix(runtime): keep image previews valid base64

### DIFF
--- a/changelog.d/fixed/7575-image-preview-base64.md
+++ b/changelog.d/fixed/7575-image-preview-base64.md
@@ -1,0 +1,1 @@
+Keep truncated image previews as valid Base64 and report truncation plus encoded byte count in separate metadata fields. (#7575) (@houko)

--- a/changelog.d/fixed/image-preview-base64.md
+++ b/changelog.d/fixed/image-preview-base64.md
@@ -1,1 +1,0 @@
-Keep truncated image previews as valid Base64 and report truncation plus encoded byte count in separate metadata fields. (@houko)

--- a/changelog.d/fixed/image-preview-base64.md
+++ b/changelog.d/fixed/image-preview-base64.md
@@ -1,0 +1,1 @@
+Keep truncated image previews as valid Base64 and report truncation plus encoded byte count in separate metadata fields. (@houko)

--- a/crates/librefang-runtime/src/tool_runner/image.rs
+++ b/crates/librefang-runtime/src/tool_runner/image.rs
@@ -14,6 +14,8 @@ use super::resolve_file_path_ext;
 use std::path::Path;
 
 const MAX_IMAGE_SIZE: u64 = 50 * 1024 * 1024;
+const INLINE_PREVIEW_LIMIT: usize = 512 * 1024;
+const TRUNCATED_PREVIEW_SIZE: usize = 64 * 1024;
 
 const ALLOWED_EXTENSIONS: &[&str] = &[
     "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico", "tiff", "tif", "svg",
@@ -84,18 +86,13 @@ pub(super) async fn tool_image_analyze(
 
     let dimensions = extract_image_dimensions(&data, &format);
 
-    let base64_preview = if file_size <= 512 * 1024 {
-        use base64::Engine;
-        base64::engine::general_purpose::STANDARD.encode(&data)
+    let (preview_bytes, preview_truncated) = if file_size <= INLINE_PREVIEW_LIMIT {
+        (data.as_slice(), false)
     } else {
-        use base64::Engine;
-        let preview_bytes = &data[..64 * 1024];
-        format!(
-            "{}... [truncated, {} total bytes]",
-            base64::engine::general_purpose::STANDARD.encode(preview_bytes),
-            file_size
-        )
+        (&data[..TRUNCATED_PREVIEW_SIZE], true)
     };
+    use base64::Engine;
+    let base64_preview = base64::engine::general_purpose::STANDARD.encode(preview_bytes);
 
     let mut result = serde_json::json!({
         "path": raw_path,
@@ -117,6 +114,8 @@ pub(super) async fn tool_image_analyze(
     }
 
     result["base64_preview"] = serde_json::json!(base64_preview);
+    result["base64_preview_bytes"] = serde_json::json!(preview_bytes.len());
+    result["base64_preview_truncated"] = serde_json::json!(preview_truncated);
 
     Ok(serde_json::to_string_pretty(&result)?)
 }
@@ -270,6 +269,36 @@ mod tests {
             r,
             Err(ToolError::InvalidParameter { name: "path", .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn image_analyze_large_preview_remains_valid_base64() {
+        use base64::Engine as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut data = vec![0; INLINE_PREVIEW_LIMIT + 1];
+        data[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+        std::fs::write(dir.path().join("large.png"), &data).unwrap();
+
+        let output = tool_image_analyze(
+            &serde_json::json!({"path": "large.png"}),
+            Some(dir.path()),
+            &[],
+        )
+        .await
+        .unwrap();
+        let result: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let preview = result["base64_preview"].as_str().unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(preview)
+            .unwrap();
+
+        assert_eq!(decoded, data[..TRUNCATED_PREVIEW_SIZE]);
+        assert_eq!(
+            result["base64_preview_bytes"].as_u64(),
+            Some(TRUNCATED_PREVIEW_SIZE as u64)
+        );
+        assert_eq!(result["base64_preview_truncated"].as_bool(), Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep `base64_preview` limited to encoded image bytes, even when a large image is truncated.
- Report the encoded byte count and truncation state in separate JSON fields.
- Add a large-image regression that decodes the returned preview with the standard Base64 engine.

## Verification

- `cargo test -q -p librefang-runtime --lib tool_runner::image::tests` (12 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Changing the 512 KiB inline threshold or 64 KiB truncated preview size.
- Full-image streaming or vision-provider dispatch.