### PR TITLE
fix(web): normalize registry icon contracts

### DIFF
--- a/changelog.d/fixed/7685-web-registry-icon-contracts.md
+++ b/changelog.d/fixed/7685-web-registry-icon-contracts.md
@@ -1,3 +1,3 @@
-Registry icons now resolve Lucide names without case sensitivity and apply shared classes to legacy emoji fallbacks. (#7685) (@houko)
+Registry icons now resolve Lucide names without case sensitivity, warn during development when names are unknown, and apply shared classes to legacy emoji fallbacks. (#7685) (@houko)
 
 The registry icon map now uses the SVG component contract shared by Lucide and local brand icons. (#7685) (@houko)

--- a/changelog.d/fixed/7685-web-registry-icon-contracts.md
+++ b/changelog.d/fixed/7685-web-registry-icon-contracts.md
@@ -1,0 +1,3 @@
+Registry icons now resolve Lucide names without case sensitivity and apply shared classes to legacy emoji fallbacks. (#7685) (@houko)
+
+The registry icon map now uses the SVG component contract shared by Lucide and local brand icons. (#7685) (@houko)

--- a/web/src/components/RegistryIcon.test.tsx
+++ b/web/src/components/RegistryIcon.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import RegistryIcon from './RegistryIcon'
 
 describe('RegistryIcon', () => {
@@ -21,5 +21,15 @@ describe('RegistryIcon', () => {
     expect(markup).toContain('w-10')
     expect(markup).toContain('text-4xl')
     expect(markup).not.toContain('text-xl')
+  })
+
+  it('warns during development when a normalized icon name is unknown', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const markup = renderToStaticMarkup(<RegistryIcon icon="Lucide:Not-In-The-Map" />)
+
+    expect(markup).toContain('lucide-box')
+    expect(warn).toHaveBeenCalledWith('Unknown registry icon: Lucide:Not-In-The-Map')
+    warn.mockRestore()
   })
 })

--- a/web/src/components/RegistryIcon.test.tsx
+++ b/web/src/components/RegistryIcon.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import RegistryIcon from './RegistryIcon'
+
+describe('RegistryIcon', () => {
+  it('resolves lucide and brand icon names without case sensitivity', () => {
+    const github = renderToStaticMarkup(<RegistryIcon icon="Lucide:GitHub" className="registry-size" />)
+    const search = renderToStaticMarkup(<RegistryIcon icon="lucide:SEARCH" className="registry-size" />)
+
+    expect(github).toContain('fill="currentColor"')
+    expect(github).toContain('class="registry-size"')
+    expect(search).toContain('class="lucide lucide-search registry-size"')
+  })
+
+  it('forwards common and fallback classes to legacy emoji icons', () => {
+    const markup = renderToStaticMarkup(
+      <RegistryIcon icon="🦊" className="shared-color w-10" fallbackClassName="text-4xl" />,
+    )
+
+    expect(markup).toContain('shared-color')
+    expect(markup).toContain('w-10')
+    expect(markup).toContain('text-4xl')
+    expect(markup).not.toContain('text-xl')
+  })
+})

--- a/web/src/components/RegistryIcon.tsx
+++ b/web/src/components/RegistryIcon.tsx
@@ -8,13 +8,16 @@ import {
   Save, Search, Shield, Shuffle, Signal, Smartphone, Sparkles, Square,
   Target, TrendingUp, Users, Volume2,
 } from 'lucide-react'
-import type { LucideIcon } from 'lucide-react'
+import type { JSXElementConstructor, SVGProps } from 'react'
 import { Github, Twitter } from './BrandIcons'
+import { cn } from '../lib/utils'
+
+type RegistryIconComponent = JSXElementConstructor<SVGProps<SVGSVGElement>>
 
 // Mapping of the kebab-case lucide names used in librefang-registry TOMLs
 // to the actual React components. Keep in sync with the set of icons
 // the registry repo ships — anything missing falls back to <Box/>.
-const MAP: Record<string, LucideIcon> = {
+const MAP: Record<string, RegistryIconComponent> = {
   'bar-chart-3': BarChart3, bell: Bell, bird: Bird, 'book-open': BookOpen,
   bot: Bot, briefcase: Briefcase, bug: Bug, building: Building,
   calendar: Calendar, castle: Castle, 'check-circle': CheckCircle,
@@ -44,14 +47,14 @@ interface Props {
 // emoji glyph, which we render as text for backwards compatibility.
 export default function RegistryIcon({ icon, className = 'w-5 h-5', fallbackClassName }: Props) {
   if (!icon) return null
-  if (icon.startsWith('lucide:')) {
-    const name = icon.slice(7)
+  if (/^lucide:/i.test(icon)) {
+    const name = icon.slice(7).trim().toLowerCase()
     const Cmp = MAP[name] ?? Box
     return <Cmp className={className} aria-hidden />
   }
   // Legacy emoji — render as glyph.
   return (
-    <span className={fallbackClassName ?? 'text-xl leading-none'} aria-hidden>
+    <span className={cn('text-xl leading-none', className, fallbackClassName)} aria-hidden>
       {icon}
     </span>
   )

--- a/web/src/components/RegistryIcon.tsx
+++ b/web/src/components/RegistryIcon.tsx
@@ -49,7 +49,11 @@ export default function RegistryIcon({ icon, className = 'w-5 h-5', fallbackClas
   if (!icon) return null
   if (/^lucide:/i.test(icon)) {
     const name = icon.slice(7).trim().toLowerCase()
-    const Cmp = MAP[name] ?? Box
+    const mappedIcon = MAP[name]
+    if (!mappedIcon && import.meta.env.DEV) {
+      console.warn(`Unknown registry icon: ${icon}`)
+    }
+    const Cmp = mappedIcon ?? Box
     return <Cmp className={className} aria-hidden />
   }
   // Legacy emoji — render as glyph.


### PR DESCRIPTION
## Summary

- type the registry map against the SVG component contract shared by Lucide and local brand icons
- resolve `lucide:` schemes and icon names without case sensitivity and warn during development when normalized names remain unknown
- preserve shared classes on legacy emoji fallbacks

## Verification

- `mise exec -- pnpm --dir web test` (46 tests across 10 files)
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- This PR only addresses the audited registry icon component.
- The broader OCR audit remains for follow-up PRs.