### PR TITLE
fix(web): keep boundary errors local

### DIFF
--- a/changelog.d/fixed/7690-web-error-boundary-privacy.md
+++ b/changelog.d/fixed/7690-web-error-boundary-privacy.md
@@ -1,0 +1,3 @@
+The website error boundary no longer sends exception messages, stacks, paths, or browser metadata to an external reporting endpoint without consent. (#7690) (@houko)
+
+Reload recovery no longer clears component state immediately before reloading the page. (#7690) (@houko)

--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ErrorBoundary from './ErrorBoundary'
+import { useAppStore } from '../store'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root | undefined
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount())
+    root = undefined
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+function ThrowingChild(): never {
+  throw new Error('secret-token=should-stay-local')
+}
+
+describe('ErrorBoundary', () => {
+  it('renders recovery UI without sending exception details externally', async () => {
+    const fetch = vi.fn()
+    const sendBeacon = vi.fn()
+    vi.stubGlobal('fetch', fetch)
+    vi.stubGlobal('navigator', { sendBeacon })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    useAppStore.setState({ lang: 'en' })
+    document.body.innerHTML = '<div id="root"></div>'
+    root = createRoot(document.querySelector('#root')!)
+
+    await act(async () => root?.render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    ))
+
+    expect(document.body.textContent).toContain('secret-token=should-stay-local')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(sendBeacon).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -31,29 +31,9 @@ class ErrorBoundaryImpl extends Component<ErrorBoundaryImplProps, State> {
   componentDidCatch(error: Error, info: ErrorInfo) {
     // eslint-disable-next-line no-console
     console.error('LibreFang UI error:', error, info.componentStack)
-    // Fire-and-forget report to the worker. sendBeacon has the nice property
-    // that the request survives page unload if the user reloads. If anything
-    // throws here (no network, CSP block, serialization weirdness), swallow
-    // — reporting must never cascade a crash.
-    try {
-      const body = JSON.stringify({
-        message: error.message || String(error),
-        stack: error.stack || info.componentStack || '',
-        pathname: typeof window !== 'undefined' ? window.location.pathname : '',
-        lang: typeof document !== 'undefined' ? document.documentElement.lang : '',
-        ua: typeof navigator !== 'undefined' ? navigator.userAgent.slice(0, 256) : '',
-      })
-      const url = 'https://stats.librefang.ai/api/errors'
-      if (typeof navigator !== 'undefined' && 'sendBeacon' in navigator) {
-        navigator.sendBeacon(url, new Blob([body], { type: 'application/json' }))
-      } else if (typeof fetch !== 'undefined') {
-        fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, keepalive: true }).catch(() => {})
-      }
-    } catch { /* reporting must not crash */ }
   }
 
   handleReload = () => {
-    this.setState({ error: null })
     window.location.reload()
   }
 


### PR DESCRIPTION
## Summary

- stop automatically transmitting exception messages, stacks, paths, language, and browser metadata without consent
- retain local console diagnostics and the recovery UI
- remove the now-unused external error-reporting endpoint literal
- reload directly without clearing boundary state and briefly remounting the failed subtree

## Verification

- `mise exec -- pnpm --dir web test` (44 tests across 10 files)
- focused React boundary regression confirms recovery UI renders while `fetch` and `sendBeacon` remain unused
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- A future opt-in reporting feature would need an explicit consent contract and bounded redaction policy before reintroducing external transmission.
- The broader OCR audit remains for follow-up PRs.