### PR TITLE
chore(acp): trim redundant Tokio test features

### DIFF
--- a/crates/librefang-acp/Cargo.toml
+++ b/crates/librefang-acp/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { workspace = true }
 dashmap = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 # Used by `tests/acp_integration.rs` for the duplex transport's
 # `AsyncRead` / `AsyncWrite` bounds and for stamping `ApprovalRequest`
 # fixtures. Production code in this crate doesn't touch them directly


### PR DESCRIPTION
## Summary
- keep only the additive `test-util` feature on the ACP Tokio dev dependency
- continue inheriting Tokio `full` from the workspace dependency
- close the remaining ACP manifest audit item after #6957 added repository and MSRV inheritance

## Verification
- `cargo metadata --no-deps --format-version 1` shows normal Tokio features as `full` and dev features as `full,test-util`
- `cargo test -p librefang-acp --no-fail-fast` (37 unit tests, 8 integration tests)
- `cargo clippy -p librefang-acp --all-targets -- -D warnings`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Out of scope
- no Tokio version or workspace feature changes
- no production dependency or runtime behavior changes
- no changelog fragment because this is dependency-declaration cleanup only