### PR TITLE
docs(channels): document embedded SDK module

### DIFF
--- a/changelog.d/documentation/7665-channels-embedded-sdk-module.md
+++ b/changelog.d/documentation/7665-channels-embedded-sdk-module.md
@@ -1,0 +1,1 @@
+Document the public channel `embedded_sdk` module and its role in bundling and extracting the Python SDK for zero-setup sidecar startup (#7665) (@houko)

--- a/crates/librefang-channels/src/lib.rs
+++ b/crates/librefang-channels/src/lib.rs
@@ -1,12 +1,8 @@
 //! Channel infrastructure for the LibreFang Agent OS.
 //!
-//! Every channel adapter is out-of-process — see `librefang.sidecar.adapters.*`
-//! in the SDK at `sdk/python/`. This crate owns the **trampoline** that
-//! connects the kernel to those sidecars (`sidecar.rs`), the shared bridge
-//! types every adapter speaks (`types`, `bridge`, `router`, `commands`,
-//! `formatter`, `sanitizer`, `roster`, `rate_limiter`, `thread_ownership`,
-//! `group_history`, `message_journal`, `message_truncator`,
-//! `attachment_enrich`), and the shared HTTP client (`http_client`).
+//! Every channel adapter is out-of-process — see `librefang.sidecar.adapters.*` in the SDK at `sdk/python/`.
+//! This crate owns the **trampoline** that connects the kernel to those sidecars (`sidecar.rs`), the shared bridge types every adapter speaks (`types`, `bridge`, `router`, `commands`, `formatter`, `sanitizer`, `roster`, `rate_limiter`, `thread_ownership`, `group_history`, `message_journal`, `message_truncator`, `attachment_enrich`), and the shared HTTP client (`http_client`).
+//! The `embedded_sdk` module bundles the Python `librefang-sdk` package and extracts it as a fallback for zero-setup sidecar startup.
 //!
 //! No in-process channel adapters live here. Re-introducing one requires
 //! editing `crates/librefang-channels/src/channels-allowlist.txt` — see


### PR DESCRIPTION
## Substantive changes

- Add the public `embedded_sdk` module to the crate-level API overview.
- Explain that the module bundles and extracts the Python SDK as the zero-setup sidecar fallback.
- Reflow the touched overview paragraph at sentence boundaries according to the repository prose convention.

## Verification

- `cargo test -p librefang-channels --doc` (3 passed).
- `cargo check -p librefang-channels --lib`.
- `cargo check --workspace --lib`.
- `cargo clippy --workspace --all-targets -- -D warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.

## Out of scope

- Embedded SDK extraction behavior, cache policy, and sidecar startup remain unchanged.