### PR TITLE
fix(api): scrub messaging error details

### DIFF
--- a/changelog.d/fixed/7603-api-messaging-error-scrub.md
+++ b/changelog.d/fixed/7603-api-messaging-error-scrub.md
@@ -1,0 +1,1 @@
+Scrubbed internal agent-injection and proactive channel-delivery failures from API responses while retaining actionable server-side diagnostics. (#7603) (@houko)

--- a/crates/librefang-api/src/routes/agents/messaging.rs
+++ b/crates/librefang-api/src/routes/agents/messaging.rs
@@ -831,15 +831,17 @@ pub async fn inject_message(
                 .with_code("backpressure")
                 .into_response()
         }
-        Err(e) => if e.to_string().contains("not found") {
-            ApiErrorResponse::not_found(e.to_string())
-        } else {
+        Err(crate::error::KernelError::LibreFang(
+            librefang_types::error::LibreFangError::AgentNotFound(_),
+        )) => ApiErrorResponse::not_found("agent not found")
+            .with_code("agent_not_found")
+            .into_response(),
+        Err(e) => {
             // Scrub the catch-all 500 (audit: rusqlite-errors-leak):
             // an inject failure rooted in the memory substrate would
             // otherwise leak SQL detail. Full error logged in scrub.
-            ApiErrorResponse::internal_scrub(&e)
+            ApiErrorResponse::internal_scrub(&e).into_response()
         }
-        .into_response(),
     }
 }
 
@@ -931,13 +933,21 @@ pub async fn push_message(
                 "agent_id": agent_id.to_string(),
             })),
         ),
-        Err(e) => (
-            StatusCode::BAD_GATEWAY,
-            Json(serde_json::json!({
-                "success": false,
-                "detail": e,
-                "agent_id": agent_id.to_string(),
-            })),
-        ),
+        Err(e) => {
+            tracing::warn!(
+                agent_id = %agent_id,
+                channel = %req.channel,
+                error = %e,
+                "Channel adapter rejected proactive message"
+            );
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "success": false,
+                    "detail": "Channel adapter rejected the message",
+                    "agent_id": agent_id.to_string(),
+                })),
+            )
+        }
     }
 }

--- a/crates/librefang-api/tests/agents_clone_bulk_integration.rs
+++ b/crates/librefang-api/tests/agents_clone_bulk_integration.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `/api/agents` clone/reload/push + bulk-ops
+//! Integration tests for the `/api/agents` clone/reload/inject/push + bulk-ops
 //! route clusters.
 //!
 //! Refs the "agents-mutation-routes-untested" umbrella (Critical) — final
@@ -9,8 +9,9 @@
 //!   POST   /api/agents/{id}/clone   (201 + read-back; 409 on duplicate name;
 //!                                     404 on unknown source; 400 invalid id)
 //!   POST   /api/agents/{id}/reload  (200 + read-back side effect; negative)
+//!   POST   /api/agents/{id}/inject  (404 unknown agent without error leakage)
 //!   POST   /api/agents/{id}/push    (400 validation; 404 unknown agent;
-//!                                     502 when no channel adapter is wired)
+//!                                     scrubbed 502 when no channel adapter is wired)
 //!   POST   /api/agents/bulk         (multi-create + read-back)
 //!   DELETE /api/agents/bulk         (multi-delete + read-back 404)
 //!   POST   /api/agents/bulk/start   (set Full mode + read-back)
@@ -392,6 +393,29 @@ async fn test_reload_unknown_agent_is_rejected() {
 }
 
 // ===========================================================================
+// INJECT — POST /api/agents/{id}/inject
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_inject_unknown_agent_scrubs_kernel_error() {
+    let h = boot(TEST_TOKEN).await;
+    let missing_id = unknown_agent_id();
+    let (status, body) = send(
+        h.app.clone(),
+        post_json(
+            &format!("/api/agents/{missing_id}/inject"),
+            serde_json::json!({"message": "interrupt"}),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
+    assert_eq!(body["error"]["message"], "agent not found");
+    assert_eq!(body["error"]["code"], "agent_not_found");
+    assert!(!body.to_string().contains(&missing_id.to_string()));
+}
+
+// ===========================================================================
 // PUSH — POST /api/agents/{id}/push
 //
 // The push happy path delivers through a live channel adapter (Telegram,
@@ -478,6 +502,8 @@ async fn test_push_no_channel_adapter_returns_502() {
     assert_eq!(status, StatusCode::BAD_GATEWAY, "body: {body}");
     assert_eq!(body["success"], false);
     assert_eq!(body["agent_id"], id.to_string());
+    assert_eq!(body["detail"], "Channel adapter rejected the message");
+    assert!(!body.to_string().contains("telegram"));
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Changes

- Match typed agent-not-found errors for message injection and return a stable `agent_not_found` response without kernel detail.
- Log proactive channel delivery failures server-side while returning a stable 502 detail to clients.
- Add HTTP integration regressions for both leakage paths.
- Add the required attributed changelog fragment.

## Verification

- `cargo test -p librefang-api --test agents_clone_bulk_integration -- --test-threads=1` (27 passed)
- `cargo test -p librefang-api -- --test-threads=1` (full API crate passed; 1009 library tests and every integration/doc-test binary)
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check origin/main...HEAD`
- After merging latest `origin/main` at `232406090`, repeated the 27-test HTTP integration binary, workspace check, clippy, format, changelog, and diff checks.

## Out of scope

- Backpressure response semantics, channel adapter selection, delivery retries, and successful response bodies are unchanged.