### PR TITLE
fix(api): offload migration filesystem work

### DIFF
--- a/changelog.d/fixed/7611-api-migration-offload-target.md
+++ b/changelog.d/fixed/7611-api-migration-offload-target.md
@@ -1,0 +1,1 @@
+Offloaded migration filesystem work, relocated only agents imported by the request, and kept relocation and response paths consistent on failures. (#7611) (@houko)

--- a/crates/librefang-api/src/routes/config/migration.rs
+++ b/crates/librefang-api/src/routes/config/migration.rs
@@ -9,34 +9,53 @@ enum MigrationTaskError {
 fn relocate_migrated_agent_dirs(
     target_dir: &std::path::Path,
     workspaces_agents_dir: &std::path::Path,
+    report: &librefang_import::report::MigrationReport,
 ) -> Result<Vec<(std::path::PathBuf, std::path::PathBuf)>, String> {
     let legacy_agents = target_dir.join("agents");
-    if legacy_agents == workspaces_agents_dir {
-        return Ok(Vec::new());
-    }
     if !legacy_agents.is_dir() {
         return Ok(Vec::new());
     }
 
-    let entries = std::fs::read_dir(&legacy_agents)
-        .map_err(|error| format!("read {}: {error}", legacy_agents.display()))?;
-    let mut moved = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|error| {
-            format!(
-                "read directory entry in {}: {error}",
-                legacy_agents.display()
-            )
-        })?;
-        let source = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|error| format!("inspect {}: {error}", source.display()))?;
-        if !file_type.is_dir() || !source.join("agent.toml").is_file() {
+    let mut imported_agent_dirs = std::collections::BTreeSet::new();
+    for item in &report.imported {
+        let Ok(relative) = std::path::Path::new(&item.destination).strip_prefix(&legacy_agents)
+        else {
             continue;
-        }
+        };
+        let Some(std::path::Component::Normal(agent_name)) = relative.components().next() else {
+            continue;
+        };
+        imported_agent_dirs.insert(legacy_agents.join(agent_name));
+    }
+    imported_agent_dirs.retain(|source| source.join("agent.toml").is_file());
+    if imported_agent_dirs.is_empty() {
+        return Ok(Vec::new());
+    }
 
-        let destination = workspaces_agents_dir.join(entry.file_name());
+    std::fs::create_dir_all(workspaces_agents_dir)
+        .map_err(|error| format!("create {}: {error}", workspaces_agents_dir.display()))?;
+    let canonical_legacy = legacy_agents
+        .canonicalize()
+        .map_err(|error| format!("resolve {}: {error}", legacy_agents.display()))?;
+    let canonical_workspaces = workspaces_agents_dir
+        .canonicalize()
+        .map_err(|error| format!("resolve {}: {error}", workspaces_agents_dir.display()))?;
+    if canonical_legacy == canonical_workspaces {
+        return Ok(Vec::new());
+    }
+
+    let moves: Vec<_> = imported_agent_dirs
+        .into_iter()
+        .map(|source| {
+            let destination = workspaces_agents_dir.join(
+                source
+                    .file_name()
+                    .expect("imported agent directory always has a name"),
+            );
+            (source, destination)
+        })
+        .collect();
+    for (source, destination) in &moves {
         if destination.exists() {
             return Err(format!(
                 "cannot relocate {} because {} already exists",
@@ -44,29 +63,39 @@ fn relocate_migrated_agent_dirs(
                 destination.display()
             ));
         }
-        std::fs::create_dir_all(workspaces_agents_dir)
-            .map_err(|error| format!("create {}: {error}", workspaces_agents_dir.display()))?;
-        std::fs::rename(&source, &destination).map_err(|error| {
-            format!(
-                "relocate {} to {}: {error}",
+    }
+
+    let mut moved: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::with_capacity(moves.len());
+    for (source, destination) in moves {
+        if let Err(error) = std::fs::rename(&source, &destination) {
+            let mut rollback_errors = Vec::new();
+            for (previous_source, previous_destination) in moved.iter().rev() {
+                if let Err(rollback_error) = std::fs::rename(previous_destination, previous_source)
+                {
+                    rollback_errors.push(format!(
+                        "restore {} to {}: {rollback_error}",
+                        previous_destination.display(),
+                        previous_source.display()
+                    ));
+                }
+            }
+            let rollback = if rollback_errors.is_empty() {
+                String::new()
+            } else {
+                format!("; rollback failures: {}", rollback_errors.join("; "))
+            };
+            return Err(format!(
+                "relocate {} to {}: {error}{rollback}",
                 source.display(),
                 destination.display()
-            )
-        })?;
+            ));
+        }
         moved.push((source, destination));
     }
 
-    match std::fs::remove_dir(&legacy_agents) {
-        Ok(()) => {}
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
-            ) => {}
-        Err(error) => {
-            return Err(format!("remove {}: {error}", legacy_agents.display()));
-        }
-    }
+    // An unrelated legacy directory may remain. Removal is cleanup only;
+    // every imported agent has already reached its canonical destination.
+    let _ = std::fs::remove_dir(&legacy_agents);
     Ok(moved)
 }
 
@@ -76,8 +105,8 @@ fn rewrite_relocated_agent_destinations(
 ) {
     for item in &mut report.imported {
         for (source, destination) in moved {
-            if std::path::Path::new(&item.destination) == source.join("agent.toml") {
-                item.destination = destination.join("agent.toml").display().to_string();
+            if let Ok(relative) = std::path::Path::new(&item.destination).strip_prefix(source) {
+                item.destination = destination.join(relative).display().to_string();
                 break;
             }
         }
@@ -281,7 +310,7 @@ pub async fn run_migrate(
         let mut report = librefang_import::run_migration(&options)
             .map_err(|error| MigrationTaskError::Migration(error.to_string()))?;
         if !dry_run {
-            let moved = relocate_migrated_agent_dirs(&target_dir, &workspaces_agents_dir)
+            let moved = relocate_migrated_agent_dirs(&target_dir, &workspaces_agents_dir, &report)
                 .map_err(MigrationTaskError::Relocation)?;
             rewrite_relocated_agent_destinations(&mut report, &moved);
         }
@@ -357,8 +386,16 @@ mod tests {
             name: "main".to_string(),
             destination: source_agent.join("agent.toml").display().to_string(),
         });
+        report.imported.push(librefang_import::report::MigrateItem {
+            kind: librefang_import::report::ItemKind::Memory,
+            name: "main/MEMORY.md".to_string(),
+            destination: source_agent
+                .join("imported_memory.md")
+                .display()
+                .to_string(),
+        });
 
-        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents).unwrap();
+        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents, &report).unwrap();
         rewrite_relocated_agent_destinations(&mut report, &moved);
 
         let canonical_manifest = canonical_agents.join("main").join("agent.toml");
@@ -367,6 +404,14 @@ mod tests {
         assert_eq!(
             report.imported[0].destination,
             canonical_manifest.display().to_string()
+        );
+        assert_eq!(
+            report.imported[1].destination,
+            canonical_agents
+                .join("main")
+                .join("imported_memory.md")
+                .display()
+                .to_string()
         );
     }
 
@@ -378,11 +423,75 @@ mod tests {
         let manifest = canonical_agents.join("main").join("agent.toml");
         std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
         std::fs::write(&manifest, "name = \"main\"\n").unwrap();
+        let mut report = librefang_import::report::MigrationReport::default();
+        report.imported.push(librefang_import::report::MigrateItem {
+            kind: librefang_import::report::ItemKind::Agent,
+            name: "main".to_string(),
+            destination: manifest.display().to_string(),
+        });
 
-        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents).unwrap();
+        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents, &report).unwrap();
 
         assert!(moved.is_empty());
         assert!(manifest.is_file());
+    }
+
+    #[test]
+    fn relocation_ignores_agents_not_imported_by_this_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let imported_agent = target.join("agents").join("imported");
+        let unrelated_agent = target.join("agents").join("unrelated");
+        let canonical_agents = dir.path().join("workspaces").join("agents");
+        for agent in [&imported_agent, &unrelated_agent] {
+            std::fs::create_dir_all(agent).unwrap();
+            std::fs::write(agent.join("agent.toml"), "name = \"agent\"\n").unwrap();
+        }
+        let mut report = librefang_import::report::MigrationReport::default();
+        report.imported.push(librefang_import::report::MigrateItem {
+            kind: librefang_import::report::ItemKind::Agent,
+            name: "imported".to_string(),
+            destination: imported_agent.join("agent.toml").display().to_string(),
+        });
+
+        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents, &report).unwrap();
+
+        assert_eq!(moved.len(), 1);
+        assert!(!imported_agent.exists());
+        assert!(canonical_agents
+            .join("imported")
+            .join("agent.toml")
+            .is_file());
+        assert!(unrelated_agent.join("agent.toml").is_file());
+    }
+
+    #[test]
+    fn relocation_preflights_all_destinations_before_moving_any_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let legacy_agents = target.join("agents");
+        let canonical_agents = dir.path().join("workspaces").join("agents");
+        let mut report = librefang_import::report::MigrationReport::default();
+        for name in ["first", "second"] {
+            let source = legacy_agents.join(name);
+            std::fs::create_dir_all(&source).unwrap();
+            std::fs::write(source.join("agent.toml"), format!("name = \"{name}\"\n")).unwrap();
+            report.imported.push(librefang_import::report::MigrateItem {
+                kind: librefang_import::report::ItemKind::Agent,
+                name: name.to_string(),
+                destination: source.join("agent.toml").display().to_string(),
+            });
+        }
+        let conflicting = canonical_agents.join("second");
+        std::fs::create_dir_all(&conflicting).unwrap();
+        std::fs::write(conflicting.join("agent.toml"), "name = \"existing\"\n").unwrap();
+
+        let error = relocate_migrated_agent_dirs(&target, &canonical_agents, &report).unwrap_err();
+
+        assert!(error.contains("already exists"));
+        assert!(legacy_agents.join("first").join("agent.toml").is_file());
+        assert!(legacy_agents.join("second").join("agent.toml").is_file());
+        assert!(!canonical_agents.join("first").exists());
     }
 
     #[test]

--- a/crates/librefang-api/src/routes/config/migration.rs
+++ b/crates/librefang-api/src/routes/config/migration.rs
@@ -1,5 +1,89 @@
 use super::*;
 
+enum MigrationTaskError {
+    Validation(crate::validation::ValidationError),
+    Migration(String),
+    Relocation(String),
+}
+
+fn relocate_migrated_agent_dirs(
+    target_dir: &std::path::Path,
+    workspaces_agents_dir: &std::path::Path,
+) -> Result<Vec<(std::path::PathBuf, std::path::PathBuf)>, String> {
+    let legacy_agents = target_dir.join("agents");
+    if legacy_agents == workspaces_agents_dir {
+        return Ok(Vec::new());
+    }
+    if !legacy_agents.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let entries = std::fs::read_dir(&legacy_agents)
+        .map_err(|error| format!("read {}: {error}", legacy_agents.display()))?;
+    let mut moved = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "read directory entry in {}: {error}",
+                legacy_agents.display()
+            )
+        })?;
+        let source = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("inspect {}: {error}", source.display()))?;
+        if !file_type.is_dir() || !source.join("agent.toml").is_file() {
+            continue;
+        }
+
+        let destination = workspaces_agents_dir.join(entry.file_name());
+        if destination.exists() {
+            return Err(format!(
+                "cannot relocate {} because {} already exists",
+                source.display(),
+                destination.display()
+            ));
+        }
+        std::fs::create_dir_all(workspaces_agents_dir)
+            .map_err(|error| format!("create {}: {error}", workspaces_agents_dir.display()))?;
+        std::fs::rename(&source, &destination).map_err(|error| {
+            format!(
+                "relocate {} to {}: {error}",
+                source.display(),
+                destination.display()
+            )
+        })?;
+        moved.push((source, destination));
+    }
+
+    match std::fs::remove_dir(&legacy_agents) {
+        Ok(()) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+            ) => {}
+        Err(error) => {
+            return Err(format!("remove {}: {error}", legacy_agents.display()));
+        }
+    }
+    Ok(moved)
+}
+
+fn rewrite_relocated_agent_destinations(
+    report: &mut librefang_import::report::MigrationReport,
+    moved: &[(std::path::PathBuf, std::path::PathBuf)],
+) {
+    for item in &mut report.imported {
+        for (source, destination) in moved {
+            if std::path::Path::new(&item.destination) == source.join("agent.toml") {
+                item.destination = destination.join("agent.toml").display().to_string();
+                break;
+            }
+        }
+    }
+}
+
 fn migration_validation_error(
     error: crate::validation::ValidationError,
 ) -> (StatusCode, Json<serde_json::Value>) {
@@ -24,45 +108,47 @@ fn migration_validation_error(
     )
 )]
 pub async fn migrate_detect() -> impl IntoResponse {
-    // Check OpenClaw first
-    if let Some(path) = librefang_import::openclaw::detect_openclaw_home() {
-        let scan = librefang_import::openclaw::scan_openclaw_workspace(&path);
-        return (
-            StatusCode::OK,
-            Json(serde_json::json!({
+    let detection = tokio::task::spawn_blocking(|| {
+        // Check OpenClaw first.
+        if let Some(path) = librefang_import::openclaw::detect_openclaw_home() {
+            let scan = librefang_import::openclaw::scan_openclaw_workspace(&path);
+            return serde_json::json!({
                 "detected": true,
                 "source": "openclaw",
                 "path": path.display().to_string(),
                 "scan": scan,
-            })),
-        );
-    }
+            });
+        }
 
-    // Check OpenFang
-    if let Some(home) = dirs::home_dir() {
-        let openfang_path = home.join(".openfang");
-        if openfang_path.exists() && openfang_path.is_dir() {
-            return (
-                StatusCode::OK,
-                Json(serde_json::json!({
+        // Check OpenFang.
+        if let Some(home) = dirs::home_dir() {
+            let openfang_path = home.join(".openfang");
+            if openfang_path.is_dir() {
+                return serde_json::json!({
                     "detected": true,
                     "source": "openfang",
                     "path": openfang_path.display().to_string(),
                     "scan": null,
-                })),
-            );
+                });
+            }
         }
-    }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
+        serde_json::json!({
             "detected": false,
             "source": null,
             "path": null,
             "scan": null,
-        })),
-    )
+        })
+    })
+    .await;
+
+    match detection {
+        Ok(body) => (StatusCode::OK, Json(body)),
+        Err(error) => {
+            ApiErrorResponse::internal_scrub(format!("migration detection task failed: {error}"))
+                .into_json_tuple()
+        }
+    }
 }
 
 /// POST /api/migrate/scan — Scan a specific directory for OpenClaw workspace.
@@ -88,20 +174,30 @@ pub async fn migrate_scan(
     // that exist under the OS home (see `migrate_source_roots`).
     let home_dir = state.kernel.home_dir().to_path_buf();
     let source_roots = migrate_source_roots(&home_dir, dirs::home_dir().as_deref());
-    let allowed_roots: Vec<&std::path::Path> = source_roots.iter().map(|p| p.as_path()).collect();
+    let requested_path = req.path;
+    let scan = tokio::task::spawn_blocking(move || {
+        let allowed_roots: Vec<&std::path::Path> =
+            source_roots.iter().map(|path| path.as_path()).collect();
+        let path = crate::validation::validate_path_containment(
+            "path",
+            std::path::Path::new(requested_path.trim()),
+            &allowed_roots,
+            true,
+        )?;
+        Ok::<_, crate::validation::ValidationError>(
+            librefang_import::openclaw::scan_openclaw_workspace(&path),
+        )
+    })
+    .await;
 
-    let path = match crate::validation::validate_path_containment(
-        "path",
-        std::path::Path::new(req.path.trim()),
-        &allowed_roots,
-        true, // scan target must already exist
-    ) {
-        Ok(p) => p,
-        Err(error) => return migration_validation_error(error),
-    };
-
-    let scan = librefang_import::openclaw::scan_openclaw_workspace(&path);
-    (StatusCode::OK, Json(serde_json::json!(scan)))
+    match scan {
+        Ok(Ok(scan)) => (StatusCode::OK, Json(serde_json::json!(scan))),
+        Ok(Err(error)) => migration_validation_error(error),
+        Err(error) => {
+            ApiErrorResponse::internal_scrub(format!("migration scan task failed: {error}"))
+                .into_json_tuple()
+        }
+    }
 }
 
 /// POST /api/migrate — Run migration from another agent framework.
@@ -146,50 +242,55 @@ pub async fn run_migrate(
     // dir, but writes never leave the librefang home.
     let home_dir = state.kernel.home_dir().to_path_buf();
     let source_roots = migrate_source_roots(&home_dir, dirs::home_dir().as_deref());
-    let source_allowed: Vec<&std::path::Path> = source_roots.iter().map(|p| p.as_path()).collect();
-    let target_allowed: Vec<&std::path::Path> = vec![home_dir.as_path()];
+    let requested_source = req.source_dir;
+    let requested_target = req.target_dir;
+    let dry_run = req.dry_run;
+    let workspaces_agents_dir = state
+        .kernel
+        .config_snapshot()
+        .effective_agent_workspaces_dir();
 
-    let source_dir = match crate::validation::validate_path_containment(
-        "source_dir",
-        std::path::Path::new(req.source_dir.trim()),
-        &source_allowed,
-        true, // source must already exist
-    ) {
-        Ok(p) => p,
-        Err(error) => return migration_validation_error(error),
-    };
-
-    let target_dir = if req.target_dir.trim().is_empty() {
-        home_dir.clone()
-    } else {
-        match crate::validation::validate_path_containment(
-            "target_dir",
-            std::path::Path::new(req.target_dir.trim()),
-            &target_allowed,
-            false, // target may not exist yet — migration creates it
-        ) {
-            Ok(p) => p,
-            Err(error) => return migration_validation_error(error),
+    let migration = tokio::task::spawn_blocking(move || {
+        let source_allowed: Vec<&std::path::Path> =
+            source_roots.iter().map(|path| path.as_path()).collect();
+        let target_allowed: Vec<&std::path::Path> = vec![home_dir.as_path()];
+        let source_dir = crate::validation::validate_path_containment(
+            "source_dir",
+            std::path::Path::new(requested_source.trim()),
+            &source_allowed,
+            true,
+        )
+        .map_err(MigrationTaskError::Validation)?;
+        let target_dir = if requested_target.trim().is_empty() {
+            home_dir
+        } else {
+            crate::validation::validate_path_containment(
+                "target_dir",
+                std::path::Path::new(requested_target.trim()),
+                &target_allowed,
+                false,
+            )
+            .map_err(MigrationTaskError::Validation)?
+        };
+        let options = librefang_import::MigrateOptions {
+            source,
+            source_dir,
+            target_dir: target_dir.clone(),
+            dry_run,
+        };
+        let mut report = librefang_import::run_migration(&options)
+            .map_err(|error| MigrationTaskError::Migration(error.to_string()))?;
+        if !dry_run {
+            let moved = relocate_migrated_agent_dirs(&target_dir, &workspaces_agents_dir)
+                .map_err(MigrationTaskError::Relocation)?;
+            rewrite_relocated_agent_destinations(&mut report, &moved);
         }
-    };
+        Ok::<_, MigrationTaskError>(report)
+    })
+    .await;
 
-    let options = librefang_import::MigrateOptions {
-        source,
-        source_dir,
-        target_dir,
-        dry_run: req.dry_run,
-    };
-
-    match librefang_import::run_migration(&options) {
-        Ok(report) => {
-            // Migrate writes agent manifests under `<target>/agents/<name>/`
-            // (legacy schema). Relocate them into the canonical
-            // `workspaces/agents/<name>/` layout immediately so the running
-            // daemon can use them without a restart.
-            if !req.dry_run {
-                state.kernel.relocate_legacy_agent_dirs();
-            }
-
+    match migration {
+        Ok(Ok(report)) => {
             let imported: Vec<serde_json::Value> = report
                 .imported
                 .iter()
@@ -218,7 +319,7 @@ pub async fn run_migrate(
                 StatusCode::OK,
                 Json(serde_json::json!({
                     "status": "completed",
-                    "dry_run": req.dry_run,
+                    "dry_run": dry_run,
                     "imported": imported,
                     "imported_count": imported.len(),
                     "skipped": skipped,
@@ -228,13 +329,61 @@ pub async fn run_migrate(
                 })),
             )
         }
-        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
+        Ok(Err(MigrationTaskError::Validation(error))) => migration_validation_error(error),
+        Ok(Err(MigrationTaskError::Migration(error)))
+        | Ok(Err(MigrationTaskError::Relocation(error))) => {
+            ApiErrorResponse::internal_scrub(error).into_json_tuple()
+        }
+        Err(error) => ApiErrorResponse::internal_scrub(format!("migration task failed: {error}"))
+            .into_json_tuple(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn relocation_uses_actual_migration_target_and_rewrites_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("custom-target");
+        let source_agent = target.join("agents").join("main");
+        let canonical_agents = dir.path().join("workspaces").join("agents");
+        std::fs::create_dir_all(&source_agent).unwrap();
+        std::fs::write(source_agent.join("agent.toml"), "name = \"main\"\n").unwrap();
+        let mut report = librefang_import::report::MigrationReport::default();
+        report.imported.push(librefang_import::report::MigrateItem {
+            kind: librefang_import::report::ItemKind::Agent,
+            name: "main".to_string(),
+            destination: source_agent.join("agent.toml").display().to_string(),
+        });
+
+        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents).unwrap();
+        rewrite_relocated_agent_destinations(&mut report, &moved);
+
+        let canonical_manifest = canonical_agents.join("main").join("agent.toml");
+        assert!(canonical_manifest.is_file());
+        assert!(!source_agent.exists());
+        assert_eq!(
+            report.imported[0].destination,
+            canonical_manifest.display().to_string()
+        );
+    }
+
+    #[test]
+    fn relocation_is_a_noop_when_target_already_uses_canonical_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("workspaces");
+        let canonical_agents = target.join("agents");
+        let manifest = canonical_agents.join("main").join("agent.toml");
+        std::fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        std::fs::write(&manifest, "name = \"main\"\n").unwrap();
+
+        let moved = relocate_migrated_agent_dirs(&target, &canonical_agents).unwrap();
+
+        assert!(moved.is_empty());
+        assert!(manifest.is_file());
+    }
 
     #[test]
     fn migration_validation_preserves_client_errors() {


### PR DESCRIPTION
## Changes

- Offload migration detection, containment validation, workspace scans, imports, and relocation onto blocking workers.
- Relocate only agent directories touched by the current request from its actual target into the configured canonical workspace.
- Treat canonical path aliases as a no-op instead of attempting a self-rename.
- Preflight every destination and roll back earlier moves if a later rename fails.
- Rewrite every relocated report destination, including nested memory and workspace paths.
- Return scrubbed server errors when blocking work or relocation fails instead of reporting false success.
- Add the required changelog entry.

## Verification

- `cargo test -p librefang-api routes::config::migration::tests --lib` — 8 passed.
- `cargo test -p librefang-api --test api_integration_test test_run_migrate` — 5 passed.
- `cargo test -p librefang-api --test api_integration_test migrate_scan` — 1 passed.
- `cargo test -p librefang-api routes::mcp_auth::tests::flow_vault_cleanup_removes_all_per_flow_keys_on_drop --lib` — 1 passed in isolation.
- `cargo test -p librefang-api --lib -- --test-threads=1` — 1,018 passed.
- `cargo check --workspace --lib` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check origin/main...HEAD` — passed.

The ordinary parallel API library run passed 1,017 tests and failed only the pre-existing vault cleanup race in `mcp_auth`. The same test passed in isolation, and the full 1,018-test library suite passed with one test thread.

## Out of scope

- The import crate legacy output layout remains unchanged for non-HTTP callers.
- Agent registry loading behavior after files reach the canonical workspace remains unchanged.
- The separate multi-field agent config transaction finding remains for a kernel-level transaction.