### PR TITLE
fix(channels): normalize slash command policy input

### DIFF
--- a/changelog.d/fixed/7660-command-policy-slash-input.md
+++ b/changelog.d/fixed/7660-command-policy-slash-input.md
@@ -1,0 +1,1 @@
+Treat slash-prefixed command names identically to bare names at the channel policy boundary, preventing public callers from bypassing blacklist entries through input shape (#7660) (@houko)

--- a/crates/librefang-channels/src/commands/mod.rs
+++ b/crates/librefang-channels/src/commands/mod.rs
@@ -489,9 +489,9 @@ pub fn is_channel_command(name: &str) -> bool {
 /// `blocked_commands` (blacklist). When no overrides are configured,
 /// everything is allowed.
 ///
-/// Config entries may be written with or without a leading `/`
-/// (`"agent"` and `"/agent"` both match the dispatcher's bare token).
+/// Command names and config entries may be written with or without a leading `/`.
 pub fn is_command_allowed(cmd: &str, overrides: Option<&ChannelOverrides>) -> bool {
+    let cmd = cmd.strip_prefix('/').unwrap_or(cmd);
     let Some(ov) = overrides else { return true };
     if ov.disable_commands {
         return false;
@@ -550,8 +550,7 @@ pub fn channel_help_text(overrides: Option<&ChannelOverrides>) -> String {
                 out.push_str(&format!("/{} {} - {}", c.name, sub.args, sub.description));
                 first_in_section = false;
             }
-            // Defer setting first_in_section=false to common path below
-            // — already handled inside loop.
+            // The loop already updated `first_in_section`, so intentionally skip the common assignment below.
             continue;
         }
 
@@ -749,8 +748,11 @@ mod tests {
         };
         // Whitelist wins over blacklist.
         assert!(is_command_allowed("help", Some(&ov)));
+        assert!(is_command_allowed("/help", Some(&ov)));
         assert!(is_command_allowed("start", Some(&ov)));
+        assert!(is_command_allowed("/start", Some(&ov)));
         assert!(!is_command_allowed("agent", Some(&ov)));
+        assert!(!is_command_allowed("/agent", Some(&ov)));
     }
 
     #[test]
@@ -760,8 +762,11 @@ mod tests {
             ..Default::default()
         };
         assert!(!is_command_allowed("agent", Some(&ov)));
+        assert!(!is_command_allowed("/agent", Some(&ov)));
         assert!(!is_command_allowed("new", Some(&ov)));
+        assert!(!is_command_allowed("/new", Some(&ov)));
         assert!(is_command_allowed("help", Some(&ov)));
+        assert!(is_command_allowed("/help", Some(&ov)));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- Normalize the public command-policy input before whitelist and blacklist matching, so bare and slash-prefixed command names receive the same decision.
- Extend whitelist and blacklist regressions to cover both input forms.
- Clarify the help-rendering state comment around the intentional `continue`.

## Verification

- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo test -p librefang-channels commands::tests` (15 passed)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out-of-scope follow-ups

- None. Telegram menu limits remain enforced against the static registry by the existing complete invariant test; duplicating those checks as release-disabled debug assertions would not strengthen production behavior.