### PR TITLE
fix(web): harden app store contracts

### DIFF
--- a/changelog.d/fixed/7693-web-store-contracts.md
+++ b/changelog.d/fixed/7693-web-store-contracts.md
@@ -1,0 +1,3 @@
+Website language switching now uses one boundary-aware locale list, safe path construction, and complete server-side guards. (#7693) (@houko)
+
+Theme initialization validates persisted values, keeps state updates pure, and remains usable when browser storage is unavailable. (#7693) (@houko)

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildLocalizedPath,
+  detectLangFromPath,
+  readStoredTheme,
+  stripLocalePrefix,
+  useAppStore,
+} from './store'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  document.documentElement.classList.remove('dark', 'light')
+  document.head.querySelectorAll('link[href*="fonts.googleapis.com"]').forEach(link => link.remove())
+  window.history.replaceState(null, '', '/')
+  useAppStore.setState({ lang: 'en', theme: 'dark' })
+})
+
+describe('app store contracts', () => {
+  it('detects supported locales from one ordered boundary-aware list', () => {
+    expect(detectLangFromPath('/zh-TW/skills/example')).toBe('zh-TW')
+    expect(detectLangFromPath('/zh/skills/example')).toBe('zh')
+    expect(detectLangFromPath('/zh-not-a-locale')).toBe('en')
+    expect(detectLangFromPath('/', 'ja')).toBe('ja')
+    expect(detectLangFromPath('/', 'invalid')).toBe('en')
+  })
+
+  it('builds localized paths without nested URL branching', () => {
+    expect(stripLocalePrefix('/de/skills/example')).toBe('/skills/example')
+    expect(buildLocalizedPath('ja', '/de/skills/example')).toBe('/ja/skills/example')
+    expect(buildLocalizedPath('ja', '/')).toBe('/ja')
+    expect(buildLocalizedPath('en', '/uk')).toBe('/')
+  })
+
+  it('accepts only supported stored theme values and survives storage errors', () => {
+    expect(readStoredTheme({ getItem: () => 'light' })).toBe('light')
+    expect(readStoredTheme({ getItem: () => 'system' })).toBe('dark')
+    expect(readStoredTheme({ getItem: () => { throw new Error('blocked') } })).toBe('dark')
+  })
+
+  it('switches locale with query and hash preservation and no server-side effects', () => {
+    window.history.replaceState(null, '', '/de/skills/example?tab=readme#usage')
+    useAppStore.setState({ lang: 'de' })
+
+    useAppStore.getState().switchLang('ja')
+
+    expect(window.location.pathname).toBe('/ja/skills/example')
+    expect(window.location.search).toBe('?tab=readme')
+    expect(window.location.hash).toBe('#usage')
+    expect(document.documentElement.lang).toBe('ja')
+    expect(document.head.querySelector('link[href*="Noto+Sans+JP"]')).not.toBeNull()
+
+    const activeLang = useAppStore.getState().lang
+    vi.stubGlobal('window', undefined)
+    useAppStore.getState().switchLang('ko')
+    expect(useAppStore.getState().lang).toBe(activeLang)
+  })
+
+  it('keeps side effects outside the pure Zustand state update', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    useAppStore.setState({ theme: 'dark' })
+
+    useAppStore.getState().toggleTheme()
+
+    expect(useAppStore.getState().theme).toBe('light')
+    expect(setItem).toHaveBeenCalledWith('theme', 'light')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,18 +1,21 @@
 import { create } from 'zustand'
 
+type Theme = 'dark' | 'light'
+
+const LOCALE_PREFIXES = ['zh-TW', 'zh', 'de', 'ja', 'ko', 'es', 'pl', 'uk'] as const
+const SUPPORTED_LANGS = new Set<string>(['en', ...LOCALE_PREFIXES])
+
+export function detectLangFromPath(path: string, initialLang?: string): string {
+  if (initialLang && SUPPORTED_LANGS.has(initialLang)) return initialLang
+  for (const prefix of LOCALE_PREFIXES) {
+    if (path === `/${prefix}` || path.startsWith(`/${prefix}/`)) return prefix
+  }
+  return 'en'
+}
+
 function detectLang(): string {
   if (typeof window === 'undefined') return 'en'
-  if (window.__INITIAL_LANG__) return window.__INITIAL_LANG__
-  const path = window.location.pathname
-  if (path.startsWith('/zh-TW')) return 'zh-TW'
-  if (path.startsWith('/zh')) return 'zh'
-  if (path.startsWith('/de')) return 'de'
-  if (path.startsWith('/ja')) return 'ja'
-  if (path.startsWith('/ko')) return 'ko'
-  if (path.startsWith('/es')) return 'es'
-  if (path.startsWith('/pl')) return 'pl'
-  if (path.startsWith('/uk')) return 'uk'
-  return 'en'
+  return detectLangFromPath(window.location.pathname, window.__INITIAL_LANG__)
 }
 
 const CJK_FONTS: Record<string, string> = {
@@ -24,7 +27,12 @@ const CJK_FONTS: Record<string, string> = {
 
 const loadedFonts = new Set<string>()
 
-function loadCJKFont(lang: string) {
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => loadedFonts.clear())
+}
+
+export function loadCJKFont(lang: string) {
+  if (typeof document === 'undefined') return
   const font = CJK_FONTS[lang]
   if (!font || loadedFonts.has(font)) return
   loadedFonts.add(font)
@@ -37,15 +45,13 @@ function loadCJKFont(lang: string) {
 interface AppState {
   lang: string
   switchLang: (code: string) => void
-  theme: 'dark' | 'light'
+  theme: Theme
   toggleTheme: () => void
 }
 
-const LOCALE_PREFIXES = ['zh-TW', 'zh', 'de', 'ja', 'ko', 'es', 'pl', 'uk']
-
 // Strip any locale prefix from a pathname so we can re-attach the new one.
 // `/zh/skills/foo` → `/skills/foo`, `/skills` → `/skills`, `/` → `/`.
-function stripLocalePrefix(pathname: string): string {
+export function stripLocalePrefix(pathname: string): string {
   for (const prefix of LOCALE_PREFIXES) {
     if (pathname === `/${prefix}`) return '/'
     if (pathname.startsWith(`/${prefix}/`)) return pathname.slice(prefix.length + 1)
@@ -53,29 +59,61 @@ function stripLocalePrefix(pathname: string): string {
   return pathname
 }
 
+export function buildLocalizedPath(code: string, pathname: string): string {
+  const bare = stripLocalePrefix(pathname)
+  const prefix = code === 'en' ? '' : `/${code}`
+  const suffix = bare === '/' ? '' : bare
+  return prefix ? `${prefix}${suffix}` : bare
+}
+
+export function readStoredTheme(storage?: Pick<Storage, 'getItem'>): Theme {
+  try {
+    const stored = storage?.getItem('theme')
+    return stored === 'dark' || stored === 'light' ? stored : 'dark'
+  } catch {
+    return 'dark'
+  }
+}
+
+function readBrowserTheme(): Theme {
+  if (typeof window === 'undefined') return 'dark'
+  try {
+    return readStoredTheme(window.localStorage)
+  } catch {
+    return 'dark'
+  }
+}
+
 export const useAppStore = create<AppState>((set) => ({
   lang: detectLang(),
   switchLang: (code: string) => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return
+    const url = buildLocalizedPath(code, window.location.pathname)
     set({ lang: code })
-    const bare = typeof window === 'undefined' ? '/' : stripLocalePrefix(window.location.pathname)
-    const url = code === 'en' ? bare : `/${code}${bare === '/' ? '' : bare}`
     window.history.pushState(null, '', url + window.location.search + window.location.hash)
     document.documentElement.lang = code
     loadCJKFont(code)
   },
-  theme: (typeof window !== 'undefined' && localStorage.getItem('theme') as 'dark' | 'light') || 'dark',
+  theme: readBrowserTheme(),
   toggleTheme: () => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return
     // Wrap the class swap in document.startViewTransition when the browser
     // supports it, so dark↔light cross-fades instead of popping. Falls back
     // to the direct swap on Safari / Firefox stable (as of early 2026).
-    const apply = () => set((state) => {
-      const next = state.theme === 'dark' ? 'light' : 'dark'
-      localStorage.setItem('theme', next)
+    const apply = () => {
+      const next = useAppStore.getState().theme === 'dark' ? 'light' : 'dark'
+      try {
+        window.localStorage.setItem('theme', next)
+      } catch {
+        // Keep the in-memory theme usable when browser storage is unavailable.
+      }
       document.documentElement.classList.toggle('dark', next === 'dark')
       document.documentElement.classList.toggle('light', next === 'light')
-      return { theme: next }
-    })
-    const start = typeof document !== 'undefined' && (document as Document & { startViewTransition?: (cb: () => void) => void }).startViewTransition
+      set({ theme: next })
+    }
+    const start = (document as Document & {
+      startViewTransition?: (callback: () => void) => void
+    }).startViewTransition
     if (start) start.call(document, apply)
     else apply()
   },


### PR DESCRIPTION
## Summary

- derive locale detection and stripping from one ordered boundary-aware list
- guard complete language and font actions in non-browser environments
- build localized paths without nested conditional expressions
- validate persisted themes and tolerate unavailable browser storage
- move storage and DOM side effects outside Zustand state updaters
- clear the loaded-font cache during hot-module disposal

## Verification

- `mise exec -- pnpm --dir web test` (48 tests across 10 files)
- focused regressions cover locale boundaries, path rewriting, invalid and throwing storage, SSR actions, query/hash preservation, font loading, and theme side effects
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Supported locale and CJK font values remain unchanged.
- The broader OCR audit remains for follow-up PRs.