### PR TITLE
fix(kernel): clear manual dream lock holder

### DIFF
--- a/changelog.d/fixed/7623-auto-dream-record-now.md
+++ b/changelog.d/fixed/7623-auto-dream-record-now.md
@@ -1,0 +1,2 @@
+Let manual dream completion record time without retaining the current PID as a live lock holder.
+This prevents the next manual dream from being suppressed for up to the one-hour stale window (#7623) (@houko)

--- a/crates/librefang-kernel/src/auto_dream/lock.rs
+++ b/crates/librefang-kernel/src/auto_dream/lock.rs
@@ -267,10 +267,20 @@ impl ConsolidationLock {
                 LibreFangError::Internal(format!("auto_dream: create lock parent dir failed: {e}"))
             })?;
         }
-        let token = format!("{}:{}", std::process::id(), uuid::Uuid::new_v4());
-        fs::write(&self.path, token.as_bytes())
+        // `record_now` records a completed manual consolidation. It must not
+        // leave a holder token: our PID remains live, so `try_acquire` would
+        // otherwise treat this completed run as active for up to an hour.
+        fs::write(&self.path, b"")
             .await
             .map_err(|e| LibreFangError::Internal(format!("auto_dream: touch lock failed: {e}")))?;
+        // Keep the completion timestamp explicit, matching `release`. This is
+        // also needed on coarse-resolution filesystems when the lock file was
+        // written earlier in the same clock tick.
+        set_mtime_ms(&self.path, now_ms()).map_err(|e| {
+            LibreFangError::Internal(format!(
+                "auto_dream: refresh mtime after manual consolidation failed: {e}"
+            ))
+        })?;
         Ok(())
     }
 
@@ -536,6 +546,28 @@ mod tests {
             "expected Some after release (live-holder gate should not trip)",
         );
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn record_now_leaves_no_holder_so_next_acquire_succeeds() {
+        let path = tmpfile("record-now");
+        let lock = ConsolidationLock::new(path.clone());
+
+        lock.record_now().await.unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(&path).await.unwrap(),
+            "",
+            "a completed manual consolidation must not retain a live PID token"
+        );
+        let prior = lock.try_acquire().await.unwrap();
+        assert!(
+            prior.is_some(),
+            "record_now must not make a completed run look like a live holder"
+        );
+
+        lock.release().await.unwrap();
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     // Unix-only: `is_process_running` always returns true on Windows


### PR DESCRIPTION
## Changes

- Make `ConsolidationLock::record_now` persist a completed manual consolidation with an empty holder body instead of a live PID token.
- Refresh the lock mtime explicitly so it represents completion time, matching the successful `release` path.
- Add a regression test proving a lock recorded by `record_now` can be acquired again immediately.
- Merge the latest `main` before final verification.

## Verification

- `cargo test -p librefang-kernel auto_dream::lock --lib` — 12 passed.
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/check-changelog-attribution.py --base origin/main --head HEAD`

## Out of scope

- Lock acquisition protocol and stale-holder policy are unchanged.
- Automated dream acquisition/release behavior is unchanged.
- Other OCR audit findings remain separate follow-ups.

Audit finding: `F-12263a2197d74224`.