### PR TITLE
fix(kernel): coordinate EveryAPI credential retries

### DIFF
--- a/changelog.d/fixed/7635-everyapi-credential-retries.md
+++ b/changelog.d/fixed/7635-everyapi-credential-retries.md
@@ -1,0 +1,1 @@
+Coordinate EveryAPI credential refreshes, keep managed gate I/O off Tokio workers, and prevent stream retries after any event reaches the caller. (#7635) (@houko)

--- a/changelog.d/fixed/7635-everyapi-credential-retries.md
+++ b/changelog.d/fixed/7635-everyapi-credential-retries.md
@@ -1,1 +1,1 @@
-Coordinate EveryAPI credential refreshes, keep managed gate I/O off Tokio workers, and prevent stream retries after any event reaches the caller. (#7635) (@houko)
+Coordinate EveryAPI credential refreshes, return generation-consistent credentials, recognize typed authentication errors, keep managed gate I/O off Tokio workers, and prevent stream retries after any event reaches the caller. (#7635) (@houko)

--- a/crates/librefang-kernel/src/everyapi_driver.rs
+++ b/crates/librefang-kernel/src/everyapi_driver.rs
@@ -8,6 +8,7 @@ use librefang_llm_driver::{
 };
 use librefang_llm_drivers::drivers::DriverCache;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 #[async_trait]
@@ -22,8 +23,12 @@ impl EveryApiCredentialSource for LocalEveryApiCredentialSource {
     async fn resolve(&self, invalidate: bool) -> Result<EveryApiCredential, CredentialError> {
         tokio::task::spawn_blocking(move || everyapi_credentials::resolve(invalidate))
             .await
-            .map_err(|_| CredentialError::Unavailable)?
+            .map_err(credential_task_error)?
     }
+}
+
+fn credential_task_error(error: tokio::task::JoinError) -> CredentialError {
+    CredentialError::InvalidOutput(format!("credential resolver task failed: {error}"))
 }
 
 /// Resolves the current EveryAPI relay key for each request.
@@ -35,6 +40,9 @@ pub struct ManagedEveryApiDriver {
     cache: Arc<DriverCache>,
     base_config: DriverConfig,
     managed_gate: Option<PathBuf>,
+    /// Serializes credential invalidation and records completed refreshes.
+    /// Requests that fail with the same generation share one invalidation.
+    credential_generation: tokio::sync::Mutex<u64>,
 }
 
 impl ManagedEveryApiDriver {
@@ -44,6 +52,7 @@ impl ManagedEveryApiDriver {
             cache,
             base_config,
             managed_gate: None,
+            credential_generation: tokio::sync::Mutex::new(0),
         }
     }
 
@@ -57,6 +66,7 @@ impl ManagedEveryApiDriver {
             cache,
             base_config,
             managed_gate: Some(home_dir),
+            credential_generation: tokio::sync::Mutex::new(0),
         }
     }
 
@@ -71,18 +81,23 @@ impl ManagedEveryApiDriver {
                 ..DriverConfig::default()
             },
             managed_gate: None,
+            credential_generation: tokio::sync::Mutex::new(0),
         }
     }
 
     async fn resolve_driver(&self, invalidate: bool) -> Result<Arc<dyn LlmDriver>, LlmError> {
-        if self
-            .managed_gate
-            .as_ref()
-            .is_some_and(|home| managed_everyapi_is_disabled(home))
-        {
-            return Err(LlmError::MissingApiKey(
-                "EveryAPI managed provider is disabled or explicitly configured".to_string(),
-            ));
+        if let Some(home_dir) = self.managed_gate.clone() {
+            let disabled =
+                tokio::task::spawn_blocking(move || managed_everyapi_is_disabled(&home_dir))
+                    .await
+                    .map_err(|error| {
+                        LlmError::Http(format!("EveryAPI managed gate task failed: {error}"))
+                    })?;
+            if disabled {
+                return Err(LlmError::MissingApiKey(
+                    "EveryAPI managed provider is disabled or explicitly configured".to_string(),
+                ));
+            }
         }
         let credential = self
             .source
@@ -94,6 +109,26 @@ impl ManagedEveryApiDriver {
         config.api_key = Some(credential.api_key);
         config.base_url = Some(credential.base_url);
         self.cache.get_or_create(&config)
+    }
+
+    async fn resolve_initial_driver(&self) -> Result<(Arc<dyn LlmDriver>, u64), LlmError> {
+        let generation = *self.credential_generation.lock().await;
+        let driver = self.resolve_driver(false).await?;
+        Ok((driver, generation))
+    }
+
+    async fn resolve_after_authentication_failure(
+        &self,
+        observed_generation: u64,
+    ) -> Result<Arc<dyn LlmDriver>, LlmError> {
+        let mut generation = self.credential_generation.lock().await;
+        if *generation != observed_generation {
+            return self.resolve_driver(false).await;
+        }
+
+        let driver = self.resolve_driver(true).await?;
+        *generation = (*generation).wrapping_add(1);
+        Ok(driver)
     }
 }
 
@@ -126,13 +161,43 @@ fn is_authentication_error(error: &LlmError) -> bool {
     )
 }
 
+fn should_retry_stream(error: &LlmError, event_emitted: bool) -> bool {
+    !event_emitted && is_authentication_error(error)
+}
+
+async fn stream_attempt(
+    driver: Arc<dyn LlmDriver>,
+    request: CompletionRequest,
+    tx: tokio::sync::mpsc::Sender<StreamEvent>,
+) -> (Result<CompletionResponse, LlmError>, bool) {
+    let (intercept_tx, mut intercept_rx) = tokio::sync::mpsc::channel::<StreamEvent>(32);
+    let event_emitted = Arc::new(AtomicBool::new(false));
+    let relay_emitted = Arc::clone(&event_emitted);
+    let relay = tokio::spawn(async move {
+        while let Some(event) = intercept_rx.recv().await {
+            relay_emitted.store(true, Ordering::Release);
+            if tx.send(event).await.is_err() {
+                intercept_rx.close();
+                break;
+            }
+        }
+    });
+
+    let result = driver.stream(request, intercept_tx).await;
+    let _ = relay.await;
+    (result, event_emitted.load(Ordering::Acquire))
+}
+
 #[async_trait]
 impl LlmDriver for ManagedEveryApiDriver {
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        let driver = self.resolve_driver(false).await?;
+        let (driver, generation) = self.resolve_initial_driver().await?;
         match driver.complete(request.clone()).await {
             Err(error) if is_authentication_error(&error) => {
-                self.resolve_driver(true).await?.complete(request).await
+                self.resolve_after_authentication_failure(generation)
+                    .await?
+                    .complete(request)
+                    .await
             }
             result => result,
         }
@@ -143,10 +208,14 @@ impl LlmDriver for ManagedEveryApiDriver {
         request: CompletionRequest,
         tx: tokio::sync::mpsc::Sender<StreamEvent>,
     ) -> Result<CompletionResponse, LlmError> {
-        let driver = self.resolve_driver(false).await?;
-        match driver.stream(request.clone(), tx.clone()).await {
-            Err(error) if is_authentication_error(&error) => {
-                self.resolve_driver(true).await?.stream(request, tx).await
+        let (driver, generation) = self.resolve_initial_driver().await?;
+        let (result, event_emitted) = stream_attempt(driver, request.clone(), tx.clone()).await;
+        match result {
+            Err(error) if should_retry_stream(&error, event_emitted) => {
+                self.resolve_after_authentication_failure(generation)
+                    .await?
+                    .stream(request, tx)
+                    .await
             }
             result => result,
         }
@@ -183,6 +252,65 @@ mod tests {
                 api_key: if invalidate { "fresh-key" } else { "old-key" }.to_string(),
                 expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
             })
+        }
+    }
+
+    struct RotatingSource {
+        invalidations: Mutex<Vec<bool>>,
+        fresh: AtomicBool,
+        base_url: String,
+    }
+
+    #[async_trait]
+    impl EveryApiCredentialSource for RotatingSource {
+        async fn resolve(&self, invalidate: bool) -> Result<EveryApiCredential, CredentialError> {
+            self.invalidations.lock().unwrap().push(invalidate);
+            if invalidate {
+                self.fresh.store(true, Ordering::Release);
+            }
+            Ok(EveryApiCredential {
+                base_url: self.base_url.clone(),
+                api_key: if self.fresh.load(Ordering::Acquire) {
+                    "fresh-key"
+                } else {
+                    "old-key"
+                }
+                .to_string(),
+                expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
+            })
+        }
+    }
+
+    struct AuthenticationStreamDriver {
+        emit_event: bool,
+    }
+
+    #[async_trait]
+    impl LlmDriver for AuthenticationStreamDriver {
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            Err(LlmError::AuthenticationFailed("rejected".to_string()))
+        }
+
+        async fn stream(
+            &self,
+            _request: CompletionRequest,
+            tx: tokio::sync::mpsc::Sender<StreamEvent>,
+        ) -> Result<CompletionResponse, LlmError> {
+            if self.emit_event {
+                let _ = tx
+                    .send(StreamEvent::TextDelta {
+                        text: "partial".to_string(),
+                    })
+                    .await;
+            }
+            Err(LlmError::AuthenticationFailed("rejected".to_string()))
+        }
+
+        fn family(&self) -> LlmFamily {
+            LlmFamily::OpenAi
         }
     }
 
@@ -238,6 +366,58 @@ mod tests {
         assert_eq!(*source.invalidations.lock().unwrap(), [false, true]);
     }
 
+    #[tokio::test]
+    async fn concurrent_auth_failures_share_one_invalidation() {
+        let source = Arc::new(RotatingSource {
+            invalidations: Mutex::new(Vec::new()),
+            fresh: AtomicBool::new(false),
+            base_url: "http://127.0.0.1:9/v1".to_string(),
+        });
+        let driver = ManagedEveryApiDriver::with_source(source.clone(), 0);
+
+        let (_, first_generation) = driver.resolve_initial_driver().await.unwrap();
+        let (_, second_generation) = driver.resolve_initial_driver().await.unwrap();
+        assert_eq!(first_generation, second_generation);
+
+        let (first, second) = tokio::join!(
+            driver.resolve_after_authentication_failure(first_generation),
+            driver.resolve_after_authentication_failure(second_generation)
+        );
+        assert!(first.is_ok());
+        assert!(second.is_ok());
+        assert_eq!(
+            *source.invalidations.lock().unwrap(),
+            [false, false, true, false],
+            "the second stale failure must reuse the completed refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_attempt_reports_any_forwarded_event() {
+        for (emit_event, expected) in [(false, false), (true, true)] {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+            let (result, emitted) = stream_attempt(
+                Arc::new(AuthenticationStreamDriver { emit_event }),
+                request(),
+                tx,
+            )
+            .await;
+
+            assert!(matches!(result, Err(LlmError::AuthenticationFailed(_))));
+            assert_eq!(emitted, expected);
+            assert_eq!(rx.try_recv().is_ok(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn credential_resolver_join_error_keeps_panic_context() {
+        let join_error = tokio::spawn(async { panic!("credential resolver boom") })
+            .await
+            .unwrap_err();
+        let error = credential_task_error(join_error).to_string();
+        assert!(error.contains("credential resolver boom"), "{error}");
+    }
+
     #[test]
     fn quota_or_policy_forbidden_does_not_rotate_credentials() {
         assert!(!is_authentication_error(&LlmError::Api {
@@ -245,6 +425,13 @@ mod tests {
             message: "quota or policy rejection".to_string(),
             code: None,
         }));
+    }
+
+    #[test]
+    fn stream_authentication_retry_requires_a_clean_event_stream() {
+        let error = LlmError::AuthenticationFailed("rejected".to_string());
+        assert!(should_retry_stream(&error, false));
+        assert!(!should_retry_stream(&error, true));
     }
 
     #[test]

--- a/crates/librefang-kernel/src/everyapi_driver.rs
+++ b/crates/librefang-kernel/src/everyapi_driver.rs
@@ -2,6 +2,7 @@
 
 use crate::everyapi_credentials::{self, CredentialError, EveryApiCredential};
 use async_trait::async_trait;
+use librefang_llm_driver::llm_errors::ProviderErrorCode;
 use librefang_llm_driver::{
     CompletionRequest, CompletionResponse, DriverConfig, LlmDriver, LlmError, LlmFamily,
     StreamEvent,
@@ -112,9 +113,16 @@ impl ManagedEveryApiDriver {
     }
 
     async fn resolve_initial_driver(&self) -> Result<(Arc<dyn LlmDriver>, u64), LlmError> {
-        let generation = *self.credential_generation.lock().await;
-        let driver = self.resolve_driver(false).await?;
-        Ok((driver, generation))
+        loop {
+            let generation = *self.credential_generation.lock().await;
+            let driver = self.resolve_driver(false).await?;
+            if *self.credential_generation.lock().await == generation {
+                return Ok((driver, generation));
+            }
+            // A refresh completed while the credential source was resolving.
+            // Resolve again so the returned driver and observed generation
+            // describe the same credential snapshot.
+        }
     }
 
     async fn resolve_after_authentication_failure(
@@ -157,7 +165,12 @@ fn credential_error_to_llm(error: CredentialError) -> LlmError {
 fn is_authentication_error(error: &LlmError) -> bool {
     matches!(
         error,
-        LlmError::AuthenticationFailed(_) | LlmError::Api { status: 401, .. }
+        LlmError::AuthenticationFailed(_)
+            | LlmError::Api { status: 401, .. }
+            | LlmError::Api {
+                code: Some(ProviderErrorCode::AuthError),
+                ..
+            }
     )
 }
 
@@ -234,6 +247,7 @@ mod tests {
     use chrono::Utc;
     use librefang_llm_driver::{CompletionRequest, LlmDriver};
     use librefang_types::message::Message;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Mutex};
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -267,6 +281,38 @@ mod tests {
             self.invalidations.lock().unwrap().push(invalidate);
             if invalidate {
                 self.fresh.store(true, Ordering::Release);
+            }
+            Ok(EveryApiCredential {
+                base_url: self.base_url.clone(),
+                api_key: if self.fresh.load(Ordering::Acquire) {
+                    "fresh-key"
+                } else {
+                    "old-key"
+                }
+                .to_string(),
+                expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
+            })
+        }
+    }
+
+    struct InterleavingSource {
+        invalidations: Mutex<Vec<bool>>,
+        fresh: AtomicBool,
+        non_invalidating_lookups: AtomicUsize,
+        initial_started: tokio::sync::Notify,
+        release_initial: tokio::sync::Notify,
+        base_url: String,
+    }
+
+    #[async_trait]
+    impl EveryApiCredentialSource for InterleavingSource {
+        async fn resolve(&self, invalidate: bool) -> Result<EveryApiCredential, CredentialError> {
+            self.invalidations.lock().unwrap().push(invalidate);
+            if invalidate {
+                self.fresh.store(true, Ordering::Release);
+            } else if self.non_invalidating_lookups.fetch_add(1, Ordering::AcqRel) == 0 {
+                self.initial_started.notify_one();
+                self.release_initial.notified().await;
             }
             Ok(EveryApiCredential {
                 base_url: self.base_url.clone(),
@@ -393,6 +439,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn initial_resolution_retries_when_refresh_changes_generation() {
+        let source = Arc::new(InterleavingSource {
+            invalidations: Mutex::new(Vec::new()),
+            fresh: AtomicBool::new(false),
+            non_invalidating_lookups: AtomicUsize::new(0),
+            initial_started: tokio::sync::Notify::new(),
+            release_initial: tokio::sync::Notify::new(),
+            base_url: "http://127.0.0.1:9/v1".to_string(),
+        });
+        let driver = Arc::new(ManagedEveryApiDriver::with_source(source.clone(), 0));
+        let initial = {
+            let driver = Arc::clone(&driver);
+            tokio::spawn(async move { driver.resolve_initial_driver().await })
+        };
+
+        source.initial_started.notified().await;
+        driver
+            .resolve_after_authentication_failure(0)
+            .await
+            .unwrap();
+        source.release_initial.notify_one();
+
+        let (_, generation) = initial.await.unwrap().unwrap();
+        assert_eq!(generation, 1);
+        assert_eq!(
+            *source.invalidations.lock().unwrap(),
+            [false, true, false],
+            "the overlapping initial lookup must be repeated after refresh"
+        );
+    }
+
+    #[tokio::test]
     async fn stream_attempt_reports_any_forwarded_event() {
         for (emit_event, expected) in [(false, false), (true, true)] {
             let (tx, mut rx) = tokio::sync::mpsc::channel(4);
@@ -424,6 +502,11 @@ mod tests {
             status: 403,
             message: "quota or policy rejection".to_string(),
             code: None,
+        }));
+        assert!(is_authentication_error(&LlmError::Api {
+            status: 403,
+            message: "credential rejected".to_string(),
+            code: Some(ProviderErrorCode::AuthError),
         }));
     }
 


### PR DESCRIPTION
## Summary

- move the managed EveryAPI gate filesystem and environment probe off Tokio worker threads
- preserve credential resolver task failure context, coordinate concurrent authentication refreshes by credential generation, and re-resolve initial drivers when a refresh interleaves
- recognize typed provider authentication errors while leaving untyped policy or quota 403 responses untouched
- relay the first streaming attempt through an interceptor and retry authentication failures only before any event reaches the caller

## Verification

- `cargo test -p librefang-kernel everyapi_driver::tests --lib` (8 passed after review fix)
- `cargo check --workspace --lib`
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `git diff --check`

## Out of scope

- removing the low-priority `DriverConfig` clone from each credential resolution
- changing the existing single-retry policy
- caching credentials beyond the credential source and `DriverCache`
- generalizing the stream relay helper to other providers