### PR TITLE
fix(runtime): surface browser navigation errors

### DIFF
--- a/changelog.d/fixed/7578-browser-navigation-error-text.md
+++ b/changelog.d/fixed/7578-browser-navigation-error-text.md
@@ -1,0 +1,1 @@
+Report Chrome DevTools navigation failures returned through `Page.navigate.errorText` instead of reading stale page content as a successful navigation. (#7578) (@houko)

--- a/changelog.d/fixed/browser-navigation-error-text.md
+++ b/changelog.d/fixed/browser-navigation-error-text.md
@@ -1,0 +1,1 @@
+Report Chrome DevTools navigation failures returned through `Page.navigate.errorText` instead of reading stale page content as a successful navigation. (@houko)

--- a/changelog.d/fixed/browser-navigation-error-text.md
+++ b/changelog.d/fixed/browser-navigation-error-text.md
@@ -1,1 +1,0 @@
-Report Chrome DevTools navigation failures returned through `Page.navigate.errorText` instead of reading stale page content as a successful navigation. (@houko)

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -369,6 +369,14 @@ struct BrowserSession {
     target_created_over_cdp: bool,
 }
 
+fn navigation_error_text(result: &serde_json::Value) -> Option<&str> {
+    result
+        .get("errorText")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+}
+
 impl BrowserSession {
     /// Launch Chromium and establish a CDP connection.
     async fn launch(config: &BrowserConfig) -> Result<Self, String> {
@@ -771,9 +779,12 @@ impl BrowserSession {
             .cdp
             .send("Page.navigate", serde_json::json!({ "url": url }))
             .await;
-
-        if let Err(e) = result {
-            return BrowserResponse::err(format!("Navigate failed: {e}"));
+        let result = match result {
+            Ok(result) => result,
+            Err(error) => return BrowserResponse::err(format!("Navigate failed: {error}")),
+        };
+        if let Some(error) = navigation_error_text(&result) {
+            return BrowserResponse::err(format!("Navigate failed: {error}"));
         }
 
         // Wait for page load
@@ -2757,6 +2768,27 @@ mod tests {
         let err = BrowserResponse::err("bad");
         assert!(!err.success);
         assert_eq!(err.error.unwrap(), "bad");
+    }
+
+    #[test]
+    fn test_navigation_error_text_classifies_cdp_failures() {
+        let failed = serde_json::json!({
+            "frameId": "frame-1",
+            "errorText": "net::ERR_NAME_NOT_RESOLVED"
+        });
+        assert_eq!(
+            navigation_error_text(&failed),
+            Some("net::ERR_NAME_NOT_RESOLVED")
+        );
+
+        assert_eq!(
+            navigation_error_text(&serde_json::json!({"frameId": "frame-1"})),
+            None
+        );
+        assert_eq!(
+            navigation_error_text(&serde_json::json!({"errorText": "  "})),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Inspect successful `Page.navigate` CDP results for a non-empty `errorText`.
- Return a failed browser response immediately for network-level navigation errors.
- Avoid waiting for load and reading stale page content after a failed navigation.

## Verification

- `cargo test -q -p librefang-runtime --lib browser::tests` (54 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Changing SSRF validation or page-load timeout policy.
- Retrying navigation failures.