### PR TITLE
fix(runtime): wire SQLite MCP database path

### DIFF
--- a/changelog.d/fixed/7620-runtime-sqlite-mcp-database-path.md
+++ b/changelog.d/fixed/7620-runtime-sqlite-mcp-database-path.md
@@ -1,0 +1,1 @@
+Launch the published SQLite MCP server with its configured database path instead of the unavailable npm package. (#7620) (@houko)

--- a/crates/librefang-runtime/tests/fixtures/registry/mcp/sqlite-mcp.toml
+++ b/crates/librefang-runtime/tests/fixtures/registry/mcp/sqlite-mcp.toml
@@ -7,19 +7,20 @@ tags = ["database", "sql", "relational", "sqlite", "local", "embedded"]
 
 setup_instructions = """
 1. Locate the SQLite database file you want to connect to on your local filesystem.
-2. Enter the absolute path to the database file in the SQLITE_DB_PATH field above.
-3. Ensure the file has appropriate read/write permissions for the LibreFang process.
+2. Ensure the database already exists inside a directory reserved for LibreFang data.
+3. Enter its absolute path in the SQLITE_DB_PATH field above.
+4. Ensure the file has appropriate read/write permissions for the LibreFang process.
 """
 
 [transport]
 type = "stdio"
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-sqlite"]
+command = "uvx"
+args = ["mcp-server-sqlite==2025.4.25", "--db-path", "$SQLITE_DB_PATH"]
 
 [[required_env]]
 name = "SQLITE_DB_PATH"
 label = "SQLite Database Path"
-help = "Absolute path to the SQLite database file (e.g., /home/user/data/mydb.sqlite)"
+help = "Absolute path to an existing SQLite database file within your data directory (e.g., /home/user/data/mydb.sqlite)"
 is_secret = false
 get_url = ""
 

--- a/crates/librefang-runtime/tests/registry_mcp_fixture_contract.rs
+++ b/crates/librefang-runtime/tests/registry_mcp_fixture_contract.rs
@@ -1,4 +1,4 @@
-use librefang_types::mcp::McpCatalogEntry;
+use librefang_types::mcp::{McpCatalogEntry, McpCatalogTransport};
 use std::path::PathBuf;
 
 #[test]
@@ -26,5 +26,31 @@ fn every_mcp_fixture_keeps_setup_instructions_at_the_catalog_root() {
             "{} lost top-level setup_instructions (check TOML table ordering)",
             path.display(),
         );
+    }
+}
+
+#[test]
+fn sqlite_fixture_forwards_the_declared_database_path() {
+    let entry =
+        toml::from_str::<McpCatalogEntry>(include_str!("fixtures/registry/mcp/sqlite-mcp.toml"))
+            .expect("SQLite MCP fixture must parse");
+
+    assert!(entry
+        .required_env
+        .iter()
+        .any(|env| env.name == "SQLITE_DB_PATH"));
+    match entry.transport {
+        McpCatalogTransport::Stdio { command, args } => {
+            assert_eq!(command, "uvx");
+            assert_eq!(
+                args,
+                [
+                    "mcp-server-sqlite==2025.4.25",
+                    "--db-path",
+                    "$SQLITE_DB_PATH",
+                ]
+            );
+        }
+        _ => panic!("SQLite MCP fixture must use stdio transport"),
     }
 }


### PR DESCRIPTION
## Changes

- replace the nonexistent npm SQLite MCP package with the published `mcp-server-sqlite` PyPI package
- pin version `2025.4.25` and forward the declared `SQLITE_DB_PATH` through `--db-path`
- clarify that the database should already exist inside a dedicated data directory
- add a fixture contract test for the executable, pinned package, argument, and declared environment variable
- add the numbered changelog attribution for this PR

## Verification

- `cargo test -p librefang-runtime --test registry_mcp_fixture_contract` — 2 passed
- `cargo clippy -p librefang-runtime --test registry_mcp_fixture_contract -- -D warnings`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `uvx --from mcp-server-sqlite==2025.4.25 mcp-server-sqlite --help`

## Out of scope

- runtime-wide filesystem sandboxing for operator-supplied MCP database paths
- changes to other MCP catalog entries
