### PR TITLE
fix(web): make favorites store tear-safe

### DIFF
--- a/changelog.d/fixed/7694-web-favorites-store.md
+++ b/changelog.d/fixed/7694-web-favorites-store.md
@@ -1,0 +1,3 @@
+Website favorites now use React's tear-safe external-store contract and one shared cross-tab storage listener. (#7694) (@houko)
+
+Favorite lists keep stable identities across unrelated renders, and failed persistence no longer commits an in-memory change. (#7694) (@houko)

--- a/web/src/lib/useFavorites.test.tsx
+++ b/web/src/lib/useFavorites.test.tsx
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useFavorites } from './useFavorites'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root | undefined
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount())
+    root = undefined
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+describe('useFavorites', () => {
+  it('shares stable snapshots and rejects in-memory changes when persistence fails', async () => {
+    let raw: string | null = null
+    let failWrites = false
+    const setItem = vi.fn((_key: string, value: string) => {
+      if (failWrites) throw new Error('quota exceeded')
+      raw = value
+    })
+    vi.stubGlobal('localStorage', {
+      getItem: () => raw,
+      setItem,
+      removeItem: () => {},
+      clear: () => { raw = null },
+      key: () => null,
+      length: 0,
+    } satisfies Storage)
+
+    const snapshots = new Map<string, string[]>()
+    const listReferences = new Map<string, string[]>()
+    function Consumer({ id }: { id: string }) {
+      const favorites = useFavorites()
+      const [, setRenderCount] = useState(0)
+      snapshots.set(id, favorites.list)
+      listReferences.set(id, favorites.list)
+      return (
+        <div data-consumer={id}>
+          <span data-count>{favorites.count}</span>
+          <span data-favorite>{String(favorites.isFavorite('skills', 'alpha'))}</span>
+          <button data-toggle onClick={() => favorites.toggle('skills', 'alpha')}>toggle</button>
+          <button data-rerender onClick={() => setRenderCount(count => count + 1)}>rerender</button>
+        </div>
+      )
+    }
+
+    document.body.innerHTML = '<div id="root"></div>'
+    root = createRoot(document.querySelector('#root')!)
+    await act(async () => root?.render(<><Consumer id="first" /><Consumer id="second" /></>))
+
+    await act(async () => document.querySelector<HTMLElement>('[data-consumer="first"] [data-toggle]')?.click())
+    expect(Array.from(document.querySelectorAll('[data-count]'), node => node.textContent)).toEqual(['1', '1'])
+    expect(setItem).toHaveBeenCalledWith('librefang-favorites', '["skills/alpha"]')
+
+    const stableList = listReferences.get('first')
+    await act(async () => document.querySelector<HTMLElement>('[data-consumer="first"] [data-rerender]')?.click())
+    expect(listReferences.get('first')).toBe(stableList)
+
+    failWrites = true
+    await act(async () => document.querySelector<HTMLElement>('[data-consumer="second"] [data-toggle]')?.click())
+    expect(Array.from(document.querySelectorAll('[data-count]'), node => node.textContent)).toEqual(['1', '1'])
+    expect(Array.from(document.querySelectorAll('[data-favorite]'), node => node.textContent)).toEqual(['true', 'true'])
+
+    failWrites = false
+    raw = '["plugins/beta"]'
+    await act(async () => window.dispatchEvent(new StorageEvent('storage', { key: 'librefang-favorites' })))
+    expect(snapshots.get('first')).toEqual(['plugins/beta'])
+    expect(snapshots.get('second')).toEqual(['plugins/beta'])
+  })
+})

--- a/web/src/lib/useFavorites.ts
+++ b/web/src/lib/useFavorites.ts
@@ -1,31 +1,36 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
 
 const KEY = 'librefang-favorites'
 
 type FavSet = Set<string> // "category/id" tokens
+
+const EMPTY_FAVORITES: FavSet = new Set()
 
 function read(): FavSet {
   if (typeof window === 'undefined') return new Set()
   try {
     const raw = window.localStorage.getItem(KEY)
     if (!raw) return new Set()
-    const arr = JSON.parse(raw) as string[]
-    return new Set(Array.isArray(arr) ? arr : [])
+    const parsed: unknown = JSON.parse(raw)
+    return new Set(Array.isArray(parsed) ? parsed.filter(value => typeof value === 'string') : [])
   } catch {
     return new Set()
   }
 }
 
-function write(set: FavSet) {
-  if (typeof window === 'undefined') return
+function write(set: FavSet): boolean {
+  if (typeof window === 'undefined') return false
   try {
     window.localStorage.setItem(KEY, JSON.stringify([...set]))
-  } catch { /* quota / privacy mode — silent */ }
+    return true
+  } catch {
+    return false
+  }
 }
 
 // Shared subscriber list so multiple hook instances stay in sync within
-// the same tab (e.g., star toggled on a card re-renders the count in the
-// header). Cross-tab sync is handled by the 'storage' event below.
+// the same tab. One storage listener handles cross-tab updates regardless
+// of how many components subscribe.
 const listeners = new Set<() => void>()
 let current: FavSet | null = null
 
@@ -34,43 +39,57 @@ function getCurrent(): FavSet {
   return current
 }
 
+function getServerSnapshot(): FavSet {
+  return EMPTY_FAVORITES
+}
+
 function notify() {
-  for (const l of listeners) l()
+  for (const listener of listeners) listener()
+}
+
+function handleStorage(event: StorageEvent) {
+  if (event.key !== KEY && event.key !== null) return
+  current = read()
+  notify()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  if (listeners.size === 1 && typeof window !== 'undefined') {
+    window.addEventListener('storage', handleStorage)
+  }
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0 && typeof window !== 'undefined') {
+      window.removeEventListener('storage', handleStorage)
+    }
+  }
+}
+
+function favoriteKey(category: string, id: string): string {
+  return `${category}/${id}`
 }
 
 export function useFavorites() {
-  const [tick, setTick] = useState(0)
+  const favs = useSyncExternalStore(subscribe, getCurrent, getServerSnapshot)
+  const isFavorite = useCallback(
+    (category: string, id: string) => favs.has(favoriteKey(category, id)),
+    [favs],
+  )
 
-  useEffect(() => {
-    const bump = () => setTick(t => t + 1)
-    listeners.add(bump)
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === KEY) { current = read(); bump() }
-    }
-    window.addEventListener('storage', onStorage)
-    return () => {
-      listeners.delete(bump)
-      window.removeEventListener('storage', onStorage)
-    }
-  }, [])
-
-  const favs = getCurrent()
-  const key = useCallback((category: string, id: string) => `${category}/${id}`, [])
-  const isFavorite = useCallback((category: string, id: string) => favs.has(key(category, id)), [favs, key])
-
-  const toggle = useCallback((category: string, id: string) => {
-    const k = key(category, id)
+  const toggle = useCallback((category: string, id: string): boolean => {
+    const token = favoriteKey(category, id)
     const next = new Set(getCurrent())
-    if (next.has(k)) next.delete(k)
-    else next.add(k)
+    if (next.has(token)) next.delete(token)
+    else next.add(token)
+    if (!write(next)) return false
     current = next
-    write(next)
     notify()
-  }, [key])
+    return true
+  }, [])
 
   // For future use: a page listing all starred items. Returns an ordered
   // array of tokens; callers resolve them against registry data.
-  const list = [...favs]
-  void tick
+  const list = useMemo(() => [...favs], [favs])
   return { isFavorite, toggle, list, count: favs.size }
 }


### PR DESCRIPTION
## Summary

- replace the manual tick subscription with React `useSyncExternalStore` snapshots
- share one cross-tab storage listener across all hook consumers
- memoize the ordered favorites list for stable identity across unrelated renders
- commit and notify only after browser persistence succeeds
- reject malformed non-string entries while loading stored favorites

## Verification

- `mise exec -- pnpm --dir web test` (44 tests across 10 files)
- focused multi-consumer regression covers synchronized snapshots, stable list identity, persistence rollback, and storage-event refresh
- `mise exec -- pnpm --dir web lint`
- authenticated production dashboard build (17 hands, 44 channels, 57 providers, 22 workflows, 32 agents, 11 plugins, 61 skills, and 33 MCP servers)
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo check --workspace --lib`
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 mise exec -- cargo clippy --workspace --all-targets -- -D warnings`

## Out of scope

- Favorite token format and insertion ordering remain unchanged.
- The broader OCR audit remains for follow-up PRs.