### PR TITLE
fix(runtime): repair sparse persisted history after trim

### DIFF
--- a/changelog.d/fixed/7592-persisted-session-trim-fallback.md
+++ b/changelog.d/fixed/7592-persisted-session-trim-fallback.md
@@ -1,0 +1,1 @@
+Synthesize a valid user turn when trimming leaves persistent session history too sparse to reload. (#7592) (@houko)

--- a/changelog.d/fixed/persisted-session-trim-fallback.md
+++ b/changelog.d/fixed/persisted-session-trim-fallback.md
@@ -1,1 +1,0 @@
-Synthesize a valid user turn when trimming leaves persistent session history too sparse to reload. (@houko)

--- a/changelog.d/fixed/persisted-session-trim-fallback.md
+++ b/changelog.d/fixed/persisted-session-trim-fallback.md
@@ -1,0 +1,1 @@
+Synthesize a valid user turn when trimming leaves persistent session history too sparse to reload. (@houko)

--- a/crates/librefang-runtime/src/agent_loop/message.rs
+++ b/crates/librefang-runtime/src/agent_loop/message.rs
@@ -540,10 +540,11 @@ mod safe_trim_session_repair_tests {
     }
 
     #[test]
-    fn safe_trim_synthesizes_user_in_persisted_session_without_user_turns() {
-        let mut session: Vec<Message> = (0..20)
-            .map(|i| Message::assistant(format!("assistant-only-{i}")))
-            .collect();
+    fn safe_trim_preserves_system_and_synthesizes_user_in_persisted_session() {
+        let mut system = Message::system("pinned system policy");
+        system.pinned = true;
+        let mut session = vec![system];
+        session.extend((0..20).map(|i| Message::assistant(format!("assistant-only-{i}"))));
         let mut working = session.clone();
 
         let (_, session_mutated) = safe_trim_messages(
@@ -555,8 +556,10 @@ mod safe_trim_session_repair_tests {
         );
 
         assert!(session_mutated);
-        assert_eq!(session.len(), 1);
-        assert_eq!(session[0].role, Role::User);
-        assert_eq!(session[0].content.text_content(), "current user message");
+        assert_eq!(session.len(), 2);
+        assert_eq!(session[0].role, Role::System);
+        assert_eq!(session[0].content.text_content(), "pinned system policy");
+        assert_eq!(session[1].role, Role::User);
+        assert_eq!(session[1].content.text_content(), "current user message");
     }
 }

--- a/crates/librefang-runtime/src/agent_loop/message.rs
+++ b/crates/librefang-runtime/src/agent_loop/message.rs
@@ -194,6 +194,26 @@ pub(super) fn is_parameter_error_content(content: &str) -> bool {
     lower.contains("argument is required")
 }
 
+fn ensure_post_trim_minimum(
+    messages: &mut Vec<Message>,
+    agent_name: &str,
+    user_message: &str,
+    history_kind: &str,
+) {
+    if messages.len() >= 2 && messages.iter().any(|m| m.role == Role::User) {
+        return;
+    }
+
+    warn!(
+        agent = %agent_name,
+        history = history_kind,
+        remaining = messages.len(),
+        "Trim + repair left too few messages, synthesizing minimal conversation"
+    );
+    messages.retain(|message| message.role == Role::System);
+    messages.push(Message::user(user_message));
+}
+
 /// Safely trim message history to `DEFAULT_MAX_HISTORY_MESSAGES`, cutting at
 /// conversation-turn boundaries so ToolUse/ToolResult pairs are never split.
 ///
@@ -259,6 +279,12 @@ pub(super) fn safe_trim_messages(
         *session_messages = crate::session_repair::validate_and_repair(session_messages);
         *session_messages =
             crate::session_repair::ensure_starts_with_user(std::mem::take(session_messages));
+        ensure_post_trim_minimum(
+            session_messages,
+            agent_name,
+            user_message,
+            "persistent session",
+        );
     }
 
     if messages.len() <= max_history {
@@ -309,20 +335,7 @@ pub(super) fn safe_trim_messages(
 
     // Post-trim safety: ensure at least a user message survives so the LLM
     // request body is never empty.
-    if messages.len() < 2 || !messages.iter().any(|m| m.role == Role::User) {
-        warn!(
-            agent = %agent_name,
-            remaining = messages.len(),
-            "Trim + repair left too few messages, synthesizing minimal conversation"
-        );
-        // Keep any surviving system message, then append the current user turn.
-        let system_msgs: Vec<Message> = messages
-            .drain(..)
-            .filter(|m| m.role == Role::System)
-            .collect();
-        *messages = system_msgs;
-        messages.push(Message::user(user_message));
-    }
+    ensure_post_trim_minimum(messages, agent_name, user_message, "working copy");
 
     (working_mutated, session_mutated)
 }
@@ -524,5 +537,26 @@ mod safe_trim_session_repair_tests {
              got {:?} — this is the regression the audit closed",
             session[0].role
         );
+    }
+
+    #[test]
+    fn safe_trim_synthesizes_user_in_persisted_session_without_user_turns() {
+        let mut session: Vec<Message> = (0..20)
+            .map(|i| Message::assistant(format!("assistant-only-{i}")))
+            .collect();
+        let mut working = session.clone();
+
+        let (_, session_mutated) = safe_trim_messages(
+            &mut working,
+            &mut session,
+            "agent-under-test",
+            "current user message",
+            4,
+        );
+
+        assert!(session_mutated);
+        assert_eq!(session.len(), 1);
+        assert_eq!(session[0].role, Role::User);
+        assert_eq!(session[0].content.text_content(), "current user message");
     }
 }


### PR DESCRIPTION
## Changes

- share the post-trim minimum-conversation repair between working and persistent histories
- preserve surviving system messages and synthesize the current user turn when repaired history is sparse or userless
- cover assistant-only persistent history through trim and repair

Audit finding: `F-300fd496408fb74a`

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime safe_trim --lib -- --nocapture` (9 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `git diff --check`

## Out of scope

- no changes to trim boundaries, pinning, tool-pair repair, history caps, or session save scheduling