### PR TITLE
fix(runtime): clean expired auth cooldowns

### DIFF
--- a/changelog.d/fixed/7577-auth-cooldown-selection-cleanup.md
+++ b/changelog.d/fixed/7577-auth-cooldown-selection-cleanup.md
@@ -1,0 +1,1 @@
+Clean up closed provider cooldown entries without racing refreshed state, preserve half-open backoff history, and keep profile priority when every authentication profile is cooling down. (#7577) (@houko)

--- a/changelog.d/fixed/auth-cooldown-selection-cleanup.md
+++ b/changelog.d/fixed/auth-cooldown-selection-cleanup.md
@@ -1,1 +1,0 @@
-Clean up naturally expired provider cooldown entries and preserve profile priority when every authentication profile is cooling down. (@houko)

--- a/changelog.d/fixed/auth-cooldown-selection-cleanup.md
+++ b/changelog.d/fixed/auth-cooldown-selection-cleanup.md
@@ -1,0 +1,1 @@
+Clean up naturally expired provider cooldown entries and preserve profile priority when every authentication profile is cooling down. (@houko)

--- a/crates/librefang-runtime/src/auth_cooldown.rs
+++ b/crates/librefang-runtime/src/auth_cooldown.rs
@@ -384,16 +384,18 @@ impl ProviderCooldown {
             .collect()
     }
 
-    /// Clear expired cooldowns (call periodically, e.g. every 60s).
+    /// Clear closed cooldown entries (call periodically, e.g. every 60s).
+    ///
+    /// A failed entry whose cooldown duration elapsed is still `HalfOpen` and
+    /// retains the error count needed for the next backoff step. Only a
+    /// successful, fully reset entry is safe to discard.
     pub fn clear_expired(&self) {
         self.states.retain(|provider, state| {
-            let expired = state
-                .cooldown_start
-                .is_some_and(|start| start.elapsed() >= state.cooldown_duration);
-            if expired {
-                debug!(provider, "circuit breaker: cleared expired entry");
+            let closed = state.error_count == 0 && state.cooldown_start.is_none();
+            if closed {
+                debug!(provider, "circuit breaker: cleared closed entry");
             }
-            !expired
+            !closed
         });
     }
 
@@ -670,18 +672,33 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_expired() {
+    fn test_clear_expired_removes_closed_entries() {
         let mut config = fast_config();
         config.base_cooldown_secs = 0;
         let cb = ProviderCooldown::new(config);
 
         cb.record_failure("openai", false);
-        assert_eq!(cb.states.get("openai").unwrap().error_count, 1);
+        cb.record_success("openai");
+        assert_eq!(cb.states.get("openai").unwrap().error_count, 0);
         assert!(cb.states.contains_key("openai"));
 
         cb.clear_expired();
 
         assert!(!cb.states.contains_key("openai"));
+    }
+
+    #[test]
+    fn test_clear_expired_preserves_half_open_failure_state() {
+        let mut config = fast_config();
+        config.base_cooldown_secs = 0;
+        let cb = ProviderCooldown::new(config);
+
+        cb.record_failure("openai", false);
+        cb.clear_expired();
+
+        assert_eq!(cb.states.get("openai").unwrap().error_count, 1);
+        assert_eq!(cb.get_state("openai"), CircuitState::HalfOpen);
+        assert_eq!(cb.check("openai"), CooldownVerdict::AllowProbe);
     }
 
     #[test]

--- a/crates/librefang-runtime/src/auth_cooldown.rs
+++ b/crates/librefang-runtime/src/auth_cooldown.rs
@@ -386,20 +386,15 @@ impl ProviderCooldown {
 
     /// Clear expired cooldowns (call periodically, e.g. every 60s).
     pub fn clear_expired(&self) {
-        let mut to_remove = Vec::new();
-        for entry in self.states.iter() {
-            if let Some(start) = entry.value().cooldown_start {
-                if start.elapsed() >= entry.value().cooldown_duration
-                    && entry.value().error_count == 0
-                {
-                    to_remove.push(entry.key().clone());
-                }
+        self.states.retain(|provider, state| {
+            let expired = state
+                .cooldown_start
+                .is_some_and(|start| start.elapsed() >= state.cooldown_duration);
+            if expired {
+                debug!(provider, "circuit breaker: cleared expired entry");
             }
-        }
-        for key in to_remove {
-            self.states.remove(&key);
-            debug!(provider = %key, "circuit breaker: cleared expired entry");
-        }
+            !expired
+        });
     }
 
     /// Force-reset a specific provider (admin action).
@@ -427,7 +422,7 @@ impl ProviderCooldown {
         let mut sorted: Vec<_> = profiles.iter().collect();
         sorted.sort_by_key(|p| p.priority);
 
-        for profile in sorted {
+        for profile in &sorted {
             let key = format!("{}::{}", provider, profile.name);
             let state = self.states.get(&key);
 
@@ -448,7 +443,7 @@ impl ProviderCooldown {
         }
 
         // All profiles in cooldown — return the first one anyway (least bad)
-        let first = &profiles[0];
+        let first = sorted[0];
         Some((first.name.clone(), first.api_key_env.clone()))
     }
 
@@ -681,16 +676,39 @@ mod tests {
         let cb = ProviderCooldown::new(config);
 
         cb.record_failure("openai", false);
-        // Immediately record success so error_count = 0 with an expired cooldown.
-        cb.record_success("openai");
-
-        // The entry still exists in the map.
+        assert_eq!(cb.states.get("openai").unwrap().error_count, 1);
         assert!(cb.states.contains_key("openai"));
 
-        // After success the cooldown_start is None, so clear_expired won't match.
-        // Instead, let's test with a scenario where cooldown expired naturally:
-        cb.force_reset("openai");
+        cb.clear_expired();
+
         assert!(!cb.states.contains_key("openai"));
+    }
+
+    #[test]
+    fn test_all_cooled_profiles_fall_back_to_highest_priority() {
+        let mut config = fast_config();
+        config.base_cooldown_secs = 100;
+        let cb = ProviderCooldown::new(config);
+        let profiles = vec![
+            librefang_types::config::AuthProfile {
+                name: "secondary".to_string(),
+                api_key_env: "SECONDARY_KEY".to_string(),
+                priority: 10,
+            },
+            librefang_types::config::AuthProfile {
+                name: "primary".to_string(),
+                api_key_env: "PRIMARY_KEY".to_string(),
+                priority: 0,
+            },
+        ];
+
+        cb.advance_profile("openai", "secondary", false);
+        cb.advance_profile("openai", "primary", false);
+
+        assert_eq!(
+            cb.select_profile("openai", &profiles),
+            Some(("primary".to_string(), "PRIMARY_KEY".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove only fully closed cooldown entries with an atomic DashMap retain pass.
- Avoid deleting a state refreshed between a stale scan and a later removal.
- Preserve half-open failure counts so subsequent probe failures keep their escalating backoff history.
- Preserve sorted priority order when every authentication profile is cooling down.

## Verification

- `cargo test -q -p librefang-runtime --lib auth_cooldown::tests` (19 passed after review fix)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Adding a new periodic cleanup scheduler.
- Changing cooldown durations, probe cadence, or profile priority semantics.