### PR TITLE
fix(runtime): pseudonymize only matched PII spans

### DIFF
--- a/changelog.d/fixed/7588-pii-pseudonym-spans.md
+++ b/changelog.d/fixed/7588-pii-pseudonym-spans.md
@@ -1,0 +1,1 @@
+Restrict PII pseudonym replacement to regex match spans instead of replacing equal substrings globally. (#7588) (@houko)

--- a/changelog.d/fixed/pii-pseudonym-spans.md
+++ b/changelog.d/fixed/pii-pseudonym-spans.md
@@ -1,1 +1,0 @@
-Restrict PII pseudonym replacement to regex match spans instead of replacing equal substrings globally. (@houko)

--- a/changelog.d/fixed/pii-pseudonym-spans.md
+++ b/changelog.d/fixed/pii-pseudonym-spans.md
@@ -1,0 +1,1 @@
+Restrict PII pseudonym replacement to regex match spans instead of replacing equal substrings globally. (@houko)

--- a/crates/librefang-runtime/src/pii_filter.rs
+++ b/crates/librefang-runtime/src/pii_filter.rs
@@ -258,15 +258,11 @@ impl PiiFilter {
     fn pseudonymize(&self, text: &str) -> String {
         let mut result = text.to_string();
         for (label, re) in &self.patterns {
-            // Collect matches first to avoid borrow issues
-            let matches: Vec<String> = re
-                .find_iter(&result)
-                .map(|m| m.as_str().to_string())
-                .collect();
-            for matched in matches {
-                let pseudonym = self.get_or_create_pseudonym(&matched, label);
-                result = result.replace(&matched, &pseudonym);
-            }
+            result = re
+                .replace_all(&result, |captures: &regex::Captures<'_>| {
+                    self.get_or_create_pseudonym(&captures[0], label)
+                })
+                .into_owned();
         }
         result
     }
@@ -372,6 +368,17 @@ mod tests {
         assert!(!result.contains("bob@example.com"));
         assert!(result.contains("[Email-A]"));
         assert!(result.contains("[Email-B]"));
+    }
+
+    #[test]
+    fn test_pseudonymize_replaces_only_regex_match_spans() {
+        let filter = PiiFilter::new(&[r"\bSECRET\b".to_string()]);
+        let result = filter.filter_message(
+            "SECRET stays private; XSECRETY stays intact",
+            &PrivacyMode::Pseudonymize,
+        );
+
+        assert_eq!(result, "[Custom_0-A] stays private; XSECRETY stays intact");
     }
 
     // -- Phone detection --


### PR DESCRIPTION
## Changes

- replace PII values through regex match spans instead of global substring replacement
- preserve stable pseudonyms through the existing bounded pseudonym map
- add a regression proving an equal substring outside regex boundaries remains unchanged

Audit handoff finding: `F-69d3eb77ce53363e`.

## Verification

- `cargo test -p librefang-runtime pii_filter --lib` (27 passed)
- `cargo test -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings`

## Out of scope

- built-in PII regex definitions and precedence
- pseudonym labels, cache capacity, and eviction policy
- redaction mode behavior