### PR TITLE
fix(runtime): persist context engine compaction

### DIFF
--- a/changelog.d/fixed/7594-context-compaction-session-persistence.md
+++ b/changelog.d/fixed/7594-context-compaction-session-persistence.md
@@ -1,0 +1,1 @@
+Persist context-engine compaction results in both streaming and non-streaming agent sessions without losing the current-turn boundary. (#7594) (@houko)

--- a/changelog.d/fixed/context-compaction-session-persistence.md
+++ b/changelog.d/fixed/context-compaction-session-persistence.md
@@ -1,0 +1,1 @@
+Persist context-engine compaction results in both streaming and non-streaming agent sessions. (@houko)

--- a/changelog.d/fixed/context-compaction-session-persistence.md
+++ b/changelog.d/fixed/context-compaction-session-persistence.md
@@ -1,1 +1,0 @@
-Persist context-engine compaction results in both streaming and non-streaming agent sessions. (@houko)

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -130,6 +130,30 @@ fn repair_session_before_save(session: &mut Session, agent_id: &str, reason: &st
     session.last_repaired_generation = Some(session.messages_generation);
 }
 
+fn apply_context_compaction(
+    session: &mut Session,
+    messages: &mut Vec<Message>,
+    summary: String,
+    kept_messages: Vec<Message>,
+) {
+    let mut compacted = Vec::with_capacity(kept_messages.len() + usize::from(!summary.is_empty()));
+    if !summary.is_empty() {
+        compacted.push(Message {
+            role: Role::User,
+            content: MessageContent::Text(format!(
+                "[Context compaction summary] Earlier conversation turns were summarised to \
+                 preserve context space. Summary of removed messages: {summary}"
+            )),
+            pinned: false,
+            timestamp: None,
+        });
+    }
+    compacted.extend(kept_messages);
+
+    session.set_messages(compacted.clone());
+    *messages = compacted;
+}
+
 /// Maximum consecutive iterations where every executed tool failed before
 /// the loop exits with `RepeatedToolFailures`. Catches expensive wheel-spinning
 /// when the LLM cannot fix a tool call (bad auth, permanent 404, etc.).
@@ -1004,26 +1028,12 @@ async fn run_agent_loop_inner(
                             kept = result.kept_messages.len(),
                             "Context engine compaction complete"
                         );
-                        // Inject the LLM-generated summary as a synthetic user message
-                        // so the agent retains context about what was compacted.
-                        // Without this, the summary is silently discarded and the agent
-                        // loses all knowledge of earlier turns.
-                        let mut compacted = Vec::with_capacity(result.kept_messages.len() + 1);
-                        if !result.summary.is_empty() {
-                            compacted.push(Message {
-                                role: Role::User,
-                                content: MessageContent::Text(format!(
-                                    "[Context compaction summary] Earlier conversation turns \
-                                     were summarised to preserve context space. Summary of \
-                                     removed messages: {}",
-                                    result.summary
-                                )),
-                                pinned: false,
-                                timestamp: None,
-                            });
-                        }
-                        compacted.extend(result.kept_messages);
-                        messages = compacted;
+                        apply_context_compaction(
+                            session,
+                            &mut messages,
+                            result.summary,
+                            result.kept_messages,
+                        );
                         // `last_prompt_tokens` is intentionally NOT reset here.
                         // A second compaction should only fire after the next
                         // LLM call raises it above threshold again.  Resetting

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -165,7 +165,7 @@ fn apply_context_compaction(
     let compacted_new_messages_start = first_new_message_json
         .as_ref()
         .and_then(|first| {
-            compacted.iter().position(|message| {
+            compacted.iter().rposition(|message| {
                 serde_json::to_value(message).is_ok_and(|candidate| candidate == *first)
             })
         })

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -133,9 +133,21 @@ fn repair_session_before_save(session: &mut Session, agent_id: &str, reason: &st
 fn apply_context_compaction(
     session: &mut Session,
     messages: &mut Vec<Message>,
+    new_messages_start: &mut usize,
     summary: String,
     kept_messages: Vec<Message>,
 ) {
+    let previous_new_messages_start = (*new_messages_start).min(session.messages.len());
+    let first_new_message = session.messages.get(previous_new_messages_start);
+    let first_new_message_json =
+        first_new_message.and_then(|message| match serde_json::to_value(message) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                warn!(%error, "Failed to identify current-turn boundary during compaction");
+                None
+            }
+        });
+
     let mut compacted = Vec::with_capacity(kept_messages.len() + usize::from(!summary.is_empty()));
     if !summary.is_empty() {
         compacted.push(Message {
@@ -150,8 +162,25 @@ fn apply_context_compaction(
     }
     compacted.extend(kept_messages);
 
+    let compacted_new_messages_start = first_new_message_json
+        .as_ref()
+        .and_then(|first| {
+            compacted.iter().position(|message| {
+                serde_json::to_value(message).is_ok_and(|candidate| candidate == *first)
+            })
+        })
+        .unwrap_or_else(|| {
+            // A custom context engine may omit or rewrite the current turn.
+            // Keep it in persistent history and in the next LLM request rather
+            // than letting a stale pre-compaction boundary hide or lose it.
+            let start = compacted.len();
+            compacted.extend_from_slice(&session.messages[previous_new_messages_start..]);
+            start
+        });
+
     session.set_messages(compacted.clone());
     *messages = compacted;
+    *new_messages_start = compacted_new_messages_start;
 }
 
 /// Maximum consecutive iterations where every executed tool failed before
@@ -1031,6 +1060,7 @@ async fn run_agent_loop_inner(
                         apply_context_compaction(
                             session,
                             &mut messages,
+                            &mut new_messages_start,
                             result.summary,
                             result.kept_messages,
                         );

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -138,15 +138,15 @@ fn apply_context_compaction(
     kept_messages: Vec<Message>,
 ) {
     let previous_new_messages_start = (*new_messages_start).min(session.messages.len());
-    let first_new_message = session.messages.get(previous_new_messages_start);
-    let first_new_message_json =
-        first_new_message.and_then(|message| match serde_json::to_value(message) {
-            Ok(value) => Some(value),
-            Err(error) => {
-                warn!(%error, "Failed to identify current-turn boundary during compaction");
-                None
-            }
-        });
+    let current_turn = &session.messages[previous_new_messages_start..];
+    let current_turn_json = current_turn
+        .iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            warn!(%error, "Failed to identify current-turn boundary during compaction");
+        })
+        .ok();
 
     let mut compacted = Vec::with_capacity(kept_messages.len() + usize::from(!summary.is_empty()));
     if !summary.is_empty() {
@@ -162,19 +162,30 @@ fn apply_context_compaction(
     }
     compacted.extend(kept_messages);
 
-    let compacted_new_messages_start = first_new_message_json
+    let compacted_new_messages_start = current_turn_json
         .as_ref()
-        .and_then(|first| {
-            compacted.iter().rposition(|message| {
-                serde_json::to_value(message).is_ok_and(|candidate| candidate == *first)
-            })
+        .and_then(|turn| {
+            if turn.is_empty() {
+                return Some(compacted.len());
+            }
+            let compacted_json = compacted
+                .iter()
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| {
+                    warn!(%error, "Failed to identify compacted current-turn boundary");
+                })
+                .ok()?;
+            compacted_json
+                .windows(turn.len())
+                .rposition(|window| window == turn.as_slice())
         })
         .unwrap_or_else(|| {
             // A custom context engine may omit or rewrite the current turn.
             // Keep it in persistent history and in the next LLM request rather
             // than letting a stale pre-compaction boundary hide or lose it.
             let start = compacted.len();
-            compacted.extend_from_slice(&session.messages[previous_new_messages_start..]);
+            compacted.extend_from_slice(current_turn);
             start
         });
 

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -589,26 +589,12 @@ async fn run_agent_loop_streaming_inner(
                             kept = result.kept_messages.len(),
                             "Context engine compaction complete (streaming)"
                         );
-                        // Inject the LLM-generated summary as a synthetic user message
-                        // so the agent retains context about what was compacted.
-                        // Without this, the summary is silently discarded and the agent
-                        // loses all knowledge of earlier turns.
-                        let mut compacted = Vec::with_capacity(result.kept_messages.len() + 1);
-                        if !result.summary.is_empty() {
-                            compacted.push(Message {
-                                role: Role::User,
-                                content: MessageContent::Text(format!(
-                                    "[Context compaction summary] Earlier conversation turns \
-                                     were summarised to preserve context space. Summary of \
-                                     removed messages: {}",
-                                    result.summary
-                                )),
-                                pinned: false,
-                                timestamp: None,
-                            });
-                        }
-                        compacted.extend(result.kept_messages);
-                        messages = compacted;
+                        apply_context_compaction(
+                            session,
+                            &mut messages,
+                            result.summary,
+                            result.kept_messages,
+                        );
                         // `last_prompt_tokens` is NOT reset — see non-streaming
                         // comment for rationale.
                     }

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -592,6 +592,7 @@ async fn run_agent_loop_streaming_inner(
                         apply_context_compaction(
                             session,
                             &mut messages,
+                            &mut new_messages_start,
                             result.summary,
                             result.kept_messages,
                         );

--- a/crates/librefang-runtime/src/agent_loop/tests/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/mod.rs
@@ -31,7 +31,12 @@ fn test_max_iterations_constant() {
 
 #[test]
 fn context_compaction_updates_working_and_persistent_messages() {
-    let original = vec![Message::user("old user"), Message::assistant("old answer")];
+    let current_user = Message::user("current user");
+    let original = vec![
+        Message::user("old user"),
+        Message::assistant("old answer"),
+        current_user.clone(),
+    ];
     let mut session = Session {
         id: librefang_types::agent::SessionId::new(),
         agent_id: librefang_types::agent::AgentId::new(),
@@ -44,13 +49,14 @@ fn context_compaction_updates_working_and_persistent_messages() {
         peer_id: None,
     };
     let mut working = original;
-    let kept = Message::assistant("kept answer");
+    let mut new_messages_start = 2;
 
     apply_context_compaction(
         &mut session,
         &mut working,
+        &mut new_messages_start,
         "earlier facts".to_string(),
-        vec![kept.clone()],
+        vec![current_user.clone()],
     );
 
     assert_eq!(working.len(), session.messages.len());
@@ -64,17 +70,55 @@ fn context_compaction_updates_working_and_persistent_messages() {
     }
     assert_eq!(session.messages_generation, 8);
     assert_eq!(session.last_repaired_generation, Some(7));
+    assert_eq!(new_messages_start, 1);
     assert_eq!(session.messages.len(), 2);
     assert_eq!(session.messages[0].role, Role::User);
     assert!(session.messages[0]
         .content
         .text_content()
         .contains("earlier facts"));
-    assert_eq!(session.messages[1].role, kept.role);
+    assert_eq!(session.messages[1].role, current_user.role);
     assert_eq!(
         session.messages[1].content.text_content(),
-        kept.content.text_content()
+        current_user.content.text_content()
     );
+}
+
+#[test]
+fn context_compaction_preserves_current_turn_when_engine_omits_it() {
+    let current_user = Message::user("current user");
+    let current_tool_result = Message::user("current tool result");
+    let mut session = Session {
+        id: librefang_types::agent::SessionId::new(),
+        agent_id: librefang_types::agent::AgentId::new(),
+        messages: vec![
+            Message::user("old user"),
+            current_user.clone(),
+            current_tool_result.clone(),
+        ],
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+        messages_generation: 0,
+        last_repaired_generation: None,
+        peer_id: None,
+    };
+    let mut working = session.messages.clone();
+    let mut new_messages_start = 1;
+
+    apply_context_compaction(
+        &mut session,
+        &mut working,
+        &mut new_messages_start,
+        "old history".to_string(),
+        Vec::new(),
+    );
+
+    assert_eq!(new_messages_start, 1);
+    assert_eq!(session.messages.len(), 3);
+    assert_eq!(session.messages[1].timestamp, current_user.timestamp);
+    assert_eq!(session.messages[2].timestamp, current_tool_result.timestamp);
+    assert_eq!(working.len(), session.messages.len());
 }
 
 // ── push_accumulated_text bounded growth ──────────────────────────────

--- a/crates/librefang-runtime/src/agent_loop/tests/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/mod.rs
@@ -155,6 +155,49 @@ fn context_compaction_uses_last_duplicate_as_current_turn_boundary() {
     assert_eq!(working.len(), session.messages.len());
 }
 
+#[test]
+fn context_compaction_keeps_full_current_turn_when_first_message_repeats() {
+    let repeated_user = Message::user("same request");
+    let original = vec![
+        Message::user("old request"),
+        repeated_user.clone(),
+        Message::assistant("intermediate answer"),
+        repeated_user,
+    ];
+    let mut session = Session {
+        id: librefang_types::agent::SessionId::new(),
+        agent_id: librefang_types::agent::AgentId::new(),
+        messages: original.clone(),
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+        messages_generation: 0,
+        last_repaired_generation: None,
+        peer_id: None,
+    };
+    let mut working = original.clone();
+    let mut new_messages_start = 1;
+
+    apply_context_compaction(
+        &mut session,
+        &mut working,
+        &mut new_messages_start,
+        String::new(),
+        original,
+    );
+
+    assert_eq!(new_messages_start, 1);
+    let current_turn_text: Vec<_> = session.messages[new_messages_start..]
+        .iter()
+        .map(|message| message.content.text_content())
+        .collect();
+    assert_eq!(
+        current_turn_text,
+        ["same request", "intermediate answer", "same request"]
+    );
+    assert_eq!(working.len(), session.messages.len());
+}
+
 // ── push_accumulated_text bounded growth ──────────────────────────────
 
 #[test]

--- a/crates/librefang-runtime/src/agent_loop/tests/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/mod.rs
@@ -121,6 +121,40 @@ fn context_compaction_preserves_current_turn_when_engine_omits_it() {
     assert_eq!(working.len(), session.messages.len());
 }
 
+#[test]
+fn context_compaction_uses_last_duplicate_as_current_turn_boundary() {
+    let duplicate_user = Message::user("same request");
+    let original = vec![
+        duplicate_user.clone(),
+        Message::assistant("old answer"),
+        duplicate_user.clone(),
+    ];
+    let mut session = Session {
+        id: librefang_types::agent::SessionId::new(),
+        agent_id: librefang_types::agent::AgentId::new(),
+        messages: original.clone(),
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+        messages_generation: 0,
+        last_repaired_generation: None,
+        peer_id: None,
+    };
+    let mut working = original.clone();
+    let mut new_messages_start = 2;
+
+    apply_context_compaction(
+        &mut session,
+        &mut working,
+        &mut new_messages_start,
+        String::new(),
+        original,
+    );
+
+    assert_eq!(new_messages_start, 2);
+    assert_eq!(working.len(), session.messages.len());
+}
+
 // ── push_accumulated_text bounded growth ──────────────────────────────
 
 #[test]

--- a/crates/librefang-runtime/src/agent_loop/tests/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/mod.rs
@@ -29,6 +29,54 @@ fn test_max_iterations_constant() {
     );
 }
 
+#[test]
+fn context_compaction_updates_working_and_persistent_messages() {
+    let original = vec![Message::user("old user"), Message::assistant("old answer")];
+    let mut session = Session {
+        id: librefang_types::agent::SessionId::new(),
+        agent_id: librefang_types::agent::AgentId::new(),
+        messages: original.clone(),
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+        messages_generation: 7,
+        last_repaired_generation: Some(7),
+        peer_id: None,
+    };
+    let mut working = original;
+    let kept = Message::assistant("kept answer");
+
+    apply_context_compaction(
+        &mut session,
+        &mut working,
+        "earlier facts".to_string(),
+        vec![kept.clone()],
+    );
+
+    assert_eq!(working.len(), session.messages.len());
+    for (working_message, persisted_message) in working.iter().zip(&session.messages) {
+        assert_eq!(working_message.role, persisted_message.role);
+        assert_eq!(
+            working_message.content.text_content(),
+            persisted_message.content.text_content()
+        );
+        assert_eq!(working_message.pinned, persisted_message.pinned);
+    }
+    assert_eq!(session.messages_generation, 8);
+    assert_eq!(session.last_repaired_generation, Some(7));
+    assert_eq!(session.messages.len(), 2);
+    assert_eq!(session.messages[0].role, Role::User);
+    assert!(session.messages[0]
+        .content
+        .text_content()
+        .contains("earlier facts"));
+    assert_eq!(session.messages[1].role, kept.role);
+    assert_eq!(
+        session.messages[1].content.text_content(),
+        kept.content.text_content()
+    );
+}
+
 // ── push_accumulated_text bounded growth ──────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Changes

- centralize application of context-engine compaction results
- write compacted summaries and retained messages back to `session.messages`
- use the same persistence path in streaming and non-streaming loops
- preserve the complete current-turn boundary when compacted output retains, duplicates, rewrites, or omits current messages
- advance the session message generation after compaction

Audit finding: `F-d6fdf2e58a03d2b3`

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime context_compaction_updates_working_and_persistent_messages --lib -- --nocapture` (1 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime --lib -- --test-threads=1` (2277 passed, 2 ignored)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `cargo test -p librefang-runtime context_compaction --lib` (4 passed after review fixes)
- `git diff --check`

## Out of scope

- no changes to compaction thresholds, summary prompts, retained-message selection, context-engine implementations, or session save scheduling