### PR TITLE
fix(runtime): preserve refreshed web cache entries

### DIFF
--- a/changelog.d/fixed/7583-web-cache-expiry-race.md
+++ b/changelog.d/fixed/7583-web-cache-expiry-race.md
@@ -1,0 +1,1 @@
+Remove expired web-cache entries conditionally so cleanup cannot delete a fresh value inserted for the same key. (#7583) (@houko)

--- a/changelog.d/fixed/web-cache-expiry-race.md
+++ b/changelog.d/fixed/web-cache-expiry-race.md
@@ -1,0 +1,1 @@
+Remove expired web-cache entries conditionally so cleanup cannot delete a fresh value inserted for the same key. (@houko)

--- a/changelog.d/fixed/web-cache-expiry-race.md
+++ b/changelog.d/fixed/web-cache-expiry-race.md
@@ -1,1 +1,0 @@
-Remove expired web-cache entries conditionally so cleanup cannot delete a fresh value inserted for the same key. (@houko)

--- a/crates/librefang-runtime/src/web_cache.rs
+++ b/crates/librefang-runtime/src/web_cache.rs
@@ -37,11 +37,16 @@ impl WebCache {
         let entry = self.entries.get(key)?;
         if entry.inserted_at.elapsed() > self.ttl {
             drop(entry); // release read lock before removing
-            self.entries.remove(key);
+            self.evict_key_if_expired(key);
             None
         } else {
             Some(entry.value.clone())
         }
+    }
+
+    fn evict_key_if_expired(&self, key: &str) {
+        self.entries
+            .remove_if(key, |_, entry| entry.inserted_at.elapsed() > self.ttl);
     }
 
     /// Store a value in the cache. No-op if TTL is zero.
@@ -124,6 +129,25 @@ mod tests {
         cache.put("key1".to_string(), "old".to_string());
         cache.put("key1".to_string(), "new".to_string());
         assert_eq!(cache.get("key1"), Some("new".to_string()));
+    }
+
+    #[test]
+    fn stale_expiry_cleanup_preserves_replacement() {
+        let cache = WebCache::new(Duration::from_secs(60));
+        cache.put("key1".to_string(), "expired".to_string());
+        cache.entries.get_mut("key1").unwrap().inserted_at =
+            Instant::now() - Duration::from_secs(61);
+        assert!(cache
+            .entries
+            .get("key1")
+            .is_some_and(|entry| entry.inserted_at.elapsed() > cache.ttl));
+
+        // Simulate a concurrent put after get() observed the old entry but
+        // before its cleanup acquired the map's write path.
+        cache.put("key1".to_string(), "fresh".to_string());
+        cache.evict_key_if_expired("key1");
+
+        assert_eq!(cache.get("key1"), Some("fresh".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace unconditional expired-key removal with DashMap `remove_if`.
- Recheck the currently mapped entry under the removal path before eviction.
- Preserve a fresh same-key value inserted after another thread observed the old entry as expired.

## Verification

- `cargo test -q -p librefang-runtime --lib web_cache::tests` (9 passed)
- `cargo test -q -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -q -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- Changing TTL semantics or adding proactive cache sweeping.
- Cache size limits or eviction ordering.