### PR TITLE
fix(web): harden marketplace data loading

### DIFF
--- a/changelog.d/fixed/7696-web-marketplace-data.md
+++ b/changelog.d/fixed/7696-web-marketplace-data.md
@@ -1,1 +1,1 @@
-Website marketplace metadata now uses a deployment-configurable endpoint and loads every result page instead of silently truncating large registries. (@houko)
+Website marketplace metadata now uses a deployment-configurable endpoint and loads every result page instead of silently truncating large registries (#7696) (@houko)

--- a/changelog.d/fixed/7696-web-marketplace-data.md
+++ b/changelog.d/fixed/7696-web-marketplace-data.md
@@ -1,0 +1,1 @@
+Website marketplace metadata now uses a deployment-configurable endpoint and loads every result page instead of silently truncating large registries. (@houko)

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,1 @@
+VITE_MARKETPLACE_API_URL=https://marketplace.librefang.ai/v1/packages

--- a/web/src/lib/useMarketplace.test.ts
+++ b/web/src/lib/useMarketplace.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchMarketplace, marketplaceQueryOptions } from './useMarketplace'
+
+vi.mock('@tanstack/react-query', () => ({ useQuery: vi.fn() }))
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('fetchMarketplace', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('loads every package page with the API maximum page size', async () => {
+    const first = Array.from({ length: 100 }, (_, id) => ({ id: String(id) }))
+    const second = [{ id: '100' }]
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response({ packages: first, total: 101 }))
+      .mockResolvedValueOnce(response({ packages: second, total: 101 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const packages = await fetchMarketplace('skill')
+
+    expect(packages).toHaveLength(101)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/v1/packages?kind=skill&limit=100&offset=0')
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/v1/packages?kind=skill&limit=100&offset=100')
+  })
+
+  it('rejects an incomplete paginated response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ packages: [], total: 1 })))
+
+    await expect(fetchMarketplace('hand')).rejects.toThrow('incomplete package list')
+  })
+})
+
+describe('marketplaceQueryOptions', () => {
+  it('keys covered categories by the requested marketplace kind', () => {
+    const options = marketplaceQueryOptions('plugins')
+
+    expect(options.queryKey).toEqual(['marketplace', 'extension'])
+    expect(options.enabled).toBe(true)
+  })
+
+  it('guards categories without marketplace coverage', async () => {
+    const options = marketplaceQueryOptions('agents')
+
+    expect(options.queryKey).toEqual(['marketplace', null])
+    expect(options.enabled).toBe(false)
+    await expect(options.queryFn()).resolves.toEqual([])
+  })
+})

--- a/web/src/lib/useMarketplace.ts
+++ b/web/src/lib/useMarketplace.ts
@@ -2,7 +2,8 @@ import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { RegistryCategory } from '../useRegistry'
 
-const MARKETPLACE_API = 'https://marketplace.librefang.ai/v1/packages'
+const MARKETPLACE_API = import.meta.env.VITE_MARKETPLACE_API_URL ?? '/v1/packages'
+const PAGE_SIZE = 100
 
 // Maps registry categories to marketplace `kind` values.
 // Categories with no marketplace coverage return null.
@@ -21,24 +22,46 @@ export interface MarketplacePkg {
   latest_version: string | null
 }
 
-async function fetchMarketplace(kind: string): Promise<MarketplacePkg[]> {
-  // limit=1000 is a safe ceiling — the registry is unlikely to exceed this
-  // in the foreseeable future. If it does, the sort will silently truncate.
-  const res = await fetch(`${MARKETPLACE_API}?kind=${encodeURIComponent(kind)}&limit=1000`)
-  if (!res.ok) throw new Error(`marketplace HTTP ${res.status}`)
-  const json = await res.json() as { packages: MarketplacePkg[] }
-  return json.packages ?? []
+export async function fetchMarketplace(kind: string): Promise<MarketplacePkg[]> {
+  const packages: MarketplacePkg[] = []
+  let total: number | null = null
+
+  do {
+    const params = new URLSearchParams({
+      kind,
+      limit: String(PAGE_SIZE),
+      offset: String(packages.length),
+    })
+    const res = await fetch(`${MARKETPLACE_API}?${params}`)
+    if (!res.ok) throw new Error(`marketplace HTTP ${res.status}`)
+
+    const json = await res.json() as { packages?: unknown; total?: unknown }
+    if (!Array.isArray(json.packages) || !Number.isSafeInteger(json.total) || (json.total as number) < 0) {
+      throw new Error('marketplace returned an invalid package page')
+    }
+    total ??= json.total as number
+    if (json.packages.length === 0 && packages.length < total) {
+      throw new Error('marketplace returned an incomplete package list')
+    }
+    packages.push(...json.packages as MarketplacePkg[])
+  } while (packages.length < total)
+
+  return packages.slice(0, total)
 }
 
-export function useMarketplace(category: RegistryCategory): Map<string, MarketplacePkg> {
+export function marketplaceQueryOptions(category: RegistryCategory) {
   const kind = CATEGORY_KIND[category] ?? null
-  const { data } = useQuery<MarketplacePkg[]>({
-    queryKey: ['marketplace', category],
-    queryFn: () => fetchMarketplace(kind!),
+  return {
+    queryKey: ['marketplace', kind],
+    queryFn: () => kind ? fetchMarketplace(kind) : Promise.resolve([]),
     enabled: !!kind,
     staleTime: 1000 * 60 * 15,
     retry: 0,
-  })
+  }
+}
+
+export function useMarketplace(category: RegistryCategory): Map<string, MarketplacePkg> {
+  const { data } = useQuery<MarketplacePkg[]>(marketplaceQueryOptions(category))
   return useMemo(() => {
     const map = new Map<string, MarketplacePkg>()
     for (const pkg of data ?? []) map.set(pkg.id, pkg)


### PR DESCRIPTION
## Changes

- Configure the production marketplace endpoint through `VITE_MARKETPLACE_API_URL` with a same-origin development fallback.
- Fetch the API maximum of 100 packages per page until the reported total is complete.
- Reject malformed or prematurely empty page responses instead of returning partial metadata.
- Key queries by marketplace kind and explicitly guard categories without marketplace coverage.

## Verification

- `mise exec -- pnpm --dir web test` (10 files, 47 tests).
- `mise exec -- pnpm --dir web lint`.
- `mise exec -- pnpm --dir web build`.
- The production bundle contains the configured marketplace endpoint.
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo check --workspace --lib`.
- `CARGO_TARGET_DIR=/Volumes/Lexar/worktrees/fix-api-source-date-epoch/target CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`.
- Local gitleaks was unavailable, so CI remains the secret-scan gate.

## Out of scope

- Loading and error state propagation remains deferred because open #7681 owns both `RegistryPage.tsx` and `RegistryDetailPage.tsx`, the two consumers that must render those states.