### PR TITLE
fix: detect nearby narrative skill triggers

### DIFF
--- a/changelog.d/fixed/7628-workshop-narrative-prefix.md
+++ b/changelog.d/fixed/7628-workshop-narrative-prefix.md
@@ -1,0 +1,1 @@
+Prevent Skill Workshop explicit-instruction detection from capturing narrative `always` phrases when their subject appears within the documented two-word prefix window (#7628) (@houko)

--- a/changelog.d/fixed/7628-workshop-narrative-prefix.md
+++ b/changelog.d/fixed/7628-workshop-narrative-prefix.md
@@ -1,1 +1,1 @@
-Prevent Skill Workshop explicit-instruction detection from capturing narrative `always` phrases when their subject appears within the documented two-word prefix window (#7628) (@houko)
+Prevent Skill Workshop explicit-instruction detection from capturing narrative `always` phrases when their subject appears within the documented punctuation-aware two-word prefix window (#7628) (@houko)

--- a/crates/librefang-kernel/src/skill_workshop/heuristic.rs
+++ b/crates/librefang-kernel/src/skill_workshop/heuristic.rs
@@ -153,11 +153,11 @@ fn is_conversational_filler(sentence: &str, trigger: &str) -> bool {
     };
     // Look at up to the 2 words preceding the trigger.
     let prefix = lower[..idx].trim_end();
-    let preceding_words: Vec<&str> = prefix
+    let has_narrative_subject = prefix
         .rsplit(|c: char| c.is_whitespace())
         .filter(|w| !w.is_empty())
-        .take(3)
-        .collect();
+        .take(2)
+        .any(|word| matches!(word, "i" | "we" | "you" | "he" | "she" | "they"));
     // If `trigger` itself starts with the subject ("you should always")
     // there's no filler to detect — the trigger already includes the
     // imperative subject.
@@ -172,10 +172,7 @@ fn is_conversational_filler(sentence: &str, trigger: &str) -> bool {
     }
     // Otherwise, "I/we/you/he/she/they … always run/do" is narrative
     // ("I always run into this issue") — drop.
-    matches!(
-        preceding_words.last().copied(),
-        Some("i") | Some("we") | Some("you") | Some("he") | Some("she") | Some("they")
-    )
+    has_narrative_subject
 }
 
 /// Inspect a user message for a correction relative to the previous
@@ -486,6 +483,31 @@ mod tests {
         assert!(
             extract_explicit_instruction("We always check our work, in my opinion.").is_none(),
             "we-narrative must not be captured"
+        );
+    }
+
+    #[test]
+    fn explicit_narrative_subject_with_leading_words_is_dropped() {
+        assert!(
+            extract_explicit_instruction("Well they always run the formatter before submitting.")
+                .is_none(),
+            "the immediately preceding narrative subject must be detected"
+        );
+        assert!(
+            extract_explicit_instruction(
+                "In practice we sometimes always check the generated output before publishing."
+            )
+            .is_none(),
+            "a narrative subject within the two-word lookback must be detected"
+        );
+    }
+
+    #[test]
+    fn explicit_non_subject_prefix_remains_capturable() {
+        assert!(
+            extract_explicit_instruction("For this project always run cargo fmt before commit.")
+                .is_some(),
+            "a non-subject prefix must not be mistaken for conversational filler"
         );
     }
 

--- a/crates/librefang-kernel/src/skill_workshop/heuristic.rs
+++ b/crates/librefang-kernel/src/skill_workshop/heuristic.rs
@@ -154,7 +154,7 @@ fn is_conversational_filler(sentence: &str, trigger: &str) -> bool {
     // Look at up to the 2 words preceding the trigger.
     let prefix = lower[..idx].trim_end();
     let has_narrative_subject = prefix
-        .rsplit(|c: char| c.is_whitespace())
+        .rsplit(|c: char| !c.is_ascii_alphabetic() && c != '\'')
         .filter(|w| !w.is_empty())
         .take(2)
         .any(|word| matches!(word, "i" | "we" | "you" | "he" | "she" | "they"));
@@ -499,6 +499,16 @@ mod tests {
             )
             .is_none(),
             "a narrative subject within the two-word lookback must be detected"
+        );
+        assert!(
+            extract_explicit_instruction("Well, they—always run the formatter before submitting.")
+                .is_none(),
+            "punctuation between the subject and trigger must remain a word boundary"
+        );
+        assert!(
+            extract_explicit_instruction("They don't always run the formatter before submitting.")
+                .is_none(),
+            "an apostrophe word must count as one lookback word"
         );
     }
 


### PR DESCRIPTION
## Changes

- inspect both punctuation-aware words in the documented conversational-prefix lookback, keeping apostrophe words intact
- suppress narrative subjects even when a leading word or adverb precedes the `always` trigger
- retain capture behavior for non-subject prefixes

## Verification

- `cargo test -p librefang-kernel skill_workshop::heuristic::tests --lib` (25 passed)
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p librefang-kernel skill_workshop::heuristic::tests::explicit_ --lib` (11 passed after review fix)
- formatting and diff checks

## Out of scope

- changing correction trigger regexes or repeated-tool-pattern ranking