### PR TITLE
fix(runtime): qualify truncated search misses

### DIFF
--- a/changelog.d/fixed/7582-search-truncation-no-match.md
+++ b/changelog.d/fixed/7582-search-truncation-no-match.md
@@ -1,0 +1,1 @@
+Report zero-match code searches as incomplete when the file-scan ceiling is reached instead of claiming the pattern is absent. (#7582) (@houko)

--- a/changelog.d/fixed/search-truncation-no-match.md
+++ b/changelog.d/fixed/search-truncation-no-match.md
@@ -1,1 +1,0 @@
-Report zero-match code searches as incomplete when the file-scan ceiling is reached instead of claiming the pattern is absent. (@houko)

--- a/changelog.d/fixed/search-truncation-no-match.md
+++ b/changelog.d/fixed/search-truncation-no-match.md
@@ -1,0 +1,1 @@
+Report zero-match code searches as incomplete when the file-scan ceiling is reached instead of claiming the pattern is absent. (@houko)

--- a/crates/librefang-runtime/src/tool_runner/search.rs
+++ b/crates/librefang-runtime/src/tool_runner/search.rs
@@ -132,7 +132,7 @@ pub(super) async fn tool_code_search(
     }
 
     if matches.is_empty() {
-        return Ok(format!("No matches for /{query}/ under '{raw_path}'."));
+        return Ok(format_empty_result(query, raw_path, truncated));
     }
     matches.sort();
     let mut out = String::with_capacity(matches.len() * 48);
@@ -146,6 +146,16 @@ pub(super) async fn tool_code_search(
         ));
     }
     Ok(out)
+}
+
+fn format_empty_result(query: &str, raw_path: &str, truncated: bool) -> String {
+    if truncated {
+        format!(
+            "Search incomplete after scanning {MAX_FILES_SCANNED} files under '{raw_path}'; no matches were found in the scanned files for /{query}/. Narrow `path` or refine the query."
+        )
+    } else {
+        format!("No matches for /{query}/ under '{raw_path}'.")
+    }
 }
 
 /// Trim a matched line and cap it at [`MAX_LINE_CHARS`] characters, counting by
@@ -248,5 +258,15 @@ mod tests {
             .await
             .unwrap();
         assert!(out.contains("No matches"), "got: {out}");
+    }
+
+    #[test]
+    fn truncated_scan_without_matches_is_not_reported_as_complete() {
+        let out = format_empty_result("needle", ".", true);
+
+        assert!(out.contains("Search incomplete"));
+        assert!(out.contains(&MAX_FILES_SCANNED.to_string()));
+        assert!(out.contains("scanned files"));
+        assert!(!out.starts_with("No matches"));
     }
 }


### PR DESCRIPTION
## Summary

- Distinguish a complete zero-match code search from one stopped at the 20,000-file ceiling.
- Report the truncated search as incomplete instead of claiming the pattern is absent.
- Tell callers to narrow `path` or refine the query before treating the result as definitive.

## Verification

- `cargo test -q -p librefang-runtime --lib tool_runner::search::tests` (7 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Changing the 20,000-file ceiling or traversal order.
- Pagination or resumable search scans.