### PR TITLE
perf(skill-sdk): disable serde std features

### DIFF
--- a/changelog.d/changed/7671-skill-sdk-serde-alloc.md
+++ b/changelog.d/changed/7671-skill-sdk-serde-alloc.md
@@ -1,0 +1,1 @@
+Build Rust WASM skills with serde's allocation support instead of its unnecessary standard-library default feature (#7671) (@houko)

--- a/changelog.d/changed/pending-skill-sdk-serde-alloc.md
+++ b/changelog.d/changed/pending-skill-sdk-serde-alloc.md
@@ -1,1 +1,0 @@
-Build Rust WASM skills with serde's allocation support instead of its unnecessary standard-library default feature. (@houko)

--- a/changelog.d/changed/pending-skill-sdk-serde-alloc.md
+++ b/changelog.d/changed/pending-skill-sdk-serde-alloc.md
@@ -1,0 +1,1 @@
+Build Rust WASM skills with serde's allocation support instead of its unnecessary standard-library default feature. (@houko)

--- a/sdk/rust/librefang-skill/Cargo.toml
+++ b/sdk/rust/librefang-skill/Cargo.toml
@@ -18,8 +18,8 @@ readme = "README.md"
 rust-version = "1.80"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+serde_json = { version = "1", default-features = false, features = ["alloc"] }
 
 [[example]]
 name = "echo"


### PR DESCRIPTION
## Changes

- Disable serde and serde_json default features in the standalone Rust skill SDK.
- Enable only the allocation and derive features used by the WASM guest.
- Keep the public API and guest ABI unchanged.

## Verification

- `cargo test --manifest-path sdk/rust/librefang-skill/Cargo.toml` (11 passed, 1 doc test ignored)
- `cargo check --manifest-path sdk/rust/librefang-skill/Cargo.toml --target wasm32-unknown-unknown`
- `cargo clippy --manifest-path sdk/rust/librefang-skill/Cargo.toml --all-targets -- -D warnings`
- `cargo tree --manifest-path sdk/rust/librefang-skill/Cargo.toml -e features` confirms no serde or serde_json `std` feature
- `cargo check --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --manifest-path sdk/rust/librefang-skill/Cargo.toml -- --check`
- `python3 scripts/check-changelog-attribution.py --staged`
- `git diff --check`

## Out of scope

- The SDK remains a `std` crate.
- Serialization formats and host-call behavior are unchanged.
- A future crate-level `no_std` mode remains separate.