### PR TITLE
fix(api): report live security configuration

### DIFF
--- a/changelog.d/fixed/7613-api-security-status-live-config.md
+++ b/changelog.d/fixed/7613-api-security-status-live-config.md
@@ -1,0 +1,1 @@
+Reported applied HTTP and WebSocket limits and only marked manifest signing available when every configured trust anchor is usable. (#7613) (@houko)

--- a/crates/librefang-api/src/routes/agents/mod.rs
+++ b/crates/librefang-api/src/routes/agents/mod.rs
@@ -1766,6 +1766,7 @@ mod monitoring_tests {
             pending_a2a_agents: dashmap::DashMap::new(),
             auth_login_limiter: std::sync::Arc::new(crate::rate_limiter::AuthLoginLimiter::new()),
             gcra_limiter: crate::rate_limiter::create_rate_limiter(0),
+            gcra_tokens_per_minute: 1,
             trusted_proxies: Arc::new(crate::client_ip::TrustedProxies::default()),
             trust_forwarded_for: false,
             idempotency_store,

--- a/crates/librefang-api/src/routes/config/security.rs
+++ b/crates/librefang-api/src/routes/config/security.rs
@@ -2,6 +2,7 @@ use super::*;
 
 fn security_status_payload(
     rate_limit: &librefang_types::config::RateLimitConfig,
+    gcra_tokens_per_minute: u32,
     trusted_manifest_signers: &[String],
     api_key_empty: bool,
     audit_count: usize,
@@ -11,7 +12,10 @@ fn security_status_payload(
     } else {
         "bearer_token"
     };
-    let manifest_signing_available = !trusted_manifest_signers.is_empty();
+    let manifest_signing_available = !trusted_manifest_signers.is_empty()
+        && trusted_manifest_signers.iter().all(|signer| {
+            hex::decode(signer.trim()).is_ok_and(|public_key| public_key.len() == 32)
+        });
 
     serde_json::json!({
         // These are runtime invariants, not operator-configurable switches.
@@ -28,8 +32,7 @@ fn security_status_payload(
         "configurable": {
             "rate_limiter": {
                 "enabled": true,
-                // The middleware clamps zero to one when constructing its quota.
-                "tokens_per_minute": rate_limit.api_requests_per_minute.max(1),
+                "tokens_per_minute": gcra_tokens_per_minute,
                 "algorithm": "GCRA"
             },
             "websocket_limits": {
@@ -104,6 +107,7 @@ pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoRes
 
     Json(security_status_payload(
         &config.rate_limit,
+        state.gcra_tokens_per_minute,
         &config.trusted_manifest_signers,
         api_key_empty,
         audit_count,
@@ -124,13 +128,13 @@ mod tests {
             ws_idle_timeout_secs: 73,
             ..RateLimitConfig::default()
         };
-        let signers = vec!["trusted-key".to_string()];
+        let signers = vec!["00".repeat(32)];
 
-        let status = security_status_payload(&rate_limit, &signers, false, 12);
+        let status = security_status_payload(&rate_limit, 193, &signers, false, 12);
 
         assert_eq!(
             status["configurable"]["rate_limiter"]["tokens_per_minute"],
-            237
+            193
         );
         assert_eq!(status["configurable"]["websocket_limits"]["max_per_ip"], 9);
         assert_eq!(
@@ -153,7 +157,7 @@ mod tests {
             ..RateLimitConfig::default()
         };
 
-        let status = security_status_payload(&rate_limit, &[], true, 0);
+        let status = security_status_payload(&rate_limit, 1, &[], true, 0);
 
         assert_eq!(
             status["configurable"]["rate_limiter"]["tokens_per_minute"],
@@ -162,5 +166,19 @@ mod tests {
         assert_eq!(status["monitoring"]["manifest_signing"]["available"], false);
         assert_eq!(status["configurable"]["auth"]["mode"], "localhost_only");
         assert_eq!(status["total_features"], 14);
+    }
+
+    #[test]
+    fn security_status_rejects_malformed_manifest_trust_anchors() {
+        let rate_limit = RateLimitConfig::default();
+        for signers in [
+            vec!["not-hex".to_string()],
+            vec!["00".repeat(31)],
+            vec!["00".repeat(32), "invalid".to_string()],
+        ] {
+            let status = security_status_payload(&rate_limit, 500, &signers, false, 0);
+            assert_eq!(status["monitoring"]["manifest_signing"]["available"], false);
+            assert_eq!(status["total_features"], 14);
+        }
     }
 }

--- a/crates/librefang-api/src/routes/config/security.rs
+++ b/crates/librefang-api/src/routes/config/security.rs
@@ -1,38 +1,20 @@
 use super::*;
 
-// ---------------------------------------------------------------------------
-// Migration endpoint
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Security dashboard endpoint
-// ---------------------------------------------------------------------------
-/// GET /api/security — Security feature status for the dashboard.
-#[utoipa::path(
-    get,
-    path = "/api/security",
-    tag = "system",
-    responses(
-        (status = 200, description = "Security feature status", body = crate::types::JsonObject)
-    )
-)]
-pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    // Ask the live master-credential handle — the same one the auth middleware
-    // verifies against (#6613). Reading `api_key` alone reported
-    // `localhost_only` for a hash-only or env-sourced deployment that is in
-    // fact fully bearer-gated; re-resolving the field from a config snapshot
-    // would report correctly but unlock the vault per request for a
-    // `vault:NAME` value, to answer a yes/no question the handle already holds.
-    let api_key_empty = !state.master_key.is_configured().await;
+fn security_status_payload(
+    rate_limit: &librefang_types::config::RateLimitConfig,
+    trusted_manifest_signers: &[String],
+    api_key_empty: bool,
+    audit_count: usize,
+) -> serde_json::Value {
     let auth_mode = if api_key_empty {
         "localhost_only"
     } else {
         "bearer_token"
     };
+    let manifest_signing_available = !trusted_manifest_signers.is_empty();
 
-    let audit_count = state.kernel.audit().len();
-
-    Json(serde_json::json!({
+    serde_json::json!({
+        // These are runtime invariants, not operator-configurable switches.
         "core_protections": {
             "path_traversal": true,
             "ssrf_protection": true,
@@ -46,14 +28,15 @@ pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoRes
         "configurable": {
             "rate_limiter": {
                 "enabled": true,
-                "tokens_per_minute": 500,
+                // The middleware clamps zero to one when constructing its quota.
+                "tokens_per_minute": rate_limit.api_requests_per_minute.max(1),
                 "algorithm": "GCRA"
             },
             "websocket_limits": {
-                "max_per_ip": 5,
-                "idle_timeout_secs": 1800,
-                "max_message_size": 65536,
-                "max_messages_per_minute": 10
+                "max_per_ip": rate_limit.max_ws_per_ip,
+                "idle_timeout_secs": rate_limit.ws_idle_timeout_secs,
+                "max_message_size": 64 * 1024,
+                "max_messages_per_minute": rate_limit.ws_messages_per_minute
             },
             "wasm_sandbox": {
                 "fuel_metering": true,
@@ -84,10 +67,100 @@ pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoRes
             },
             "manifest_signing": {
                 "algorithm": "Ed25519",
-                "available": true
+                "available": manifest_signing_available
             }
         },
         "secret_zeroization": true,
-        "total_features": 15
-    }))
+        "total_features": if manifest_signing_available { 15 } else { 14 }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Migration endpoint
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Security dashboard endpoint
+// ---------------------------------------------------------------------------
+/// GET /api/security — Security feature status for the dashboard.
+#[utoipa::path(
+    get,
+    path = "/api/security",
+    tag = "system",
+    responses(
+        (status = 200, description = "Security feature status", body = crate::types::JsonObject)
+    )
+)]
+pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    // Ask the live master-credential handle — the same one the auth middleware
+    // verifies against (#6613). Reading `api_key` alone reported
+    // `localhost_only` for a hash-only or env-sourced deployment that is in
+    // fact fully bearer-gated; re-resolving the field from a config snapshot
+    // would report correctly but unlock the vault per request for a
+    // `vault:NAME` value, to answer a yes/no question the handle already holds.
+    let api_key_empty = !state.master_key.is_configured().await;
+    let audit_count = state.kernel.audit().len();
+    let config = state.kernel.config_ref();
+
+    Json(security_status_payload(
+        &config.rate_limit,
+        &config.trusted_manifest_signers,
+        api_key_empty,
+        audit_count,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::security_status_payload;
+    use librefang_types::config::RateLimitConfig;
+
+    #[test]
+    fn security_status_reports_applied_limits_and_manifest_trust() {
+        let rate_limit = RateLimitConfig {
+            api_requests_per_minute: 237,
+            max_ws_per_ip: 9,
+            ws_messages_per_minute: 41,
+            ws_idle_timeout_secs: 73,
+            ..RateLimitConfig::default()
+        };
+        let signers = vec!["trusted-key".to_string()];
+
+        let status = security_status_payload(&rate_limit, &signers, false, 12);
+
+        assert_eq!(
+            status["configurable"]["rate_limiter"]["tokens_per_minute"],
+            237
+        );
+        assert_eq!(status["configurable"]["websocket_limits"]["max_per_ip"], 9);
+        assert_eq!(
+            status["configurable"]["websocket_limits"]["idle_timeout_secs"],
+            73
+        );
+        assert_eq!(
+            status["configurable"]["websocket_limits"]["max_messages_per_minute"],
+            41
+        );
+        assert_eq!(status["monitoring"]["manifest_signing"]["available"], true);
+        assert_eq!(status["monitoring"]["audit_trail"]["entry_count"], 12);
+        assert_eq!(status["total_features"], 15);
+    }
+
+    #[test]
+    fn security_status_matches_effective_minimum_quota_and_missing_signers() {
+        let rate_limit = RateLimitConfig {
+            api_requests_per_minute: 0,
+            ..RateLimitConfig::default()
+        };
+
+        let status = security_status_payload(&rate_limit, &[], true, 0);
+
+        assert_eq!(
+            status["configurable"]["rate_limiter"]["tokens_per_minute"],
+            1
+        );
+        assert_eq!(status["monitoring"]["manifest_signing"]["available"], false);
+        assert_eq!(status["configurable"]["auth"]["mode"], "localhost_only");
+        assert_eq!(status["total_features"], 14);
+    }
 }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -2394,6 +2394,7 @@ mod tests {
             pending_a2a_agents: dashmap::DashMap::new(),
             auth_login_limiter: std::sync::Arc::new(crate::rate_limiter::AuthLoginLimiter::new()),
             gcra_limiter: crate::rate_limiter::create_rate_limiter(0),
+            gcra_tokens_per_minute: 1,
             trusted_proxies: Arc::new(crate::client_ip::TrustedProxies::default()),
             trust_forwarded_for: false,
             idempotency_store,

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -321,6 +321,10 @@ pub struct AppState {
     /// task can call `retain_recent()` to evict stale per-IP entries and prevent
     /// the DashMap from growing unbounded over a long-running daemon. See #3668.
     pub gcra_limiter: Arc<KeyedRateLimiter>,
+    /// Effective quota captured with `gcra_limiter` at server boot.
+    /// A mixed config reload can update `config_ref()` without rebuilding this
+    /// restart-required limiter, so status routes must use this applied value.
+    pub gcra_tokens_per_minute: u32,
     /// Compiled `trusted_proxies` allowlist — built once at boot and shared with
     /// the GCRA + auth-login middlewares (see `server.rs`). Re-used by WS
     /// upgrade handlers (`ws::agent_ws`, `routes::terminal::terminal_ws`) to

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -2392,6 +2392,7 @@ mod tests {
             pending_a2a_agents: dashmap::DashMap::new(),
             auth_login_limiter: Arc::new(crate::rate_limiter::AuthLoginLimiter::new()),
             gcra_limiter: crate::rate_limiter::create_rate_limiter(0),
+            gcra_tokens_per_minute: 1,
             trusted_proxies: Arc::new(crate::client_ip::TrustedProxies::default()),
             trust_forwarded_for: false,
             idempotency_store,

--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -2025,6 +2025,7 @@ mod hash_only_terminal_auth_tests {
             pending_a2a_agents: dashmap::DashMap::new(),
             auth_login_limiter: Arc::new(crate::rate_limiter::AuthLoginLimiter::new()),
             gcra_limiter: crate::rate_limiter::create_rate_limiter(0),
+            gcra_tokens_per_minute: 1,
             trusted_proxies: Arc::new(crate::client_ip::TrustedProxies::default()),
             trust_forwarded_for: false,
             idempotency_store,

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1658,6 +1658,7 @@ pub async fn build_router(
         pending_a2a_agents: dashmap::DashMap::new(),
         auth_login_limiter: auth_login_limiter.clone(),
         gcra_limiter: gcra_limiter_arc.clone(),
+        gcra_tokens_per_minute: rl_cfg_early.api_requests_per_minute.max(1),
         trusted_proxies: trusted_proxies_arc.clone(),
         trust_forwarded_for: trust_forwarded_for_cached,
         idempotency_store,

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -334,6 +334,7 @@ impl TestAppState {
                 librefang_api::rate_limiter::AuthLoginLimiter::new(),
             ),
             gcra_limiter: librefang_api::rate_limiter::create_rate_limiter(0),
+            gcra_tokens_per_minute: 1,
             // Tests run with header-trust off (the production default) so
             // per-IP rate-limiter / WS slot keying always uses the TCP peer.
             trusted_proxies: Arc::new(librefang_api::client_ip::TrustedProxies::default()),


### PR DESCRIPTION
## Changes

- Report the boot-applied HTTP GCRA quota instead of a restart-required value from a mixed live reload.
- Report live WebSocket connection and idle-timeout limits.
- Clamp the applied HTTP quota consistently with limiter construction.
- Mark manifest signing available only when every configured trust anchor is valid hexadecimal and exactly 32 bytes.
- Adjust the enabled-feature count when signing is unavailable.
- Add focused regressions and the required changelog fragment.

## Verification

- cargo test -p librefang-api routes::config::security::tests --lib — 3 passed.
- cargo test -p librefang-api --lib -- --test-threads=1 — 1022 passed.
- cargo check --workspace --lib — passed.
- cargo clippy --workspace --all-targets -- -D warnings — passed.
- cargo fmt --all -- --check — passed.
- git diff --check origin/main...HEAD — passed.

## Out of scope

- RuntimePage still ignores the manifest-signing available field.
- RuntimePage is currently owned by open #7482, so that visual follow-up remains deferred.
- Compile-time WASM sandbox defaults and core runtime invariants are unchanged.