### PR TITLE
fix(api): roll back failed webhook persistence

### DIFF
--- a/changelog.d/fixed/7607-webhook-persistence-rollback.md
+++ b/changelog.d/fixed/7607-webhook-persistence-rollback.md
@@ -1,0 +1,1 @@
+Rolled back webhook mutations that fail before durable replacement while retaining committed in-memory state when only the post-replacement directory sync fails. (#7607) (@houko)

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -78,6 +78,41 @@ fn hex_val(b: u8) -> Option<u8> {
 /// The file is `sync_all`-ed before the rename.
 /// On Unix, the parent directory is synced after the rename so the new directory entry is durable.
 pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
+    atomic_write_detailed(path, content).map_err(AtomicWriteError::into_io_error)
+}
+
+#[derive(Debug)]
+pub(crate) enum AtomicWriteError {
+    BeforeCommit(std::io::Error),
+    AfterCommit(std::io::Error),
+}
+
+impl AtomicWriteError {
+    fn into_io_error(self) -> std::io::Error {
+        match self {
+            Self::BeforeCommit(error) | Self::AfterCommit(error) => error,
+        }
+    }
+}
+
+pub(crate) fn atomic_write_detailed(
+    path: &std::path::Path,
+    content: &[u8],
+) -> Result<(), AtomicWriteError> {
+    atomic_write_detailed_with_parent_sync(path, content, |parent| {
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
+        #[cfg(not(unix))]
+        let _ = parent;
+        Ok(())
+    })
+}
+
+fn atomic_write_detailed_with_parent_sync(
+    path: &std::path::Path,
+    content: &[u8],
+    sync_parent: impl FnOnce(&std::path::Path) -> std::io::Result<()>,
+) -> Result<(), AtomicWriteError> {
     use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(0);
@@ -86,7 +121,8 @@ pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::R
     let mut tmp = path.to_path_buf();
     let file_name = path
         .file_name()
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename"))?
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing filename"))
+        .map_err(AtomicWriteError::BeforeCommit)?
         .to_os_string();
     let mut tmp_name = file_name;
     tmp_name.push(format!(".{}.{seq}.tmp", std::process::id()));
@@ -101,35 +137,32 @@ pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::R
 
     if let Err(e) = write_result {
         let _ = std::fs::remove_file(&tmp);
-        return Err(e);
+        return Err(AtomicWriteError::BeforeCommit(e));
     }
 
     if let Err(e) = std::fs::rename(&tmp, path) {
         let _ = std::fs::remove_file(&tmp);
-        return Err(e);
+        return Err(AtomicWriteError::BeforeCommit(e));
     }
 
-    #[cfg(unix)]
-    {
-        // `Path::parent()` returns `Some("")` (not `None`) for a bare
-        // relative filename like `config.toml` — `None` only happens for
-        // `/` or an empty path itself. Map that empty-but-present case to
-        // `.` so we still fsync the actual containing directory instead of
-        // failing `File::open("")` with ENOENT after the rename already
-        // succeeded.
-        let parent = match path.parent() {
-            Some(p) if !p.as_os_str().is_empty() => p,
-            _ => std::path::Path::new("."),
-        };
-        std::fs::File::open(parent)?.sync_all()?;
-    }
+    // `Path::parent()` returns `Some("")` (not `None`) for a bare
+    // relative filename like `config.toml` — `None` only happens for
+    // `/` or an empty path itself. Map that empty-but-present case to
+    // `.` so we still fsync the actual containing directory instead of
+    // failing `File::open("")` with ENOENT after the rename already
+    // succeeded.
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => std::path::Path::new("."),
+    };
+    sync_parent(parent).map_err(AtomicWriteError::AfterCommit)?;
 
     Ok(())
 }
 
 #[cfg(test)]
 mod atomic_write_tests {
-    use super::atomic_write;
+    use super::{atomic_write, atomic_write_detailed_with_parent_sync, AtomicWriteError};
 
     #[test]
     fn replaces_existing_content_and_leaves_no_staging_file() {
@@ -145,6 +178,21 @@ mod atomic_write_tests {
             .map(|entry| entry.expect("directory entry").file_name())
             .collect();
         assert_eq!(entries, vec![std::ffi::OsString::from("config.toml")]);
+    }
+
+    #[test]
+    fn distinguishes_parent_sync_failure_after_replacement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, b"old").expect("seed file");
+
+        let error = atomic_write_detailed_with_parent_sync(&path, b"new", |_| {
+            Err(std::io::Error::other("injected parent sync failure"))
+        })
+        .expect_err("parent sync should fail");
+
+        assert!(matches!(error, AtomicWriteError::AfterCommit(_)));
+        assert_eq!(std::fs::read(&path).expect("read result"), b"new");
     }
 }
 

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -532,6 +532,8 @@ impl WebhookStore {
         data.webhooks.push(webhook.clone());
         if let Err(e) = self.persist(&data).await {
             tracing::warn!("Failed to persist webhook store: {e}");
+            data.webhooks.pop();
+            return Err("webhook persistence failed".to_string());
         }
         Ok(webhook)
     }
@@ -543,11 +545,13 @@ impl WebhookStore {
         req: UpdateWebhookRequest,
     ) -> Result<WebhookSubscription, String> {
         let mut data = self.data.write().await;
-        let webhook = data
+        let index = data
             .webhooks
-            .iter_mut()
-            .find(|w| w.id == id)
+            .iter()
+            .position(|w| w.id == id)
             .ok_or_else(|| "webhook not found".to_string())?;
+        let previous = data.webhooks[index].clone();
+        let mut updated = previous.clone();
 
         if let Some(ref name) = req.name {
             if name.trim().is_empty() {
@@ -559,7 +563,7 @@ impl WebhookStore {
                     MAX_NAME_LEN
                 ));
             }
-            webhook.name = name.clone();
+            updated.name = name.clone();
         }
         if let Some(ref url_str) = req.url {
             if url_str.trim().is_empty() {
@@ -572,34 +576,36 @@ impl WebhookStore {
                 ));
             }
             validate_webhook_url(url_str)?;
-            webhook.url = url_str.clone();
+            updated.url = url_str.clone();
         }
         if let Some(ref secret) = req.secret {
             if secret.is_empty() {
                 // Treat empty string as "clear the secret"
-                webhook.secret = None;
+                updated.secret = None;
             } else if secret.len() > MAX_SECRET_LEN {
                 return Err(format!(
                     "secret exceeds maximum length of {} chars",
                     MAX_SECRET_LEN
                 ));
             } else {
-                webhook.secret = Some(secret.clone());
+                updated.secret = Some(secret.clone());
             }
         }
         if let Some(ref events) = req.events {
             if events.is_empty() {
                 return Err("events must not be empty".to_string());
             }
-            webhook.events = events.clone();
+            updated.events = events.clone();
         }
         if let Some(enabled) = req.enabled {
-            webhook.enabled = enabled;
+            updated.enabled = enabled;
         }
-        webhook.updated_at = Utc::now();
-        let updated = webhook.clone();
+        updated.updated_at = Utc::now();
+        data.webhooks[index] = updated.clone();
         if let Err(e) = self.persist(&data).await {
             tracing::warn!("Failed to persist webhook store: {e}");
+            data.webhooks[index] = previous;
+            return Err("webhook persistence failed".to_string());
         }
         Ok(updated)
     }
@@ -607,15 +613,16 @@ impl WebhookStore {
     /// Delete a webhook subscription.
     pub async fn delete(&self, id: WebhookId) -> bool {
         let mut data = self.data.write().await;
-        let before = data.webhooks.len();
-        data.webhooks.retain(|w| w.id != id);
-        let removed = data.webhooks.len() < before;
-        if removed {
-            if let Err(e) = self.persist(&data).await {
-                tracing::warn!("Failed to persist webhook store: {e}");
-            }
+        let Some(index) = data.webhooks.iter().position(|webhook| webhook.id == id) else {
+            return false;
+        };
+        let removed = data.webhooks.remove(index);
+        if let Err(e) = self.persist(&data).await {
+            tracing::warn!("Failed to persist webhook store: {e}");
+            data.webhooks.insert(index, removed);
+            return false;
         }
-        removed
+        true
     }
 }
 
@@ -646,6 +653,31 @@ mod tests {
         }
     }
 
+    fn failing_store_with(webhooks: Vec<WebhookSubscription>) -> (WebhookStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("not-a-directory");
+        std::fs::write(&blocker, b"block parent creation").unwrap();
+        let store = WebhookStore {
+            data: RwLock::new(StoreData { webhooks }),
+            path: blocker.join("webhooks.json"),
+        };
+        (store, dir)
+    }
+
+    fn webhook_fixture() -> WebhookSubscription {
+        let now = Utc::now();
+        WebhookSubscription {
+            id: WebhookId(Uuid::new_v4()),
+            name: "persisted-hook".to_string(),
+            url: "https://example.com/hook".to_string(),
+            secret: Some("secret".to_string()),
+            events: vec![WebhookEvent::AgentSpawned],
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     #[tokio::test]
     async fn create_and_list() {
         let (store, _dir) = temp_store();
@@ -653,6 +685,16 @@ mod tests {
         let wh = store.create(valid_create_req()).await.unwrap();
         assert_eq!(wh.name, "test-hook");
         assert_eq!(store.list().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn create_persist_failure_rolls_back_and_returns_error() {
+        let (store, _dir) = failing_store_with(Vec::new());
+
+        let error = store.create(valid_create_req()).await.unwrap_err();
+
+        assert_eq!(error, "webhook persistence failed");
+        assert!(store.list().await.is_empty());
     }
 
     #[tokio::test]
@@ -891,6 +933,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_persist_failure_restores_previous_subscription() {
+        let webhook = webhook_fixture();
+        let (store, _dir) = failing_store_with(vec![webhook.clone()]);
+
+        let error = store
+            .update(
+                webhook.id,
+                UpdateWebhookRequest {
+                    name: Some("not-durable".to_string()),
+                    url: None,
+                    secret: None,
+                    events: None,
+                    enabled: Some(false),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, "webhook persistence failed");
+        let restored = store.get(webhook.id).await.unwrap();
+        assert_eq!(restored.name, webhook.name);
+        assert_eq!(restored.enabled, webhook.enabled);
+        assert_eq!(restored.updated_at, webhook.updated_at);
+    }
+
+    #[tokio::test]
     async fn update_clears_secret_with_empty_string() {
         let (store, _dir) = temp_store();
         let wh = store.create(valid_create_req()).await.unwrap();
@@ -937,6 +1005,15 @@ mod tests {
         assert!(store.delete(wh.id).await);
         assert!(store.list().await.is_empty());
         assert!(!store.delete(wh.id).await);
+    }
+
+    #[tokio::test]
+    async fn delete_persist_failure_restores_subscription_and_reports_false() {
+        let webhook = webhook_fixture();
+        let (store, _dir) = failing_store_with(vec![webhook.clone()]);
+
+        assert!(!store.delete(webhook.id).await);
+        assert_eq!(store.get(webhook.id).await.unwrap().name, webhook.name);
     }
 
     #[tokio::test]

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -424,6 +424,24 @@ pub struct WebhookStore {
     path: PathBuf,
 }
 
+fn settle_webhook_write(
+    path: &std::path::Path,
+    result: Result<(), crate::AtomicWriteError>,
+) -> std::io::Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(crate::AtomicWriteError::BeforeCommit(error)) => Err(error),
+        Err(crate::AtomicWriteError::AfterCommit(error)) => {
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "Webhook store replaced but parent directory sync failed"
+            );
+            Ok(())
+        }
+    }
+}
+
 impl WebhookStore {
     /// Load or create a webhook store at the given path.
     ///
@@ -478,7 +496,8 @@ impl WebhookStore {
             if let Some(parent) = path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
-            crate::atomic_write(&path, json.as_bytes())?;
+            let write_result = crate::atomic_write_detailed(&path, json.as_bytes());
+            settle_webhook_write(&path, write_result)?;
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
@@ -676,6 +695,31 @@ mod tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    #[test]
+    fn webhook_write_accepts_only_post_commit_sync_failures() {
+        let path = std::path::Path::new("webhooks.json");
+        let post_commit = super::settle_webhook_write(
+            path,
+            Err(crate::AtomicWriteError::AfterCommit(std::io::Error::other(
+                "injected parent sync failure",
+            ))),
+        );
+        assert!(post_commit.is_ok());
+
+        let before_commit = super::settle_webhook_write(
+            path,
+            Err(crate::AtomicWriteError::BeforeCommit(
+                std::io::Error::other("injected write failure"),
+            )),
+        );
+        assert_eq!(
+            before_commit
+                .expect_err("pre-commit failure must propagate")
+                .to_string(),
+            "injected write failure"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Substantive changes

- Roll back newly created webhook subscriptions when persistence fails before replacement and return a stable error.
- Apply updates to a clone, restoring the prior subscription on pre-commit persistence failure.
- Restore deleted subscriptions at their original position when a durable write is not committed, and report the delete as unsuccessful.
- Distinguish atomic-write failures before and after `rename`, retaining committed in-memory state when only the parent-directory sync fails so memory and disk cannot diverge.
- Keep underlying filesystem details in server logs rather than returned store errors.
- Add regression coverage for create, update, delete, and post-replacement sync failures.
- Add the #7607 changelog fragment.

## Verification

- `cargo test -p librefang-api --lib -- --test-threads=1` — 1014 passed.
- `cargo test -p librefang-api webhook_store::tests --lib -- --test-threads=1` — 43 passed.
- `cargo test -p librefang-api atomic_write_tests --lib -- --test-threads=1` — 2 passed.
- `cargo check --workspace --lib` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `python3 scripts/check-changelog-attribution.py --all-unreleased` — passed.
- `git diff --check origin/main...HEAD` — passed.

## Out of scope

- HTTP delete-error classification remains in `routes/webhooks.rs`, currently owned by #7106. This change preserves its boolean store contract while ensuring a failed durable delete cannot be reported as success.
- Webhook delivery, SSRF validation, retry policy, and persistence format are unchanged.
