### PR TITLE
test(api): strengthen media route boundaries

### DIFF
--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -375,7 +375,7 @@ async fn media_music_rejects_when_neither_prompt_nor_lyrics() {
 #[tokio::test(flavor = "multi_thread")]
 async fn media_music_rejects_overlong_lyrics() {
     let h = boot().await;
-    let huge = "la ".repeat(2000); // > 3500 chars
+    let huge = "la ".repeat(1200); // 3600 chars, just over the 3500-char limit
     let (status, body) = json_request(
         &h,
         Method::POST,
@@ -470,7 +470,7 @@ async fn media_transcribe_rejects_oversized_body() {
         Method::POST,
         "/api/media/transcribe",
         Some("audio/webm"),
-        vec![0u8; 11 * 1024 * 1024],
+        vec![0u8; 10 * 1024 * 1024 + 1],
     )
     .await;
     assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
@@ -483,7 +483,7 @@ async fn media_transcribe_strips_content_type_parameters() {
     // will hit the kernel's MediaEngine and bubble back a 5xx — but the
     // status MUST NOT be 400 (the content-type gate has already passed).
     let h = boot().await;
-    let (status, _body) = raw_request(
+    let (status, body) = raw_request(
         &h,
         Method::POST,
         "/api/media/transcribe",
@@ -491,9 +491,9 @@ async fn media_transcribe_strips_content_type_parameters() {
         b"\x00\x01\x02fake-audio-bytes".to_vec(),
     )
     .await;
-    assert_ne!(
-        status,
-        StatusCode::BAD_REQUEST,
-        "audio/webm;codecs=opus must pass the content-type gate"
+    assert!(
+        status.is_server_error(),
+        "audio/webm;codecs=opus must pass the content-type gate and reach the kernel; \
+         expected 5xx, got {status}: {body}"
     );
 }


### PR DESCRIPTION
## Changes

- require parameterized audio MIME types to reach the media engine and return a server error
- exercise the transcription body limit at exactly one byte over 10 MiB
- keep the overlong lyrics fixture just above the 3,500-character boundary

## Verification

- `cargo test -p librefang-api --test media_routes_integration -- --nocapture` (19 passed)
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

## Out of scope

- No production media behavior changed.
- The expected provider list remains independent of the production constant so the contract test can detect omissions.
- No changelog fragment: this PR changes tests only.