### PR TITLE
fix(web): harden homepage data contracts

### DIFF
--- a/changelog.d/fixed/7682-web-app-contracts.md
+++ b/changelog.d/fixed/7682-web-app-contracts.md
@@ -1,0 +1,2 @@
+Harden homepage release data, large asset-size labels, SDK copy feedback, and analytics typing.
+Homepage download copy now lives in the shared translation catalog for every selectable locale, and conflicting theme classes and dead scroll state were removed (#7682) (@houko)

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,9 +3,10 @@
 
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { Translation } from './i18n'
+import { getTranslation, type Translation } from './i18n'
 
 const withStats = {
   common: {
@@ -92,5 +93,87 @@ describe('GitHubStats', () => {
 
     expect(signals).toHaveLength(4)
     expect(signals.every(signal => signal.aborted)).toBe(true)
+  })
+})
+
+describe('homepage downloads', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    Reflect.deleteProperty(navigator, 'clipboard')
+    document.body.innerHTML = ''
+  })
+
+  it('formats gigabyte assets without inflating the megabyte label', async () => {
+    const { formatSize } = await import('./App')
+
+    expect(formatSize(1536 * 1024 ** 2)).toBe('1.5GB')
+    expect(formatSize(16 * 1024 ** 2)).toBe('16MB')
+    expect(formatSize(512 * 1024)).toBe('512KB')
+  })
+
+  it('rejects an empty release response explicitly', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response))
+    const { fetchLatestRelease } = await import('./App')
+
+    await expect(fetchLatestRelease()).rejects.toThrow('No releases available')
+  })
+
+  it('drives SDK copy feedback from React state after a successful write', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    vi.stubGlobal('IntersectionObserver', class {
+      readonly root = null
+      readonly rootMargin = '0px'
+      readonly thresholds = [0]
+      disconnect() {}
+      observe() {}
+      takeRecords(): IntersectionObserverEntry[] { return [] }
+      unobserve() {}
+    })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})))
+    const { Downloads } = await import('./App')
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <Downloads t={getTranslation('en')} />
+        </QueryClientProvider>,
+      )
+    })
+    const button = container.querySelector<HTMLButtonElement>('[aria-label="Copy Python"]')!
+    const feedback = button.querySelector('.copy-tip')!
+    expect(feedback.classList.contains('opacity-0')).toBe(true)
+
+    await act(async () => {
+      button.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(writeText).toHaveBeenCalledWith('pip install librefang')
+    expect(feedback.classList.contains('opacity-100')).toBe(true)
+    expect(feedback.classList.contains('opacity-0')).toBe(false)
+
+    await act(async () => root.unmount())
+    client.clear()
   })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -270,7 +270,7 @@ function Architecture({ t }: SectionProps) {
     <section id="architecture" className="py-28 px-6 scroll-mt-20">
       <div className="max-w-6xl mx-auto">
         <FadeIn>
-          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">{t.architecture.label}</div>
+          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">{t.architecture.label}</div>
           <h2 className="text-3xl md:text-5xl font-black text-slate-900 dark:text-white tracking-tight mb-4">{t.architecture.title}</h2>
           <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mb-16">{t.architecture.desc}</p>
         </FadeIn>
@@ -380,13 +380,11 @@ function Hands({ t }: SectionProps) {
   const lang = useAppStore((s) => s.lang)
   const rawHands = registry?.hands && registry.hands.length > 0 ? registry.hands : []
   const hands = sortByPopularity(rawHands)
-  const scrollRef = useRef<HTMLDivElement>(null)
-
   return (
     <section id="hands" className="py-28 scroll-mt-20">
       <div className="max-w-6xl mx-auto px-6">
         <FadeIn>
-          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">{t.hands.label}</div>
+          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">{t.hands.label}</div>
           <h2 className="text-3xl md:text-5xl font-black text-slate-900 dark:text-white tracking-tight mb-4">{t.hands.title}</h2>
           <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mb-16">{t.hands.desc}</p>
         </FadeIn>
@@ -394,10 +392,7 @@ function Hands({ t }: SectionProps) {
 
       <div className="max-w-6xl mx-auto px-6">
         <FadeIn>
-          <div
-            ref={scrollRef}
-            className="overflow-x-auto scrollbar-hide -mr-6 pr-6 pb-4 touch-pan-x"
-          >
+          <div className="overflow-x-auto scrollbar-hide -mr-6 pr-6 pb-4 touch-pan-x">
             <div className="grid grid-rows-2 grid-flow-col gap-3 w-max">
               {hands.map((hand) => {
                 const colorClass = categoryColors[hand.category] ?? 'text-gray-600 dark:text-gray-400/60'
@@ -433,7 +428,7 @@ function Performance({ t }: SectionProps) {
     <section id="performance" className="py-28 px-6 scroll-mt-20">
       <div className="max-w-6xl mx-auto">
         <FadeIn>
-          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">{t.performance.label}</div>
+          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">{t.performance.label}</div>
           <h2 className="text-3xl md:text-5xl font-black text-slate-900 dark:text-white tracking-tight mb-4">{t.performance.title}</h2>
           <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mb-16">{t.performance.desc}</p>
         </FadeIn>
@@ -669,8 +664,9 @@ interface DownloadItem {
   assets: { name: string; url: string; size: string }[]
 }
 
-function formatSize(bytes: number): string {
-  if (bytes > 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(0)}MB`
+export function formatSize(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)}GB`
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(0)}MB`
   return `${(bytes / 1024).toFixed(0)}KB`
 }
 
@@ -733,17 +729,30 @@ function categorizeAssets(assets: ReleaseAsset[]): DownloadItem[] {
 // Need to import Monitor at the top - it's used in Downloads
 // Adding it via the LucideIcon type already imported
 
-function Downloads(_props: SectionProps) {
-  const lang = useAppStore((s) => s.lang)
-  const common = getTranslation(lang).common!
+interface ReleaseInfo {
+  tag_name: string
+  assets: ReleaseAsset[]
+  html_url: string
+}
+
+export async function fetchLatestRelease(): Promise<ReleaseInfo> {
+  const res = await fetch('https://stats.librefang.ai/api/releases')
+  if (!res.ok) throw new Error('Failed to load releases')
+  const releases = await res.json() as ReleaseInfo[]
+  const release = releases[0]
+  if (!release) throw new Error('No releases available')
+  return release
+}
+
+export function Downloads({ t }: SectionProps) {
+  const common = t.common!
+  const labels = t.downloads ?? getTranslation('en').downloads!
+  const [copiedPackage, setCopiedPackage] = useState<string | null>(null)
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const copyRequestRef = useRef(0)
   const { data: release, isLoading } = useQuery({
     queryKey: ['latestRelease'],
-    queryFn: async () => {
-      const res = await fetch('https://stats.librefang.ai/api/releases')
-      if (!res.ok) throw new Error('Failed')
-      const releases = await res.json() as { tag_name: string; assets: ReleaseAsset[]; html_url: string }[]
-      return releases[0]
-    },
+    queryFn: fetchLatestRelease,
     staleTime: 1000 * 60 * 60,
     retry: 2,
   })
@@ -751,24 +760,35 @@ function Downloads(_props: SectionProps) {
   const categories = release ? categorizeAssets(release.assets) : []
   const version = release?.tag_name ?? ''
 
-  const labels: Record<string, Record<string, string>> = {
-    title: { en: 'Downloads', zh: '下载', 'zh-TW': '下載', ja: 'ダウンロード', ko: '다운로드', de: 'Downloads', es: 'Descargas', pl: 'Pobieranie' },
-    desc: {
-      en: 'Desktop app, CLI binaries, and deployment options.',
-      zh: '桌面应用、CLI 二进制文件和部署选项。',
-      'zh-TW': '桌面應用、CLI 二進位檔和部署選項。',
-      ja: 'デスクトップアプリ、CLIバイナリ、デプロイオプション。',
-      ko: '데스크톱 앱, CLI 바이너리, 배포 옵션.',
-      de: 'Desktop-App, CLI-Binaries und Deployment-Optionen.',
-      es: 'App de escritorio, binarios CLI y opciones de despliegue.',
-      pl: 'Aplikacja komputerowa, pliki binarne CLI i opcje wdrażania.',
-    },
-    onlineDeply: { en: 'One-Click Deploy', zh: '一键部署', 'zh-TW': '一鍵部署', ja: 'ワンクリックデプロイ', ko: '원클릭 배포', de: 'Ein-Klick-Deploy', es: 'Despliegue en un clic', pl: 'Wdrożenie jednym kliknięciem' },
-    allReleases: { en: 'All Releases', zh: '所有版本', 'zh-TW': '所有版本', ja: '全リリース', ko: '모든 릴리스', de: 'Alle Releases', es: 'Todas las versiones', pl: 'Wszystkie wydania' },
-    sdk: { en: 'SDK & Packages', zh: 'SDK 和包', 'zh-TW': 'SDK 和套件', ja: 'SDK & パッケージ', ko: 'SDK & 패키지', de: 'SDK & Pakete', es: 'SDK y paquetes', pl: 'SDK i pakiety' },
-  }
+  useEffect(() => () => {
+    copyRequestRef.current += 1
+    if (copyResetRef.current !== null) clearTimeout(copyResetRef.current)
+    copyResetRef.current = null
+  }, [])
 
-  const l = (key: string) => labels[key]?.[lang] ?? labels[key]?.['en'] ?? key
+  const copyPackage = (key: string, text: string) => {
+    const request = ++copyRequestRef.current
+    if (copyResetRef.current !== null) {
+      clearTimeout(copyResetRef.current)
+      copyResetRef.current = null
+    }
+    setCopiedPackage(null)
+    void Promise.resolve()
+      .then(() => navigator.clipboard.writeText(text))
+      .then(
+        () => {
+          if (request !== copyRequestRef.current) return
+          setCopiedPackage(key)
+          copyResetRef.current = setTimeout(() => {
+            if (request === copyRequestRef.current) setCopiedPackage(null)
+            copyResetRef.current = null
+          }, 1500)
+        },
+        () => {
+          if (request === copyRequestRef.current) setCopiedPackage(null)
+        },
+      )
+  }
 
   return (
     <section id="downloads" className="py-28 px-6 scroll-mt-20">
@@ -776,10 +796,10 @@ function Downloads(_props: SectionProps) {
         <FadeIn>
           <div className="text-xs font-mono text-cyan-600 dark:text-cyan-500 uppercase tracking-widest mb-3">
             {version && <span className="text-gray-400 dark:text-gray-600 mr-2">{version}</span>}
-            {l('title')}
+            {labels.title}
           </div>
-          <h2 className="text-3xl md:text-5xl font-black text-slate-900 dark:text-white tracking-tight mb-4">{l('title')}</h2>
-          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mb-16">{l('desc')}</p>
+          <h2 className="text-3xl md:text-5xl font-black text-slate-900 dark:text-white tracking-tight mb-4">{labels.title}</h2>
+          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mb-16">{labels.desc}</p>
         </FadeIn>
 
         {/* Desktop & CLI */}
@@ -814,7 +834,7 @@ function Downloads(_props: SectionProps) {
                 <div className="flex items-center gap-3 mb-4">
                   <Globe className="w-5 h-5 text-cyan-600 dark:text-cyan-500" />
                   <div>
-                    <h3 className="text-base font-bold text-slate-900 dark:text-white">{l('onlineDeply')}</h3>
+                    <h3 className="text-base font-bold text-slate-900 dark:text-white">{labels.onlineDeploy}</h3>
                     <span className="text-xs text-gray-500">deploy.librefang.ai</span>
                   </div>
                 </div>
@@ -844,7 +864,7 @@ function Downloads(_props: SectionProps) {
             <div className="bg-surface-100 border border-black/10 dark:border-white/5 p-5">
               <div className="flex items-center gap-3 mb-4">
                 <Box className="w-5 h-5 text-cyan-600 dark:text-cyan-500" />
-                <h3 className="text-base font-bold text-slate-900 dark:text-white">{l('sdk')}</h3>
+                <h3 className="text-base font-bold text-slate-900 dark:text-white">{labels.sdk}</h3>
               </div>
               <div className="grid grid-cols-2 gap-3">
                 {[
@@ -853,22 +873,30 @@ function Downloads(_props: SectionProps) {
                   { cmd: 'cargo add librefang', copy: 'cargo add librefang', label: 'Rust' },
                   { cmd: 'go get librefang/sdk', copy: 'go get github.com/librefang/librefang/sdk/go', label: 'Go' },
                 ].map((pkg) => (
-                  <button key={pkg.label} className="bg-surface-200 px-3 py-2.5 text-left hover:bg-surface-300 transition-colors relative group" onClick={(e) => {
-                    navigator.clipboard.writeText(pkg.copy)
-                    const el = e.currentTarget.querySelector('.copy-tip') as HTMLElement
-                    if (el) { el.classList.remove('opacity-0'); setTimeout(() => el.classList.add('opacity-0'), 1500) }
-                  }}>
+                  <button
+                    key={pkg.label}
+                    className="bg-surface-200 px-3 py-2.5 text-left hover:bg-surface-300 transition-colors relative group"
+                    onClick={() => copyPackage(pkg.label, pkg.copy)}
+                    aria-label={`${common.copy} ${pkg.label}`}
+                  >
                     <div className="text-xs text-gray-500 mb-1">{pkg.label}</div>
                     <code className="text-[11px] text-gray-700 dark:text-gray-300 font-mono">{pkg.cmd}</code>
                     <Copy className="absolute top-2 right-2 w-3 h-3 text-gray-400 dark:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity" />
-                    <span className="copy-tip absolute top-1 right-1 text-[9px] text-cyan-600 dark:text-cyan-400 opacity-0 transition-opacity">{common.copied}</span>
+                    <span
+                      className={cn(
+                        'copy-tip absolute top-1 right-1 text-[9px] text-cyan-600 dark:text-cyan-400 transition-opacity',
+                        copiedPackage === pkg.label ? 'opacity-100' : 'opacity-0',
+                      )}
+                    >
+                      {common.copied}
+                    </span>
                   </button>
                 ))}
               </div>
             </div>
             <a href="https://github.com/librefang/librefang/releases" target="_blank" rel="noopener noreferrer" className="flex flex-col items-center justify-center bg-surface-100 border border-black/10 dark:border-white/5 hover:border-cyan-500/20 p-6 transition-all group">
               <Github className="w-8 h-8 text-gray-400 dark:text-gray-600 group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors mb-3" />
-              <span className="text-sm font-semibold text-gray-700 dark:text-gray-300 group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors">{l('allReleases')}</span>
+              <span className="text-sm font-semibold text-gray-700 dark:text-gray-300 group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors">{labels.allReleases}</span>
               <span className="text-xs text-gray-500 mt-1">{version}</span>
             </a>
           </div>
@@ -1315,8 +1343,8 @@ function Footer({ t }: SectionProps) {
 
 // ─── GA event tracking ───
 function trackEvent(action: string, label: string) {
-  if (typeof window !== 'undefined' && 'gtag' in window) {
-    (window as any).gtag('event', action, { event_category: 'engagement', event_label: label })
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', action, { event_category: 'engagement', event_label: label })
   }
 }
 

--- a/web/src/i18n.test.ts
+++ b/web/src/i18n.test.ts
@@ -33,6 +33,17 @@ describe('i18n completeness', () => {
     expect(languages.some(lang => lang.code === 'uk')).toBe(true)
   })
 
+  it('keeps homepage download copy in every raw locale catalog', () => {
+    for (const lang of languages) {
+      const downloads = rawTranslations[lang.code]?.downloads
+      expect(downloads?.title, `${lang.code} downloads.title`).toBeTruthy()
+      expect(downloads?.desc, `${lang.code} downloads.desc`).toBeTruthy()
+      expect(downloads?.onlineDeploy, `${lang.code} downloads.onlineDeploy`).toBeTruthy()
+      expect(downloads?.allReleases, `${lang.code} downloads.allReleases`).toBeTruthy()
+      expect(downloads?.sdk, `${lang.code} downloads.sdk`).toBeTruthy()
+    }
+  })
+
   it('falls back to English when a locale is unknown', () => {
     expect(getTranslation('missing-locale').hero.title1).toBe(rawTranslations.en!.hero.title1)
   })

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -68,6 +68,13 @@ export interface Translation {
     reqItems: string[]
     incItems: string[]
   }
+  downloads?: {
+    title: string
+    desc: string
+    onlineDeploy: string
+    allReleases: string
+    sdk: string
+  }
   faq: {
     label: string
     title: string
@@ -335,6 +342,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   pl: {
     nav: { architecture: 'Architektura', hands: 'Ręce', performance: 'Wydajność', install: 'Instalacja', downloads: 'Pobieranie', docs: 'Dokumentacja', features: 'Rynek', evolution: 'Samodoskonalenie Umiejętności', workflows: 'Przepływy Pracy', registry: 'Rejestr', learnMore: 'Funkcje' },
+    downloads: {
+      title: 'Pobieranie',
+      desc: 'Aplikacja komputerowa, pliki binarne CLI i opcje wdrażania.',
+      onlineDeploy: 'Wdrożenie jednym kliknięciem',
+      allReleases: 'Wszystkie wydania',
+      sdk: 'SDK i pakiety',
+    },
     hero: {
       badge: 'Open Source',
       title1: 'Agentowy',
@@ -842,6 +856,13 @@ export const rawTranslations: Record<string, Translation> = {
   },
   en: {
     nav: { architecture: 'Architecture', hands: 'Hands', performance: 'Performance', install: 'Install', downloads: 'Downloads', docs: 'Docs', features: 'Marketplace', evolution: 'Skills Self-Evolution', workflows: 'Workflows', registry: 'Registry', learnMore: 'Features' },
+    downloads: {
+      title: 'Downloads',
+      desc: 'Desktop app, CLI binaries, and deployment options.',
+      onlineDeploy: 'One-Click Deploy',
+      allReleases: 'All Releases',
+      sdk: 'SDK & Packages',
+    },
     hero: {
       badge: 'Open Source',
       title1: 'The Agent',
@@ -1285,6 +1306,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   zh: {
     nav: { architecture: '架构', hands: '能力单元', performance: '性能', install: '安装', downloads: '下载', docs: '文档', features: '市场', evolution: '技能自我进化', workflows: '工作流', registry: '注册表', learnMore: '功能' },
+    downloads: {
+      title: '下载',
+      desc: '桌面应用、CLI 二进制文件和部署选项。',
+      onlineDeploy: '一键部署',
+      allReleases: '所有版本',
+      sdk: 'SDK 和包',
+    },
     hero: {
       badge: '开源',
       title1: 'Agent',
@@ -1775,6 +1803,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   'zh-TW': {
     nav: { architecture: '架構', hands: '能力單元', performance: '效能', install: '安裝', downloads: '下載', docs: '文件', features: '市場', evolution: '技能自我進化', workflows: '工作流', registry: '註冊表', learnMore: '功能' },
+    downloads: {
+      title: '下載',
+      desc: '桌面應用、CLI 二進位檔和部署選項。',
+      onlineDeploy: '一鍵部署',
+      allReleases: '所有版本',
+      sdk: 'SDK 和套件',
+    },
     hero: {
       badge: '開源',
       title1: 'Agent',
@@ -2257,6 +2292,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   ja: {
     nav: { architecture: 'アーキテクチャ', hands: 'Hands', performance: 'パフォーマンス', install: 'インストール', downloads: 'ダウンロード', docs: 'ドキュメント', features: 'マーケットプレイス', evolution: 'スキル自己進化', workflows: 'ワークフロー', registry: 'レジストリ', learnMore: '機能' },
+    downloads: {
+      title: 'ダウンロード',
+      desc: 'デスクトップアプリ、CLIバイナリ、デプロイオプション。',
+      onlineDeploy: 'ワンクリックデプロイ',
+      allReleases: '全リリース',
+      sdk: 'SDK & パッケージ',
+    },
     hero: {
       badge: 'オープンソース',
       title1: 'Agent',
@@ -2739,6 +2781,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   ko: {
     nav: { architecture: '아키텍처', hands: 'Hands', performance: '성능', install: '설치', downloads: '다운로드', docs: '문서', features: '마켓플레이스', evolution: '스킬 자가 진화', workflows: '워크플로우', registry: '레지스트리', learnMore: '기능' },
+    downloads: {
+      title: '다운로드',
+      desc: '데스크톱 앱, CLI 바이너리, 배포 옵션.',
+      onlineDeploy: '원클릭 배포',
+      allReleases: '모든 릴리스',
+      sdk: 'SDK & 패키지',
+    },
     hero: {
       badge: '오픈소스',
       title1: 'Agent',
@@ -3221,6 +3270,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   de: {
     nav: { architecture: 'Architektur', hands: 'Hands', performance: 'Leistung', install: 'Installation', downloads: 'Downloads', docs: 'Dokumentation', features: 'Marktplatz', evolution: 'Skill-Selbstentwicklung', workflows: 'Workflows', registry: 'Registry', learnMore: 'Funktionen' },
+    downloads: {
+      title: 'Downloads',
+      desc: 'Desktop-App, CLI-Binaries und Deployment-Optionen.',
+      onlineDeploy: 'Ein-Klick-Deploy',
+      allReleases: 'Alle Releases',
+      sdk: 'SDK & Pakete',
+    },
     hero: {
       badge: 'Open Source',
       title1: 'Der Agent',
@@ -3703,6 +3759,13 @@ export const rawTranslations: Record<string, Translation> = {
 
   es: {
     nav: { architecture: 'Arquitectura', hands: 'Hands', performance: 'Rendimiento', install: 'Instalar', downloads: 'Descargas', docs: 'Documentación', features: 'Marketplace', evolution: 'Autoevolución de Skills', workflows: 'Flujos de trabajo', registry: 'Registry', learnMore: 'Funciones' },
+    downloads: {
+      title: 'Descargas',
+      desc: 'App de escritorio, binarios CLI y opciones de despliegue.',
+      onlineDeploy: 'Despliegue en un clic',
+      allReleases: 'Todas las versiones',
+      sdk: 'SDK y paquetes',
+    },
     hero: {
       badge: 'Código Abierto',
       title1: 'El Agente',
@@ -4186,6 +4249,13 @@ export const rawTranslations: Record<string, Translation> = {
 
 rawTranslations.uk = {
   nav: { architecture: 'Архітектура', hands: 'Hands', performance: 'Продуктивність', install: 'Встановлення', downloads: 'Завантаження', docs: 'Документація', features: 'Маркетплейс', evolution: 'Саморозвиток навичок', workflows: 'Робочі процеси', registry: 'Реєстр', learnMore: 'Можливості' },
+  downloads: {
+    title: 'Завантаження',
+    desc: 'Десктопний застосунок, CLI-бінарні файли та варіанти розгортання.',
+    onlineDeploy: 'Розгортання в один клік',
+    allReleases: 'Усі релізи',
+    sdk: 'SDK і пакети',
+  },
   hero: {
     badge: 'Open Source',
     title1: 'Агентна',

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -2,6 +2,11 @@
 declare global {
   interface Window {
     __INITIAL_LANG__?: string
+    gtag?: (
+      command: 'event',
+      action: string,
+      params: { event_category: string; event_label: string },
+    ) => void
   }
 }
 export {}


### PR DESCRIPTION
## Substantive changes

- Reject an empty latest-release response explicitly and format assets of at least one GiB with a GB label.
- Drive SDK package copy feedback from React state after a successful Clipboard API write, with stale-request and unmount cleanup.
- Move homepage download copy into the shared translation catalog for all nine selectable locales and correct `onlineDeploy` naming.
- Remove conflicting dark-mode utilities and unused carousel ref state.
- Declare the analytics function on `Window` and remove the unchecked `any` cast.
- Add regressions for empty release data, GB formatting, React-driven copy feedback, and raw-locale download coverage.

## Verification

- `mise exec -- pnpm --dir web test` (47 tests)
- `mise exec -- pnpm --dir web lint`
- `GITHUB_TOKEN="$(gh auth token)" mise exec -- pnpm --dir web build`
- `mise exec -- pnpm --dir web i18n:audit --all` (all new `downloads.*` keys complete; still reports the seven pre-existing `partner.*` / `footer.everyapi` gaps outside `zh`)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Merged #6795 already fixes the conditional GitHub stats hooks and aborts their requests during unmount.
- The existing EveryAPI partner translation gaps require separate translation review.
- This PR addresses the remaining audited `App.tsx` findings only.
- The broader OCR audit remains in progress.