### PR TITLE
test(api): give LIBREFANG_VAULT_KEY a single owner

### DIFF
--- a/changelog.d/fixed/7706-vault-key-test-race.md
+++ b/changelog.d/fixed/7706-vault-key-test-race.md
@@ -1,0 +1,5 @@
+`cargo test -p librefang-api --lib` no longer fails roughly one run in two on a vault decryption error.
+Two test modules each pinned the process-global `LIBREFANG_VAULT_KEY` to a different value, each under its own `std::sync::Once` and each documenting that it was the only writer.
+`cargo test` runs a crate's tests as threads in one process, so whichever module wrote last won and the other's freshly written vault could no longer be decrypted — surfacing as `Crypto("Decryption failed: aead::Error")` in whichever test lost the race.
+CI never saw it because nextest gives every test its own process, which is also why the contributor-facing command in CLAUDE.md was the one that broke.
+The key and its `Once` now have a single owner, `crate::test_vault`, and both modules call it (#7706) (@houko)

--- a/changelog.d/fixed/7707-vault-key-test-race.md
+++ b/changelog.d/fixed/7707-vault-key-test-race.md
@@ -2,4 +2,4 @@
 Two test modules each pinned the process-global `LIBREFANG_VAULT_KEY` to a different value, each under its own `std::sync::Once` and each documenting that it was the only writer.
 `cargo test` runs a crate's tests as threads in one process, so whichever module wrote last won and the other's freshly written vault could no longer be decrypted — surfacing as `Crypto("Decryption failed: aead::Error")` in whichever test lost the race.
 CI never saw it because nextest gives every test its own process, which is also why the contributor-facing command in CLAUDE.md was the one that broke.
-The key and its `Once` now have a single owner, `crate::test_vault`, and both modules call it (#7706) (@houko)
+The key and its `Once` now have a single owner, `crate::test_vault`, and both modules call it (#7707) (@houko)

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -196,6 +196,56 @@ mod atomic_write_tests {
     }
 }
 
+/// One owner for the process-global `LIBREFANG_VAULT_KEY` that this crate's
+/// tests pin.
+///
+/// The vault master key is resolved from an environment variable, so it is
+/// process-global state that every test in the binary shares. `cargo test` runs
+/// the whole crate's tests as threads in one process, so two tests that pin
+/// *different* keys race: whichever writes last wins, and the vault the loser
+/// already wrote can no longer be decrypted — surfacing as
+/// `Crypto("Decryption failed: aead::Error")` in whichever test happens to lose.
+///
+/// That is not hypothetical. `server.rs`'s TOTP-lockout tests pinned one key
+/// while `routes/mcp_auth.rs`'s flow-cleanup test pinned 32 zero bytes, each
+/// under its own `Once` and each believing it was the only writer. Under
+/// `cargo test -p librefang-api --lib` the pair failed roughly one run in two,
+/// and CI never caught it because nextest gives every test its own process.
+///
+/// So the key lives here, exactly once, and both call [`pin_vault_key`].
+/// Anything else in this crate that needs a usable vault must do the same
+/// rather than setting the variable itself.
+#[cfg(test)]
+pub(crate) mod test_vault {
+    /// Syntactically-valid master key: base64 of exactly 32 bytes, so it
+    /// decodes to the `[u8; 32]` the vault expects rather than failing key
+    /// resolution. (32 ASCII characters would *not* work — see the
+    /// `LIBREFANG_VAULT_KEY` note in CLAUDE.md.)
+    pub(crate) const TEST_VAULT_KEY: &str = "dGVzdC12YXVsdC1rZXktZm9yLXRvdHAtbG9ja291dHM=";
+
+    /// Pin the vault master key for this process, idempotently.
+    ///
+    /// `resolve_master_key` (`crates/librefang-extensions/src/vault.rs`) reads
+    /// `LIBREFANG_VAULT_KEY` first and otherwise falls back to a store shared
+    /// beyond any single test's tempdir, so leaving it unset lets `init()` and a
+    /// later resolution settle on different keys. Setting it takes the
+    /// documented env-first branch, making the two agree by construction.
+    ///
+    /// Set once and never removed: unsetting it on drop would reopen the race
+    /// for whichever test is still running.
+    pub(crate) fn pin_vault_key() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            // SAFETY: the `Once` makes this the only writer in the process —
+            // which now holds, because this function is the crate's only
+            // writer of this variable.
+            unsafe {
+                std::env::set_var("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY);
+            }
+        });
+    }
+}
+
 #[cfg(windows)]
 pub mod acp_pipe;
 #[cfg(unix)]

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -196,43 +196,28 @@ mod atomic_write_tests {
     }
 }
 
-/// One owner for the process-global `LIBREFANG_VAULT_KEY` that this crate's
-/// tests pin.
+/// One owner for the process-global `LIBREFANG_VAULT_KEY` that this crate's tests pin.
 ///
-/// The vault master key is resolved from an environment variable, so it is
-/// process-global state that every test in the binary shares. `cargo test` runs
-/// the whole crate's tests as threads in one process, so two tests that pin
-/// *different* keys race: whichever writes last wins, and the vault the loser
-/// already wrote can no longer be decrypted — surfacing as
-/// `Crypto("Decryption failed: aead::Error")` in whichever test happens to lose.
+/// The vault master key is resolved from an environment variable, so it is process-global state that every test in the binary shares.
+/// `cargo test` runs the whole crate's tests as threads in one process, so two tests that pin *different* keys race: whichever writes last wins, and the vault the loser already wrote can no longer be decrypted — surfacing as `Crypto("Decryption failed: aead::Error")` in whichever test happens to lose.
 ///
-/// That is not hypothetical. `server.rs`'s TOTP-lockout tests pinned one key
-/// while `routes/mcp_auth.rs`'s flow-cleanup test pinned 32 zero bytes, each
-/// under its own `Once` and each believing it was the only writer. Under
-/// `cargo test -p librefang-api --lib` the pair failed roughly one run in two,
-/// and CI never caught it because nextest gives every test its own process.
+/// That is not hypothetical. `server.rs`'s TOTP-lockout tests pinned one key while `routes/mcp_auth.rs`'s flow-cleanup test pinned 32 zero bytes, each under its own `Once` and each believing it was the only writer.
+/// Under `cargo test -p librefang-api --lib` the pair failed roughly one run in two, and CI never caught it because nextest gives every test its own process.
 ///
 /// So the key lives here, exactly once, and both call [`pin_vault_key`].
-/// Anything else in this crate that needs a usable vault must do the same
-/// rather than setting the variable itself.
+/// Anything else in this crate that needs a usable vault must do the same rather than setting the variable itself.
 #[cfg(test)]
 pub(crate) mod test_vault {
-    /// Syntactically-valid master key: base64 of exactly 32 bytes, so it
-    /// decodes to the `[u8; 32]` the vault expects rather than failing key
-    /// resolution. (32 ASCII characters would *not* work — see the
-    /// `LIBREFANG_VAULT_KEY` note in CLAUDE.md.)
+    /// Syntactically-valid master key: base64 of exactly 32 bytes, so it decodes to the `[u8; 32]` the vault expects rather than failing key resolution.
+    /// (32 ASCII characters would *not* work — see the `LIBREFANG_VAULT_KEY` note in CLAUDE.md.)
     pub(crate) const TEST_VAULT_KEY: &str = "dGVzdC12YXVsdC1rZXktZm9yLXRvdHAtbG9ja291dHM=";
 
     /// Pin the vault master key for this process, idempotently.
     ///
-    /// `resolve_master_key` (`crates/librefang-extensions/src/vault.rs`) reads
-    /// `LIBREFANG_VAULT_KEY` first and otherwise falls back to a store shared
-    /// beyond any single test's tempdir, so leaving it unset lets `init()` and a
-    /// later resolution settle on different keys. Setting it takes the
-    /// documented env-first branch, making the two agree by construction.
+    /// `resolve_master_key` (`crates/librefang-extensions/src/vault.rs`) reads `LIBREFANG_VAULT_KEY` first and otherwise falls back to a store shared beyond any single test's tempdir, so leaving it unset lets `init()` and a later resolution settle on different keys.
+    /// Setting it takes the documented env-first branch, making the two agree by construction.
     ///
-    /// Set once and never removed: unsetting it on drop would reopen the race
-    /// for whichever test is still running.
+    /// Set once and never removed: unsetting it on drop would reopen the race for whichever test is still running.
     pub(crate) fn pin_vault_key() {
         static ONCE: std::sync::Once = std::sync::Once::new();
         ONCE.call_once(|| {

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -1844,13 +1844,15 @@ mod tests {
 
     #[test]
     fn flow_vault_cleanup_removes_all_per_flow_keys_on_drop() {
-        // Vault crypto needs a 32-byte key (this base64 decodes to 32 zero
-        // bytes). No other api test reads LIBREFANG_VAULT_KEY, so setting it
-        // process-wide here does not affect sibling tests.
-        std::env::set_var(
-            "LIBREFANG_VAULT_KEY",
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        );
+        // Vault crypto needs a 32-byte key. Pin it through the crate's single
+        // owner rather than setting the variable here: `server.rs`'s
+        // TOTP-lockout tests pin one too, and under `cargo test` (one process,
+        // tests as threads) two different keys race — whoever writes last wins
+        // and the loser's freshly written vault no longer decrypts, which is
+        // how this test came to fail with `Decryption failed: aead::Error`
+        // while passing in isolation. nextest hides it by giving every test its
+        // own process, so CI never saw it.
+        crate::test_vault::pin_vault_key();
         let home = std::env::temp_dir().join(format!("lf-vault-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&home).unwrap();
         let provider = KernelOAuthProvider::new(home.clone());

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -1844,14 +1844,9 @@ mod tests {
 
     #[test]
     fn flow_vault_cleanup_removes_all_per_flow_keys_on_drop() {
-        // Vault crypto needs a 32-byte key. Pin it through the crate's single
-        // owner rather than setting the variable here: `server.rs`'s
-        // TOTP-lockout tests pin one too, and under `cargo test` (one process,
-        // tests as threads) two different keys race — whoever writes last wins
-        // and the loser's freshly written vault no longer decrypts, which is
-        // how this test came to fail with `Decryption failed: aead::Error`
-        // while passing in isolation. nextest hides it by giving every test its
-        // own process, so CI never saw it.
+        // Vault crypto needs a 32-byte key.
+        // Pin it through the crate's single owner rather than setting the variable here: `server.rs`'s TOTP-lockout tests pin one too, and under `cargo test` (one process, tests as threads) two different keys race — whoever writes last wins and the loser's freshly written vault no longer decrypts, which is how this test came to fail with `Decryption failed: aead::Error` while passing in isolation.
+        // nextest hides it by giving every test its own process, so CI never saw it.
         crate::test_vault::pin_vault_key();
         let home = std::env::temp_dir().join(format!("lf-vault-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&home).unwrap();

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -3957,26 +3957,14 @@ mod dashboard_login_totp_lockout_tests {
     const DASH_USER: &str = "admin";
     const DASH_PASS: &str = "correct horse battery staple";
 
-    /// Syntactically-valid master key: base64 of exactly 32 bytes, so it decodes to the `[u8; 32]` the vault expects rather than failing key resolution.
-    const TEST_VAULT_KEY: &str = "dGVzdC12YXVsdC1rZXktZm9yLXRvdHAtbG9ja291dHM=";
-
     /// Pin the vault master key for this process before any test boots a kernel.
     ///
     /// Both tests below call `LibreFangKernel::boot_with_config`, which initialises the credential vault.
-    /// Each gets its own `home_dir` tempdir, but the *key* does not come from there: `resolve_master_key` (crates/librefang-extensions/src/vault.rs:703) reads `LIBREFANG_VAULT_KEY` and otherwise falls back to a store that is shared beyond the test's tempdir.
+    /// Each gets its own `home_dir` tempdir, but the *key* does not come from there: `resolve_master_key` (crates/librefang-extensions/src/vault.rs) reads `LIBREFANG_VAULT_KEY` and otherwise falls back to a store that is shared beyond the test's tempdir.
     /// With neither pinned, `init()` and a later `resolve_master_key()` can settle on different keys and the freshly written vault fails to decrypt — the failure is which test loses the race, not which test is wrong, which is why CI showed a different one failing on each lane (`Test / Unit (lib+bin)` blamed the new test, `Test / Ubuntu (shard 1/4)` the pre-existing one).
     ///
-    /// Setting the env var takes the documented env-first branch of `resolve_master_key`, so `init()` and every later resolution agree by construction.
-    /// It is set once and never removed: unsetting it on drop would reopen the same race for whichever test is still running.
-    fn pin_vault_key() {
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| {
-            // SAFETY: a `Once` makes this the only writer of this variable in the process, and it runs before either test constructs a kernel, so no other thread can observe a torn value.
-            unsafe {
-                std::env::set_var("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY);
-            }
-        });
-    }
+    /// The key and the `Once` live in `crate::test_vault` rather than here, so this module cannot become a second writer of the variable competing with another test module's key — which is exactly the bug that made `routes::mcp_auth::tests::flow_vault_cleanup_removes_all_per_flow_keys_on_drop` fail under `cargo test`. See that module's doc-comment.
+    use crate::test_vault::pin_vault_key;
 
     /// Produce `count` 6-digit codes that are guaranteed NOT to match the
     /// enrolled secret in the current TOTP window (or the adjacent windows a


### PR DESCRIPTION
## What

`cargo test -p librefang-api --lib` — the command CLAUDE.md tells contributors to run — failed roughly one run in two with a vault decryption error. This gives `LIBREFANG_VAULT_KEY` a single owner so it cannot.

## Root cause

The vault master key is resolved from an environment variable, so it is process-global state shared by every test in the binary. Two test modules pinned it to *different* values:

- `crates/librefang-api/src/server.rs` (`dashboard_login_totp_lockout_tests`) → `dGVzdC12YXVsdC1rZXktZm9yLXRvdHAtbG9ja291dHM=`
- `crates/librefang-api/src/routes/mcp_auth.rs` (`tests`) → `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=` (32 zero bytes)

Each sat behind its own `std::sync::Once`, and each carried a comment asserting it was the only writer:

> `// SAFETY: a Once makes this the only writer of this variable in the process`

> `// No other api test reads LIBREFANG_VAULT_KEY, so setting it process-wide here does not affect sibling tests.`

Both were true when written. Neither was true once the other existed. `cargo test` runs a crate's tests as threads in one process, so whichever module wrote last won, and the vault the loser had already written under the other key could no longer be decrypted:

```
thread 'routes::mcp_auth::tests::flow_vault_cleanup_removes_all_per_flow_keys_on_drop'
panicked at crates/librefang-api/src/routes/mcp_auth.rs:1893:22:
called `Result::unwrap()` on an `Err` value: Crypto("Decryption failed: aead::Error")
```

The same test passes when run alone, which is the signature of the race rather than a broken assertion.

**Why CI stayed green:** nextest gives every test its own process, so neither module ever observes the other's write. The Unit and shard lanes could not see this, and the breakage landed entirely on the scoped `cargo test` path in the contributor workflow.

## Change

- New `#[cfg(test)] pub(crate) mod test_vault` in `lib.rs` holding `TEST_VAULT_KEY` and a `Once`-guarded `pin_vault_key()`, with the reasoning recorded so the next module needing a vault calls it instead of setting the variable.
- Both modules call `pin_vault_key()`. The `Once`'s safety claim is accurate again, because that module is now the crate's only writer.
- No production code touched.

## Verification

Three consecutive full runs, where the pre-change tree gave `1029 passed; 1 failed`:

```
run 1: test result: ok. 1030 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.17s
run 2: test result: ok. 1030 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.62s
run 3: test result: ok. 1030 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.14s
```

```
cargo clippy -p librefang-api --all-targets -- -D warnings   exit 0
cargo fmt --check -p librefang-api                           exit 0
cargo check --workspace --lib                                exit 0
```

## Note

The count goes 1029 → 1030 because the pre-change run reported one test as failed rather than passed; no test was added.
