### PR TITLE
fix: scrub ACP internal errors

### DIFF
--- a/changelog.d/fixed/7640-acp-error-boundaries.md
+++ b/changelog.d/fixed/7640-acp-error-boundaries.md
@@ -1,0 +1,1 @@
+Return concurrent ACP prompts as invalid parameters and keep kernel and internal diagnostics server-side instead of exposing them through JSON-RPC error data. (#7640) (@houko)

--- a/crates/librefang-acp/src/error.rs
+++ b/crates/librefang-acp/src/error.rs
@@ -63,14 +63,59 @@ impl AcpError {
         use agent_client_protocol::util::internal_error;
         match self {
             Self::Transport(e) => e,
-            Self::UnknownSession(_) | Self::AgentNotFound(_) => {
-                let msg = self.to_string();
+            error @ (Self::UnknownSession(_) | Self::AgentNotFound(_)) => {
+                let msg = error.to_string();
                 agent_client_protocol::Error::invalid_params()
                     .data(serde_json::json!({ "reason": msg }))
             }
-            other => internal_error(other.to_string()),
+            Self::PromptInFlight(session_id) => agent_client_protocol::Error::invalid_params()
+                .data(serde_json::json!({
+                    "reason": format!("session {session_id} already has an in-flight prompt")
+                })),
+            error => {
+                tracing::error!(error = %error, "ACP request failed");
+                internal_error("internal acp error")
+            }
         }
     }
 }
 
 pub type AcpResult<T> = Result<T, AcpError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::ErrorCode;
+
+    #[test]
+    fn prompt_in_flight_is_an_invalid_params_error() {
+        let error = AcpError::PromptInFlight("session-7".to_string()).into_acp_error();
+
+        assert_eq!(error.code, ErrorCode::InvalidParams);
+        assert_eq!(
+            error.data,
+            Some(serde_json::json!({
+                "reason": "session session-7 already has an in-flight prompt"
+            }))
+        );
+    }
+
+    #[test]
+    fn internal_error_details_are_not_exposed_to_clients() {
+        let error = AcpError::internal("channel dropped at /private/agent.sock").into_acp_error();
+
+        assert_eq!(error.code, ErrorCode::InternalError);
+        assert_eq!(error.data, Some(serde_json::json!("internal acp error")));
+    }
+
+    #[test]
+    fn kernel_error_details_are_not_exposed_to_clients() {
+        let error = AcpError::Kernel(librefang_types::error::LibreFangError::Config(
+            "secret config path: /private/config.toml".to_string(),
+        ))
+        .into_acp_error();
+
+        assert_eq!(error.code, ErrorCode::InternalError);
+        assert_eq!(error.data, Some(serde_json::json!("internal acp error")));
+    }
+}

--- a/crates/librefang-acp/tests/acp_integration.rs
+++ b/crates/librefang-acp/tests/acp_integration.rs
@@ -299,7 +299,7 @@ async fn initialize_and_prompt_emits_text_chunks_and_end_turn() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn prompt_channel_close_without_completion_returns_internal_error() {
+async fn prompt_channel_close_without_completion_returns_scrubbed_internal_error() {
     use tokio::task::LocalSet;
 
     let local = LocalSet::new();
@@ -345,9 +345,7 @@ async fn prompt_channel_close_without_completion_returns_internal_error() {
                     );
                     assert_eq!(
                         error.data,
-                        Some(serde_json::json!(
-                            "internal acp error: prompt event channel closed before ContentComplete"
-                        ))
+                        Some(serde_json::json!("internal acp error"))
                     );
                     Ok(())
                 })


### PR DESCRIPTION
## Changes

- return ACP `PromptInFlight` failures as JSON-RPC invalid-params errors
- log full kernel and internal ACP failures on the server
- replace client-visible internal diagnostics with a fixed generic error
- add direct mapping regressions and update the end-to-end channel-close contract

## Verification

- `cargo test -p librefang-acp --no-fail-fast`
- `cargo clippy -p librefang-acp --all-targets -- -D warnings`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Out of scope

- `AcpError::Internal(String)` still stores synthesized internal failures as strings. Preserving typed source chains requires a separate constructor and caller migration; this PR changes only the client/server error boundary.