### PR TITLE
fix(web): harden search dialog contracts

### DIFF
--- a/changelog.d/fixed/7687-web-search-dialog-contracts.md
+++ b/changelog.d/fixed/7687-web-search-dialog-contracts.md
@@ -1,0 +1,3 @@
+Website search now ranks tightly clustered fuzzy matches correctly and avoids guessing when a pasted registry ID exists in multiple categories. (#7687) (@houko)
+
+Keyboard navigation follows the active locale callback, and selection resets with the debounced result set. (#7687) (@houko)

--- a/web/src/components/SearchDialog.test.ts
+++ b/web/src/components/SearchDialog.test.ts
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest'
+import type { Detail, RegistryCategory } from '../useRegistry'
+import { fuzzySubseq, resolvePastedItem } from './SearchDialog'
+
+function item(category: RegistryCategory, id: string) {
+  const detail: Detail = {
+    id,
+    name: id,
+    description: '',
+    category,
+    icon: '',
+  }
+  return { kind: 'item' as const, category, item: detail }
+}
+
+describe('SearchDialog helpers', () => {
+  it('penalizes subsequences whose matching span is not contiguous', () => {
+    expect(fuzzySubseq('abc', 'abc')).toBe(80)
+    expect(fuzzySubseq('abc', 'a--b--c')).toBe(72)
+    expect(fuzzySubseq('abc', 'acb')).toBe(0)
+  })
+
+  it('requires category qualification when a pasted bare id is ambiguous', () => {
+    const hits = [item('skills', 'shared'), item('plugins', 'shared'), item('agents', 'unique')]
+
+    expect(resolvePastedItem('shared', hits)).toBeUndefined()
+    expect(resolvePastedItem('unique', hits)?.category).toBe('agents')
+    expect(resolvePastedItem('https://librefang.ai/zh/plugins/shared?tab=readme', hits)?.category).toBe('plugins')
+  })
+})

--- a/web/src/components/SearchDialog.tsx
+++ b/web/src/components/SearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ClipboardEventHandler } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ClipboardEventHandler } from 'react'
 import { Search, X, Sparkles, Hash } from 'lucide-react'
 import { useRegistry, getLocalizedDesc, getLocalizedName } from '../useRegistry'
 import RegistryIcon from './RegistryIcon'
@@ -16,9 +16,12 @@ type Hit =
   | { kind: 'item'; category: RegistryCategory; item: Detail }
   | { kind: 'anchor'; id: string; label: string; desc: string }
 
+type ItemHit = Extract<Hit, { kind: 'item' }>
+
 const CATEGORIES: RegistryCategory[] = [
   'skills', 'hands', 'agents', 'providers', 'workflows', 'channels', 'plugins', 'mcp',
 ]
+const LOCALE_PREFIXES = new Set(['zh', 'zh-TW', 'ja', 'ko', 'de', 'es', 'pl', 'uk'])
 
 const PER_CATEGORY_CAP = 5
 
@@ -29,15 +32,17 @@ function isPopular(d: Detail) {
 // Simple subsequence fuzzy match: returns a bonus if every character of
 // query appears in order in target (not necessarily contiguous). Scores
 // higher when characters cluster tightly. Cheap: O(|target|) per call.
-function fuzzySubseq(query: string, target: string): number {
+export function fuzzySubseq(query: string, target: string): number {
   if (!query) return 0
   const q = query.toLowerCase()
   const t = target.toLowerCase()
   let qi = 0
+  let firstMatch = -1
   let lastMatch = -1
   let gaps = 0
   for (let i = 0; i < t.length && qi < q.length; i++) {
     if (t[i] === q[qi]) {
+      if (firstMatch < 0) firstMatch = i
       if (lastMatch >= 0) gaps += (i - lastMatch - 1)
       lastMatch = i
       qi++
@@ -45,8 +50,25 @@ function fuzzySubseq(query: string, target: string): number {
   }
   if (qi < q.length) return 0
   // Reward short spans: full score when all chars are contiguous.
-  const span = lastMatch - (lastMatch - q.length + 1) + 1
+  const span = lastMatch - firstMatch + 1
   return Math.max(20, 80 - Math.min(60, gaps)) - Math.min(15, span - q.length)
+}
+
+export function resolvePastedItem(raw: string, itemHits: ItemHit[]): ItemHit | undefined {
+  const path = raw.trim().replace(/^https?:\/\/[^/]+/i, '').replace(/^\/+/, '').replace(/[?#].*$/, '')
+  const segs = path.split('/').filter(Boolean)
+  const [first, ...rest] = segs
+  const parts = first && LOCALE_PREFIXES.has(first) ? rest : segs
+
+  if (parts.length >= 2 && CATEGORIES.includes(parts[0] as RegistryCategory)) {
+    const category = parts[0] as RegistryCategory
+    const id = parts[1]
+    return itemHits.find(hit => hit.category === category && hit.item.id === id)
+  }
+  if (parts.length !== 1 || !parts[0]) return undefined
+
+  const matches = itemHits.filter(hit => hit.item.id === parts[0])
+  return matches.length === 1 ? matches[0] : undefined
 }
 
 function scoreText(query: string, ...fields: string[]): number {
@@ -132,7 +154,7 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
       // No query — show homepage anchors first (navigation shortcut), then a
       // sampling of popular items across categories.
       const perCat = new Map<RegistryCategory, number>()
-      const items = itemHits
+      const items = allHits
         .filter(h => h.kind === 'item' && isPopular(h.item))
         .filter(h => {
           if (h.kind !== 'item') return false
@@ -169,9 +191,21 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
       if (out.length >= 40) break
     }
     return out
-  }, [allHits, itemHits, anchorHits, debouncedQuery, lang])
+  }, [allHits, anchorHits, debouncedQuery, lang])
 
-  useEffect(() => { setActiveIndex(0) }, [query])
+  useEffect(() => { setActiveIndex(0) }, [debouncedQuery])
+
+  // App selects its page route once during startup and does not expose a
+  // client router, so route changes intentionally require hard navigation.
+  const navigate = useCallback((hit: Hit) => {
+    const prefix = lang === 'en' ? '' : `/${lang}`
+    if (hit.kind === 'item') {
+      window.location.href = `${prefix}/${hit.category}/${hit.item.id}`
+    } else {
+      const home = lang === 'en' ? '/' : `/${lang}/`
+      window.location.href = `${home}#${hit.id}`
+    }
+  }, [lang])
 
   useEffect(() => {
     if (!open) return
@@ -195,19 +229,7 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, filtered, activeIndex])
-
-  const navigate = (hit: Hit) => {
-    const prefix = lang === 'en' ? '' : `/${lang}`
-    if (hit.kind === 'item') {
-      window.location.href = `${prefix}/${hit.category}/${hit.item.id}`
-    } else {
-      // Anchor: homepage + hash. Same-page case is handled by the browser.
-      const home = lang === 'en' ? '/' : `/${lang}/`
-      window.location.href = `${home}#${hit.id}`
-    }
-  }
+  }, [open, filtered, activeIndex, navigate, onClose])
 
   // Paste handler: when a user pastes a URL or "category/id" string that
   // matches an existing registry item, navigate straight to it. Prevents
@@ -216,25 +238,8 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
   const onPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
     const raw = e.clipboardData.getData('text').trim()
     if (!raw) return
-    // Strip scheme + host if a full URL was pasted.
-    const path = raw.replace(/^https?:\/\/[^/]+/i, '').replace(/^\/+/, '').replace(/[?#].*$/, '')
-    const segs = path.split('/').filter(Boolean)
-    // Tolerate a leading lang prefix (zh/ja/...) when present.
-    const langs = new Set(['zh', 'zh-TW', 'ja', 'ko', 'de', 'es', 'pl', 'uk'])
-    const [first, ...rest] = segs
-    const parts = first && langs.has(first) ? rest : segs
-    if (parts.length >= 2 && CATEGORIES.includes(parts[0] as RegistryCategory)) {
-      const cat = parts[0] as RegistryCategory
-      const id = parts[1]!
-      const hit = itemHits.find(h => h.kind === 'item' && h.category === cat && h.item.id === id)
-      if (hit) { e.preventDefault(); navigate(hit); return }
-    }
-    // Bare ID paste — match against any category.
-    if (parts.length === 1 && parts[0]) {
-      const id = parts[0]
-      const hit = itemHits.find(h => h.kind === 'item' && h.item.id === id)
-      if (hit) { e.preventDefault(); navigate(hit); return }
-    }
+    const hit = resolvePastedItem(raw, itemHits.filter((item): item is ItemHit => item.kind === 'item'))
+    if (hit) { e.preventDefault(); navigate(hit) }
   }
 
   if (!open) return null


### PR DESCRIPTION
## Summary

- score fuzzy subsequences from their actual first-to-last matching span
- keep keyboard navigation synchronized with the active locale callback and debounced result set
- require category qualification when a pasted bare ID is ambiguous
- derive empty-query popular items from the existing aggregate dependency
- document why route changes intentionally use hard navigation with the current boot-time route owner

## Verification

- `mise exec -- pnpm --dir web test` (45 tests across 10 files)
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Replacing hard navigation requires reactive route ownership in `App.tsx`; open #7682 currently owns that file.
- The broader OCR audit remains for follow-up PRs.