### PR TITLE
fix(web): harden registry data loading

### DIFF
--- a/changelog.d/fixed/7692-web-registry-data-contracts.md
+++ b/changelog.d/fixed/7692-web-registry-data-contracts.md
@@ -1,0 +1,3 @@
+Website registry loading now requests local and remote sources concurrently and falls back independently when either source fails or returns malformed data. (#7692) (@houko)
+
+Nullable counts, localized names, and category count lookups now use explicit typed contracts. (#7692) (@houko)

--- a/web/src/useRegistry.test.ts
+++ b/web/src/useRegistry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  fetchRegistryData,
+  getCategoryItems,
+  getLocalizedDesc,
+  getLocalizedName,
+  type Detail,
+  type RegistryData,
+} from './useRegistry'
+
+function detail(id: string, category = 'hands'): Detail {
+  return {
+    id,
+    name: `Name ${id}`,
+    description: `Description ${id}`,
+    category,
+    icon: 'box',
+  }
+}
+
+function response(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response
+}
+
+function registryData(overrides: Partial<RegistryData>): RegistryData {
+  return {
+    hands: [],
+    channels: [],
+    providers: [],
+    workflows: [],
+    agents: [],
+    plugins: [],
+    skills: [],
+    mcp: [],
+    ...overrides,
+  }
+}
+
+describe('registry data contracts', () => {
+  it('starts local and API requests together and falls back when local loading rejects', async () => {
+    const apiData = { hands: [detail('api')] }
+    const fetcher = vi.fn((url: string | URL | Request) => {
+      if (String(url) === '/registry.json') return Promise.reject(new Error('cache unavailable'))
+      return Promise.resolve(response(apiData))
+    }) as unknown as typeof fetch
+
+    const resultPromise = fetchRegistryData(fetcher)
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    await expect(resultPromise).resolves.toMatchObject(apiData)
+  })
+
+  it('keeps valid API items when count values are explicitly null', async () => {
+    const local = { hands: [detail('local')], handsCount: 4 }
+    const api = { hands: [detail('api')], handsCount: null }
+    const fetcher = vi.fn((url: string | URL | Request) => Promise.resolve(
+      response(String(url) === '/registry.json' ? local : api),
+    )) as unknown as typeof fetch
+
+    const result = await fetchRegistryData(fetcher)
+
+    expect(result.hands.map(item => item.id)).toEqual(['local', 'api'])
+    expect(getCategoryItems(result, 'hands')).toMatchObject({ count: 4 })
+  })
+
+  it('falls back to API data when local JSON parsing fails', async () => {
+    const api = { skills: [detail('api-skill', 'skills')], skillsCount: 1 }
+    const fetcher = vi.fn((url: string | URL | Request) => {
+      if (String(url) === '/registry.json') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => { throw new SyntaxError('invalid JSON') },
+        } as unknown as Response)
+      }
+      return Promise.resolve(response(api))
+    }) as unknown as typeof fetch
+
+    await expect(fetchRegistryData(fetcher)).resolves.toMatchObject(api)
+  })
+
+  it('uses exact and language-prefix translations without unchecked indexing', () => {
+    const translated = {
+      ...detail('localized'),
+      i18n: {
+        zh: { name: '中文名称', description: '中文描述' },
+        'zh-TW': { name: '繁體名稱' },
+      },
+    }
+
+    expect(getLocalizedName(translated, 'zh-TW')).toBe('繁體名稱')
+    expect(getLocalizedDesc(translated, 'zh-TW')).toBe('中文描述')
+    expect(getLocalizedName(translated, '')).toBe('Name localized')
+  })
+
+  it('reads counts only through the category count-field map', () => {
+    const data = registryData({
+      hands: [detail('one')],
+      handsCount: 7,
+      skills: [detail('skill', 'skills')],
+    })
+
+    expect(getCategoryItems(data, 'hands').count).toBe(7)
+    expect(getCategoryItems(data, 'skills').count).toBe(1)
+  })
+})

--- a/web/src/useRegistry.ts
+++ b/web/src/useRegistry.ts
@@ -20,6 +20,8 @@ const DetailSchema = z.object({
   i18n: z.record(z.string(), I18nEntrySchema).optional(),
 })
 
+const CountSchema = z.number().nullable().transform(value => value ?? undefined).optional()
+
 // All 8 category arrays are optional on the wire — a stale worker response
 // (or the older registry.json shape) may be missing newer ones like skills/mcp.
 // The hook normalizes missing arrays to [].
@@ -32,19 +34,20 @@ const RegistryDataSchema = z.object({
   plugins: z.array(DetailSchema).optional().default([]),
   skills: z.array(DetailSchema).optional().default([]),
   mcp: z.array(DetailSchema).optional().default([]),
-  // Keep the count fields nullable (no `.default(0)`) so missing keys in
-  // a partial/stale API response stay `undefined`. The merge step below
+  // Keep the count fields nullish (no `.default(0)`) so missing or explicit
+  // unknown values in a partial API response do not invalidate its items.
+  // The merge step below
   // uses `apiData.*Count ?? localData.*Count` to prefer local counts
   // when the API omits them — defaulting here to 0 would shadow that
   // fallback and clobber valid local counts with zeros.
-  handsCount: z.number().optional(),
-  channelsCount: z.number().optional(),
-  providersCount: z.number().optional(),
-  workflowsCount: z.number().optional(),
-  agentsCount: z.number().optional(),
-  pluginsCount: z.number().optional(),
-  skillsCount: z.number().optional(),
-  mcpCount: z.number().optional(),
+  handsCount: CountSchema,
+  channelsCount: CountSchema,
+  providersCount: CountSchema,
+  workflowsCount: CountSchema,
+  agentsCount: CountSchema,
+  pluginsCount: CountSchema,
+  skillsCount: CountSchema,
+  mcpCount: CountSchema,
 })
 
 export type Detail = z.infer<typeof DetailSchema>
@@ -56,12 +59,29 @@ export type RegistryCategory =
   | 'hands' | 'channels' | 'providers'
   | 'workflows' | 'agents' | 'plugins' | 'skills' | 'mcp'
 
+const COUNT_FIELDS = {
+  hands: 'handsCount',
+  channels: 'channelsCount',
+  providers: 'providersCount',
+  workflows: 'workflowsCount',
+  agents: 'agentsCount',
+  plugins: 'pluginsCount',
+  skills: 'skillsCount',
+  mcp: 'mcpCount',
+} as const satisfies Record<RegistryCategory, `${RegistryCategory}Count`>
+
+function languagePrefix(lang: string): string | undefined {
+  return lang.split('-')[0] || undefined
+}
+
 /** Get localized description for a Detail item */
 export function getLocalizedDesc(item: Detail, lang: string): string {
   if (lang === 'en') return item.description
   // Try exact match first (zh-TW), then prefix (zh)
-  const desc = item.i18n?.[lang]?.description ?? item.i18n?.[lang.split('-')[0]!]?.description
-  return desc || item.description
+  const prefix = languagePrefix(lang)
+  const description = item.i18n?.[lang]?.description
+    ?? (prefix ? item.i18n?.[prefix]?.description : undefined)
+  return description || item.description
 }
 
 /** Get localized name for a Detail item — falls back to English if the
@@ -69,27 +89,30 @@ export function getLocalizedDesc(item: Detail, lang: string): string {
  * description helper. */
 export function getLocalizedName(item: Detail, lang: string): string {
   if (lang === 'en') return item.name
-  const name = item.i18n?.[lang]?.name ?? item.i18n?.[lang.split('-')[0]!]?.name
+  const prefix = languagePrefix(lang)
+  const name = item.i18n?.[lang]?.name
+    ?? (prefix ? item.i18n?.[prefix]?.name : undefined)
   return name || item.name
 }
 
-async function fetchRegistryData(): Promise<RegistryData> {
-  // 1. Load local registry.json (has full descriptions from build time)
-  const localRes = await fetch(LOCAL_JSON)
-  const local = localRes.ok ? RegistryDataSchema.safeParse(await localRes.json()) : null
-  const localData = local?.success ? local.data : null
-
-  // 2. Load API for latest counts (descriptions may be empty)
-  let apiData: RegistryData | null = null
+async function fetchRegistrySource(url: string, fetcher: typeof fetch): Promise<RegistryData | null> {
   try {
-    const apiRes = await fetch(REGISTRY_API)
-    if (apiRes.ok) {
-      const parsed = RegistryDataSchema.safeParse(await apiRes.json())
-      if (parsed.success) apiData = parsed.data
-    }
-  } catch { /* API unavailable, use local only */ }
+    const response = await fetcher(url)
+    if (!response.ok) return null
+    const parsed = RegistryDataSchema.safeParse(await response.json())
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
 
-  // 3. Merge: prefer local details (have descriptions), append new items from API
+export async function fetchRegistryData(fetcher: typeof fetch = fetch): Promise<RegistryData> {
+  const [localData, apiData] = await Promise.all([
+    fetchRegistrySource(LOCAL_JSON, fetcher),
+    fetchRegistrySource(REGISTRY_API, fetcher),
+  ])
+
+  // Prefer local details (have descriptions), append new items from API.
   if (localData && apiData) {
     return {
       hands: mergeDetails(localData.hands, apiData.hands),
@@ -133,7 +156,7 @@ function mergeDetails(local: Detail[], api: Detail[]): Detail[] {
 export function useRegistry() {
   return useQuery<RegistryData>({
     queryKey: ['registry'],
-    queryFn: fetchRegistryData,
+    queryFn: () => fetchRegistryData(),
     staleTime: 1000 * 60 * 60,
     retry: 2,
   })
@@ -143,6 +166,6 @@ export function useRegistry() {
 export function getCategoryItems(data: RegistryData | undefined, category: RegistryCategory): { items: Detail[]; count: number } {
   if (!data) return { items: [], count: 0 }
   const items = data[category] ?? []
-  const count = (data[`${category}Count` as keyof RegistryData] as number | undefined) ?? items.length
+  const count = data[COUNT_FIELDS[category]] ?? items.length
   return { items, count }
 }


### PR DESCRIPTION
## Summary

- request local and remote registry sources concurrently with independent failure isolation
- preserve API fallback when local fetch or JSON decoding fails
- accept wire-level null counts and normalize them before application consumers
- preserve exact-then-prefix localization without unchecked indexing
- map every registry category to its count field through a closed typed contract

## Verification

- `mise exec -- pnpm --dir web test` (48 tests across 10 files)
- focused regressions cover parallel request start, rejected and malformed local data, nullable API counts, merge behavior, locale fallback, and typed count lookup
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Registry source URLs and the existing local-detail-first merge policy remain unchanged.
- The broader OCR audit remains for follow-up PRs.