### PR TITLE
fix(web): close mobile header menus consistently

### DIFF
--- a/changelog.d/fixed/7688-web-site-header-interactions.md
+++ b/changelog.d/fixed/7688-web-site-header-interactions.md
@@ -1,0 +1,3 @@
+The website mobile navigation drawer now closes on outside clicks while remaining open for interactions inside the drawer. (#7688) (@houko)
+
+Desktop and mobile language menus use distinct interaction selectors. (#7688) (@houko)

--- a/web/src/components/SiteHeader.test.tsx
+++ b/web/src/components/SiteHeader.test.tsx
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SiteHeader from './SiteHeader'
+import { useAppStore } from '../store'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root | undefined
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>'
+  useAppStore.setState({ lang: 'en', theme: 'dark' })
+})
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount())
+    root = undefined
+  }
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('SiteHeader', () => {
+  it('keeps mobile selectors distinct and closes the drawer only on outside clicks', async () => {
+    root = createRoot(document.querySelector('#root')!)
+    await act(async () => root?.render(<SiteHeader isSubpage />))
+
+    expect(document.querySelectorAll('[data-lang-menu]')).toHaveLength(1)
+    expect(document.querySelectorAll('[data-lang-menu-mobile]')).toHaveLength(1)
+
+    const menuButton = document.querySelector('.lucide-menu')?.closest('button')
+    await act(async () => menuButton?.click())
+    const drawer = document.querySelector<HTMLElement>('[data-mobile-menu]')
+    expect(drawer).not.toBeNull()
+
+    await act(async () => drawer?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(document.querySelector('[data-mobile-menu]')).not.toBeNull()
+
+    await act(async () => document.body.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(document.querySelector('[data-mobile-menu]')).toBeNull()
+  })
+})

--- a/web/src/components/SiteHeader.tsx
+++ b/web/src/components/SiteHeader.tsx
@@ -9,6 +9,9 @@ import type { Translation } from '../i18n'
 import { useAppStore } from '../store'
 import { cn } from '../lib/utils'
 
+const FEATURE_ACTIVE_IDS = ['hands', 'agents', 'skills', 'mcp', 'plugins', 'providers', 'workflows', 'channels']
+const LEARN_ACTIVE_IDS = ['architecture', 'hands', 'evolution', 'workflows', 'performance', 'downloads', 'install', 'faq', 'community']
+
 interface SiteHeaderProps {
   onOpenSearch?: () => void
   // True on non-homepage routes so we rewrite flat links to cross-page
@@ -71,9 +74,11 @@ export default function SiteHeader({ onOpenSearch, isSubpage = false, sourceUrl,
       if (e.key === 'Escape') { setOpen(false); setLangOpen(false); setFeaturesOpen(false); setLearnOpen(false) }
     }
     const handleClickOutside = (e: MouseEvent) => {
-      if (langOpen && !(e.target as HTMLElement).closest('[data-lang-menu]')) setLangOpen(false)
-      if (featuresOpen && !(e.target as HTMLElement).closest('[data-features-menu]')) setFeaturesOpen(false)
-      if (learnOpen && !(e.target as HTMLElement).closest('[data-learn-menu]')) setLearnOpen(false)
+      const target = e.target instanceof Element ? e.target : null
+      if (open && !target?.closest('[data-mobile-menu]')) setOpen(false)
+      if (langOpen && !target?.closest('[data-lang-menu], [data-lang-menu-mobile]')) setLangOpen(false)
+      if (featuresOpen && !target?.closest('[data-features-menu]')) setFeaturesOpen(false)
+      if (learnOpen && !target?.closest('[data-learn-menu]')) setLearnOpen(false)
     }
     document.addEventListener('keydown', handleEscape)
     document.addEventListener('click', handleClickOutside)
@@ -81,7 +86,7 @@ export default function SiteHeader({ onOpenSearch, isSubpage = false, sourceUrl,
       document.removeEventListener('keydown', handleEscape)
       document.removeEventListener('click', handleClickOutside)
     }
-  }, [langOpen, featuresOpen, learnOpen])
+  }, [open, langOpen, featuresOpen, learnOpen])
 
   const langPrefix = lang === 'en' ? '' : `/${lang}`
   const homeHref = lang === 'en' ? '/' : `/${lang}/`
@@ -122,10 +127,8 @@ export default function SiteHeader({ onOpenSearch, isSubpage = false, sourceUrl,
   const flatLinks: NavLink[] = [
     { label: t.nav.docs, href: 'https://docs.librefang.ai', external: true },
   ]
-  const featureActiveIds = ['hands', 'agents', 'skills', 'mcp', 'plugins', 'providers', 'workflows', 'channels']
-  const isFeatureActive = featureActiveIds.includes(activeSection)
-  const learnActiveIds = ['architecture', 'hands', 'evolution', 'workflows', 'performance', 'downloads', 'install', 'faq', 'community']
-  const isLearnActive = learnActiveIds.includes(activeSection)
+  const isFeatureActive = FEATURE_ACTIVE_IDS.includes(activeSection)
+  const isLearnActive = LEARN_ACTIVE_IDS.includes(activeSection)
 
   const headerClass = cn(
     'fixed top-0 left-0 right-0 z-50 transition-all duration-300',
@@ -316,7 +319,7 @@ export default function SiteHeader({ onOpenSearch, isSubpage = false, sourceUrl,
           <button onClick={toggleTheme} className="p-2 text-gray-600 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors" aria-label={headerCopy.toggleTheme}>
             {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
           </button>
-          <div className="relative" data-lang-menu>
+          <div className="relative" data-lang-menu-mobile>
             <button className="p-2 text-gray-600 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors" onClick={() => setLangOpen(!langOpen)} aria-label={headerCopy.switchLanguage}>
               <Globe className="w-4 h-4" />
             </button>
@@ -335,7 +338,7 @@ export default function SiteHeader({ onOpenSearch, isSubpage = false, sourceUrl,
       </div>
 
       {open && (
-        <div className="md:hidden bg-surface-100 border-t border-black/10 dark:border-white/5 px-6 py-4 space-y-1">
+        <div data-mobile-menu className="md:hidden bg-surface-100 border-t border-black/10 dark:border-white/5 px-6 py-4 space-y-1">
           <div className="pb-1">
             <div className="text-[10px] font-mono text-gray-400 dark:text-gray-600 uppercase tracking-widest py-1.5">
               {t.nav.learnMore!}


### PR DESCRIPTION
## Summary

- close the mobile navigation drawer when a click lands outside it
- keep interactions inside the drawer from dismissing it
- use distinct desktop and mobile language-menu selectors
- hoist immutable active-section ID lists out of the render path

## Verification

- `mise exec -- pnpm --dir web test` (44 tests across 10 files)
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- This PR only addresses the audited site header interactions.
- The broader OCR audit remains for follow-up PRs.