### PR TITLE
fix: allow diamond config includes

### DIFF
--- a/changelog.d/fixed/7627-config-diamond-includes.md
+++ b/changelog.d/fixed/7627-config-diamond-includes.md
@@ -1,0 +1,1 @@
+Allow configuration include graphs to reuse a shared file after an earlier branch has unwound, while continuing to reject real recursive include cycles (#7627) (@houko)

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -561,6 +561,10 @@ fn resolve_config_includes(
         // Recursively resolve includes in the included file
         let include_dir = canonical.parent().unwrap_or(config_dir).to_path_buf();
         resolve_config_includes(&mut include_value, &include_dir, visited, depth + 1)?;
+        // `visited` models the active recursion stack, not every file seen
+        // during the whole traversal. A shared dependency in a diamond graph
+        // is valid once the first branch has unwound.
+        visited.remove(&canonical);
 
         // Remove include field from the included file
         if let toml::Value::Table(ref mut tbl) = include_value {
@@ -914,12 +918,46 @@ mod tests {
     }
 
     #[test]
+    fn test_diamond_include_is_not_treated_as_a_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let shared = dir.path().join("shared.toml");
+        let left = dir.path().join("left.toml");
+        let right = dir.path().join("right.toml");
+        let root = dir.path().join("config.toml");
+
+        std::fs::write(&shared, "network_enabled = true\n").unwrap();
+        std::fs::write(
+            &left,
+            "include = [\"shared.toml\"]\nlog_level = \"debug\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &right,
+            "include = [\"shared.toml\"]\napi_listen = \"127.0.0.1:5555\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &root,
+            format!(
+                "config_version = {CONFIG_VERSION}\ninclude = [\"left.toml\", \"right.toml\"]\n"
+            ),
+        )
+        .unwrap();
+
+        let config = try_load_config(&root).expect("diamond includes must be valid");
+        assert!(config.network_enabled, "shared config must be retained");
+        assert_eq!(config.log_level, "debug");
+        assert_eq!(config.api_listen, "127.0.0.1:5555");
+    }
+
+    #[test]
     fn test_circular_include_detected() {
         let dir = tempfile::tempdir().unwrap();
         let a_path = dir.path().join("a.toml");
         let b_path = dir.path().join("b.toml");
 
         let mut f = std::fs::File::create(&a_path).unwrap();
+        writeln!(f, "config_version = {CONFIG_VERSION}").unwrap();
         writeln!(f, "include = [\"b.toml\"]").unwrap();
         writeln!(f, "log_level = \"info\"").unwrap();
         drop(f);
@@ -931,6 +969,12 @@ mod tests {
         // Include errors are tolerated — the root file still loads with its own fields.
         let config = load_config(Some(&a_path)).unwrap();
         assert!(!config.log_level.is_empty());
+
+        let error = try_load_config(&a_path).expect_err("real cycles must remain invalid");
+        assert!(
+            error.contains("Circular config include detected"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- track only the active recursion stack while resolving configuration includes
- allow valid diamond include graphs to reuse a shared file after the first branch unwinds
- strengthen cycle coverage so real recursive includes remain rejected by strict reloads

## Verification

- `cargo test -p librefang-kernel config::tests --lib` (41 passed)
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- formatting and diff checks

## Out of scope

- changing include merge precedence, path-containment checks, or maximum nesting depth