### PR TITLE
test(api): tighten webhook SSRF assertions

### DIFF
--- a/crates/librefang-api/tests/webhooks_routes_integration.rs
+++ b/crates/librefang-api/tests/webhooks_routes_integration.rs
@@ -149,8 +149,8 @@ async fn create_event_webhook_rejects_ssrf_urls() {
     );
     let err = err_message(&json);
     assert!(
-        err.contains("169.254.169.254") || err.contains("not allowed"),
-        "error should mention the rejected host; got {err:?}"
+        err.contains("169.254.169.254"),
+        "error should mention the rejected SSRF host; got {err:?}"
     );
 
     // The other internal-URL families the gate blocks.
@@ -222,7 +222,7 @@ async fn update_event_webhook_rejects_ssrf_url() {
     );
     let id = created["id"]
         .as_str()
-        .expect("created webhook id")
+        .unwrap_or_else(|| panic!("created webhook id should be a string; body={created}"))
         .to_string();
 
     // 2. Try to repoint it at the metadata IP — must be rejected.
@@ -240,8 +240,8 @@ async fn update_event_webhook_rejects_ssrf_url() {
     );
     let err = err_message(&json);
     assert!(
-        err.contains("169.254.169.254") || err.contains("not allowed"),
-        "error should mention the rejected host; got {err:?}"
+        err.contains("169.254.169.254"),
+        "error should mention the rejected SSRF host; got {err:?}"
     );
 
     // 3. The stored webhook must still hold the original benign URL.


### PR DESCRIPTION
## Changes

- require both create and update SSRF regressions to report the rejected metadata IP explicitly
- remove the generic `not allowed` fallback that could accept unrelated 400 responses
- include the full create response when the webhook id is absent or not a string

## Verification

- `cargo test -p librefang-api --test webhooks_routes_integration`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- Webhook validation and storage behavior are unchanged.
- No changelog entry: test-only assertion hardening with no user-facing behavior change.