### PR TITLE
fix(web): harden bootstrap contracts

### DIFF
--- a/changelog.d/fixed/7691-web-bootstrap-contracts.md
+++ b/changelog.d/fixed/7691-web-bootstrap-contracts.md
@@ -1,0 +1,3 @@
+Website startup now reports a clear template error when the required root element is missing. (#7691) (@houko)
+
+Global query defaults refresh after 30 seconds and on window focus, while stable queries retain their explicit longer cache policies. (#7691) (@houko)

--- a/web/src/lib/bootstrap.test.ts
+++ b/web/src/lib/bootstrap.test.ts
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createAppQueryClient,
+  DEFAULT_QUERY_STALE_TIME_MS,
+  requireRootElement,
+} from './bootstrap'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('website bootstrap contracts', () => {
+  it('reports a clear error when the HTML root is absent', () => {
+    expect(() => requireRootElement(document)).toThrow(
+      'Root element #root not found; ensure the HTML template includes <div id="root"></div>',
+    )
+
+    document.body.innerHTML = '<div id="root"></div>'
+    expect(requireRootElement(document)).toBe(document.getElementById('root'))
+  })
+
+  it('uses a fresh global query policy while allowing stable queries to override it', () => {
+    const queryClient = createAppQueryClient()
+    const defaults = queryClient.getDefaultOptions().queries
+
+    expect(DEFAULT_QUERY_STALE_TIME_MS).toBe(30_000)
+    expect(defaults?.staleTime).toBe(30_000)
+    expect(defaults?.refetchOnWindowFocus).toBe(true)
+  })
+})

--- a/web/src/lib/bootstrap.ts
+++ b/web/src/lib/bootstrap.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const DEFAULT_QUERY_STALE_TIME_MS = 30_000
+
+export function createAppQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: DEFAULT_QUERY_STALE_TIME_MS,
+        refetchOnWindowFocus: true,
+      },
+    },
+  })
+}
+
+export function requireRootElement(document: Document): HTMLElement {
+  const rootElement = document.getElementById('root')
+  if (!rootElement) {
+    throw new Error('Root element #root not found; ensure the HTML template includes <div id="root"></div>')
+  }
+  return rootElement
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,20 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App'
 import ErrorBoundary from './components/ErrorBoundary'
+import { createAppQueryClient, requireRootElement } from './lib/bootstrap'
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60 * 30,
-      refetchOnWindowFocus: false,
-    },
-  },
-})
+const queryClient = createAppQueryClient()
+const rootElement = requireRootElement(document)
 
-createRoot(document.getElementById('root')!).render(
+createRoot(rootElement).render(
   <StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

- fail with a clear template diagnostic when the required `#root` element is absent
- replace the global 30-minute query cache default with a 30-second freshness window
- restore refetch-on-window-focus globally while preserving explicit long-lived per-query overrides
- isolate bootstrap policies in a directly testable helper

## Verification

- `mise exec -- pnpm --dir web test` (45 tests across 10 files)
- focused regressions cover missing/present root elements and exact Query Client defaults
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Stable registry, release, metrics, and detail queries keep their explicit per-query cache durations.
- The broader OCR audit remains for follow-up PRs.