### PR TITLE
perf(router): release regex cache lock before matching

### DIFF
--- a/changelog.d/changed/7604-router-regex-lock-scope.md
+++ b/changelog.d/changed/7604-router-regex-lock-scope.md
@@ -1,0 +1,1 @@
+Released the shared router regex-cache lock before evaluating message matches, avoiding unnecessary serialization across routing requests. (#7604) (@houko)

--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -923,18 +923,22 @@ impl RegexCache {
 /// manifest pattern would otherwise live in the cache forever).
 static REGEX_CACHE: OnceLock<Mutex<RegexCache>> = OnceLock::new();
 
+fn cached_regex(cache: &Mutex<RegexCache>, pattern: &str) -> Option<Regex> {
+    let mut guard = lock_router_state(cache, "regex_cache");
+    guard.get_or_compile(pattern).cloned()
+}
+
 fn regex_matches(message: &str, pattern: &str) -> bool {
     let cache = REGEX_CACHE.get_or_init(|| Mutex::new(RegexCache::new()));
-    let mut guard = lock_router_state(cache, "regex_cache");
     // None == compile error → never matches. Mirrors the historical
     // "never-match sentinel" branch but without the panic-risk of
     // the previous `Regex::new("(?!x)x").unwrap()` (regex_lite
     // doesn't support look-around, so the sentinel would have
     // panicked the first time any invalid pattern reached this
-    // path).
-    guard
-        .get_or_compile(pattern)
-        .map(|r| r.is_match(message))
+    // path). Clone the compiled regex out of the cache so matching
+    // does not serialize every routing request on the global mutex.
+    cached_regex(cache, pattern)
+        .map(|regex| regex.is_match(message))
         .unwrap_or(false)
 }
 
@@ -1745,6 +1749,20 @@ system_prompt = "override"
             1,
             "exactly one entry for a single distinct pattern"
         );
+    }
+
+    #[test]
+    fn cached_regex_releases_lock_before_matching() {
+        let cache = Mutex::new(RegexCache::new());
+        let regex = cached_regex(&cache, "hello").expect("valid pattern compiles");
+
+        let guard = cache
+            .try_lock()
+            .expect("cache lock must be released after cloning the regex");
+        assert_eq!(guard.entries.len(), 1);
+        drop(guard);
+
+        assert!(regex.is_match("hello world"));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- Clone compiled regexes out of the bounded router cache while holding its mutex.
- Run `is_match` after the global cache lock has been released.
- Add a regression proving the cache lock is immediately reacquirable before matching.
- Add the required attributed changelog fragment.

## Verification

- `cargo test -p librefang-kernel-router` (57 passed)
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check origin/main...HEAD`
- After merging latest `origin/main` at `e3fee4b4e`, repeated the full router crate test, workspace check, clippy, format, changelog, and diff checks.

## Out of scope

- Cache capacity, FIFO eviction, regex syntax, route scoring, and matching semantics are unchanged.