### PR TITLE
fix(router): anchor multi-domain markers

### DIFF
--- a/changelog.d/fixed/7637-router-multi-domain-boundaries.md
+++ b/changelog.d/fixed/7637-router-multi-domain-boundaries.md
@@ -1,0 +1,1 @@
+Require complete ASCII multi-domain markers so words such as `multimedia` and `altogether` do not force specialist requests through the orchestrator. (#7637) (@houko)

--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -524,6 +524,20 @@ pub fn auto_select_hand(
     }
 }
 
+fn has_multi_domain_marker(normalized: &str) -> bool {
+    ["同时", "分别", "协作", "多个", "multi", "together"]
+        .iter()
+        .any(|token| {
+            if token.is_ascii() {
+                normalized
+                    .split(|character: char| !character.is_ascii_alphanumeric())
+                    .any(|word| word == *token)
+            } else {
+                normalized.contains(token)
+            }
+        })
+}
+
 pub fn auto_select_template(
     message: &str,
     agents_dir: &Path,
@@ -583,9 +597,7 @@ pub fn auto_select_template(
 
     if scored.len() > 1 {
         let (second_score, second_template, _) = &scored[1];
-        let multi_domain = ["同时", "分别", "协作", "多个", "multi", "together"]
-            .iter()
-            .any(|token| normalized.contains(token));
+        let multi_domain = has_multi_domain_marker(&normalized);
         if *second_score > 0 && best_template != second_template && multi_domain {
             return TemplateSelection {
                 template: "orchestrator".to_string(),
@@ -1319,6 +1331,27 @@ weak_aliases = ["changelog"]
         );
         assert_eq!(selection.template, "orchestrator");
         assert!(selection.score > 0);
+    }
+
+    #[test]
+    fn test_auto_select_template_requires_ascii_multi_domain_word_boundaries() {
+        for message in [
+            "Research and code this multimedia parser",
+            "Research and code this multitask parser",
+            "Research and code an altogether different parser",
+            "Research and code a multithreaded parser",
+        ] {
+            let selection = auto_select_template(message, Path::new("/tmp/does-not-exist"), None);
+            assert_eq!(selection.template, "researcher", "{message}");
+        }
+
+        for message in [
+            "Research and code this multi domain task",
+            "Research and code this together",
+        ] {
+            let selection = auto_select_template(message, Path::new("/tmp/does-not-exist"), None);
+            assert_eq!(selection.template, "orchestrator", "{message}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require ASCII multi-domain markers such as `multi` and `together` to appear as complete alphanumeric-delimited words
- keep substring matching for the existing Chinese multi-domain markers
- preserve orchestrator routing for real multi-domain requests while preventing `multimedia`, `multitask`, `multithreaded`, and `altogether` false positives

## Verification

- `cargo test -p librefang-kernel-router` (58 passed)
- `cargo test -p librefang-kernel-router test_auto_select_template_requires_ascii_multi_domain_word_boundaries --lib` after rebasing onto current `origin/main`
- `CARGO_INCREMENTAL=0 cargo check --workspace --lib`
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Out of scope

- changing the routing weights or specialist tie-break order
- changing operator-defined routing regexes
- changing semantic-score blending
- changing the existing Chinese marker matching semantics