### PR TITLE
fix(runtime): release A2A task lock before persistence

### DIFF
--- a/changelog.d/fixed/7591-a2a-persistence-lock-scope.md
+++ b/changelog.d/fixed/7591-a2a-persistence-lock-scope.md
@@ -1,0 +1,1 @@
+Release the A2A task-map lock before potentially blocking SQLite persistence writes. (#7591) (@houko)

--- a/changelog.d/fixed/a2a-persistence-lock-scope.md
+++ b/changelog.d/fixed/a2a-persistence-lock-scope.md
@@ -1,1 +1,0 @@
-Release the A2A task-map lock before potentially blocking SQLite persistence writes. (@houko)

--- a/changelog.d/fixed/a2a-persistence-lock-scope.md
+++ b/changelog.d/fixed/a2a-persistence-lock-scope.md
@@ -1,0 +1,1 @@
+Release the A2A task-map lock before potentially blocking SQLite persistence writes. (@houko)

--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -256,6 +256,8 @@ const DB_TASK_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 #[derive(Debug)]
 pub struct A2aTaskStore {
     tasks: Mutex<HashMap<String, TrackedTask>>,
+    /// Serializes mutations through their best-effort persistence write.
+    mutation_order: Mutex<()>,
     /// Maximum number of tasks to retain.
     max_tasks: usize,
     /// Time-to-live for any task regardless of state.
@@ -269,6 +271,7 @@ impl A2aTaskStore {
     pub fn new(max_tasks: usize) -> Self {
         Self {
             tasks: Mutex::new(HashMap::new()),
+            mutation_order: Mutex::new(()),
             max_tasks,
             task_ttl: DEFAULT_TASK_TTL,
             db: None,
@@ -279,6 +282,7 @@ impl A2aTaskStore {
     pub fn with_ttl(max_tasks: usize, task_ttl: Duration) -> Self {
         Self {
             tasks: Mutex::new(HashMap::new()),
+            mutation_order: Mutex::new(()),
             max_tasks,
             task_ttl,
             db: None,
@@ -331,6 +335,7 @@ impl A2aTaskStore {
                 let db = Arc::new(Mutex::new(conn));
                 let mut store = Self {
                     tasks: Mutex::new(HashMap::new()),
+                    mutation_order: Mutex::new(()),
                     max_tasks,
                     task_ttl: DEFAULT_TASK_TTL,
                     db: Some(Arc::clone(&db)),
@@ -510,6 +515,7 @@ impl A2aTaskStore {
     /// Insert a task. Expired tasks are swept first, then capacity eviction
     /// is applied if needed.
     pub fn insert(&self, task: A2aTask) {
+        let _mutation_order = lock_a2a_recover(&self.mutation_order, "mutation order");
         // Persist first so we never miss a task even if eviction removes it.
         self.db_upsert(&task);
 
@@ -614,37 +620,52 @@ impl A2aTaskStore {
 
     /// Update a task's status and optionally add messages/artifacts.
     pub fn update_status(&self, task_id: &str, status: A2aTaskStatus) -> bool {
-        let mut tasks = lock_a2a_recover(&self.tasks, "tasks");
-        if let Some(tracked) = tasks.get_mut(task_id) {
+        let _mutation_order = lock_a2a_recover(&self.mutation_order, "mutation order");
+        let task = {
+            let mut tasks = lock_a2a_recover(&self.tasks, "tasks");
+            let Some(tracked) = tasks.get_mut(task_id) else {
+                return false;
+            };
             tracked.task.status = status.into();
             tracked.updated_at = Instant::now();
-            self.db_upsert(&tracked.task);
-            true
-        } else {
-            false
-        }
+            tracked.task.clone()
+        };
+        self.db_upsert(&task);
+        true
     }
 
     /// Complete a task with a response message and optional artifacts.
     pub fn complete(&self, task_id: &str, response: A2aMessage, artifacts: Vec<A2aArtifact>) {
-        let mut tasks = lock_a2a_recover(&self.tasks, "tasks");
-        if let Some(tracked) = tasks.get_mut(task_id) {
-            tracked.task.messages.push(response);
-            tracked.task.artifacts.extend(artifacts);
-            tracked.task.status = A2aTaskStatus::Completed.into();
-            tracked.updated_at = Instant::now();
-            self.db_upsert(&tracked.task);
+        let _mutation_order = lock_a2a_recover(&self.mutation_order, "mutation order");
+        let task = {
+            let mut tasks = lock_a2a_recover(&self.tasks, "tasks");
+            tasks.get_mut(task_id).map(|tracked| {
+                tracked.task.messages.push(response);
+                tracked.task.artifacts.extend(artifacts);
+                tracked.task.status = A2aTaskStatus::Completed.into();
+                tracked.updated_at = Instant::now();
+                tracked.task.clone()
+            })
+        };
+        if let Some(task) = task {
+            self.db_upsert(&task);
         }
     }
 
     /// Fail a task with an error message.
     pub fn fail(&self, task_id: &str, error_message: A2aMessage) {
-        let mut tasks = lock_a2a_recover(&self.tasks, "tasks");
-        if let Some(tracked) = tasks.get_mut(task_id) {
-            tracked.task.messages.push(error_message);
-            tracked.task.status = A2aTaskStatus::Failed.into();
-            tracked.updated_at = Instant::now();
-            self.db_upsert(&tracked.task);
+        let _mutation_order = lock_a2a_recover(&self.mutation_order, "mutation order");
+        let task = {
+            let mut tasks = lock_a2a_recover(&self.tasks, "tasks");
+            tasks.get_mut(task_id).map(|tracked| {
+                tracked.task.messages.push(error_message);
+                tracked.task.status = A2aTaskStatus::Failed.into();
+                tracked.updated_at = Instant::now();
+                tracked.task.clone()
+            })
+        };
+        if let Some(task) = task {
+            self.db_upsert(&task);
         }
     }
 
@@ -1297,6 +1318,53 @@ mod tests {
         assert_eq!(
             store.get("poison-recovery").unwrap().status,
             A2aTaskStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn persistence_wait_does_not_hold_task_map_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("a2a.db");
+        let store = Arc::new(A2aTaskStore::with_persistence(10, &db_path));
+        store.insert(A2aTask {
+            id: "nonblocking-persistence".to_string(),
+            session_id: None,
+            status: A2aTaskStatus::Working.into(),
+            messages: vec![],
+            artifacts: vec![],
+            agent_id: None,
+            caller_a2a_agent_id: None,
+        });
+
+        let db = Arc::clone(store.db.as_ref().unwrap());
+        let db_guard = lock_a2a_recover(&db, "database test gate");
+        let updater_store = Arc::clone(&store);
+        let updater = std::thread::spawn(move || {
+            updater_store.update_status("nonblocking-persistence", A2aTaskStatus::InputRequired)
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Ok(tasks) = store.tasks.try_lock() {
+                if tasks["nonblocking-persistence"].task.status == A2aTaskStatus::InputRequired {
+                    break;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "task map stayed locked while persistence waited for SQLite"
+            );
+            std::thread::yield_now();
+        }
+
+        drop(db_guard);
+        assert!(updater.join().unwrap());
+        drop(store);
+
+        let reopened = A2aTaskStore::with_persistence(10, &db_path);
+        assert_eq!(
+            reopened.get("nonblocking-persistence").unwrap().status,
+            A2aTaskStatus::InputRequired
         );
     }
 

--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -1343,7 +1343,7 @@ mod tests {
             updater_store.update_status("nonblocking-persistence", A2aTaskStatus::InputRequired)
         });
 
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let deadline = Instant::now() + Duration::from_secs(5);
         loop {
             if let Ok(tasks) = store.tasks.try_lock() {
                 if tasks["nonblocking-persistence"].task.status == A2aTaskStatus::InputRequired {


### PR DESCRIPTION
## Changes

- serialize A2A mutations through their best-effort persistence write to retain database ordering
- clone mutated task state and release the shared task map before SQLite access
- cover a blocked persistence write, concurrent task-map availability, and persistence after reopen

Audit finding: `F-949a97f7690af36d`

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime a2a::tests --lib -- --nocapture` (23 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `git diff --check`

## Out of scope

- no changes to A2A retention, capacity eviction, persistence error policy, or client networking