### PR TITLE
perf(channels): preserve roundtrip benchmark work

### DIFF
--- a/crates/librefang-channels/benches/dispatch.rs
+++ b/crates/librefang-channels/benches/dispatch.rs
@@ -60,7 +60,7 @@ fn bench_message_roundtrip(c: &mut Criterion) {
     c.bench_function("message_roundtrip", |b| {
         b.iter(|| {
             let json = serde_json::to_string(black_box(&msg)).unwrap();
-            let _: ChannelMessage = serde_json::from_str(&json).unwrap();
+            black_box(serde_json::from_str::<ChannelMessage>(&json).unwrap())
         })
     });
 }


### PR DESCRIPTION
## Changes

- return the deserialized channel message through `black_box` in the serialization roundtrip benchmark
- keep both serialization and deserialization observable so LLVM cannot elide the benchmark body

## Verification

- `cargo bench -p librefang-channels --bench dispatch -- --test`
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope

- Other dispatch benchmarks already return their computed values to Criterion and need no duplicate outer `black_box`.
- No changelog entry: benchmark-only correction with no runtime behavior change.