### PR TITLE
fix(web): refresh offline HTML cache

### DIFF
--- a/changelog.d/fixed/7624-web-html-cache.md
+++ b/changelog.d/fixed/7624-web-html-cache.md
@@ -1,0 +1,2 @@
+Refresh the website's bounded offline HTML shell after successful navigation.
+Deep links now receive the latest cached application instead of an install-time-only root page or no fallback at all (#7624) (@houko)

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -6,8 +6,9 @@
 // chunk alongside fresh RegistryPage chunk, triggering "Cannot read
 // properties of null (reading 'useCallback')". Don't do that.
 const CACHE_NAME = 'librefang-v3'
+const ROOT_HTML = '/'
 const STATIC_ASSETS = [
-  '/',
+  ROOT_HTML,
   '/logo.png',
   '/favicon.svg',
   '/og-image.svg',
@@ -43,10 +44,26 @@ self.addEventListener('fetch', (event) => {
   if (url.pathname === '/registry.json' || url.pathname === '/feed.xml') return
 
   // Network-first for HTML so deploys propagate immediately; fall back to
-  // cache only when offline.
+  // the latest cached SPA shell when offline. All navigation paths receive
+  // the same index.html from the Pages worker, so keep one bounded root entry
+  // instead of growing the cache with arbitrary paths and query strings.
   if (event.request.headers.get('accept')?.includes('text/html')) {
+    const networkResponse = fetch(event.request)
+    event.waitUntil(
+      networkResponse
+        .then((response) => {
+          if (!response.ok) return
+          return caches.open(CACHE_NAME).then((cache) =>
+            cache.put(ROOT_HTML, response.clone())
+          )
+        })
+        .catch(() => undefined)
+    )
     event.respondWith(
-      fetch(event.request).catch(() => caches.match(event.request))
+      networkResponse
+        .catch(() =>
+          caches.match(event.request).then((cached) => cached || caches.match(ROOT_HTML))
+        )
     )
     return
   }

--- a/web/scripts/service-worker.test.ts
+++ b/web/scripts/service-worker.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it, vi } from 'vitest'
+
+const ORIGIN = 'https://librefang.ai'
+const SERVICE_WORKER_SOURCE = readFileSync(
+  new URL('../public/sw.js', import.meta.url),
+  'utf8',
+)
+
+type FetchEventLike = {
+  request: Request
+  respondWith(response: Promise<Response | undefined>): void
+  waitUntil(work: Promise<unknown>): void
+}
+
+type FetchListener = (event: FetchEventLike) => void
+
+function cacheKey(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return new URL(input, ORIGIN).href
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+function loadServiceWorker(fetchImpl: typeof fetch) {
+  const entries = new Map<string, Response>()
+  const listeners = new Map<string, (event: never) => void>()
+  const cache = {
+    addAll: vi.fn(async () => undefined),
+    match: vi.fn(async (request: RequestInfo | URL) => entries.get(cacheKey(request))),
+    put: vi.fn(async (request: RequestInfo | URL, response: Response) => {
+      entries.set(cacheKey(request), response)
+    }),
+  }
+  const cacheStorage = {
+    open: vi.fn(async () => cache),
+    match: vi.fn(async (request: RequestInfo | URL) => entries.get(cacheKey(request))),
+    keys: vi.fn(async () => []),
+    delete: vi.fn(async () => true),
+  }
+  const workerGlobal = {
+    location: { origin: ORIGIN },
+    clients: { claim: vi.fn() },
+    skipWaiting: vi.fn(),
+    addEventListener: vi.fn((type: string, listener: (event: never) => void) => {
+      listeners.set(type, listener)
+    }),
+  }
+
+  runInNewContext(SERVICE_WORKER_SOURCE, {
+    self: workerGlobal,
+    caches: cacheStorage,
+    fetch: fetchImpl,
+    Request,
+    Response,
+    URL,
+  })
+
+  return {
+    entries,
+    listener: listeners.get('fetch') as FetchListener,
+  }
+}
+
+async function dispatchFetch(listener: FetchListener, request: Request): Promise<Response> {
+  const lifetimeWork: Promise<unknown>[] = []
+  let responsePromise: Promise<Response | undefined> | undefined
+
+  listener({
+    request,
+    respondWith(response) {
+      responsePromise = response
+    },
+    waitUntil(work) {
+      lifetimeWork.push(work)
+    },
+  })
+
+  if (!responsePromise) throw new Error('service worker did not handle the request')
+  const response = await responsePromise
+  await Promise.all(lifetimeWork)
+  if (!response) throw new Error('service worker returned no offline response')
+  return response
+}
+
+describe('public service worker HTML cache', () => {
+  it('refreshes one SPA shell and serves it for an offline deep link', async () => {
+    const online = vi.fn(async () => new Response('<html>fresh shell</html>'))
+    const loaded = loadServiceWorker(online as typeof fetch)
+    const navigation = new Request(`${ORIGIN}/ja/registry?category=hands`, {
+      headers: { accept: 'text/html' },
+    })
+
+    const networkResponse = await dispatchFetch(loaded.listener, navigation)
+
+    expect(await networkResponse.text()).toBe('<html>fresh shell</html>')
+    expect([...loaded.entries.keys()]).toEqual([`${ORIGIN}/`])
+    expect(await loaded.entries.get(`${ORIGIN}/`)?.text()).toBe('<html>fresh shell</html>')
+
+    const offline = vi.fn(async () => {
+      throw new TypeError('offline')
+    })
+    const offlineLoaded = loadServiceWorker(offline as typeof fetch)
+    offlineLoaded.entries.set(
+      `${ORIGIN}/`,
+      new Response('<html>latest cached shell</html>'),
+    )
+
+    const fallback = await dispatchFetch(
+      offlineLoaded.listener,
+      new Request(`${ORIGIN}/es/deploy`, { headers: { accept: 'text/html' } }),
+    )
+
+    expect(await fallback.text()).toBe('<html>latest cached shell</html>')
+  })
+})


### PR DESCRIPTION
## Changes

- refresh the cached root SPA document after each successful HTML navigation
- serve that latest bounded root entry as the offline fallback for deep links while retaining any exact cached match first
- extend the fetch event lifetime through the cache update
- add a regression that executes the checked-in service worker and proves online refresh, one-key cache bounds, and offline deep-link fallback

## Verification

- `pnpm --dir web test` — 43 passed across 9 files
- `pnpm --dir web lint`
- `pnpm --dir web exec vite build`
- `git diff --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- hashed assets remain outside service-worker caching
- registry and feed requests remain network-only
- cache namespace/versioning and service-worker activation policy are unchanged

Audit finding: `F-02ff249e4bf18ce7`.
