### PR TITLE
fix(runtime): decode web entities once

### DIFF
--- a/changelog.d/fixed/7576-web-content-single-pass-entities.md
+++ b/changelog.d/fixed/7576-web-content-single-pass-entities.md
@@ -1,0 +1,1 @@
+Decode HTML entities in fetched web content exactly once so nested escapes remain literal instead of becoming markup. (#7576) (@houko)

--- a/changelog.d/fixed/web-content-single-pass-entities.md
+++ b/changelog.d/fixed/web-content-single-pass-entities.md
@@ -1,0 +1,1 @@
+Decode HTML entities in fetched web content exactly once so nested escapes remain literal instead of becoming markup. (@houko)

--- a/changelog.d/fixed/web-content-single-pass-entities.md
+++ b/changelog.d/fixed/web-content-single-pass-entities.md
@@ -1,1 +1,0 @@
-Decode HTML entities in fetched web content exactly once so nested escapes remain literal instead of becoming markup. (@houko)

--- a/crates/librefang-runtime/src/web_content.rs
+++ b/crates/librefang-runtime/src/web_content.rs
@@ -322,19 +322,43 @@ fn strip_all_tags(s: &str) -> String {
 
 /// Decode common HTML entities.
 fn decode_entities(s: &str) -> String {
-    s.replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#x27;", "'")
-        .replace("&#39;", "'")
-        .replace("&nbsp;", " ")
-        .replace("&mdash;", "\u{2014}")
-        .replace("&ndash;", "\u{2013}")
-        .replace("&hellip;", "\u{2026}")
-        .replace("&copy;", "\u{00a9}")
-        .replace("&reg;", "\u{00ae}")
-        .replace("&trade;", "\u{2122}")
+    const ENTITIES: &[(&str, &str)] = &[
+        ("&amp;", "&"),
+        ("&lt;", "<"),
+        ("&gt;", ">"),
+        ("&quot;", "\""),
+        ("&#x27;", "'"),
+        ("&#39;", "'"),
+        ("&nbsp;", " "),
+        ("&mdash;", "\u{2014}"),
+        ("&ndash;", "\u{2013}"),
+        ("&hellip;", "\u{2026}"),
+        ("&copy;", "\u{00a9}"),
+        ("&reg;", "\u{00ae}"),
+        ("&trade;", "\u{2122}"),
+    ];
+
+    let mut output = String::with_capacity(s.len());
+    let mut remaining = s;
+
+    while let Some(entity_start) = remaining.find('&') {
+        output.push_str(&remaining[..entity_start]);
+        remaining = &remaining[entity_start..];
+
+        if let Some((entity, replacement)) = ENTITIES
+            .iter()
+            .find(|(entity, _)| remaining.starts_with(entity))
+        {
+            output.push_str(replacement);
+            remaining = &remaining[entity.len()..];
+        } else {
+            output.push('&');
+            remaining = &remaining[1..];
+        }
+    }
+
+    output.push_str(remaining);
+    output
 }
 
 /// Collapse runs of whitespace: multiple blank lines → double newline, trim lines.
@@ -396,6 +420,22 @@ mod tests {
         assert!(md.contains("# Title"), "Expected heading, got: {md}");
         assert!(md.contains("**world**"), "Expected bold, got: {md}");
         assert!(md.contains("Hello"), "Expected text, got: {md}");
+    }
+
+    #[test]
+    fn test_decode_entities_does_not_decode_emitted_entities_again() {
+        assert_eq!(
+            decode_entities("&amp;lt;script&amp;gt; &amp;amp;"),
+            "&lt;script&gt; &amp;"
+        );
+    }
+
+    #[test]
+    fn test_decode_entities_preserves_unknown_entities() {
+        assert_eq!(
+            decode_entities("known:&copy; unknown:&custom;"),
+            "known:© unknown:&custom;"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace sequential entity substitutions with one left-to-right decoding pass.
- Prevent emitted entity text from being decoded a second time.
- Preserve unknown entities while retaining the existing common named and numeric mappings.

## Verification

- `cargo test -q -p librefang-runtime --lib web_content::tests` (11 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2278 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Expanding the supported HTML entity set.
- Changing HTML tag stripping or Markdown rendering.