### PR TITLE
fix(web): harden install prompt state

### DIFF
--- a/changelog.d/fixed/7686-web-install-banner-state.md
+++ b/changelog.d/fixed/7686-web-install-banner-state.md
@@ -1,0 +1,3 @@
+The website install banner remains usable and dismissible when browser storage is unavailable. (#7686) (@houko)
+
+Install prompts are consumed once, close after either browser choice, and report genuine prompt failures for diagnosis. (#7686) (@houko)

--- a/web/src/components/InstallBanner.test.tsx
+++ b/web/src/components/InstallBanner.test.tsx
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import InstallBanner from './InstallBanner'
+import { useAppStore } from '../store'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root | undefined
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>'
+})
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount())
+    root = undefined
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+function installEvent(prompt: () => Promise<void>, outcome: 'accepted' | 'dismissed' = 'accepted') {
+  const event = new Event('beforeinstallprompt', { cancelable: true })
+  Object.assign(event, {
+    prompt,
+    userChoice: Promise.resolve({ outcome }),
+  })
+  return event
+}
+
+async function renderBanner() {
+  useAppStore.setState({ lang: 'en' })
+  root = createRoot(document.querySelector('#root')!)
+  await act(async () => root?.render(<InstallBanner />))
+}
+
+describe('InstallBanner', () => {
+  it('still captures and dismisses prompts when storage throws', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('storage disabled') },
+      setItem: () => { throw new Error('quota exceeded') },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    await renderBanner()
+
+    await act(async () => window.dispatchEvent(installEvent(vi.fn())))
+    const buttons = document.querySelectorAll('button')
+    expect(buttons).toHaveLength(2)
+
+    await act(async () => buttons[1]?.click())
+    expect(document.querySelector('button')).toBeNull()
+  })
+
+  it('consumes the prompt once and logs real prompt failures', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    const failure = new Error('browser rejected prompt')
+    const prompt = vi.fn().mockRejectedValue(failure)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await renderBanner()
+
+    await act(async () => window.dispatchEvent(installEvent(prompt)))
+    await act(async () => {
+      document.querySelector('button')?.click()
+      await Promise.resolve()
+    })
+
+    expect(prompt).toHaveBeenCalledOnce()
+    expect(document.querySelector('button')).toBeNull()
+    expect(error).toHaveBeenCalledWith('Install prompt failed:', failure)
+  })
+
+  it('closes after either defined user choice without dead branching', async () => {
+    const setItem = vi.fn()
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem,
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+    const prompt = vi.fn().mockResolvedValue(undefined)
+    await renderBanner()
+
+    await act(async () => window.dispatchEvent(installEvent(prompt, 'dismissed')))
+    await act(async () => {
+      document.querySelector('button')?.click()
+      await Promise.resolve()
+    })
+
+    expect(setItem).toHaveBeenCalledWith('librefang.install.dismissed', '1')
+    expect(document.querySelector('button')).toBeNull()
+  })
+})

--- a/web/src/components/InstallBanner.tsx
+++ b/web/src/components/InstallBanner.tsx
@@ -21,9 +21,13 @@ export default function InstallBanner() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    if (localStorage.getItem(DISMISS_KEY) === '1') {
-      setDismissed(true)
-      return
+    try {
+      if (localStorage.getItem(DISMISS_KEY) === '1') {
+        setDismissed(true)
+        return
+      }
+    } catch {
+      // Storage can be unavailable in private browsing. Keep install UI usable.
     }
     const onPrompt = (e: Event) => {
       // Capture the event — Chrome suppresses its own mini-infobar only if
@@ -38,18 +42,24 @@ export default function InstallBanner() {
   if (dismissed || !event) return null
 
   const close = () => {
-    localStorage.setItem(DISMISS_KEY, '1')
+    try {
+      localStorage.setItem(DISMISS_KEY, '1')
+    } catch {
+      // Dismiss the in-memory banner even when persistence is unavailable.
+    }
     setDismissed(true)
   }
 
   const install = async () => {
+    const promptEvent = event
+    setEvent(null)
     try {
-      await event.prompt()
-      const outcome = await event.userChoice
-      if (outcome.outcome === 'accepted' || outcome.outcome === 'dismissed') {
-        close()
-      }
-    } catch { /* user cancelled */ }
+      await promptEvent.prompt()
+      await promptEvent.userChoice
+      close()
+    } catch (error) {
+      console.error('Install prompt failed:', error)
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

- keep install prompt listener setup and in-memory dismissal working when browser storage throws
- consume each before-install event once before invoking the browser prompt
- close after either defined browser choice without dead branching
- report genuine prompt failures instead of treating every exception as cancellation

## Verification

- `mise exec -- pnpm --dir web test` (46 tests across 10 files)
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- This PR only addresses the audited install banner component.
- The broader OCR audit remains for follow-up PRs.