### PR TITLE
fix(runtime): surface browser screenshot persistence errors

### DIFF
--- a/changelog.d/fixed/7595-browser-screenshot-persistence-errors.md
+++ b/changelog.d/fixed/7595-browser-screenshot-persistence-errors.md
@@ -1,0 +1,1 @@
+Return browser screenshot decoding and persistence failures instead of reporting empty success. (#7595) (@houko)

--- a/changelog.d/fixed/browser-screenshot-persistence-errors.md
+++ b/changelog.d/fixed/browser-screenshot-persistence-errors.md
@@ -1,0 +1,1 @@
+Return browser screenshot decoding and persistence failures instead of reporting empty success. (@houko)

--- a/changelog.d/fixed/browser-screenshot-persistence-errors.md
+++ b/changelog.d/fixed/browser-screenshot-persistence-errors.md
@@ -1,1 +1,0 @@
-Return browser screenshot decoding and persistence failures instead of reporting empty success. (@houko)

--- a/crates/librefang-runtime/src/browser_tools.rs
+++ b/crates/librefang-runtime/src/browser_tools.rs
@@ -125,6 +125,25 @@ pub async fn tool_browser_type(
     Ok(format!("Typed into {selector}: {text}"))
 }
 
+/// Decode and persist browser-provided screenshot bytes when present.
+async fn persist_screenshot(
+    image_base64: &str,
+    upload_dir: &std::path::Path,
+) -> Result<Option<String>, ToolError> {
+    if image_base64.is_empty() {
+        return Ok(None);
+    }
+
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(image_base64)
+        .map_err(|error| ToolError::upstream_msg(format!("Invalid screenshot data: {error}")))?;
+    crate::uploaded_file::save_shared_upload(upload_dir, &decoded, "image/png", "screenshot.png")
+        .await
+        .map(Some)
+        .map_err(ToolError::upstream_msg)
+}
+
 /// browser_screenshot: Take a screenshot of the current page.
 pub async fn tool_browser_screenshot(
     _input: &serde_json::Value,
@@ -147,23 +166,10 @@ pub async fn tool_browser_screenshot(
     let b64 = data["image_base64"].as_str().unwrap_or("");
     let url = data["url"].as_str().unwrap_or("");
 
-    let mut image_urls: Vec<String> = Vec::new();
-    if !b64.is_empty() {
-        use base64::Engine;
-        if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64) {
-            match crate::uploaded_file::save_shared_upload(
-                upload_dir,
-                &decoded,
-                "image/png",
-                "screenshot.png",
-            )
-            .await
-            {
-                Ok(url) => image_urls.push(url),
-                Err(error) => tracing::warn!(%error, "failed to persist browser screenshot"),
-            }
-        }
-    }
+    let image_urls: Vec<String> = persist_screenshot(b64, upload_dir)
+        .await?
+        .into_iter()
+        .collect();
 
     Ok(serde_json::json!({
         "screenshot": true,
@@ -371,5 +377,26 @@ mod tests {
             render_page("https://example.com/", &data),
             crate::web_content::wrap_external_content("https://example.com/", "Just prose.")
         );
+    }
+
+    #[tokio::test]
+    async fn screenshot_rejects_invalid_base64() {
+        let dir = tempfile::tempdir().unwrap();
+        let error = persist_screenshot("not base64!", dir.path())
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("Invalid screenshot data"));
+    }
+
+    #[tokio::test]
+    async fn screenshot_surfaces_shared_upload_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let upload_path = dir.path().join("not-a-directory");
+        tokio::fs::write(&upload_path, b"occupied").await.unwrap();
+
+        let error = persist_screenshot("cG5n", &upload_path).await.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Failed to create upload directory"));
     }
 }

--- a/crates/librefang-runtime/src/browser_tools.rs
+++ b/crates/librefang-runtime/src/browser_tools.rs
@@ -127,12 +127,19 @@ pub async fn tool_browser_type(
 
 /// Decode and persist browser-provided screenshot bytes when present.
 async fn persist_screenshot(
-    image_base64: &str,
+    image_base64: Option<&serde_json::Value>,
     upload_dir: &std::path::Path,
 ) -> Result<Option<String>, ToolError> {
-    if image_base64.is_empty() {
-        return Ok(None);
-    }
+    let image_base64 = match image_base64 {
+        None | Some(serde_json::Value::Null) => return Ok(None),
+        Some(serde_json::Value::String(value)) if value.is_empty() => return Ok(None),
+        Some(serde_json::Value::String(value)) => value,
+        Some(_) => {
+            return Err(ToolError::upstream_msg(
+                "Invalid screenshot data: image_base64 must be a string",
+            ));
+        }
+    };
 
     use base64::Engine;
     let decoded = base64::engine::general_purpose::STANDARD
@@ -163,10 +170,9 @@ pub async fn tool_browser_screenshot(
     }
 
     let data = resp.data.unwrap_or_default();
-    let b64 = data["image_base64"].as_str().unwrap_or("");
     let url = data["url"].as_str().unwrap_or("");
 
-    let image_urls: Vec<String> = persist_screenshot(b64, upload_dir)
+    let image_urls: Vec<String> = persist_screenshot(data.get("image_base64"), upload_dir)
         .await?
         .into_iter()
         .collect();
@@ -382,10 +388,21 @@ mod tests {
     #[tokio::test]
     async fn screenshot_rejects_invalid_base64() {
         let dir = tempfile::tempdir().unwrap();
-        let error = persist_screenshot("not base64!", dir.path())
+        let image = serde_json::json!("not base64!");
+        let error = persist_screenshot(Some(&image), dir.path())
             .await
             .unwrap_err();
         assert!(error.to_string().contains("Invalid screenshot data"));
+    }
+
+    #[tokio::test]
+    async fn screenshot_rejects_non_string_base64() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = serde_json::json!({ "bytes": "cG5n" });
+        let error = persist_screenshot(Some(&image), dir.path())
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("image_base64 must be a string"));
     }
 
     #[tokio::test]
@@ -394,7 +411,10 @@ mod tests {
         let upload_path = dir.path().join("not-a-directory");
         tokio::fs::write(&upload_path, b"occupied").await.unwrap();
 
-        let error = persist_screenshot("cG5n", &upload_path).await.unwrap_err();
+        let image = serde_json::json!("cG5n");
+        let error = persist_screenshot(Some(&image), &upload_path)
+            .await
+            .unwrap_err();
         assert!(error
             .to_string()
             .contains("Failed to create upload directory"));


### PR DESCRIPTION
## Changes

- fail browser screenshots when returned Base64 is malformed or is not a string
- propagate shared-upload directory and write failures as typed upstream errors
- prevent persistence failures from returning successful screenshots with empty image URLs

Audit finding: `F-6fba5db6a67e959d`

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime browser_tools::tests --lib -- --nocapture` (6 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo test -p librefang-runtime --lib -- --test-threads=1` (2278 passed, 2 ignored)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `cargo test -p librefang-runtime screenshot_ --lib` (3 passed after review fix)
- `git diff --check`

## Out of scope

- no changes to browser capture, screenshot format, upload naming, shared-upload metadata, or empty-image responses