### PR TITLE
fix(channels): ignore repeated whitespace in sanitizer

### DIFF
--- a/changelog.d/fixed/7666-sanitizer-whitespace-repetition.md
+++ b/changelog.d/fixed/7666-sanitizer-whitespace-repetition.md
@@ -1,0 +1,1 @@
+Stop treating long runs of spaces, tabs, or newlines as prompt injection, so legitimate indented code, aligned tables, and blank layout are not rejected in Block mode (#7666) (@houko)

--- a/crates/librefang-channels/src/sanitizer.rs
+++ b/crates/librefang-channels/src/sanitizer.rs
@@ -16,6 +16,8 @@ use librefang_types::config::{SanitizeConfig, SanitizeMode};
 use regex_lite::Regex;
 use tracing::warn;
 
+const REPETITION_THRESHOLD: usize = 100;
+
 /// A compiled set of prompt-injection detection patterns.
 pub struct InputSanitizer {
     mode: SanitizeMode,
@@ -118,7 +120,7 @@ impl InputSanitizer {
 
         // Excessive repetition check (done without regex because regex_lite
         // does not support backreferences).
-        if has_excessive_repetition(text, 100) {
+        if has_excessive_repetition(text, REPETITION_THRESHOLD) {
             let reason = "Prompt injection detected (excessive_repetition)".to_string();
             return self.verdict(&reason);
         }
@@ -136,8 +138,12 @@ impl InputSanitizer {
 
     /// Convert a reason string into Warned or Blocked depending on mode.
     fn verdict(&self, reason: &str) -> SanitizeResult {
+        debug_assert!(
+            self.mode != SanitizeMode::Off,
+            "Off mode returns before verdict"
+        );
         match self.mode {
-            SanitizeMode::Off => SanitizeResult::Clean,
+            SanitizeMode::Off => unreachable!("Off mode returns before verdict"),
             SanitizeMode::Warn => SanitizeResult::Warned(reason.to_string()),
             SanitizeMode::Block => SanitizeResult::Blocked(reason.to_string()),
         }
@@ -149,12 +155,20 @@ impl InputSanitizer {
     }
 }
 
-/// Returns `true` if `text` contains any single character repeated `threshold`
-/// or more times consecutively.
+/// Returns `true` if `text` contains any non-whitespace character repeated `threshold` or more times consecutively.
+/// A zero threshold disables the check.
 fn has_excessive_repetition(text: &str, threshold: usize) -> bool {
+    if threshold == 0 {
+        return false;
+    }
     let mut run_len = 0usize;
     let mut prev: Option<char> = None;
     for ch in text.chars() {
+        if ch.is_whitespace() {
+            run_len = 0;
+            prev = None;
+            continue;
+        }
         if Some(ch) == prev {
             run_len += 1;
         } else {
@@ -270,6 +284,15 @@ mod tests {
         let san = InputSanitizer::from_config(&config_block());
         let msg = "A".repeat(200);
         assert!(matches!(san.check(&msg), SanitizeResult::Blocked(_)));
+    }
+
+    #[test]
+    fn repetition_policy_ignores_whitespace_and_handles_zero_threshold() {
+        assert!(!has_excessive_repetition(&" ".repeat(200), 4));
+        assert!(!has_excessive_repetition(&"\n".repeat(200), 4));
+        assert!(!has_excessive_repetition("aaa", 4));
+        assert!(has_excessive_repetition("aaaa", 4));
+        assert!(!has_excessive_repetition(&"A".repeat(200), 0));
     }
 
     #[test]


### PR DESCRIPTION
## Substantive changes

- Exclude spaces, tabs, and newlines from excessive-repetition detection so long indentation, tables, and blank layout cannot trigger a prompt-injection verdict.
- Name the current repeated-character threshold instead of leaving an unexplained numeric literal at the call site.
- Make the Off-mode early-return invariant explicit in `verdict`, failing loudly if a future caller bypasses it.
- Cover whitespace runs, the exact non-whitespace boundary, and the helper zero-threshold behavior.

## Verification

- `cargo test -p librefang-channels sanitizer::tests` (13 passed).
- `cargo test -p librefang-channels` (570 unit, 31 integration, 5 conformance, and 3 doc tests passed).
- `cargo check --workspace --lib`.
- `cargo clippy --workspace --all-targets -- -D warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.

## Out of scope

- Exposing the repetition threshold through `SanitizeConfig` remains a follow-up because adding the field requires updating a bridge test constructor in a file occupied by #7159.
- Built-in regex compile failures are already resolved by merged #7617.