### PR TITLE
fix(web): harden TOML token highlighting

### DIFF
--- a/changelog.d/fixed/7695-web-toml-highlighting.md
+++ b/changelog.d/fixed/7695-web-toml-highlighting.md
@@ -1,0 +1,3 @@
+Website TOML highlighting now keeps minus signs attached to numeric tokens and parses quoted section names containing closing brackets. (@houko)
+
+The defensive tokenizer branch now accurately documents unmatched token starts.

--- a/web/src/lib/toml-highlight.test.tsx
+++ b/web/src/lib/toml-highlight.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { highlightToml } from './toml-highlight'
+
+describe('highlightToml', () => {
+  it('keeps minus signs attached to numeric tokens in arrays', () => {
+    const markup = renderToStaticMarkup(highlightToml('values = [-5, -10, 2.5]'))
+
+    expect(markup).toContain('<span class="tk-num">-5</span>')
+    expect(markup).toContain('<span class="tk-num">-10</span>')
+    expect(markup).not.toContain('<span class="tk-punct">-</span>')
+  })
+
+  it('parses quoted section names containing a closing bracket', () => {
+    const markup = renderToStaticMarkup(highlightToml('["my]key"] # trailing'))
+
+    expect(markup).toContain('<span class="tk-header">&quot;my]key&quot;</span>')
+    expect(markup).toContain('<span class="tk-comment"># trailing</span>')
+  })
+
+  it('keeps both closing brackets outside array-table names', () => {
+    const markup = renderToStaticMarkup(highlightToml('[[array.table]]'))
+
+    expect(markup).toContain('<span class="tk-header">array.table</span>')
+    expect(markup).toContain('<span class="tk-punct">]]</span>')
+  })
+
+  it('advances safely when an unterminated token start is not consumed', () => {
+    const markup = renderToStaticMarkup(highlightToml('value = "unterminated'))
+
+    expect(markup).toContain('<span class="tk-punct">&quot;</span>')
+    expect(markup).toContain('<span class="tk-punct">unterminated</span>')
+  })
+})

--- a/web/src/lib/toml-highlight.tsx
+++ b/web/src/lib/toml-highlight.tsx
@@ -14,6 +14,40 @@ const STRING_RE = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/
 const NUM_RE = /-?\b\d+(?:\.\d+)?\b/
 const BOOL_RE = /\btrue\b|\bfalse\b/
 
+function parseHeader(rest: string): [string, string, string, string] | null {
+  const openBr = rest.startsWith('[[') ? '[[' : rest.startsWith('[') ? '[' : null
+  if (!openBr) return null
+
+  const closeBr = openBr === '[[' ? ']]' : ']'
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  for (let i = openBr.length; i < rest.length; i += 1) {
+    const char = rest[i]!
+    if (quote) {
+      if (quote === '"' && escaped) {
+        escaped = false
+      } else if (quote === '"' && char === '\\') {
+        escaped = true
+      } else if (char === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (rest.startsWith(closeBr, i)) {
+      const name = rest.slice(openBr.length, i)
+      if (!name) return null
+      return [openBr, name, closeBr, rest.slice(i + closeBr.length).trimStart()]
+    }
+  }
+
+  return null
+}
+
 function highlightValue(rest: string): Span[] {
   const out: Span[] = []
   let remaining = rest
@@ -42,7 +76,7 @@ function highlightValue(rest: string): Span[] {
     }
     // Punctuation / whitespace / identifiers — pass through up to the next
     // highlightable token.
-    const next = remaining.search(/["'0-9#]|\btrue\b|\bfalse\b/)
+    const next = remaining.search(/[-"'0-9#]|\btrue\b|\bfalse\b/)
     if (next === -1) {
       out.push({ className: 'tk-punct', text: remaining })
       break
@@ -51,8 +85,8 @@ function highlightValue(rest: string): Span[] {
       out.push({ className: 'tk-punct', text: remaining.slice(0, next) })
       remaining = remaining.slice(next)
     } else {
-      // Defensive: the regex class above matched a negative-lookbehind spot;
-      // single-char advance so we don't loop forever on pathological input.
+      // The token-start scan matched at index zero, but none of the typed
+      // token regexes consumed it. Advance once to avoid a pathological loop.
       out.push({ className: 'tk-punct', text: remaining[0]! })
       remaining = remaining.slice(1)
     }
@@ -70,9 +104,9 @@ function highlightLine(line: string): Span[] {
   if (!rest) return prefix
   if (rest.startsWith('#')) return [...prefix, { className: 'tk-comment', text: rest }]
   // Section header: [x.y] or [[x]]
-  const header = rest.match(/^(\[{1,2})([^\]]+)(\]{1,2})\s*(.*)$/)
+  const header = parseHeader(rest)
   if (header) {
-    const [, openBr, name, closeBr, trailing] = header
+    const [openBr, name, closeBr, trailing] = header
     return [
       ...prefix,
       { className: 'tk-punct', text: openBr! },


### PR DESCRIPTION
## Changes

- Keep negative signs attached to numeric tokens during value scanning.
- Parse section terminators outside quoted names while preserving double brackets for array tables.
- Correct the defensive tokenizer comment and cover the unmatched-token branch.

## Verification

- `mise exec -- pnpm --dir web test` (10 files, 47 tests).
- `mise exec -- pnpm --dir web lint`.
- `mise exec -- pnpm --dir web build`.
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo check --workspace --lib`.
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`.
- Local gitleaks was unavailable, so CI remains the secret-scan gate.

## Out of scope

- Full TOML grammar support and multiline string highlighting remain outside this focused tokenizer fix.