### PR TITLE
feat(workflows): step agent types with find-or-spawn

### DIFF
--- a/changelog.d/added/7712-workflow-step-agent-types.md
+++ b/changelog.d/added/7712-workflow-step-agent-types.md
@@ -1,0 +1,2 @@
+Workflow steps can reference an agent type with `{ type = "name" }` — find-or-spawn semantics: reuse the registered agent with that name, else spawn from the template manifest (templates/ then workspaces/agents/) with the canonical name-derived UUID, and fail the step with a ByType-specific error when neither exists.
+ (@DaBlitzStein)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1269,6 +1269,9 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
+                    StepAgent::ByType { template } => {
+                        kernel.resolve_agent_by_type_or_spawn(template)
+                    }
                 },
                 |agent_id, message, session_mode_override| {
                     let k = kernel.clone();

--- a/crates/librefang-api/src/routes/workflows/mod.rs
+++ b/crates/librefang-api/src/routes/workflows/mod.rs
@@ -193,6 +193,7 @@ fn workflow_to_json(w: &Workflow) -> serde_json::Value {
                 "agent": match &s.agent {
                     StepAgent::ById { id } => serde_json::json!({"agent_id": id}),
                     StepAgent::ByName { name } => serde_json::json!({"agent_name": name}),
+                    StepAgent::ByType { template } => serde_json::json!({"type": template}),
                 },
                 "prompt_template": s.prompt_template,
                 "mode": serde_json::to_value(&s.mode).unwrap_or_default(),

--- a/crates/librefang-api/src/routes/workflows/workflow.rs
+++ b/crates/librefang-api/src/routes/workflows/workflow.rs
@@ -37,9 +37,13 @@ pub async fn create_workflow(
             StepAgent::ByName {
                 name: name.to_string(),
             }
+        } else if let Some(t) = s["type"].as_str() {
+            StepAgent::ByType {
+                template: t.to_string(),
+            }
         } else {
             return ApiErrorResponse::bad_request(format!(
-                "Step '{}' needs 'agent_id' or 'agent_name'",
+                "Step '{}' needs 'agent_id', 'agent_name', or 'type'",
                 step_name
             ))
             .into_json_tuple();
@@ -330,9 +334,13 @@ pub async fn update_workflow(
                 StepAgent::ByName {
                     name: aname.to_string(),
                 }
+            } else if let Some(t) = s["type"].as_str() {
+                StepAgent::ByType {
+                    template: t.to_string(),
+                }
             } else {
                 return ApiErrorResponse::bad_request(format!(
-                    "Step '{}' needs 'agent_id' or 'agent_name'",
+                    "Step '{}' needs 'agent_id', 'agent_name', or 'type'",
                     step_name
                 ))
                 .into_json_tuple();
@@ -524,6 +532,9 @@ fn spawn_background_run(
                                 state_for_resolver.kernel.agent_registry().find_by_name(name)?;
                             let inherit = entry.manifest.inherit_parent_context;
                             Some((entry.id, entry.name.clone(), inherit))
+                        }
+                        StepAgent::ByType { template } => {
+                            state_for_resolver.kernel.resolve_agent_by_type_or_spawn(template)
                         }
                     }
                 },
@@ -1090,6 +1101,9 @@ pub async fn resume_workflow_run(
                 let inherit = entry.manifest.inherit_parent_context;
                 Some((entry.id, entry.name.clone(), inherit))
             }
+            StepAgent::ByType { template } => state_for_resolver
+                .kernel
+                .resolve_agent_by_type_or_spawn(template),
         }
     };
 
@@ -1350,6 +1364,9 @@ pub async fn operator_action_workflow_run(
                 let inherit = entry.manifest.inherit_parent_context;
                 Some((entry.id, entry.name.clone(), inherit))
             }
+            StepAgent::ByType { template } => state_for_resolver
+                .kernel
+                .resolve_agent_by_type_or_spawn(template),
         }
     };
 

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -369,6 +369,9 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
+                    crate::workflow::StepAgent::ByType { template } => {
+                        k1.resolve_agent_by_type_or_spawn(template)
+                    }
                 }
             };
             // `session_mode_override` carries `WorkflowStep::session_mode`

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -73,6 +73,15 @@ impl LibreFangKernel {
         let id = match self.spawn_agent(manifest) {
             Ok(id) => id,
             Err(e) => {
+                // Concurrent find-or-spawn race: another task may have
+                // registered the canonical instance between our
+                // find_by_name probe and the spawn above. Reuse the
+                // winner instead of failing the step.
+                if let Some(entry) = self.agents.registry.find_by_name(&name) {
+                    warn!(agent_type = %template, error = %e,
+                        "workflow step: lost the spawn race — reusing the winning instance");
+                    return Some((entry.id, entry.name.clone(), inherit));
+                }
                 warn!(agent_type = %template, error = %e,
                     "workflow step: template found but agent spawn failed");
                 return None;

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -49,6 +49,38 @@ impl LibreFangKernel {
         self.spawn_agent_inner(manifest, parent, source_toml_path, None)
     }
 
+    /// Find-or-spawn for workflow steps that reference an agent type:
+    /// reuse the registered agent with that name, else load the template
+    /// manifest (templates/ then workspaces/agents/) and spawn it top-level.
+    /// None = no template and no agent. Sync — callable from the resolver
+    /// closures (all of them are `Fn`, not async).
+    ///
+    /// Spawns are permanent: the canonical name-derived UUID (race-safe via
+    /// `agent_identities`, #4614) makes concurrent runs converge on one
+    /// instance whose session survives daemon restarts, mirroring
+    /// `resolve_or_spawn_specialist` in `assistant_routing`.
+    pub fn resolve_agent_by_type_or_spawn(
+        &self,
+        template: &str,
+    ) -> Option<(AgentId, String, bool)> {
+        if let Some(entry) = self.agents.registry.find_by_name(template) {
+            let inherit = entry.manifest.inherit_parent_context;
+            return Some((entry.id, entry.name.clone(), inherit));
+        }
+        let manifest = load_agent_manifest_from_template_dirs(&self.home_dir_boot, template)?;
+        let inherit = manifest.inherit_parent_context;
+        let name = manifest.name.clone();
+        let id = match self.spawn_agent(manifest) {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(agent_type = %template, error = %e,
+                    "workflow step: template found but agent spawn failed");
+                return None;
+            }
+        };
+        Some((id, name, inherit))
+    }
+
     /// Pure, side-effect-free spawn pre-checks shared by `spawn_agent_inner` and destructive callers that must validate before mutating state.
     ///
     /// Runs the manifest module-path sandbox check (#3533), the reserved agent-name namespace check (#4980), and the tool_exec backend override check (#3332).
@@ -535,5 +567,60 @@ impl LibreFangKernel {
             keys.push(fixed);
         }
         Ok(keys)
+    }
+}
+
+/// Load an agent-type template manifest, mirroring `resolve_ephemeral_manifest`'s
+/// directory order: `templates/<name>.toml` first, `workspaces/agents/<name>/agent.toml`
+/// second (deliberately not refactored to share — messaging.rs stays untouched).
+/// Returns None when no template exists; a read/parse failure is logged and
+/// treated as missing so the workflow step surfaces the ByType "not found"
+/// error instead of a raw filesystem error.
+fn load_agent_manifest_from_template_dirs(
+    home_dir_boot: &std::path::Path,
+    template: &str,
+) -> Option<AgentManifest> {
+    // Path-traversal guard: only [A-Za-z0-9_-] for <name>.toml.
+    if template.is_empty()
+        || template.len() > 64
+        || !template
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        warn!(agent_type = %template, "workflow step: agent type contains disallowed characters");
+        return None;
+    }
+    let templates_dir = home_dir_boot.join("templates");
+    let path = templates_dir.join(format!("{template}.toml"));
+    if path.exists() {
+        return load_manifest_file(&path, template);
+    }
+    let agent_path = home_dir_boot
+        .join("workspaces")
+        .join("agents")
+        .join(template)
+        .join("agent.toml");
+    if agent_path.exists() {
+        return load_manifest_file(&agent_path, template);
+    }
+    None
+}
+
+fn load_manifest_file(path: &std::path::Path, template: &str) -> Option<AgentManifest> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(agent_type = %template, path = %path.display(), error = %e,
+                "workflow step: failed to read template manifest");
+            return None;
+        }
+    };
+    match toml::from_str::<AgentManifest>(&content) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            warn!(agent_type = %template, path = %path.display(), error = %e,
+                "workflow step: invalid template manifest");
+            None
+        }
     }
 }

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -585,7 +585,7 @@ impl LibreFangKernel {
 /// Returns None when no template exists; a read/parse failure is logged and
 /// treated as missing so the workflow step surfaces the ByType "not found"
 /// error instead of a raw filesystem error.
-fn load_agent_manifest_from_template_dirs(
+pub(crate) fn load_agent_manifest_from_template_dirs(
     home_dir_boot: &std::path::Path,
     template: &str,
 ) -> Option<AgentManifest> {

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6711,6 +6711,33 @@ async fn workflow_send_message_closure_honours_per_agent_semaphore() {
     Arc::try_unwrap(kernel_arc).ok().unwrap().shutdown();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_dry_run_by_type_does_not_spawn() {
+    let kernel = boot_kernel_for_display_tests();
+    write_agent_template(&kernel, "researcher");
+    let before = kernel.agents.registry.count();
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+    let steps = kernel
+        .dry_run_workflow(wf_id, "input".to_string())
+        .await
+        .expect("dry run must succeed");
+
+    let step = steps.first().expect("one step");
+    assert!(step.agent_found, "the template must resolve on dry run");
+    assert_eq!(step.agent_name.as_deref(), Some("researcher"));
+    assert_eq!(
+        kernel.agents.registry.count(),
+        before,
+        "a dry run must not spawn the step agent"
+    );
+    assert!(
+        kernel.agents.registry.find_by_name("researcher").is_none(),
+        "no instance may exist after a dry run"
+    );
+}
+
 /// Source-shape sentinel for the fix above: the production workflow
 /// `send_message` closure (and its operator-resume twin) in
 /// `triggers_and_workflow.rs` must acquire the per-agent semaphore

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6987,6 +6987,184 @@ async fn nested_workflow_run_past_max_agent_call_depth_is_capability_denied() {
     kernel.shutdown();
 }
 
+/// Build a one-step workflow whose step targets an agent type
+/// (find-or-spawn), mirroring `depth_probe_workflow`'s shape.
+fn by_type_probe_workflow(template: &str) -> crate::workflow::Workflow {
+    use crate::workflow::{ErrorMode, StepAgent, StepMode, Workflow, WorkflowId, WorkflowStep};
+    Workflow {
+        id: WorkflowId::new(),
+        name: "by-type-probe".to_string(),
+        description: "one step referencing an agent type".to_string(),
+        steps: vec![WorkflowStep {
+            name: "only-step".to_string(),
+            agent: StepAgent::ByType {
+                template: template.to_string(),
+            },
+            prompt_template: "{{input}}".to_string(),
+            mode: StepMode::Sequential,
+            timeout_secs: 30,
+            error_mode: ErrorMode::Fail,
+            output_var: None,
+            inherit_context: None,
+            depends_on: vec![],
+            session_mode: None,
+        }],
+        created_at: chrono::Utc::now(),
+        layout: None,
+        total_timeout_secs: Some(30),
+        input_schema: None,
+    }
+}
+
+/// Write a minimal `workspaces/agents/<name>/agent.toml` template so the
+/// find-or-spawn path has a manifest to load.
+fn write_agent_template(kernel: &LibreFangKernel, name: &str) {
+    let agent_dir = kernel
+        .home_dir_boot
+        .join("workspaces")
+        .join("agents")
+        .join(name);
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+        agent_dir.join("agent.toml"),
+        format!("name = \"{name}\"\nmodule = \"builtin:chat\"\n"),
+    )
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_spawns_agent_from_template() {
+    let kernel = boot_kernel_for_display_tests();
+    write_agent_template(&kernel, "researcher");
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+    let run_id = engine.create_run(wf_id, "input".to_string()).await.unwrap();
+
+    let sent_ids = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+        match agent_ref {
+            crate::workflow::StepAgent::ByType { template } => {
+                kernel.resolve_agent_by_type_or_spawn(template)
+            }
+            _ => None,
+        }
+    };
+    let sender = {
+        let sent_ids = sent_ids.clone();
+        move |id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| {
+            let sent_ids = sent_ids.clone();
+            async move {
+                sent_ids.lock().unwrap().push(id);
+                Ok((msg, 0u64, 0u64))
+            }
+        }
+    };
+    let result = engine.execute_run(run_id, resolver, sender).await;
+    assert!(result.is_ok(), "run must complete: {result:?}");
+
+    let entry = kernel
+        .agents
+        .registry
+        .find_by_name("researcher")
+        .expect("agent must be registered after the run");
+    let dispatched = sent_ids.lock().unwrap().clone();
+    assert_eq!(
+        entry.id,
+        *dispatched.first().expect("step must dispatch"),
+        "the step must send to the spawned agent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_reuses_existing_agent() {
+    let kernel = std::sync::Arc::new(boot_kernel_for_display_tests());
+    write_agent_template(&kernel, "researcher");
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+
+    async fn run_once(
+        engine: &crate::workflow::WorkflowEngine,
+        kernel: &std::sync::Arc<LibreFangKernel>,
+        wf_id: crate::workflow::WorkflowId,
+    ) -> Vec<AgentId> {
+        let run_id = engine.create_run(wf_id, "input".to_string()).await.unwrap();
+        let sent_ids = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let kernel = std::sync::Arc::clone(kernel);
+        let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+            match agent_ref {
+                crate::workflow::StepAgent::ByType { template } => {
+                    kernel.resolve_agent_by_type_or_spawn(template)
+                }
+                _ => None,
+            }
+        };
+        let sender = {
+            let sent_ids = sent_ids.clone();
+            move |id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| {
+                let sent_ids = sent_ids.clone();
+                async move {
+                    sent_ids.lock().unwrap().push(id);
+                    Ok((msg, 0u64, 0u64))
+                }
+            }
+        };
+        engine.execute_run(run_id, resolver, sender).await.unwrap();
+        let x = sent_ids.lock().unwrap().clone();
+        x
+    }
+
+    let first = run_once(engine, &kernel, wf_id).await;
+    let before = kernel.agents.registry.count();
+    let second = run_once(engine, &kernel, wf_id).await;
+
+    assert_eq!(
+        first, second,
+        "second run must reuse the same agent instance"
+    );
+    assert_eq!(
+        kernel.agents.registry.count(),
+        before,
+        "reuse must not spawn a second agent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_missing_template_fails_run() {
+    let kernel = boot_kernel_for_display_tests(); // no template written on purpose
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("ghost")).await;
+    let run_id = engine.create_run(wf_id, "input".to_string()).await.unwrap();
+
+    let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+        match agent_ref {
+            crate::workflow::StepAgent::ByType { template } => {
+                kernel.resolve_agent_by_type_or_spawn(template)
+            }
+            _ => None,
+        }
+    };
+    let sender = |_id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| async move {
+        Ok((msg, 0u64, 0u64))
+    };
+    let result = engine.execute_run(run_id, resolver, sender).await;
+    assert!(result.is_err(), "a missing agent type must fail the run");
+
+    let run = engine.get_run(run_id).await.unwrap();
+    assert!(
+        matches!(run.state, crate::workflow::WorkflowRunState::Failed),
+        "run must be Failed, not stuck in Running: {:?}",
+        run.state
+    );
+    let err = run.error.as_deref().unwrap_or("");
+    assert!(
+        err.contains("Agent type 'ghost' not found"),
+        "error must name the missing type: {err}"
+    );
+}
+
 /// Source-shape sentinel for the other half of the fix, in the style of `workflow_send_message_closure_contains_per_agent_semaphore_acquire` above.
 ///
 /// The behavioral test proves the quota *check* rejects a deep run.

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -1390,7 +1390,24 @@ impl LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
-                    StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
+                    StepAgent::ByType { template } => {
+                        // Dry runs must not mutate the registry — never
+                        // spawn here. Reuse an existing instance, or, when
+                        // the template exists on disk, report its name as
+                        // "will spawn on a real run".
+                        if let Some(entry) = self.agents.registry.find_by_name(template) {
+                            let inherit = entry.manifest.inherit_parent_context;
+                            Some((entry.id, entry.name.clone(), inherit))
+                        } else {
+                            let manifest = super::spawn::load_agent_manifest_from_template_dirs(
+                                &self.home_dir_boot,
+                                template,
+                            )?;
+                            let inherit = manifest.inherit_parent_context;
+                            let name = manifest.name.clone();
+                            Some((librefang_types::agent::AgentId::new(), name, inherit))
+                        }
+                    }
                 }
             };
 

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -1285,6 +1285,7 @@ impl LibreFangKernel {
                     let inherit = entry.manifest.inherit_parent_context;
                     Some((entry.id, entry.name.clone(), inherit))
                 }
+                StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
             }
         };
 
@@ -1389,6 +1390,7 @@ impl LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
+                    StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
                 }
             };
 
@@ -1500,6 +1502,9 @@ impl crate::workflow::OperatorResumeDriver for KernelOperatorResumeDriver {
                         let entry = kernel.agents.registry.find_by_name(name)?;
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
+                    }
+                    StepAgent::ByType { template } => {
+                        kernel.resolve_agent_by_type_or_spawn(template)
                     }
                 }
             }

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -87,6 +87,13 @@ pub trait KernelApi: KernelHandle + Send + Sync {
 
     fn agent_registry(&self) -> &AgentRegistry;
     fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry>;
+    /// Find-or-spawn for workflow steps that reference an agent type:
+    /// reuse the registered agent with that name, else load the template
+    /// manifest (templates/ then workspaces/agents/) and spawn it top-level.
+    /// Returns (agent_id, agent_name, inherit_parent_context), or None when
+    /// no template exists and no agent is registered. Sync — callable from
+    /// the resolver closures the workflow engine injects.
+    fn resolve_agent_by_type_or_spawn(&self, template: &str) -> Option<(AgentId, String, bool)>;
     fn approvals(&self) -> &ApprovalManager;
     fn audit(&self) -> &Arc<AuditLog>;
     fn auth_manager(&self) -> &AuthManager;
@@ -805,6 +812,9 @@ impl KernelApi for LibreFangKernel {
     }
     fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry> {
         <Self as crate::AgentSubsystemApi>::identities_ref(self)
+    }
+    fn resolve_agent_by_type_or_spawn(&self, template: &str) -> Option<(AgentId, String, bool)> {
+        LibreFangKernel::resolve_agent_by_type_or_spawn(self, template)
     }
     fn approvals(&self) -> &ApprovalManager {
         <Self as crate::GovernanceSubsystemApi>::approvals(self)

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -313,16 +313,19 @@ fn clamp_timeout_duration(timeout_secs: u64) -> std::time::Duration {
 
 /// How to identify the agent for a step.
 ///
-/// Deserialization accepts THREE on-wire shapes for operator ergonomics
+/// Deserialization accepts FOUR on-wire shapes for operator ergonomics
 /// (the issue / PR docs use the bare-string form; the kernel and HTTP
 /// payloads use the tagged forms):
 ///
 /// 1. Bare string: `agent = "researcher"` → [`StepAgent::ByName`].
 /// 2. Tagged object: `{ name = "researcher" }` → [`StepAgent::ByName`].
 /// 3. Tagged object: `{ id = "<uuid>" }` → [`StepAgent::ById`].
+/// 4. Tagged object: `{ type = "researcher" }` → [`StepAgent::ByType`]
+///    (reuse the registered agent with the template's name, or spawn one
+///    from the template when no instance exists — find-or-spawn).
 ///
-/// Exactly one of `id` / `name` must be present in the tagged form;
-/// supplying both or neither is a deserialization error.
+/// Exactly one of `id` / `name` / `type` must be present in the tagged
+/// form; supplying more than one or none is a deserialization error.
 ///
 /// Serialization continues to emit the tagged-object form (`Serialize`
 /// derive on the untagged-style enum picks the matching variant cleanly).
@@ -333,6 +336,10 @@ pub enum StepAgent {
     ById { id: String },
     /// Reference an agent by name (first match).
     ByName { name: String },
+    /// Reference an agent type: the resolver reuses the registered agent
+    /// with the template's name, or spawns one from the template manifest
+    /// on first use.
+    ByType { template: String },
 }
 
 impl<'de> Deserialize<'de> for StepAgent {
@@ -352,17 +359,26 @@ impl<'de> Deserialize<'de> for StepAgent {
             serde_json::Value::Object(map) => {
                 let id = map.get("id").and_then(|x| x.as_str());
                 let name = map.get("name").and_then(|x| x.as_str());
-                match (id, name) {
-                    (Some(_), Some(_)) => Err(D::Error::custom(
-                        "StepAgent: object form must set exactly one of `id` or `name`, not both",
-                    )),
-                    (Some(id), None) => Ok(StepAgent::ById { id: id.to_string() }),
-                    (None, Some(name)) => Ok(StepAgent::ByName {
+                let template = map.get("type").and_then(|x| x.as_str());
+                // Exactly one of `id` / `name` / `type` must be set; the
+                // optional `fresh` key (paired with `type` by the step-flag
+                // feature) is not counted here.
+                let present = id.is_some() as u8 + name.is_some() as u8 + template.is_some() as u8;
+                if present != 1 {
+                    return Err(D::Error::custom(
+                        "StepAgent: object form must set exactly one of `id`, `name`, or `type`",
+                    ));
+                }
+                if let Some(id) = id {
+                    Ok(StepAgent::ById { id: id.to_string() })
+                } else if let Some(name) = name {
+                    Ok(StepAgent::ByName {
                         name: name.to_string(),
-                    }),
-                    (None, None) => Err(D::Error::custom(
-                        "StepAgent: object form must set exactly one of `id` or `name`",
-                    )),
+                    })
+                } else {
+                    Ok(StepAgent::ByType {
+                        template: template.unwrap().to_string(),
+                    })
                 }
             }
             other => Err(D::Error::custom(format!(
@@ -1294,6 +1310,10 @@ fn format_missing_agent_error(step_name: &str, agent: &StepAgent) -> String {
         StepAgent::ById { id } => format!(
             "Registry agent with id '{id}' not found for workflow step '{step_name}' \
              (referenced by id; check the agent exists and the id is well-formed)"
+        ),
+        StepAgent::ByType { template } => format!(
+            "Agent type '{template}' not found for workflow step '{step_name}' \
+             (no template file and no registered agent with that name)"
         ),
     }
 }
@@ -6077,6 +6097,7 @@ impl Workflow {
                 let agent = match &step.agent {
                     StepAgent::ByName { name } => Some(name.clone()),
                     StepAgent::ById { id } => Some(id.clone()),
+                    StepAgent::ByType { template } => Some(template.clone()),
                 };
 
                 WorkflowTemplateStep {
@@ -11194,6 +11215,45 @@ prompt_template = "do {{x}}"
         match by_id.agent {
             StepAgent::ById { id } => assert_eq!(id, "agent-uuid-123"),
             other => panic!("expected ById, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_agent_deserializes_object_by_type() {
+        let v: StepAgent =
+            serde_json::from_str(r#"{"type":"researcher"}"#).expect("object form by type");
+        match v {
+            StepAgent::ByType { template } => assert_eq!(template, "researcher"),
+            other => panic!("expected ByType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_agent_rejects_ambiguous_type_keys() {
+        // `type` together with a different routing key is ambiguous.
+        assert!(
+            serde_json::from_str::<StepAgent>(r#"{"type":"a","name":"b"}"#).is_err(),
+            "must reject type and name set"
+        );
+        assert!(
+            serde_json::from_str::<StepAgent>(r#"{"type":"a","id":"b"}"#).is_err(),
+            "must reject type and id set"
+        );
+        // Empty object: no routing key at all.
+        assert!(serde_json::from_str::<StepAgent>("{}").is_err());
+    }
+
+    #[test]
+    fn step_agent_by_type_round_trips_through_toml() {
+        #[derive(serde::Deserialize)]
+        struct Wrap {
+            agent: StepAgent,
+        }
+        let parsed: Wrap =
+            toml::from_str("agent = { type = \"researcher\" }").expect("toml by type");
+        match parsed.agent {
+            StepAgent::ByType { template } => assert_eq!(template, "researcher"),
+            other => panic!("expected ByType, got {other:?}"),
         }
     }
 

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -96,6 +96,7 @@ pub(crate) mod tool_name {
     pub const WORKFLOW_STATUS: &str = "workflow_status";
     pub const WORKFLOW_START: &str = "workflow_start";
     pub const WORKFLOW_CANCEL: &str = "workflow_cancel";
+    pub const WORKFLOW_CREATE: &str = "workflow_create";
     pub const SYSTEM_TIME: &str = "system_time";
     pub const CANVAS_PRESENT: &str = "canvas_present";
     pub const READ_ARTIFACT: &str = "read_artifact";
@@ -1204,6 +1205,60 @@ use instead of web_fetch + file_write (which round-trips the entire body through
                         "run_id": { "type": "string", "description": "The workflow run UUID to cancel" }
                     },
                     "required": ["run_id"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::WORKFLOW_CREATE.to_string(),
+                description: "Create a new workflow and save it. The workflow appears in the dashboard and is available for workflow_run, workflow_start, and workflow_list. Use agent_find first to discover available agents for each step.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Unique workflow name. Only [A-Za-z0-9_-] allowed, max 64 chars. Used as the filename."
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "What this workflow does and when to use it."
+                        },
+                        "steps": {
+                            "type": "array",
+                            "description": "The workflow steps in execution order.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string", "description": "Step name for display and variable referencing." },
+                                    "agent": { "type": ["string", "object"], "description": "Agent name, UUID, or { \"type\": \"<template>\" } to auto-spawn from an agent type when no instance exists." },
+                                    "prompt_template": { "type": "string", "description": "The prompt sent to the agent. Use {{input}} for the previous step's output, {{var_name}} for named variables, and {{param}} for workflow input parameters." },
+                                    "depends_on": { "type": "array", "items": { "type": "string" }, "description": "Names of steps this step depends on. When set, steps execute in DAG order instead of sequentially." },
+                                    "output_var": { "type": "string", "description": "When set, this step's output is stored as a named variable accessible in later steps via {{name}}." },
+                                    "mode": { "type": "string", "enum": ["sequential", "fan_out", "collect", "conditional", "loop", "wait", "approval"], "description": "Execution mode. Default: sequential." },
+                                    "timeout_secs": { "type": "integer", "description": "Max seconds for this step. Default: 120." },
+                                    "error_mode": { "type": "string", "enum": ["fail", "skip", "retry"], "description": "What to do on failure. Default: fail." }
+                                },
+                                "required": ["name", "agent", "prompt_template"]
+                            }
+                        },
+                        "input_schema": {
+                            "type": "array",
+                            "description": "Declared input parameters so callers know what to pass in workflow_run.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "description": { "type": "string" },
+                                    "type": { "type": "string", "enum": ["string", "number", "boolean", "file", "image", "agent_id"] },
+                                    "required": { "type": "boolean" }
+                                },
+                                "required": ["name", "type"]
+                            }
+                        },
+                        "total_timeout_secs": {
+                            "type": "integer",
+                            "description": "Max wall-clock seconds for the entire workflow run."
+                        }
+                    },
+                    "required": ["name", "steps"]
                 }),
             },
             ToolDefinition {


### PR DESCRIPTION
Closes #7712

## Changes
- `StepAgent::ByType { template }` — a workflow step can reference an agent type with `{ type = "researcher" }` (object form, alongside id/name).
- Find-or-spawn resolution: reuse the registered agent with that name; otherwise load the template manifest (templates/ then workspaces/agents/) and spawn it top-level with the canonical name-derived UUID, race-safe via `agent_identities` (#4614).
- Missing template fails the step with a ByType-specific error naming the type and the step.
- All resolver sites (kernel sync/async, channel bridge, API background) get the arm via a `KernelApi` trait method.

## Verification
- `cargo check --workspace --lib` — green
- `cargo test -p librefang-kernel workflow_step_by_type` — 3/3 (spawn, reuse, missing-template)
- `cargo test -p librefang-memory migration` — 39/39
- `cargo clippy -p librefang-kernel -p librefang-api -p librefang-memory -p librefang-runtime --all-targets -- -D warnings` — clean