### PR TITLE
chore(channels): clean up manifest metadata

### DIFF
--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -63,9 +63,9 @@ fs2 = "0.4"
 # Content hash of the embedded SDK tree — drives the
 # `<home>/sidecar-python/<hash>/` directory name so a daemon upgrade
 # extracts to a fresh subdirectory. The wider `librefang-channels`
-# cleanup in #5473 pruned `sha2` from this crate alongside the
-# webhook-verifying in-process adapters; `embedded_sdk.rs` is the
-# only re-consumer.
+# cleanup in #5473 removed the in-process webhook adapter uses of
+# `sha2`; `embedded_sdk.rs` remains the sole consumer, so the
+# dependency stays in this crate.
 sha2 = { workspace = true }
 
 # Sidecar migration cleanup: with every channel adapter moved
@@ -92,7 +92,6 @@ sha2 = { workspace = true }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 wiremock = "0.6"
-serde_json = { workspace = true }
 
 [[bench]]
 name = "dispatch"


### PR DESCRIPTION
## Changes

- remove the redundant `serde_json` dev-dependency already supplied as a normal dependency
- correct the `sha2` comment to explain that adapter uses were removed while embedded SDK hashing remains

## Verification

- `cargo test -p librefang-channels`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- Centralizing `image`, `pdf-extract`, `include_dir`, and `wiremock` requires the root `Cargo.toml`, currently owned by open #7256. Revisit the workspace-wide dependency policy after that PR merges or closes.
- No changelog entry: manifest cleanup and documentation only, with no dependency graph or user-facing behavior change.