### PR TITLE
fix(web): harden breadcrumb contracts

### DIFF
--- a/changelog.d/fixed/7684-web-breadcrumb-contracts.md
+++ b/changelog.d/fixed/7684-web-breadcrumb-contracts.md
@@ -1,0 +1,3 @@
+Website breadcrumbs now fall back safely when optional translation blocks are absent. (#7684) (@houko)
+
+Breadcrumb separators are hidden from assistive technology, crumb identity remains stable across updates, and overflow uses one horizontal-scroll strategy. (#7684) (@houko)

--- a/web/src/components/Breadcrumbs.test.tsx
+++ b/web/src/components/Breadcrumbs.test.tsx
@@ -1,0 +1,71 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Translation } from '../i18n'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+describe('Breadcrumbs', () => {
+  it('falls back safely when optional translation blocks are absent', async () => {
+    const { getBreadcrumbCopy } = await import('./Breadcrumbs')
+
+    expect(getBreadcrumbCopy({} as Translation)).toEqual({
+      label: 'Breadcrumb',
+      backHome: 'Back',
+    })
+  })
+
+  it('hides separators and preserves crumb nodes when entries are inserted', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    const [{ default: Breadcrumbs }, { useAppStore }] = await Promise.all([
+      import('./Breadcrumbs'),
+      import('../store'),
+    ])
+    useAppStore.setState({ lang: 'en' })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<Breadcrumbs crumbs={[{ label: 'Alpha', href: '/alpha' }, { label: 'Current' }]} />)
+    })
+    const alphaLink = container.querySelector<HTMLAnchorElement>('a[href="/alpha"]')!
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Breadcrumb')
+    expect(Array.from(container.querySelectorAll('span[aria-hidden="true"]'))).toHaveLength(2)
+    expect(alphaLink.classList.contains('truncate')).toBe(false)
+
+    await act(async () => {
+      root.render(
+        <Breadcrumbs
+          crumbs={[
+            { label: 'Inserted', href: '/inserted' },
+            { label: 'Alpha', href: '/alpha' },
+            { label: 'Current' },
+          ]}
+        />,
+      )
+    })
+
+    expect(container.querySelector('a[href="/alpha"]')).toBe(alphaLink)
+
+    await act(async () => root.unmount())
+  })
+})

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import { cn } from '../lib/utils'
 import { useAppStore } from '../store'
 import { getTranslation } from '../i18n'
+import type { Translation } from '../i18n'
 import { ArrowLeft } from 'lucide-react'
 
 export interface Crumb {
@@ -13,6 +14,13 @@ interface BreadcrumbsProps {
   className?: string
 }
 
+export function getBreadcrumbCopy(t: Translation) {
+  return {
+    label: t.common?.breadcrumb ?? 'Breadcrumb',
+    backHome: t.registry?.backHome ?? 'Back',
+  }
+}
+
 // Breadcrumb strip rendered in page content (not inside the fixed header),
 // so the header stays byte-for-byte identical across homepage and subpages.
 // The first segment is always "Home → ..." linking to the language-aware
@@ -20,23 +28,23 @@ interface BreadcrumbsProps {
 export default function Breadcrumbs({ crumbs, className }: BreadcrumbsProps) {
   const lang = useAppStore(s => s.lang)
   const t = getTranslation(lang)
-  const common = t.common!
+  const copy = getBreadcrumbCopy(t)
   const homeHref = lang === 'en' ? '/' : `/${lang}/`
   return (
-    <nav aria-label={common.breadcrumb} className={cn('flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 min-w-0 overflow-x-auto whitespace-nowrap', className)}>
+    <nav aria-label={copy.label} className={cn('flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 min-w-0 overflow-x-auto whitespace-nowrap', className)}>
       <a href={homeHref} className="inline-flex items-center gap-1 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors shrink-0">
         <ArrowLeft className="w-3.5 h-3.5" />
-        {t.registry!.backHome}
+        {copy.backHome}
       </a>
       {crumbs.map((c, i) => {
         const isLast = i === crumbs.length - 1
         return (
-          <span key={i} className="flex items-center gap-1.5 min-w-0">
-            <span className="text-gray-300 dark:text-gray-700 shrink-0">/</span>
+          <span key={`${c.href ?? 'current'}:${c.label}`} className="flex items-center gap-1.5 shrink-0">
+            <span aria-hidden="true" className="text-gray-300 dark:text-gray-700 shrink-0">/</span>
             {isLast || !c.href ? (
-              <span className={cn('truncate', isLast ? 'text-slate-900 dark:text-white font-semibold' : '')}>{c.label}</span>
+              <span className={cn(isLast && 'text-slate-900 dark:text-white font-semibold')}>{c.label}</span>
             ) : (
-              <a href={c.href} className="hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors truncate">{c.label}</a>
+              <a href={c.href} className="hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors">{c.label}</a>
             )}
           </span>
         )


### PR DESCRIPTION
## Summary

- fall back safely when optional breadcrumb translation blocks are absent
- preserve crumb identity across insertions with stable keys
- hide decorative separators from assistive technology
- use one horizontal-scroll overflow strategy and simplify conditional styling

## Verification

- `mise exec -- pnpm --dir web test` (45 tests across 10 files)
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- This PR only addresses the audited breadcrumb component.
- The broader OCR audit remains for follow-up PRs.