### PR TITLE
fix(web): complete deploy request state

### DIFF
--- a/changelog.d/fixed/7680-web-deploy-state-clipboard.md
+++ b/changelog.d/fixed/7680-web-deploy-state-clipboard.md
@@ -1,0 +1,2 @@
+Leave the website deploy form's busy state after successful requests.
+Copy buttons now report success only after the browser accepts the clipboard write, and unavailable or rejected Clipboard API calls fail without stale success feedback (#7680) (@houko)

--- a/web/src/pages/DeployPage.test.tsx
+++ b/web/src/pages/DeployPage.test.tsx
@@ -73,4 +73,152 @@ describe('FlyDeployForm progress lifecycle', () => {
     expect(requestSignal?.aborted).toBe(true)
     expect(intervalSpy).not.toHaveBeenCalled()
   })
+
+  it('leaves the form idle after a successful deployment', async () => {
+    vi.stubGlobal('scrollTo', vi.fn())
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    const { FlyDeployForm } = await import('./DeployPage')
+    let resolveRequest!: (response: Response) => void
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => {
+      resolveRequest = resolve
+    })))
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <FlyDeployForm
+          onBack={() => {}}
+          text={getTranslation('en').deploy!}
+        />,
+      )
+    })
+    const input = container.querySelector<HTMLInputElement>('#fly-token')!
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype, 'value',
+    )!.set!
+    await act(async () => {
+      valueSetter.call(input, 'fo1_test_token')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const deployButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === getTranslation('en').deploy!.deployToFly)!
+    await act(async () => {
+      deployButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('true')
+
+    await act(async () => {
+      resolveRequest({
+        ok: true,
+        json: async () => ({
+          url: 'https://demo.example.com',
+          dashboardUrl: 'https://fly.io/apps/demo',
+          appName: 'demo',
+          region: 'nrt',
+        }),
+      } as Response)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('false')
+    expect(container.textContent).toContain(getTranslation('en').deploy!.deployed)
+
+    await act(async () => root.unmount())
+  })
+})
+
+describe('useCopy', () => {
+  it('shows copied state only after the clipboard write succeeds', async () => {
+    let resolveCopy!: () => void
+    const writeText = vi.fn(() => new Promise<void>((resolve) => {
+      resolveCopy = resolve
+    }))
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    const { useCopy } = await import('./DeployPage')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    function CopyHarness() {
+      const { copiedKey, copy } = useCopy()
+      return <button onClick={() => copy('command', 'librefang start')}>{copiedKey ?? 'idle'}</button>
+    }
+
+    await act(async () => root.render(<CopyHarness />))
+    const button = container.querySelector('button')!
+    await act(async () => button.click())
+
+    expect(writeText).toHaveBeenCalledWith('librefang start')
+    expect(button.textContent).toBe('idle')
+
+    await act(async () => {
+      resolveCopy()
+      await Promise.resolve()
+    })
+    expect(button.textContent).toBe('command')
+
+    await act(async () => root.unmount())
+  })
+
+  it('handles clipboard rejection without showing copied state', async () => {
+    const writeText = vi.fn(() => Promise.reject(new Error('permission denied')))
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    const { useCopy } = await import('./DeployPage')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    function CopyHarness() {
+      const { copiedKey, copy } = useCopy()
+      return <button onClick={() => copy('command', 'librefang start')}>{copiedKey ?? 'idle'}</button>
+    }
+
+    await act(async () => root.render(<CopyHarness />))
+    const button = container.querySelector('button')!
+    await act(async () => {
+      button.click()
+      await Promise.resolve()
+    })
+
+    expect(writeText).toHaveBeenCalledWith('librefang start')
+    expect(button.textContent).toBe('idle')
+
+    await act(async () => root.unmount())
+  })
+
+  it('handles browsers without the Clipboard API', async () => {
+    vi.stubGlobal('navigator', {})
+    const { useCopy } = await import('./DeployPage')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    function CopyHarness() {
+      const { copiedKey, copy } = useCopy()
+      return <button onClick={() => copy('command', 'librefang start')}>{copiedKey ?? 'idle'}</button>
+    }
+
+    await act(async () => root.render(<CopyHarness />))
+    const button = container.querySelector('button')!
+    await act(async () => {
+      button.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(button.textContent).toBe('idle')
+
+    await act(async () => root.unmount())
+  })
 })

--- a/web/src/pages/DeployPage.tsx
+++ b/web/src/pages/DeployPage.tsx
@@ -33,13 +33,40 @@ interface ProgressStep {
 
 // ---- Copy button hook ----
 
-function useCopy() {
+export function useCopy() {
   const [copiedKey, setCopiedKey] = useState<string | null>(null)
+  const clearCopiedRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const copyRequestRef = useRef(0)
+
+  useEffect(() => () => {
+    copyRequestRef.current += 1
+    if (clearCopiedRef.current !== null) clearTimeout(clearCopiedRef.current)
+    clearCopiedRef.current = null
+  }, [])
 
   const copy = useCallback((key: string, text: string) => {
-    navigator.clipboard.writeText(text)
-    setCopiedKey(key)
-    setTimeout(() => setCopiedKey(null), 2000)
+    const request = ++copyRequestRef.current
+    if (clearCopiedRef.current !== null) {
+      clearTimeout(clearCopiedRef.current)
+      clearCopiedRef.current = null
+    }
+    setCopiedKey(null)
+
+    void Promise.resolve()
+      .then(() => navigator.clipboard.writeText(text))
+      .then(
+        () => {
+          if (request !== copyRequestRef.current) return
+          setCopiedKey(key)
+          clearCopiedRef.current = setTimeout(() => {
+            if (request === copyRequestRef.current) setCopiedKey(null)
+            clearCopiedRef.current = null
+          }, 2000)
+        },
+        () => {
+          if (request === copyRequestRef.current) setCopiedKey(null)
+        },
+      )
   }, [])
 
   return { copiedKey, copy }
@@ -524,9 +551,9 @@ export function FlyDeployForm({ onBack, text }: { onBack: () => void; text: Depl
     } catch (err) {
       if (controller.signal.aborted) return
       setError(err instanceof Error ? err.message : text.deployFailed)
-      setDeploying(false)
       setSteps(DEPLOY_STEP_IDS.map(id => ({ id, status: 'pending' as ProgressStepStatus })))
     } finally {
+      if (!controller.signal.aborted) setDeploying(false)
       if (deployRequestRef.current === controller) {
         deployRequestRef.current = null
       }
@@ -534,7 +561,7 @@ export function FlyDeployForm({ onBack, text }: { onBack: () => void; text: Depl
   }, [text.deployFailed, text.tokenRequired, token])
 
   return (
-    <div>
+    <div aria-busy={deploying}>
       {/* Back button */}
       <button
         onClick={onBack}


### PR DESCRIPTION
## Substantive changes

- Clear the Fly deploy form busy state after both successful and failed requests without updating state after an aborted request.
- Expose the request state through `aria-busy`.
- Show copied state only after the Clipboard API accepts the write.
- Handle denied, unavailable, stale, and unmounted clipboard operations without unhandled rejections or stale timers.
- Add regressions for successful deploy completion and clipboard success, rejection, and API absence.

## Verification

- `mise exec -- pnpm --dir web test` (47 tests)
- `mise exec -- pnpm --dir web lint`
- `GITHUB_TOKEN="$(gh auth token)" mise exec -- pnpm --dir web build`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Merged #6821 already removed timer-driven fake deployment progress and aborts the request during unmount.
- This PR completes the two remaining findings in the audited `DeployPage` report.
- The broader OCR audit remains in progress.