### PR TITLE
fix(web): harden registry detail interactions

### DIFF
--- a/changelog.d/fixed/7681-web-registry-detail-contracts.md
+++ b/changelog.d/fixed/7681-web-registry-detail-contracts.md
@@ -1,0 +1,2 @@
+Stop registry detail pages from tracking clicks for missing entries or duplicating a valid view under Strict Mode.
+Registry navigation now shares one popularity-ordering contract, renders localized adjacent-item names, and cleans up copy-feedback timers (#7681) (@houko)

--- a/web/src/lib/registry-raw.ts
+++ b/web/src/lib/registry-raw.ts
@@ -30,7 +30,10 @@ export async function fetchRegistryRaw(path: string): Promise<string> {
 // First element is the preferred layout; callers fall through to later ones
 // on 404. MCP in particular supports both `mcp/<id>.toml` (flat) and
 // `mcp/<id>/MCP.toml` (dir-backed) — matches `web/scripts/fetch-registry.ts`.
-export function pathCandidatesFor(category: RegistryCategory, id: string): string[] {
+export function pathCandidatesFor(
+  category: RegistryCategory,
+  id: string,
+): [string, ...string[]] {
   switch (category) {
     case 'hands':   return [`hands/${id}/HAND.toml`]
     case 'agents':  return [`agents/${id}/agent.toml`]

--- a/web/src/lib/registry-sort.test.ts
+++ b/web/src/lib/registry-sort.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { comparePopularThenName, isPopular, sortByPopular } from './registry-sort'
+
+describe('registry popularity ordering', () => {
+  const items = [
+    { name: 'Zulu' },
+    { name: 'Beta', tags: ['popular'] },
+    { name: 'Alpha', tags: ['popular'] },
+  ]
+
+  it('places popular items first and sorts each group by name', () => {
+    expect(sortByPopular(items).map((item) => item.name)).toEqual(['Alpha', 'Beta', 'Zulu'])
+    expect(items.map((item) => item.name)).toEqual(['Zulu', 'Beta', 'Alpha'])
+  })
+
+  it('exposes the same comparator and popularity predicate', () => {
+    expect([...items].sort(comparePopularThenName).map((item) => item.name)).toEqual([
+      'Alpha',
+      'Beta',
+      'Zulu',
+    ])
+    expect(isPopular(items[0])).toBe(false)
+    expect(isPopular(items[1])).toBe(true)
+  })
+})

--- a/web/src/lib/registry-sort.ts
+++ b/web/src/lib/registry-sort.ts
@@ -1,0 +1,17 @@
+interface PopularNamedItem {
+  name: string
+  tags?: string[]
+}
+
+export function isPopular(item: PopularNamedItem | undefined): boolean {
+  return item?.tags?.includes('popular') ?? false
+}
+
+export function comparePopularThenName(a: PopularNamedItem, b: PopularNamedItem): number {
+  const popularityOrder = Number(isPopular(b)) - Number(isPopular(a))
+  return popularityOrder || a.name.localeCompare(b.name)
+}
+
+export function sortByPopular<T extends PopularNamedItem>(items: readonly T[]): T[] {
+  return [...items].sort(comparePopularThenName)
+}

--- a/web/src/lib/useClipboardCopy.test.tsx
+++ b/web/src/lib/useClipboardCopy.test.tsx
@@ -1,0 +1,68 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useClipboardCopy } from './useClipboardCopy'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+  document.body.innerHTML = ''
+})
+
+describe('useClipboardCopy', () => {
+  it('clears its reset timer during unmount', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    function Harness() {
+      const { copied, copy } = useClipboardCopy()
+      return <button onClick={() => copy('registry link')}>{copied ? 'copied' : 'idle'}</button>
+    }
+
+    await act(async () => root.render(<Harness />))
+    await act(async () => {
+      container.querySelector('button')!.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toBe('copied')
+    expect(vi.getTimerCount()).toBe(1)
+
+    await act(async () => root.unmount())
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps copied state false when clipboard access fails', async () => {
+    vi.stubGlobal('navigator', {})
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    function Harness() {
+      const { copied, copy } = useClipboardCopy()
+      return <button onClick={() => copy('registry link')}>{copied ? 'copied' : 'idle'}</button>
+    }
+
+    await act(async () => root.render(<Harness />))
+    await act(async () => {
+      container.querySelector('button')!.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toBe('idle')
+    await act(async () => root.unmount())
+  })
+})

--- a/web/src/lib/useClipboardCopy.ts
+++ b/web/src/lib/useClipboardCopy.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export function useClipboardCopy(resetAfterMs = 1500) {
+  const [copied, setCopied] = useState(false)
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const copyRequestRef = useRef(0)
+
+  useEffect(() => () => {
+    copyRequestRef.current += 1
+    if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current)
+    resetTimerRef.current = null
+  }, [])
+
+  const copy = useCallback((text: string) => {
+    const request = ++copyRequestRef.current
+    if (resetTimerRef.current !== null) {
+      clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = null
+    }
+    setCopied(false)
+
+    void Promise.resolve()
+      .then(() => navigator.clipboard.writeText(text))
+      .then(
+        () => {
+          if (request !== copyRequestRef.current) return
+          setCopied(true)
+          resetTimerRef.current = setTimeout(() => {
+            if (request === copyRequestRef.current) setCopied(false)
+            resetTimerRef.current = null
+          }, resetAfterMs)
+        },
+        () => {
+          if (request === copyRequestRef.current) setCopied(false)
+        },
+      )
+  }, [resetAfterMs])
+
+  return { copied, copy }
+}

--- a/web/src/pages/RegistryDetailPage.test.tsx
+++ b/web/src/pages/RegistryDetailPage.test.tsx
@@ -1,0 +1,141 @@
+/** @vitest-environment jsdom */
+
+import { StrictMode, act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Detail, RegistryData } from '../useRegistry'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+function registryItem(id: string, name: string, localizedName: string): Detail {
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    category: 'messaging',
+    icon: 'message-circle',
+    i18n: { ja: { name: localizedName } },
+  }
+}
+
+function registryData(): RegistryData {
+  return {
+    hands: [],
+    channels: [
+      registryItem('alpha', 'Alpha', 'アルファ'),
+      registryItem('beta', 'Beta', 'ベータ'),
+      registryItem('gamma', 'Gamma', 'ガンマ'),
+    ],
+    providers: [],
+    workflows: [],
+    agents: [],
+    plugins: [],
+    skills: [],
+    mcp: [],
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(navigator, 'sendBeacon')
+  document.body.innerHTML = ''
+})
+
+describe('RegistryDetailPage click tracking', () => {
+  it('tracks a valid item once under Strict Mode and localizes adjacent names', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    const sendBeacon = vi.fn(() => true)
+    Object.defineProperty(navigator, 'sendBeacon', { configurable: true, value: sendBeacon })
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})))
+    window.history.replaceState(null, '', '/ja/channels/beta')
+
+    const [{ default: RegistryDetailPage }, { useAppStore }] = await Promise.all([
+      import('./RegistryDetailPage'),
+      import('../store'),
+    ])
+    useAppStore.setState({ lang: 'ja' })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    client.setQueryData(['registry'], registryData())
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <QueryClientProvider client={client}>
+            <RegistryDetailPage category="channels" id="beta" />
+          </QueryClientProvider>
+        </StrictMode>,
+      )
+      await Promise.resolve()
+    })
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1)
+    const adjacentNav = Array.from(container.querySelectorAll('nav')).find((nav) =>
+      nav.querySelector('a[href$="/channels/alpha"]'),
+    )
+    expect(adjacentNav?.textContent).toContain('アルファ')
+    expect(adjacentNav?.textContent).toContain('ガンマ')
+    expect(adjacentNav?.textContent).not.toContain('Alpha')
+    expect(adjacentNav?.textContent).not.toContain('Gamma')
+
+    await act(async () => root.unmount())
+    client.clear()
+    useAppStore.setState({ lang: 'en' })
+  })
+
+  it('does not track an unknown item', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    const sendBeacon = vi.fn(() => true)
+    Object.defineProperty(navigator, 'sendBeacon', { configurable: true, value: sendBeacon })
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})))
+    window.history.replaceState(null, '', '/channels/missing')
+
+    const [{ default: RegistryDetailPage }, { useAppStore }] = await Promise.all([
+      import('./RegistryDetailPage'),
+      import('../store'),
+    ])
+    useAppStore.setState({ lang: 'en' })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    client.setQueryData(['registry'], registryData())
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <QueryClientProvider client={client}>
+            <RegistryDetailPage category="channels" id="missing" />
+          </QueryClientProvider>
+        </StrictMode>,
+      )
+      await Promise.resolve()
+    })
+
+    expect(sendBeacon).not.toHaveBeenCalled()
+
+    await act(async () => root.unmount())
+    client.clear()
+  })
+})

--- a/web/src/pages/RegistryDetailPage.tsx
+++ b/web/src/pages/RegistryDetailPage.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useEffect } from 'react'
+import { useMemo, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowLeft, ArrowRight, Loader2, AlertCircle, ExternalLink, Sparkles, Copy, Check, Terminal, FileText, RotateCcw, Link as LinkIcon, Download, Star, TrendingUp } from 'lucide-react'
-import { useState } from 'react'
 import { useRegistry, getLocalizedDesc, getLocalizedName, getCategoryItems } from '../useRegistry'
-import type { RegistryCategory, Detail } from '../useRegistry'
+import type { RegistryCategory } from '../useRegistry'
 import { getTranslation } from '../i18n'
 import { useAppStore } from '../store'
 import { cn } from '../lib/utils'
@@ -15,6 +14,8 @@ import RegistryIcon from '../components/RegistryIcon'
 import { fetchRegistryRaw, pathCandidatesFor, fetchFirstAvailable } from '../lib/registry-raw'
 import { useMarketplace } from '../lib/useMarketplace'
 import { fmtNum } from '../lib/format'
+import { isPopular, sortByPopular } from '../lib/registry-sort'
+import { useClipboardCopy } from '../lib/useClipboardCopy'
 
 interface RegistryDetailPageProps {
   category: RegistryCategory
@@ -71,23 +72,17 @@ const COMMAND_TEMPLATE: Partial<Record<RegistryCategory, string>> = {
   mcp:          'librefang mcp add {id}',
 }
 
-function isPopular(item: Detail | undefined) {
-  return item?.tags?.includes('popular') ?? false
-}
-
 function AnchorLink({ id, title }: { id: string; title: string }) {
-  const [copied, setCopied] = useState(false)
+  const { copied, copy } = useClipboardCopy()
   return (
     <a
       href={`#${id}`}
       onClick={(e) => {
         e.preventDefault()
         const url = `${window.location.origin}${window.location.pathname}#${id}`
-        navigator.clipboard.writeText(url)
+        copy(url)
         // Also update history so the hash is visible in the URL bar.
         history.replaceState(null, '', `#${id}`)
-        setCopied(true)
-        setTimeout(() => setCopied(false), 1500)
       }}
       aria-label={title}
       title={title}
@@ -99,14 +94,10 @@ function AnchorLink({ id, title }: { id: string; title: string }) {
 }
 
 function CopyButton({ text, label }: { text: string; label: string }) {
-  const [copied, setCopied] = useState(false)
+  const { copied, copy } = useClipboardCopy()
   return (
     <button
-      onClick={() => {
-        navigator.clipboard.writeText(text)
-        setCopied(true)
-        setTimeout(() => setCopied(false), 1500)
-      }}
+      onClick={() => copy(text)}
       className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-mono text-gray-500 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors border border-black/10 dark:border-white/10 rounded"
     >
       {copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
@@ -125,28 +116,12 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
   // Related = same category, excluding self. Popular first, then alphabetical,
   // cap at 6 so the section is a browse surface not a wall of text.
   const related = useMemo(() => {
-    const rest = items.filter(x => x.id !== id)
-    rest.sort((a, b) => {
-      const ap = a.tags?.includes('popular') ? 0 : 1
-      const bp = b.tags?.includes('popular') ? 0 : 1
-      if (ap !== bp) return ap - bp
-      return a.name.localeCompare(b.name)
-    })
-    return rest.slice(0, 6)
+    return sortByPopular(items.filter(x => x.id !== id)).slice(0, 6)
   }, [items, id])
 
   // Prev/next for the bottom-of-page navigation strip. Same sort as the list
   // page so "next" matches what the visitor would expect from the grid.
-  const sortedCategory = useMemo(() => {
-    const sorted = [...items]
-    sorted.sort((a, b) => {
-      const ap = a.tags?.includes('popular') ? 0 : 1
-      const bp = b.tags?.includes('popular') ? 0 : 1
-      if (ap !== bp) return ap - bp
-      return a.name.localeCompare(b.name)
-    })
-    return sorted
-  }, [items])
+  const sortedCategory = useMemo(() => sortByPopular(items), [items])
   const currentIdx = sortedCategory.findIndex(x => x.id === id)
   const prevItem = currentIdx > 0 ? sortedCategory[currentIdx - 1] : undefined
   const nextItem = currentIdx >= 0 && currentIdx < sortedCategory.length - 1 ? sortedCategory[currentIdx + 1] : undefined
@@ -154,7 +129,7 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
   const pathCandidates = pathCandidatesFor(category, id)
   // Cache key is the primary path so the hover-prefetch on the list page
   // (which only knows the preferred layout) warms the same slot.
-  const primaryPath = pathCandidates[0]!
+  const primaryPath = pathCandidates[0]
   const rawQuery = useQuery({
     queryKey: ['registry-raw', primaryPath],
     queryFn: () => fetchFirstAvailable(pathCandidates),
@@ -168,7 +143,12 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
   // Fire-and-forget click tracking so trending can surface on list pages.
   // navigator.sendBeacon is queued by the browser even on unload, and doesn't
   // block the page at all. Some browsers fall back to fetch keepalive.
+  const trackedClickRef = useRef<string | null>(null)
   useEffect(() => {
+    if (!item) return
+    const trackingKey = `${category}/${id}`
+    if (trackedClickRef.current === trackingKey) return
+    trackedClickRef.current = trackingKey
     const body = JSON.stringify({ category, id })
     try {
       if ('sendBeacon' in navigator) {
@@ -183,7 +163,7 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
         }).catch(() => { /* ignore */ })
       }
     } catch { /* ignore */ }
-  }, [category, id])
+  }, [category, id, item])
 
   // Try each candidate README path in order until one 200s. Skills have
   // SKILL.md as canonical, other categories may or may not have a README.
@@ -535,7 +515,7 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
                   <ArrowLeft className="w-3 h-3" /> {t.registry?.previous || 'Previous'}
                 </span>
                 <span className="text-sm font-bold text-slate-900 dark:text-white group-hover:text-cyan-600 dark:group-hover:text-cyan-400 truncate max-w-full">
-                  {prevItem.name}
+                  {getLocalizedName(prevItem, lang)}
                 </span>
               </a>
             ) : <div />}
@@ -548,7 +528,7 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
                   {t.registry?.next || 'Next'} <ArrowRight className="w-3 h-3" />
                 </span>
                 <span className="text-sm font-bold text-slate-900 dark:text-white group-hover:text-cyan-600 dark:group-hover:text-cyan-400 truncate max-w-full">
-                  {nextItem.name}
+                  {getLocalizedName(nextItem, lang)}
                 </span>
               </a>
             ) : <div />}

--- a/web/src/pages/RegistryPage.tsx
+++ b/web/src/pages/RegistryPage.tsx
@@ -15,6 +15,7 @@ import RegistryIcon from '../components/RegistryIcon'
 import { useFavorites } from '../lib/useFavorites'
 import { useMarketplace, type MarketplacePkg } from '../lib/useMarketplace'
 import { fmtNum } from '../lib/format'
+import { comparePopularThenName, isPopular } from '../lib/registry-sort'
 // Fixed top header needs content to start below its 64px band.
 
 interface RegistryPageProps {
@@ -46,10 +47,6 @@ function getCategoryLabels(t: Translation, category: RegistryCategory): { title:
   return { title: category, desc: '' }
 }
 
-function isPopular(item: Detail) {
-  return item.tags?.includes('popular') ?? false
-}
-
 type SortKey = 'popular' | 'nameAsc' | 'nameDesc' | 'trending' | 'downloads' | 'weekly'
 
 const SORT_KEYS: SortKey[] = ['popular', 'nameAsc', 'nameDesc', 'trending', 'downloads', 'weekly']
@@ -74,12 +71,7 @@ function sortItems(items: Detail[], key: SortKey, trendingIds: Map<string, numbe
       return arr.sort((a, b) => (marketplace.get(b.id)?.weekly_downloads ?? 0) - (marketplace.get(a.id)?.weekly_downloads ?? 0))
     case 'popular':
     default:
-      return arr.sort((a, b) => {
-        const ap = isPopular(a) ? 0 : 1
-        const bp = isPopular(b) ? 0 : 1
-        if (ap !== bp) return ap - bp
-        return a.name.localeCompare(b.name)
-      })
+      return arr.sort(comparePopularThenName)
   }
 }
 
@@ -389,7 +381,7 @@ export default function RegistryPage({ category, onOpenSearch }: RegistryPagePro
               // { content, path } in this slot — we mirror that shape so
               // the prefetch and the real query share one cache entry.
               const candidates = pathCandidatesFor(category, item.id)
-              const primaryPath = candidates[0]!
+              const primaryPath = candidates[0]
               const prefetch = () => {
                 // Warm the detail page's raw-TOML cache the moment the user
                 // hovers a card. react-query dedupes if the query is already


### PR DESCRIPTION
## Substantive changes

- Track registry detail clicks only after the requested item exists and de-duplicate Strict Mode effect replay.
- Encode the non-empty registry path-candidate contract in the return type and remove unchecked primary-path assertions from list and detail pages.
- Share popular-first ordering between the registry list, related items, and previous/next navigation.
- Localize previous and next item names consistently with the rest of the detail page.
- Share clipboard feedback behavior that handles unavailable or rejected writes and clears reset timers during unmount.
- Add focused regressions for click validity and de-duplication, localized navigation, ordering, clipboard failure, and timer cleanup.

## Verification

- `mise exec -- pnpm --dir web test` (49 tests across 12 files)
- `mise exec -- pnpm --dir web lint`
- `GITHUB_TOKEN="$(gh auth token)" mise exec -- pnpm --dir web build`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Minimal Markdown parsing remains isolated in #7676.
- This PR addresses the audited `RegistryDetailPage` findings and its shared list-ordering contract only.
- The broader OCR audit remains in progress.