### PR TITLE
fix(api): bound terminal child exit waits

### DIFF
--- a/changelog.d/fixed/7614-api-terminal-exit-wait-timeout.md
+++ b/changelog.d/fixed/7614-api-terminal-exit-wait-timeout.md
@@ -1,0 +1,1 @@
+Bounded terminal child exit polling so a stuck process cannot retain its WebSocket task indefinitely. (#7614) (@houko)

--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -32,6 +32,30 @@ pub const MAX_WS_MSG_SIZE: usize = 64 * 1024;
 
 const MAX_COLS: u16 = 1000;
 const MAX_ROWS: u16 = 500;
+const PTY_EXIT_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+const PTY_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+async fn wait_for_pty_exit<P>(
+    timeout: Duration,
+    mut poll: P,
+) -> std::io::Result<Option<(u32, Option<String>)>>
+where
+    P: FnMut() -> std::io::Result<Option<(u32, Option<String>)>>,
+{
+    match tokio::time::timeout(timeout, async {
+        loop {
+            if let Some(status) = poll()? {
+                return Ok(status);
+            }
+            tokio::time::sleep(PTY_EXIT_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result.map(Some),
+        Err(_) => Ok(None),
+    }
+}
 
 fn lock_terminal_last_activity(
     last_activity: &std::sync::Mutex<std::time::Instant>,
@@ -1214,20 +1238,31 @@ async fn handle_terminal_ws(
         }
     }
 
-    // For ClientClose and Timeout the child may still be running — kill it first
-    // so that wait_exit() returns promptly with the real exit code.
+    // Stop the reader regardless of how the session ended. Waiting for child
+    // exit must not keep this task alive.
+    pty_read_handle.abort();
+
+    // For ClientClose and Timeout the child may still be running — kill it first.
     if !matches!(exit_reason, ExitReason::ProcessExited) {
         pty.kill();
     }
 
-    // Always wait for the real exit code, regardless of why the loop ended.
-    let (code, signal) = match pty.wait_exit() {
-        Ok(pair) => pair,
-        Err(e) => {
-            warn!(error = %e, "Failed to wait for child exit");
-            (1, None)
-        }
-    };
+    // Poll instead of calling the blocking child.wait() on a Tokio worker.
+    // Bound the poll so a child that ignores termination cannot retain the
+    // WebSocket task or its per-IP connection slot indefinitely.
+    let (code, signal) =
+        match wait_for_pty_exit(PTY_EXIT_WAIT_TIMEOUT, || pty.try_wait_exit()).await {
+            Ok(Some(pair)) => pair,
+            Ok(None) => {
+                warn!(pid = pty.pid, "Timed out waiting for terminal child exit");
+                pty.kill();
+                (1, None)
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to wait for child exit");
+                (1, None)
+            }
+        };
     let _ = send_json(
         &sender,
         &serde_json::json!({
@@ -1238,7 +1273,6 @@ async fn handle_terminal_ws(
     )
     .await;
 
-    pty_read_handle.abort();
     info!("Terminal WebSocket disconnected");
 }
 
@@ -1246,9 +1280,35 @@ async fn handle_terminal_ws(
 mod tests {
     use crate::routes::terminal::{
         initial_terminal_dimension, mark_terminal_activity, router, terminal_idle_duration,
-        terminal_idle_timeout_elapsed, ClientMessage, ServerMessage, MAX_COLS, MAX_ROWS,
+        terminal_idle_timeout_elapsed, wait_for_pty_exit, ClientMessage, ServerMessage, MAX_COLS,
+        MAX_ROWS,
     };
     use crate::terminal::shell_for_current_os;
+
+    #[tokio::test]
+    async fn pty_exit_wait_returns_an_immediate_status() {
+        let status = wait_for_pty_exit(std::time::Duration::from_secs(1), || {
+            Ok(Some((7, Some("TERM".to_string()))))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(status, Some((7, Some("TERM".to_string()))));
+    }
+
+    #[tokio::test]
+    async fn pty_exit_wait_is_bounded_when_child_never_exits() {
+        let mut polls = 0;
+        let status = wait_for_pty_exit(std::time::Duration::from_millis(50), || {
+            polls += 1;
+            Ok(None)
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(status, None);
+        assert!(polls > 1);
+    }
 
     #[test]
     fn terminal_last_activity_recovers_after_held_lock_panic() {

--- a/crates/librefang-api/src/routes/terminal.rs
+++ b/crates/librefang-api/src/routes/terminal.rs
@@ -1298,16 +1298,15 @@ mod tests {
 
     #[tokio::test]
     async fn pty_exit_wait_is_bounded_when_child_never_exits() {
-        let mut polls = 0;
-        let status = wait_for_pty_exit(std::time::Duration::from_millis(50), || {
-            polls += 1;
-            Ok(None)
-        })
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            wait_for_pty_exit(std::time::Duration::from_millis(50), || Ok(None)),
+        )
         .await
+        .expect("PTY exit polling must stay bounded")
         .unwrap();
 
         assert_eq!(status, None);
-        assert!(polls > 1);
     }
 
     #[test]

--- a/crates/librefang-api/src/terminal.rs
+++ b/crates/librefang-api/src/terminal.rs
@@ -255,6 +255,16 @@ impl PtySession {
         let _ = self.child.kill();
     }
 
+    /// Poll for child exit without blocking the calling thread.
+    pub fn try_wait_exit(&mut self) -> std::io::Result<Option<(u32, Option<String>)>> {
+        self.child
+            .try_wait()
+            .map(|status| {
+                status.map(|status| (status.exit_code(), status.signal().map(str::to_string)))
+            })
+            .map_err(std::io::Error::other)
+    }
+
     /// Wait for the child process to exit and return (exit_code, optional_signal).
     pub fn wait_exit(&mut self) -> std::io::Result<(u32, Option<String>)> {
         let status = self.child.wait().map_err(std::io::Error::other)?;


### PR DESCRIPTION
## Changes

- Add a non-blocking PTY child-exit poll API.
- Replace the terminal WebSocket handler blocking child wait with bounded polling.
- Abort the PTY reader before waiting on child termination.
- Retry termination and return a stable fallback exit after a 10-second deadline.
- Add deterministic regressions for immediate exit and a child that never exits.
- Add the numbered changelog fragment.

## Verification

- `CARGO_TARGET_DIR=/private/tmp/librefang-target-pr7614 cargo test -p librefang-api --lib -- --test-threads=1` — 1024 passed.
- `CARGO_TARGET_DIR=/private/tmp/librefang-target-pr7614 cargo test -p librefang-api pty_exit_wait -- --nocapture` — both matching regressions passed; the command was stopped after it began launching unrelated integration binaries with zero matching tests.
- `CARGO_TARGET_DIR=/private/tmp/librefang-target-pr7614 cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/private/tmp/librefang-target-pr7614 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check`

## Out of scope

- PTY spawn, resize, and kill semantics are unchanged.
- Tmux session-name validation remains separate.