### PR TITLE
feat(workflows): run owner attribution and per-step fresh instances

### DIFF
--- a/changelog.d/added/7714-workflow-run-owner-fresh.md
+++ b/changelog.d/added/7714-workflow-run-owner-fresh.md
@@ -1,0 +1,1 @@
+Workflow runs record their owner and bill template-spawned step agents to it; steps can request a fresh agent instance per run with `{ type = "x", fresh = true }`, which spawns a new random-id instance with a unique name tag instead of reusing the canonical one. (@DaBlitzStein)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1269,6 +1269,9 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
+                    StepAgent::ByType { template } => {
+                        kernel.resolve_agent_by_type_or_spawn(template)
+                    }
                 },
                 |agent_id, message, session_mode_override| {
                     let k = kernel.clone();

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1233,7 +1233,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         msg
     }
 
-    async fn run_workflow_text(&self, name: &str, input: &str) -> String {
+    async fn run_workflow_text(&self, name: &str, input: &str, owner: Option<AgentId>) -> String {
         let workflows = self.kernel.workflow_engine().list_workflows().await;
         let wf = match workflows.iter().find(|w| w.name.eq_ignore_ascii_case(name)) {
             Some(w) => w.clone(),
@@ -1243,7 +1243,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         let run_id = match self
             .kernel
             .workflow_engine()
-            .create_run(wf.id, input.to_string())
+            .create_run_with_owner(wf.id, input.to_string(), owner)
             .await
         {
             Some(id) => id,
@@ -1269,8 +1269,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
-                    StepAgent::ByType { template } => {
-                        kernel.resolve_agent_by_type_or_spawn(template)
+                    StepAgent::ByType { template, fresh } => {
+                        kernel.resolve_agent_by_type_or_spawn(template, owner, *fresh)
                     }
                 },
                 |agent_id, message, session_mode_override| {

--- a/crates/librefang-api/src/routes/workflows/mod.rs
+++ b/crates/librefang-api/src/routes/workflows/mod.rs
@@ -193,7 +193,10 @@ fn workflow_to_json(w: &Workflow) -> serde_json::Value {
                 "agent": match &s.agent {
                     StepAgent::ById { id } => serde_json::json!({"agent_id": id}),
                     StepAgent::ByName { name } => serde_json::json!({"agent_name": name}),
-                    StepAgent::ByType { template } => serde_json::json!({"type": template}),
+                    StepAgent::ByType { template, fresh } => serde_json::json!({
+                        "type": template,
+                        "fresh": fresh,
+                    }),
                 },
                 "prompt_template": s.prompt_template,
                 "mode": serde_json::to_value(&s.mode).unwrap_or_default(),

--- a/crates/librefang-api/src/routes/workflows/mod.rs
+++ b/crates/librefang-api/src/routes/workflows/mod.rs
@@ -193,6 +193,7 @@ fn workflow_to_json(w: &Workflow) -> serde_json::Value {
                 "agent": match &s.agent {
                     StepAgent::ById { id } => serde_json::json!({"agent_id": id}),
                     StepAgent::ByName { name } => serde_json::json!({"agent_name": name}),
+                    StepAgent::ByType { template } => serde_json::json!({"type": template}),
                 },
                 "prompt_template": s.prompt_template,
                 "mode": serde_json::to_value(&s.mode).unwrap_or_default(),

--- a/crates/librefang-api/src/routes/workflows/workflow.rs
+++ b/crates/librefang-api/src/routes/workflows/workflow.rs
@@ -37,9 +37,13 @@ pub async fn create_workflow(
             StepAgent::ByName {
                 name: name.to_string(),
             }
+        } else if let Some(t) = s["type"].as_str() {
+            StepAgent::ByType {
+                template: t.to_string(),
+            }
         } else {
             return ApiErrorResponse::bad_request(format!(
-                "Step '{}' needs 'agent_id' or 'agent_name'",
+                "Step '{}' needs 'agent_id', 'agent_name', or 'type'",
                 step_name
             ))
             .into_json_tuple();
@@ -330,9 +334,13 @@ pub async fn update_workflow(
                 StepAgent::ByName {
                     name: aname.to_string(),
                 }
+            } else if let Some(t) = s["type"].as_str() {
+                StepAgent::ByType {
+                    template: t.to_string(),
+                }
             } else {
                 return ApiErrorResponse::bad_request(format!(
-                    "Step '{}' needs 'agent_id' or 'agent_name'",
+                    "Step '{}' needs 'agent_id', 'agent_name', or 'type'",
                     step_name
                 ))
                 .into_json_tuple();
@@ -524,6 +532,9 @@ fn spawn_background_run(
                                 state_for_resolver.kernel.agent_registry().find_by_name(name)?;
                             let inherit = entry.manifest.inherit_parent_context;
                             Some((entry.id, entry.name.clone(), inherit))
+                        }
+                        StepAgent::ByType { template } => {
+                            state_for_resolver.kernel.resolve_agent_by_type_or_spawn(template)
                         }
                     }
                 },
@@ -1090,6 +1101,9 @@ pub async fn resume_workflow_run(
                 let inherit = entry.manifest.inherit_parent_context;
                 Some((entry.id, entry.name.clone(), inherit))
             }
+            StepAgent::ByType { template } => state_for_resolver
+                .kernel
+                .resolve_agent_by_type_or_spawn(template),
         }
     };
 
@@ -1350,6 +1364,9 @@ pub async fn operator_action_workflow_run(
                 let inherit = entry.manifest.inherit_parent_context;
                 Some((entry.id, entry.name.clone(), inherit))
             }
+            StepAgent::ByType { template } => state_for_resolver
+                .kernel
+                .resolve_agent_by_type_or_spawn(template),
         }
     };
 

--- a/crates/librefang-api/src/routes/workflows/workflow.rs
+++ b/crates/librefang-api/src/routes/workflows/workflow.rs
@@ -40,6 +40,7 @@ pub async fn create_workflow(
         } else if let Some(t) = s["type"].as_str() {
             StepAgent::ByType {
                 template: t.to_string(),
+                fresh: s["fresh"].as_bool().unwrap_or(false),
             }
         } else {
             return ApiErrorResponse::bad_request(format!(
@@ -337,6 +338,7 @@ pub async fn update_workflow(
             } else if let Some(t) = s["type"].as_str() {
                 StepAgent::ByType {
                     template: t.to_string(),
+                    fresh: s["fresh"].as_bool().unwrap_or(false),
                 }
             } else {
                 return ApiErrorResponse::bad_request(format!(
@@ -533,9 +535,9 @@ fn spawn_background_run(
                             let inherit = entry.manifest.inherit_parent_context;
                             Some((entry.id, entry.name.clone(), inherit))
                         }
-                        StepAgent::ByType { template } => {
-                            state_for_resolver.kernel.resolve_agent_by_type_or_spawn(template)
-                        }
+                        StepAgent::ByType { template, fresh } => state_for_resolver
+                            .kernel
+                            .resolve_agent_by_type_or_spawn(template, None, *fresh),
                     }
                 },
                 move |agent_id: librefang_types::agent::AgentId,
@@ -1081,6 +1083,7 @@ pub async fn resume_workflow_run(
     };
 
     // Build agent resolver and send_message for the resume execution.
+    let owner_for_resolver = state.kernel.workflow_engine().run_owner(run_id);
     let state_for_resolver = state.clone();
     let state_for_sender = state.clone();
 
@@ -1101,9 +1104,9 @@ pub async fn resume_workflow_run(
                 let inherit = entry.manifest.inherit_parent_context;
                 Some((entry.id, entry.name.clone(), inherit))
             }
-            StepAgent::ByType { template } => state_for_resolver
+            StepAgent::ByType { template, fresh } => state_for_resolver
                 .kernel
-                .resolve_agent_by_type_or_spawn(template),
+                .resolve_agent_by_type_or_spawn(template, owner_for_resolver, *fresh),
         }
     };
 
@@ -1346,6 +1349,7 @@ pub async fn operator_action_workflow_run(
     }
 
     let payload = payload_opt.clone();
+    let owner_for_resolver = state.kernel.workflow_engine().run_owner(run_id);
     let state_for_resolver = state.clone();
     let agent_resolver = move |agent_ref: &librefang_kernel::workflow::StepAgent| {
         use librefang_kernel::workflow::StepAgent;
@@ -1364,9 +1368,9 @@ pub async fn operator_action_workflow_run(
                 let inherit = entry.manifest.inherit_parent_context;
                 Some((entry.id, entry.name.clone(), inherit))
             }
-            StepAgent::ByType { template } => state_for_resolver
+            StepAgent::ByType { template, fresh } => state_for_resolver
                 .kernel
-                .resolve_agent_by_type_or_spawn(template),
+                .resolve_agent_by_type_or_spawn(template, owner_for_resolver, *fresh),
         }
     };
 

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -400,7 +400,12 @@ pub trait ChannelBridgeHandle: Send + Sync {
     }
 
     /// Run a workflow by name with the given input text.
-    async fn run_workflow_text(&self, _name: &str, _input: &str) -> String {
+    async fn run_workflow_text(
+        &self,
+        _name: &str,
+        _input: &str,
+        _owner: Option<librefang_types::agent::AgentId>,
+    ) -> String {
         "Workflows not available.".to_string()
     }
 
@@ -7094,7 +7099,9 @@ async fn handle_command(
                 } else {
                     String::new()
                 };
-                handle.run_workflow_text(wf_name, &input).await
+                handle
+                    .run_workflow_text(wf_name, &input, resolve_for_command())
+                    .await
             } else {
                 "Usage: /workflow run <name> [input]".to_string()
             }

--- a/crates/librefang-kernel-handle/src/workflow_runner.rs
+++ b/crates/librefang-kernel-handle/src/workflow_runner.rs
@@ -223,8 +223,9 @@ pub trait WorkflowRunner: Send + Sync {
         &self,
         workflow_id: &str,
         input: &str,
+        caller_agent_id: Option<&str>,
     ) -> Result<(String, String), KernelOpError> {
-        let _ = (workflow_id, input);
+        let _ = (workflow_id, input, caller_agent_id);
         Err(KernelOpError::unavailable("Workflow engine"))
     }
 

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -1452,8 +1452,13 @@ impl LibreFangKernel {
             .actual_provider
             .clone()
             .unwrap_or_else(|| manifest.model.provider.clone());
+        // Parent-attribution for permanent parented spawns (workflow step
+        // agents spawned from a template): their spend bills to the spawner,
+        // mirroring the ephemeral `billed_agent` pattern. Top-level agents
+        // (parent None) keep billing to themselves.
+        let billed_agent = entry.parent.unwrap_or(agent_id);
         let usage_record = librefang_memory::usage::UsageRecord {
-            agent_id,
+            agent_id: billed_agent,
             provider: billed_provider,
             // #6134: honour `actual_model` so a driver that resolved its own
             // model (e.g. codex-cli) records the model it actually ran. Mirrors

--- a/crates/librefang-kernel/src/kernel/cron_tick.rs
+++ b/crates/librefang-kernel/src/kernel/cron_tick.rs
@@ -454,7 +454,7 @@ pub(super) async fn run_cron_scheduler_loop(kernel: Arc<LibreFangKernel>) {
                             Some(wf_id) => {
                                 match tokio::time::timeout(
                                     timeout,
-                                    kernel_job.run_workflow(wf_id, input_text),
+                                    kernel_job.run_workflow(wf_id, input_text, None),
                                 )
                                 .await
                                 {

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -42,6 +42,7 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
         &self,
         workflow_id: &str,
         input: &str,
+        caller_agent_id: Option<&str>,
     ) -> Result<(String, String), kernel_handle::KernelOpError> {
         use crate::workflow::WorkflowId;
         use kernel_handle::KernelOpError;
@@ -66,7 +67,10 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
         // The nesting cap in `LibreFangKernel::run_workflow` raises `CapabilityDenied`, and folding it into `Internal` here would deliver it to `tool_workflow_run` as an opaque upstream failure — a 5xx-class shape that reads as a downstream crash and invites retry, which is exactly the confusion the comment in `tool_agent_send` argues against.
         // `KernelOpError` *is* `LibreFangError`, so the variant survives verbatim.
         // Everything else keeps the historical stringified `Internal` shape, including its prefix.
-        let (run_id, output) = LibreFangKernel::run_workflow(self, wf_id, input.to_string())
+        let owner = caller_agent_id
+            .and_then(|s| s.parse::<uuid::Uuid>().ok())
+            .map(librefang_types::agent::AgentId);
+        let (run_id, output) = LibreFangKernel::run_workflow(self, wf_id, input.to_string(), owner)
             .await
             .map_err(|e| match e {
                 crate::error::KernelError::LibreFang(
@@ -288,10 +292,13 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
                 })?
         };
 
+        let owner = caller_agent_id
+            .and_then(|s| s.parse::<uuid::Uuid>().ok())
+            .map(librefang_types::agent::AgentId);
         let run_id = self
             .workflows
             .engine
-            .create_run(wf_id, input.to_string())
+            .create_run_with_owner(wf_id, input.to_string(), owner)
             .await
             .ok_or_else(|| KernelOpError::Internal("Workflow not found".to_string()))?;
 
@@ -369,8 +376,8 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
-                    crate::workflow::StepAgent::ByType { template } => {
-                        k1.resolve_agent_by_type_or_spawn(template)
+                    crate::workflow::StepAgent::ByType { template, fresh } => {
+                        k1.resolve_agent_by_type_or_spawn(template, owner, *fresh)
                     }
                 }
             };

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -369,6 +369,9 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
+                    crate::workflow::StepAgent::ByType { template } => {
+                        k1.resolve_agent_by_type_or_spawn(template)
+                    }
                 }
             };
             // `session_mode_override` carries `WorkflowStep::session_mode`

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -62,15 +62,38 @@ impl LibreFangKernel {
     pub fn resolve_agent_by_type_or_spawn(
         &self,
         template: &str,
+        owner: Option<AgentId>,
+        fresh: bool,
     ) -> Option<(AgentId, String, bool)> {
-        if let Some(entry) = self.agents.registry.find_by_name(template) {
-            let inherit = entry.manifest.inherit_parent_context;
-            return Some((entry.id, entry.name.clone(), inherit));
+        if !fresh {
+            if let Some(entry) = self.agents.registry.find_by_name(template) {
+                let inherit = entry.manifest.inherit_parent_context;
+                return Some((entry.id, entry.name.clone(), inherit));
+            }
         }
-        let manifest = load_agent_manifest_from_template_dirs(&self.home_dir_boot, template)?;
+        let mut manifest = load_agent_manifest_from_template_dirs(&self.home_dir_boot, template)?;
         let inherit = manifest.inherit_parent_context;
         let name = manifest.name.clone();
-        let id = match self.spawn_agent(manifest) {
+        // Deterministic canonical id for reuse across runs (race-safe via
+        // agent_identities, #4614) — computed explicitly because
+        // spawn_agent_inner derives a RANDOM id once a parent is set,
+        // which would break the find-or-spawn contract. fresh=true
+        // deliberately requests a new random instance per run; the
+        // registry is name-unique (AgentAlreadyExists), so a fresh
+        // instance also gets a unique name tag — it must never shadow
+        // the canonical name in find_by_name anyway.
+        let predetermined = if fresh {
+            let tag: String = uuid::Uuid::new_v4().simple().to_string()[..8].to_string();
+            manifest.name = format!("{name}-{tag}");
+            AgentId::new()
+        } else {
+            let derived = AgentId::from_name(&name);
+            self.agents
+                .agent_identities
+                .register_if_absent(&name, derived)
+        };
+        let spawned_name = manifest.name.clone();
+        let id = match self.spawn_agent_inner(manifest, owner, None, Some(predetermined)) {
             Ok(id) => id,
             Err(e) => {
                 warn!(agent_type = %template, error = %e,
@@ -78,7 +101,7 @@ impl LibreFangKernel {
                 return None;
             }
         };
-        Some((id, name, inherit))
+        Some((id, spawned_name, inherit))
     }
 
     /// Pure, side-effect-free spawn pre-checks shared by `spawn_agent_inner` and destructive callers that must validate before mutating state.

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -610,7 +610,7 @@ impl LibreFangKernel {
 /// Returns None when no template exists; a read/parse failure is logged and
 /// treated as missing so the workflow step surfaces the ByType "not found"
 /// error instead of a raw filesystem error.
-fn load_agent_manifest_from_template_dirs(
+pub(crate) fn load_agent_manifest_from_template_dirs(
     home_dir_boot: &std::path::Path,
     template: &str,
 ) -> Option<AgentManifest> {

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -49,6 +49,38 @@ impl LibreFangKernel {
         self.spawn_agent_inner(manifest, parent, source_toml_path, None)
     }
 
+    /// Find-or-spawn for workflow steps that reference an agent type:
+    /// reuse the registered agent with that name, else load the template
+    /// manifest (templates/ then workspaces/agents/) and spawn it top-level.
+    /// None = no template and no agent. Sync — callable from the resolver
+    /// closures (all of them are `Fn`, not async).
+    ///
+    /// Spawns are permanent: the canonical name-derived UUID (race-safe via
+    /// `agent_identities`, #4614) makes concurrent runs converge on one
+    /// instance whose session survives daemon restarts, mirroring
+    /// `resolve_or_spawn_specialist` in `assistant_routing`.
+    pub fn resolve_agent_by_type_or_spawn(
+        &self,
+        template: &str,
+    ) -> Option<(AgentId, String, bool)> {
+        if let Some(entry) = self.agents.registry.find_by_name(template) {
+            let inherit = entry.manifest.inherit_parent_context;
+            return Some((entry.id, entry.name.clone(), inherit));
+        }
+        let manifest = load_agent_manifest_from_template_dirs(&self.home_dir_boot, template)?;
+        let inherit = manifest.inherit_parent_context;
+        let name = manifest.name.clone();
+        let id = match self.spawn_agent(manifest) {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(agent_type = %template, error = %e,
+                    "workflow step: template found but agent spawn failed");
+                return None;
+            }
+        };
+        Some((id, name, inherit))
+    }
+
     /// Pure, side-effect-free spawn pre-checks shared by `spawn_agent_inner` and destructive callers that must validate before mutating state.
     ///
     /// Runs the manifest module-path sandbox check (#3533), the reserved agent-name namespace check (#4980), and the tool_exec backend override check (#3332).
@@ -535,5 +567,60 @@ impl LibreFangKernel {
             keys.push(fixed);
         }
         Ok(keys)
+    }
+}
+
+/// Load an agent-type template manifest, mirroring `resolve_ephemeral_manifest`'s
+/// directory order: `templates/<name>.toml` first, `workspaces/agents/<name>/agent.toml`
+/// second (deliberately not refactored to share — messaging.rs stays untouched).
+/// Returns None when no template exists; a read/parse failure is logged and
+/// treated as missing so the workflow step surfaces the ByType "not found"
+/// error instead of a raw filesystem error.
+fn load_agent_manifest_from_template_dirs(
+    home_dir_boot: &std::path::Path,
+    template: &str,
+) -> Option<AgentManifest> {
+    // Path-traversal guard: only [A-Za-z0-9_-] for <name>.toml.
+    if template.is_empty()
+        || template.len() > 64
+        || !template
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        warn!(agent_type = %template, "workflow step: agent type contains disallowed characters");
+        return None;
+    }
+    let templates_dir = home_dir_boot.join("templates");
+    let path = templates_dir.join(format!("{template}.toml"));
+    if path.exists() {
+        return load_manifest_file(&path, template);
+    }
+    let agent_path = home_dir_boot
+        .join("workspaces")
+        .join("agents")
+        .join(template)
+        .join("agent.toml");
+    if agent_path.exists() {
+        return load_manifest_file(&agent_path, template);
+    }
+    None
+}
+
+fn load_manifest_file(path: &std::path::Path, template: &str) -> Option<AgentManifest> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(agent_type = %template, path = %path.display(), error = %e,
+                "workflow step: failed to read template manifest");
+            return None;
+        }
+    };
+    match toml::from_str::<AgentManifest>(&content) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            warn!(agent_type = %template, path = %path.display(), error = %e,
+                "workflow step: invalid template manifest");
+            None
+        }
     }
 }

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -96,6 +96,17 @@ impl LibreFangKernel {
         let id = match self.spawn_agent_inner(manifest, owner, None, Some(predetermined)) {
             Ok(id) => id,
             Err(e) => {
+                // Concurrent find-or-spawn race: another task may have
+                // registered the canonical instance between our
+                // find_by_name probe and the spawn above. Reuse the
+                // winner instead of failing the step.
+                if !fresh {
+                    if let Some(entry) = self.agents.registry.find_by_name(&name) {
+                        warn!(agent_type = %template, error = %e,
+                            "workflow step: lost the spawn race — reusing the winning instance");
+                        return Some((entry.id, entry.name.clone(), inherit));
+                    }
+                }
                 warn!(agent_type = %template, error = %e,
                     "workflow step: template found but agent spawn failed");
                 return None;

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6711,6 +6711,33 @@ async fn workflow_send_message_closure_honours_per_agent_semaphore() {
     Arc::try_unwrap(kernel_arc).ok().unwrap().shutdown();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_dry_run_by_type_does_not_spawn() {
+    let kernel = boot_kernel_for_display_tests();
+    write_agent_template(&kernel, "researcher");
+    let before = kernel.agents.registry.count();
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+    let steps = kernel
+        .dry_run_workflow(wf_id, "input".to_string())
+        .await
+        .expect("dry run must succeed");
+
+    let step = steps.first().expect("one step");
+    assert!(step.agent_found, "the template must resolve on dry run");
+    assert_eq!(step.agent_name.as_deref(), Some("researcher"));
+    assert_eq!(
+        kernel.agents.registry.count(),
+        before,
+        "a dry run must not spawn the step agent"
+    );
+    assert!(
+        kernel.agents.registry.find_by_name("researcher").is_none(),
+        "no instance may exist after a dry run"
+    );
+}
+
 /// Source-shape sentinel for the fix above: the production workflow
 /// `send_message` closure (and its operator-resume twin) in
 /// `triggers_and_workflow.rs` must acquire the per-agent semaphore

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6915,7 +6915,7 @@ async fn nested_workflow_run_past_max_agent_call_depth_is_capability_denied() {
 
     // Depth 0 — accepted.
     // It still fails (the step's agent is not registered), but with `Internal("Workflow failed: ...")`, not the depth refusal.
-    let accepted = kernel.run_workflow(wf_id, "hello".to_string()).await;
+    let accepted = kernel.run_workflow(wf_id, "hello".to_string(), None).await;
     if let Err(KernelError::LibreFang(LibreFangError::CapabilityDenied(msg))) = accepted {
         panic!("a top-level workflow run must not be refused by the depth quota, got: {msg}");
     }
@@ -6929,9 +6929,11 @@ async fn nested_workflow_run_past_max_agent_call_depth_is_capability_denied() {
     // Depth 2 == `max_agent_call_depth` — refused.
     // Two nested `with_agent_call_depth` frames stand in for two stacked agent turns, which is exactly what the workflow step dispatch establishes in production.
     let refused = librefang_runtime::tool_runner::with_agent_call_depth(
-        librefang_runtime::tool_runner::with_agent_call_depth(
-            kernel.run_workflow(wf_id, "hello".to_string()),
-        ),
+        librefang_runtime::tool_runner::with_agent_call_depth(kernel.run_workflow(
+            wf_id,
+            "hello".to_string(),
+            None,
+        )),
     )
     .await;
     match refused {
@@ -6967,7 +6969,7 @@ async fn nested_workflow_run_past_max_agent_call_depth_is_capability_denied() {
         let wf_id_str = wf_id.to_string();
         let via_trait = librefang_runtime::tool_runner::with_agent_call_depth(
             librefang_runtime::tool_runner::with_agent_call_depth(WorkflowRunner::run_workflow(
-                &kernel, &wf_id_str, "hello",
+                &kernel, &wf_id_str, "hello", None,
             )),
         )
         .await;
@@ -6999,6 +7001,7 @@ fn by_type_probe_workflow(template: &str) -> crate::workflow::Workflow {
             name: "only-step".to_string(),
             agent: StepAgent::ByType {
                 template: template.to_string(),
+                fresh: false,
             },
             prompt_template: "{{input}}".to_string(),
             mode: StepMode::Sequential,
@@ -7044,8 +7047,8 @@ async fn workflow_step_by_type_spawns_agent_from_template() {
     let sent_ids = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
         match agent_ref {
-            crate::workflow::StepAgent::ByType { template } => {
-                kernel.resolve_agent_by_type_or_spawn(template)
+            crate::workflow::StepAgent::ByType { template, fresh } => {
+                kernel.resolve_agent_by_type_or_spawn(template, None, *fresh)
             }
             _ => None,
         }
@@ -7094,8 +7097,8 @@ async fn workflow_step_by_type_reuses_existing_agent() {
         let kernel = std::sync::Arc::clone(kernel);
         let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
             match agent_ref {
-                crate::workflow::StepAgent::ByType { template } => {
-                    kernel.resolve_agent_by_type_or_spawn(template)
+                crate::workflow::StepAgent::ByType { template, fresh } => {
+                    kernel.resolve_agent_by_type_or_spawn(template, None, *fresh)
                 }
                 _ => None,
             }
@@ -7140,8 +7143,8 @@ async fn workflow_step_by_type_missing_template_fails_run() {
 
     let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
         match agent_ref {
-            crate::workflow::StepAgent::ByType { template } => {
-                kernel.resolve_agent_by_type_or_spawn(template)
+            crate::workflow::StepAgent::ByType { template, fresh } => {
+                kernel.resolve_agent_by_type_or_spawn(template, None, *fresh)
             }
             _ => None,
         }
@@ -7165,11 +7168,112 @@ async fn workflow_step_by_type_missing_template_fails_run() {
     );
 }
 
-/// Source-shape sentinel for the other half of the fix, in the style of `workflow_send_message_closure_contains_per_agent_semaphore_acquire` above.
-///
-/// The behavioral test proves the quota *check* rejects a deep run.
-/// It cannot prove the step dispatch actually enters the depth scope, because observing the depth inside `send_message_full` needs a real LLM turn and this crate's tests have no driver-injection seam.
-/// Without that wrap every nesting level would read depth 0 and the check would never fire, so pin the wiring: the `run_workflow` step dispatch must call `send_message_full` through `with_agent_call_depth`.
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_spawns_with_parent_owner() {
+    let kernel = boot_kernel_for_display_tests();
+    write_agent_template(&kernel, "researcher");
+    let owner = kernel
+        .agents
+        .registry
+        .find_by_name("assistant")
+        .expect("default assistant")
+        .id;
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+    let run_id = engine
+        .create_run_with_owner(wf_id, "input".to_string(), Some(owner))
+        .await
+        .unwrap();
+
+    let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+        match agent_ref {
+            crate::workflow::StepAgent::ByType { template, fresh } => {
+                kernel.resolve_agent_by_type_or_spawn(template, Some(owner), *fresh)
+            }
+            _ => None,
+        }
+    };
+    let sender = |_id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| async move {
+        Ok((msg, 0u64, 0u64))
+    };
+    engine.execute_run(run_id, resolver, sender).await.unwrap();
+
+    let spawned = kernel
+        .agents
+        .registry
+        .find_by_name("researcher")
+        .expect("agent spawned from template");
+    assert_eq!(
+        spawned.parent,
+        Some(owner),
+        "the spawned step agent must record the run owner as its parent"
+    );
+
+    // And a run created without an owner keeps parent None.
+    let wf_id2 = engine.register(by_type_probe_workflow("researcher2")).await;
+    write_agent_template(&kernel, "researcher2");
+    let run_id2 = engine
+        .create_run(wf_id2, "input".to_string())
+        .await
+        .unwrap();
+    let resolver2 = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+        match agent_ref {
+            crate::workflow::StepAgent::ByType { template, fresh } => {
+                kernel.resolve_agent_by_type_or_spawn(template, None, *fresh)
+            }
+            _ => None,
+        }
+    };
+    engine
+        .execute_run(run_id2, resolver2, sender)
+        .await
+        .unwrap();
+    let spawned2 = kernel
+        .agents
+        .registry
+        .find_by_name("researcher2")
+        .expect("agent spawned from template");
+    assert_eq!(
+        spawned2.parent, None,
+        "ownerless runs must spawn with parent None"
+    );
+}
+
+#[test]
+fn workflow_step_by_type_fresh_spawns_new_instance_each_run() {
+    let kernel = boot_kernel_for_display_tests();
+    write_agent_template(&kernel, "researcher");
+
+    // Direct helper semantics: fresh=false resolves the same instance every
+    // time (find-or-spawn), fresh=true requests a brand-new instance per run.
+    let reuse_first = kernel
+        .resolve_agent_by_type_or_spawn("researcher", None, false)
+        .expect("helper must find-or-spawn the template");
+    let reuse_second = kernel
+        .resolve_agent_by_type_or_spawn("researcher", None, false)
+        .expect("helper must keep resolving the template");
+    assert_eq!(
+        reuse_first.0, reuse_second.0,
+        "fresh=false must reuse the same instance"
+    );
+
+    let fresh_first = kernel
+        .resolve_agent_by_type_or_spawn("researcher", None, true)
+        .expect("fresh spawn must succeed");
+    let fresh_second = kernel
+        .resolve_agent_by_type_or_spawn("researcher", None, true)
+        .expect("a second fresh spawn must succeed");
+    assert_ne!(
+        fresh_first.0, fresh_second.0,
+        "fresh=true must spawn a new instance per run"
+    );
+    assert_ne!(
+        fresh_first.0, reuse_first.0,
+        "fresh spawns must not reuse the canonical instance"
+    );
+}
+
 #[test]
 fn workflow_step_dispatch_enters_agent_call_depth_scope() {
     let src = include_str!("triggers_and_workflow.rs");

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6987,6 +6987,184 @@ async fn nested_workflow_run_past_max_agent_call_depth_is_capability_denied() {
     kernel.shutdown();
 }
 
+/// Build a one-step workflow whose step targets an agent type
+/// (find-or-spawn), mirroring `depth_probe_workflow`'s shape.
+fn by_type_probe_workflow(template: &str) -> crate::workflow::Workflow {
+    use crate::workflow::{ErrorMode, StepAgent, StepMode, Workflow, WorkflowId, WorkflowStep};
+    Workflow {
+        id: WorkflowId::new(),
+        name: "by-type-probe".to_string(),
+        description: "one step referencing an agent type".to_string(),
+        steps: vec![WorkflowStep {
+            name: "only-step".to_string(),
+            agent: StepAgent::ByType {
+                template: template.to_string(),
+            },
+            prompt_template: "{{input}}".to_string(),
+            mode: StepMode::Sequential,
+            timeout_secs: 30,
+            error_mode: ErrorMode::Fail,
+            output_var: None,
+            inherit_context: None,
+            depends_on: vec![],
+            session_mode: None,
+        }],
+        created_at: chrono::Utc::now(),
+        layout: None,
+        total_timeout_secs: Some(30),
+        input_schema: None,
+    }
+}
+
+/// Write a minimal `workspaces/agents/<name>/agent.toml` template so the
+/// find-or-spawn path has a manifest to load.
+fn write_agent_template(kernel: &LibreFangKernel, name: &str) {
+    let agent_dir = kernel
+        .home_dir_boot
+        .join("workspaces")
+        .join("agents")
+        .join(name);
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+        agent_dir.join("agent.toml"),
+        format!("name = \"{name}\"\nmodule = \"builtin:chat\"\n"),
+    )
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_spawns_agent_from_template() {
+    let kernel = boot_kernel_for_display_tests();
+    write_agent_template(&kernel, "researcher");
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+    let run_id = engine.create_run(wf_id, "input".to_string()).await.unwrap();
+
+    let sent_ids = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+        match agent_ref {
+            crate::workflow::StepAgent::ByType { template } => {
+                kernel.resolve_agent_by_type_or_spawn(template)
+            }
+            _ => None,
+        }
+    };
+    let sender = {
+        let sent_ids = sent_ids.clone();
+        move |id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| {
+            let sent_ids = sent_ids.clone();
+            async move {
+                sent_ids.lock().unwrap().push(id);
+                Ok((msg, 0u64, 0u64))
+            }
+        }
+    };
+    let result = engine.execute_run(run_id, resolver, sender).await;
+    assert!(result.is_ok(), "run must complete: {result:?}");
+
+    let entry = kernel
+        .agents
+        .registry
+        .find_by_name("researcher")
+        .expect("agent must be registered after the run");
+    let dispatched = sent_ids.lock().unwrap().clone();
+    assert_eq!(
+        entry.id,
+        *dispatched.first().expect("step must dispatch"),
+        "the step must send to the spawned agent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_reuses_existing_agent() {
+    let kernel = std::sync::Arc::new(boot_kernel_for_display_tests());
+    write_agent_template(&kernel, "researcher");
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("researcher")).await;
+
+    async fn run_once(
+        engine: &crate::workflow::WorkflowEngine,
+        kernel: &std::sync::Arc<LibreFangKernel>,
+        wf_id: crate::workflow::WorkflowId,
+    ) -> Vec<AgentId> {
+        let run_id = engine.create_run(wf_id, "input".to_string()).await.unwrap();
+        let sent_ids = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let kernel = std::sync::Arc::clone(kernel);
+        let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+            match agent_ref {
+                crate::workflow::StepAgent::ByType { template } => {
+                    kernel.resolve_agent_by_type_or_spawn(template)
+                }
+                _ => None,
+            }
+        };
+        let sender = {
+            let sent_ids = sent_ids.clone();
+            move |id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| {
+                let sent_ids = sent_ids.clone();
+                async move {
+                    sent_ids.lock().unwrap().push(id);
+                    Ok((msg, 0u64, 0u64))
+                }
+            }
+        };
+        engine.execute_run(run_id, resolver, sender).await.unwrap();
+        let x = sent_ids.lock().unwrap().clone();
+        x
+    }
+
+    let first = run_once(engine, &kernel, wf_id).await;
+    let before = kernel.agents.registry.count();
+    let second = run_once(engine, &kernel, wf_id).await;
+
+    assert_eq!(
+        first, second,
+        "second run must reuse the same agent instance"
+    );
+    assert_eq!(
+        kernel.agents.registry.count(),
+        before,
+        "reuse must not spawn a second agent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workflow_step_by_type_missing_template_fails_run() {
+    let kernel = boot_kernel_for_display_tests(); // no template written on purpose
+
+    let engine = &kernel.workflows.engine;
+    let wf_id = engine.register(by_type_probe_workflow("ghost")).await;
+    let run_id = engine.create_run(wf_id, "input".to_string()).await.unwrap();
+
+    let resolver = |agent_ref: &crate::workflow::StepAgent| -> Option<(AgentId, String, bool)> {
+        match agent_ref {
+            crate::workflow::StepAgent::ByType { template } => {
+                kernel.resolve_agent_by_type_or_spawn(template)
+            }
+            _ => None,
+        }
+    };
+    let sender = |_id: AgentId, msg: String, _sm: Option<librefang_types::agent::SessionMode>| async move {
+        Ok((msg, 0u64, 0u64))
+    };
+    let result = engine.execute_run(run_id, resolver, sender).await;
+    assert!(result.is_err(), "a missing agent type must fail the run");
+
+    let run = engine.get_run(run_id).await.unwrap();
+    assert!(
+        matches!(run.state, crate::workflow::WorkflowRunState::Failed),
+        "run must be Failed, not stuck in Running: {:?}",
+        run.state
+    );
+    let err = run.error.as_deref().unwrap_or("");
+    assert!(
+        err.contains("Agent type 'ghost' not found"),
+        "error must name the missing type: {err}"
+    );
+}
+
 /// Source-shape sentinel for the other half of the fix, in the style of `workflow_send_message_closure_contains_per_agent_semaphore_acquire` above.
 ///
 /// The behavioral test proves the quota *check* rejects a deep run.

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -1285,6 +1285,7 @@ impl LibreFangKernel {
                     let inherit = entry.manifest.inherit_parent_context;
                     Some((entry.id, entry.name.clone(), inherit))
                 }
+                StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
             }
         };
 
@@ -1389,6 +1390,7 @@ impl LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
+                    StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
                 }
             };
 
@@ -1500,6 +1502,9 @@ impl crate::workflow::OperatorResumeDriver for KernelOperatorResumeDriver {
                         let entry = kernel.agents.registry.find_by_name(name)?;
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
+                    }
+                    StepAgent::ByType { template } => {
+                        kernel.resolve_agent_by_type_or_spawn(template)
                     }
                 }
             }

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -1393,8 +1393,23 @@ impl LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
-                    StepAgent::ByType { template, fresh } => {
-                        self.resolve_agent_by_type_or_spawn(template, None, *fresh)
+                    StepAgent::ByType { template, .. } => {
+                        // Dry runs must not mutate the registry — never
+                        // spawn here. Reuse an existing instance, or, when
+                        // the template exists on disk, report its name as
+                        // "will spawn on a real run".
+                        if let Some(entry) = self.agents.registry.find_by_name(template) {
+                            let inherit = entry.manifest.inherit_parent_context;
+                            Some((entry.id, entry.name.clone(), inherit))
+                        } else {
+                            let manifest = super::spawn::load_agent_manifest_from_template_dirs(
+                                &self.home_dir_boot,
+                                template,
+                            )?;
+                            let inherit = manifest.inherit_parent_context;
+                            let name = manifest.name.clone();
+                            Some((librefang_types::agent::AgentId::new(), name, inherit))
+                        }
                     }
                 }
             };

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -624,7 +624,7 @@ impl LibreFangKernel {
                                         tokio::spawn(async move {
                                             match tokio::time::timeout(
                                                 timeout_for_spawn,
-                                                kernel_for_spawn.run_workflow(wf_id, msg),
+                                                kernel_for_spawn.run_workflow(wf_id, msg, None),
                                             )
                                             .await
                                             {
@@ -1235,6 +1235,7 @@ impl LibreFangKernel {
         &self,
         workflow_id: WorkflowId,
         input: String,
+        owner: Option<AgentId>,
     ) -> KernelResult<(WorkflowRunId, String)> {
         let cfg = self.config.load_full();
 
@@ -1285,7 +1286,9 @@ impl LibreFangKernel {
                     let inherit = entry.manifest.inherit_parent_context;
                     Some((entry.id, entry.name.clone(), inherit))
                 }
-                StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
+                StepAgent::ByType { template, fresh } => {
+                    self.resolve_agent_by_type_or_spawn(template, owner, *fresh)
+                }
             }
         };
 
@@ -1390,7 +1393,9 @@ impl LibreFangKernel {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
-                    StepAgent::ByType { template } => self.resolve_agent_by_type_or_spawn(template),
+                    StepAgent::ByType { template, fresh } => {
+                        self.resolve_agent_by_type_or_spawn(template, None, *fresh)
+                    }
                 }
             };
 
@@ -1488,6 +1493,7 @@ impl crate::workflow::OperatorResumeDriver for KernelOperatorResumeDriver {
             );
             return;
         };
+        let run_owner = kernel.workflows.engine.run_owner(run_id);
         let resolver = {
             let kernel = kernel.clone();
             move |agent_ref: &StepAgent| -> Option<(AgentId, String, bool)> {
@@ -1503,8 +1509,8 @@ impl crate::workflow::OperatorResumeDriver for KernelOperatorResumeDriver {
                         let inherit = entry.manifest.inherit_parent_context;
                         Some((entry.id, entry.name.clone(), inherit))
                     }
-                    StepAgent::ByType { template } => {
-                        kernel.resolve_agent_by_type_or_spawn(template)
+                    StepAgent::ByType { template, fresh } => {
+                        kernel.resolve_agent_by_type_or_spawn(template, run_owner, *fresh)
                     }
                 }
             }

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -93,7 +93,12 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     /// Returns (agent_id, agent_name, inherit_parent_context), or None when
     /// no template exists and no agent is registered. Sync — callable from
     /// the resolver closures the workflow engine injects.
-    fn resolve_agent_by_type_or_spawn(&self, template: &str) -> Option<(AgentId, String, bool)>;
+    fn resolve_agent_by_type_or_spawn(
+        &self,
+        template: &str,
+        owner: Option<AgentId>,
+        fresh: bool,
+    ) -> Option<(AgentId, String, bool)>;
     fn approvals(&self) -> &ApprovalManager;
     fn audit(&self) -> &Arc<AuditLog>;
     fn auth_manager(&self) -> &AuthManager;
@@ -813,8 +818,13 @@ impl KernelApi for LibreFangKernel {
     fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry> {
         <Self as crate::AgentSubsystemApi>::identities_ref(self)
     }
-    fn resolve_agent_by_type_or_spawn(&self, template: &str) -> Option<(AgentId, String, bool)> {
-        LibreFangKernel::resolve_agent_by_type_or_spawn(self, template)
+    fn resolve_agent_by_type_or_spawn(
+        &self,
+        template: &str,
+        owner: Option<AgentId>,
+        fresh: bool,
+    ) -> Option<(AgentId, String, bool)> {
+        LibreFangKernel::resolve_agent_by_type_or_spawn(self, template, owner, fresh)
     }
     fn approvals(&self) -> &ApprovalManager {
         <Self as crate::GovernanceSubsystemApi>::approvals(self)
@@ -1320,7 +1330,7 @@ impl KernelApi for LibreFangKernel {
         workflow_id: crate::workflow::WorkflowId,
         input: String,
     ) -> KernelResult<(crate::workflow::WorkflowRunId, String)> {
-        Self::run_workflow(self, workflow_id, input).await
+        Self::run_workflow(self, workflow_id, input, None).await
     }
     async fn dry_run_workflow(
         &self,

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -87,6 +87,13 @@ pub trait KernelApi: KernelHandle + Send + Sync {
 
     fn agent_registry(&self) -> &AgentRegistry;
     fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry>;
+    /// Find-or-spawn for workflow steps that reference an agent type:
+    /// reuse the registered agent with that name, else load the template
+    /// manifest (templates/ then workspaces/agents/) and spawn it top-level.
+    /// Returns (agent_id, agent_name, inherit_parent_context), or None when
+    /// no template exists and no agent is registered. Sync — callable from
+    /// the resolver closures the workflow engine injects.
+    fn resolve_agent_by_type_or_spawn(&self, template: &str) -> Option<(AgentId, String, bool)>;
     fn approvals(&self) -> &ApprovalManager;
     fn audit(&self) -> &Arc<AuditLog>;
     fn auth_manager(&self) -> &AuthManager;
@@ -805,6 +812,9 @@ impl KernelApi for LibreFangKernel {
     }
     fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry> {
         <Self as crate::AgentSubsystemApi>::identities_ref(self)
+    }
+    fn resolve_agent_by_type_or_spawn(&self, template: &str) -> Option<(AgentId, String, bool)> {
+        LibreFangKernel::resolve_agent_by_type_or_spawn(self, template)
     }
     fn approvals(&self) -> &ApprovalManager {
         <Self as crate::GovernanceSubsystemApi>::approvals(self)

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -313,16 +313,19 @@ fn clamp_timeout_duration(timeout_secs: u64) -> std::time::Duration {
 
 /// How to identify the agent for a step.
 ///
-/// Deserialization accepts THREE on-wire shapes for operator ergonomics
+/// Deserialization accepts FOUR on-wire shapes for operator ergonomics
 /// (the issue / PR docs use the bare-string form; the kernel and HTTP
 /// payloads use the tagged forms):
 ///
 /// 1. Bare string: `agent = "researcher"` → [`StepAgent::ByName`].
 /// 2. Tagged object: `{ name = "researcher" }` → [`StepAgent::ByName`].
 /// 3. Tagged object: `{ id = "<uuid>" }` → [`StepAgent::ById`].
+/// 4. Tagged object: `{ type = "researcher" }` → [`StepAgent::ByType`]
+///    (reuse the registered agent with the template's name, or spawn one
+///    from the template when no instance exists — find-or-spawn).
 ///
-/// Exactly one of `id` / `name` must be present in the tagged form;
-/// supplying both or neither is a deserialization error.
+/// Exactly one of `id` / `name` / `type` must be present in the tagged
+/// form; supplying more than one or none is a deserialization error.
 ///
 /// Serialization continues to emit the tagged-object form (`Serialize`
 /// derive on the untagged-style enum picks the matching variant cleanly).
@@ -333,6 +336,10 @@ pub enum StepAgent {
     ById { id: String },
     /// Reference an agent by name (first match).
     ByName { name: String },
+    /// Reference an agent type: the resolver reuses the registered agent
+    /// with the template's name, or spawns one from the template manifest
+    /// on first use.
+    ByType { template: String },
 }
 
 impl<'de> Deserialize<'de> for StepAgent {
@@ -352,17 +359,26 @@ impl<'de> Deserialize<'de> for StepAgent {
             serde_json::Value::Object(map) => {
                 let id = map.get("id").and_then(|x| x.as_str());
                 let name = map.get("name").and_then(|x| x.as_str());
-                match (id, name) {
-                    (Some(_), Some(_)) => Err(D::Error::custom(
-                        "StepAgent: object form must set exactly one of `id` or `name`, not both",
-                    )),
-                    (Some(id), None) => Ok(StepAgent::ById { id: id.to_string() }),
-                    (None, Some(name)) => Ok(StepAgent::ByName {
+                let template = map.get("type").and_then(|x| x.as_str());
+                // Exactly one of `id` / `name` / `type` must be set; the
+                // optional `fresh` key (paired with `type` by the step-flag
+                // feature) is not counted here.
+                let present = id.is_some() as u8 + name.is_some() as u8 + template.is_some() as u8;
+                if present != 1 {
+                    return Err(D::Error::custom(
+                        "StepAgent: object form must set exactly one of `id`, `name`, or `type`",
+                    ));
+                }
+                if let Some(id) = id {
+                    Ok(StepAgent::ById { id: id.to_string() })
+                } else if let Some(name) = name {
+                    Ok(StepAgent::ByName {
                         name: name.to_string(),
-                    }),
-                    (None, None) => Err(D::Error::custom(
-                        "StepAgent: object form must set exactly one of `id` or `name`",
-                    )),
+                    })
+                } else {
+                    Ok(StepAgent::ByType {
+                        template: template.unwrap().to_string(),
+                    })
                 }
             }
             other => Err(D::Error::custom(format!(
@@ -1294,6 +1310,10 @@ fn format_missing_agent_error(step_name: &str, agent: &StepAgent) -> String {
         StepAgent::ById { id } => format!(
             "Registry agent with id '{id}' not found for workflow step '{step_name}' \
              (referenced by id; check the agent exists and the id is well-formed)"
+        ),
+        StepAgent::ByType { template } => format!(
+            "Agent type '{template}' not found for workflow step '{step_name}' \
+             (no template file and no registered agent with that name)"
         ),
     }
 }
@@ -6077,6 +6097,7 @@ impl Workflow {
                 let agent = match &step.agent {
                     StepAgent::ByName { name } => Some(name.clone()),
                     StepAgent::ById { id } => Some(id.clone()),
+                    StepAgent::ByType { template } => Some(template.clone()),
                 };
 
                 WorkflowTemplateStep {
@@ -11194,6 +11215,45 @@ prompt_template = "do {{x}}"
         match by_id.agent {
             StepAgent::ById { id } => assert_eq!(id, "agent-uuid-123"),
             other => panic!("expected ById, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_agent_deserializes_object_by_type() {
+        let v: StepAgent =
+            serde_json::from_str(r#"{"type":"researcher"}"#).expect("object form by type");
+        match v {
+            StepAgent::ByType { template } => assert_eq!(template, "researcher"),
+            other => panic!("expected ByType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_agent_rejects_ambiguous_type_keys() {
+        // `type` together with a different routing key is ambiguous.
+        assert!(
+            serde_json::from_str::<StepAgent>(r#"{"type":"a","name":"b"}"#).is_err(),
+            "must reject type and name set"
+        );
+        assert!(
+            serde_json::from_str::<StepAgent>(r#"{"type":"a","id":"b"}"#).is_err(),
+            "must reject type and id set"
+        );
+        // Empty object: no routing key at all.
+        assert!(serde_json::from_str::<StepAgent>("{}").is_err());
+    }
+
+    #[test]
+    fn step_agent_by_type_round_trips_through_toml() {
+        #[derive(serde::Deserialize)]
+        struct Wrap {
+            agent: StepAgent,
+        }
+        let parsed: Wrap =
+            toml::from_str("agent = { type = \"researcher\" }").expect("toml by type");
+        match parsed.agent {
+            StepAgent::ByType { template } => assert_eq!(template, "researcher"),
+            other => panic!("expected ByType, got {other:?}"),
         }
     }
 

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -339,7 +339,7 @@ pub enum StepAgent {
     /// Reference an agent type: the resolver reuses the registered agent
     /// with the template's name, or spawns one from the template manifest
     /// on first use.
-    ByType { template: String },
+    ByType { template: String, fresh: bool },
 }
 
 impl<'de> Deserialize<'de> for StepAgent {
@@ -360,6 +360,7 @@ impl<'de> Deserialize<'de> for StepAgent {
                 let id = map.get("id").and_then(|x| x.as_str());
                 let name = map.get("name").and_then(|x| x.as_str());
                 let template = map.get("type").and_then(|x| x.as_str());
+                let fresh = map.get("fresh").and_then(|x| x.as_bool());
                 // Exactly one of `id` / `name` / `type` must be set; the
                 // optional `fresh` key (paired with `type` by the step-flag
                 // feature) is not counted here.
@@ -368,6 +369,16 @@ impl<'de> Deserialize<'de> for StepAgent {
                     return Err(D::Error::custom(
                         "StepAgent: object form must set exactly one of `id`, `name`, or `type`",
                     ));
+                }
+                if map.contains_key("fresh") {
+                    if fresh.is_none() {
+                        return Err(D::Error::custom("StepAgent: `fresh` must be a boolean"));
+                    }
+                    if template.is_none() {
+                        return Err(D::Error::custom(
+                            "StepAgent: `fresh` is only valid together with `type`",
+                        ));
+                    }
                 }
                 if let Some(id) = id {
                     Ok(StepAgent::ById { id: id.to_string() })
@@ -378,6 +389,7 @@ impl<'de> Deserialize<'de> for StepAgent {
                 } else {
                     Ok(StepAgent::ByType {
                         template: template.unwrap().to_string(),
+                        fresh: fresh.unwrap_or(false),
                     })
                 }
             }
@@ -1097,6 +1109,11 @@ pub struct WorkflowRun {
     pub workflow_id: WorkflowId,
     /// Workflow name (copied for quick access).
     pub workflow_name: String,
+    /// The agent (or channel user's agent) that owns this run, when the
+    /// run was started by an agent-facing surface. Spawned step agents
+    /// are billed to this owner. `None` for API/daemon-initiated runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_agent_id: Option<AgentId>,
     /// Initial input to the workflow.
     pub input: String,
     /// Current state.
@@ -1311,7 +1328,7 @@ fn format_missing_agent_error(step_name: &str, agent: &StepAgent) -> String {
             "Registry agent with id '{id}' not found for workflow step '{step_name}' \
              (referenced by id; check the agent exists and the id is well-formed)"
         ),
-        StepAgent::ByType { template } => format!(
+        StepAgent::ByType { template, .. } => format!(
             "Agent type '{template}' not found for workflow step '{step_name}' \
              (no template file and no registered agent with that name)"
         ),
@@ -2097,6 +2114,18 @@ impl WorkflowEngine {
         workflow_id: WorkflowId,
         input: String,
     ) -> Option<WorkflowRunId> {
+        self.create_run_with_owner(workflow_id, input, None).await
+    }
+
+    /// [`Self::create_run`] with an explicit owner: the agent that
+    /// initiated the run (from `workflow_run` / `workflow_start` tools
+    /// or a channel command). Spawned step agents are billed to it.
+    pub async fn create_run_with_owner(
+        &self,
+        workflow_id: WorkflowId,
+        input: String,
+        owner_agent_id: Option<AgentId>,
+    ) -> Option<WorkflowRunId> {
         let workflow = self.workflows.read().await.get(&workflow_id)?.clone();
         let run_id = WorkflowRunId::new();
 
@@ -2104,6 +2133,7 @@ impl WorkflowEngine {
             id: run_id,
             workflow_id,
             workflow_name: workflow.name,
+            owner_agent_id,
             input,
             state: WorkflowRunState::Pending,
             step_results: Vec::new(),
@@ -2338,6 +2368,13 @@ impl WorkflowEngine {
     }
 
     /// List all workflow runs (optionally filtered by state).
+    /// The billing owner of a run, if it was started by an agent-facing
+    /// surface. Used by resume / operator-action resolvers so spawned step
+    /// agents keep billing to the original owner.
+    pub fn run_owner(&self, run_id: WorkflowRunId) -> Option<AgentId> {
+        self.runs.get(&run_id).and_then(|r| r.owner_agent_id)
+    }
+
     pub async fn list_runs(&self, state_filter: Option<&str>) -> Vec<WorkflowRun> {
         self.runs
             .iter()
@@ -6097,7 +6134,7 @@ impl Workflow {
                 let agent = match &step.agent {
                     StepAgent::ByName { name } => Some(name.clone()),
                     StepAgent::ById { id } => Some(id.clone()),
-                    StepAgent::ByType { template } => Some(template.clone()),
+                    StepAgent::ByType { template, .. } => Some(template.clone()),
                 };
 
                 WorkflowTemplateStep {
@@ -6598,6 +6635,8 @@ fn workflow_run_to_row(run: &WorkflowRun) -> WorkflowRunRow {
     let step_results_json =
         serde_json::to_string(&run.step_results).unwrap_or_else(|_| "[]".to_string());
 
+    let owner_agent_id = run.owner_agent_id.map(|a| a.0.to_string());
+
     let paused_variables_json = if run.paused_variables.is_empty() {
         None
     } else {
@@ -6608,6 +6647,7 @@ fn workflow_run_to_row(run: &WorkflowRun) -> WorkflowRunRow {
         id: run.id.to_string(),
         workflow_id: run.workflow_id.to_string(),
         workflow_name: run.workflow_name.clone(),
+        owner_agent_id,
         state: state_str,
         input: run.input.clone(),
         output: run.output.clone(),
@@ -6634,6 +6674,15 @@ fn row_to_workflow_run(row: &WorkflowRunRow) -> Result<WorkflowRun, String> {
         Uuid::parse_str(&row.workflow_id)
             .map_err(|e| format!("invalid workflow_id '{}': {e}", row.workflow_id))?,
     );
+
+    let owner_agent_id = match row.owner_agent_id.as_deref() {
+        Some(oid) => {
+            Some(AgentId(Uuid::parse_str(oid).map_err(|e| {
+                format!("invalid owner_agent_id '{oid}': {e}")
+            })?))
+        }
+        None => None,
+    };
 
     let state = match row.state.as_str() {
         "pending" => WorkflowRunState::Pending,
@@ -6731,6 +6780,7 @@ fn row_to_workflow_run(row: &WorkflowRunRow) -> Result<WorkflowRun, String> {
         id,
         workflow_id,
         workflow_name: row.workflow_name.clone(),
+        owner_agent_id,
         input: row.input.clone(),
         state,
         step_results,
@@ -9478,6 +9528,7 @@ prompt_template = "do {{x}}"
             id: WorkflowRunId::new(),
             workflow_id: WorkflowId::new(),
             workflow_name: "persist-test".to_string(),
+            owner_agent_id: None,
             input: "hello".to_string(),
             state,
             step_results: vec![StepResult {
@@ -9554,6 +9605,7 @@ prompt_template = "do {{x}}"
             id: WorkflowRunId::new(),
             workflow_id: WorkflowId::new(),
             workflow_name: "in-progress".to_string(),
+            owner_agent_id: None,
             input: "data".to_string(),
             state: WorkflowRunState::Running,
             step_results: vec![],
@@ -11223,7 +11275,7 @@ prompt_template = "do {{x}}"
         let v: StepAgent =
             serde_json::from_str(r#"{"type":"researcher"}"#).expect("object form by type");
         match v {
-            StepAgent::ByType { template } => assert_eq!(template, "researcher"),
+            StepAgent::ByType { template, .. } => assert_eq!(template, "researcher"),
             other => panic!("expected ByType, got {other:?}"),
         }
     }
@@ -11252,7 +11304,7 @@ prompt_template = "do {{x}}"
         let parsed: Wrap =
             toml::from_str("agent = { type = \"researcher\" }").expect("toml by type");
         match parsed.agent {
-            StepAgent::ByType { template } => assert_eq!(template, "researcher"),
+            StepAgent::ByType { template, .. } => assert_eq!(template, "researcher"),
             other => panic!("expected ByType, got {other:?}"),
         }
     }

--- a/crates/librefang-kernel/tests/workflow_integration_test.rs
+++ b/crates/librefang-kernel/tests/workflow_integration_test.rs
@@ -400,6 +400,7 @@ async fn test_workflow_e2e_with_groq() {
         .run_workflow(
             wf_id,
             "The Rust programming language is growing rapidly.".to_string(),
+            None,
         )
         .await;
 

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 47;
+const SCHEMA_VERSION: u32 = 48;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -225,6 +225,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     // which is backward compatible with every existing row and a no-op for
     // single-user agents.
     run_step!(47, migrate_v47);
+    run_step!(48, migrate_v48);
 
     // Audit-trail consistency (#3538): user_version must match the count
     // of distinct rows in `migrations`. Drift means an earlier migration
@@ -884,6 +885,23 @@ fn migrate_v47(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) VALUES (47, datetime('now'), 'Add peer_id to entities and relations for per-user isolation (#6494)')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// V48: Add `owner_agent_id` to `workflow_runs` so resumed/restored runs
+/// keep their billed owner (workflow step agents bill to the run owner).
+fn migrate_v48(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !try_column_exists(conn, "workflow_runs", "owner_agent_id")? {
+        conn.execute(
+            "ALTER TABLE workflow_runs ADD COLUMN owner_agent_id TEXT",
+            [],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) VALUES (48, datetime('now'), 'Add owner_agent_id to workflow_runs (#workflow-owner)')",
         [],
     )?;
     Ok(())
@@ -2435,6 +2453,17 @@ mod tests {
             dup.is_err(),
             "a duplicate shared entity must violate the (id, '') PK"
         );
+    }
+
+    #[test]
+    fn test_migrate_v48_adds_owner_agent_id_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        assert!(column_exists(&conn, "workflow_runs", "owner_agent_id"));
+        // Idempotence: the registered step must tolerate a rerun (the column
+        // guard makes the ALTER a no-op the second time).
+        migrate_v48(&conn).unwrap();
     }
 
     #[test]

--- a/crates/librefang-memory/src/workflow_store.rs
+++ b/crates/librefang-memory/src/workflow_store.rs
@@ -22,6 +22,8 @@ pub struct WorkflowRunRow {
     pub id: String,
     pub workflow_id: String,
     pub workflow_name: String,
+    /// The agent that initiated the run (billed owner), if any.
+    pub owner_agent_id: Option<String>,
     pub state: String,
     pub input: String,
     pub output: Option<String>,
@@ -81,12 +83,12 @@ impl WorkflowStore {
                 id, workflow_id, workflow_name, state, input, output, error,
                 resume_token, pause_reason, paused_at, paused_step_index,
                 paused_variables, paused_current_input,
-                step_results, started_at, completed_at
+                step_results, started_at, completed_at, owner_agent_id
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7,
                 ?8, ?9, ?10, ?11,
                 ?12, ?13,
-                ?14, ?15, ?16
+                ?14, ?15, ?16, ?17
             ) ON CONFLICT(id) DO UPDATE SET
                 state = excluded.state,
                 input = excluded.input,
@@ -99,7 +101,8 @@ impl WorkflowStore {
                 paused_variables = excluded.paused_variables,
                 paused_current_input = excluded.paused_current_input,
                 step_results = excluded.step_results,
-                completed_at = excluded.completed_at",
+                completed_at = excluded.completed_at,
+                owner_agent_id = excluded.owner_agent_id",
             rusqlite::params![
                 row.id,
                 row.workflow_id,
@@ -117,6 +120,7 @@ impl WorkflowStore {
                 row.step_results,
                 row.started_at,
                 row.completed_at,
+                row.owner_agent_id,
             ],
         )
         .map_err(|e| LibreFangError::memory_msg(format!("workflow upsert failed: {e}")))?;
@@ -131,7 +135,7 @@ impl WorkflowStore {
                 "SELECT id, workflow_id, workflow_name, state, input, output, error,
                         resume_token, pause_reason, paused_at, paused_step_index,
                         paused_variables, paused_current_input,
-                        step_results, started_at, completed_at, created_at
+                        step_results, started_at, completed_at, created_at, owner_agent_id
                  FROM workflow_runs WHERE id = ?1",
             )
             .map_err(|e| {
@@ -159,7 +163,7 @@ impl WorkflowStore {
                 "SELECT id, workflow_id, workflow_name, state, input, output, error,
                         resume_token, pause_reason, paused_at, paused_step_index,
                         paused_variables, paused_current_input,
-                        step_results, started_at, completed_at, created_at
+                        step_results, started_at, completed_at, created_at, owner_agent_id
                  FROM workflow_runs WHERE state = ?1 ORDER BY started_at DESC"
                     .to_string(),
                 vec![Box::new(state.to_string()) as Box<dyn rusqlite::types::ToSql>],
@@ -168,7 +172,7 @@ impl WorkflowStore {
                 "SELECT id, workflow_id, workflow_name, state, input, output, error,
                         resume_token, pause_reason, paused_at, paused_step_index,
                         paused_variables, paused_current_input,
-                        step_results, started_at, completed_at, created_at
+                        step_results, started_at, completed_at, created_at, owner_agent_id
                  FROM workflow_runs ORDER BY started_at DESC"
                     .to_string(),
                 vec![],
@@ -314,6 +318,7 @@ fn row_from_sqlite(row: &rusqlite::Row<'_>) -> Result<WorkflowRunRow, rusqlite::
         started_at: row.get(14)?,
         completed_at: row.get(15)?,
         created_at: row.get(16)?,
+        owner_agent_id: row.get(17)?,
     })
 }
 
@@ -335,6 +340,7 @@ mod tests {
             id: id.to_string(),
             workflow_id: "wf-001".to_string(),
             workflow_name: "test-workflow".to_string(),
+            owner_agent_id: None,
             state: state.to_string(),
             input: "hello world".to_string(),
             output: None,

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -96,6 +96,7 @@ pub(crate) mod tool_name {
     pub const WORKFLOW_STATUS: &str = "workflow_status";
     pub const WORKFLOW_START: &str = "workflow_start";
     pub const WORKFLOW_CANCEL: &str = "workflow_cancel";
+    pub const WORKFLOW_CREATE: &str = "workflow_create";
     pub const SYSTEM_TIME: &str = "system_time";
     pub const CANVAS_PRESENT: &str = "canvas_present";
     pub const READ_ARTIFACT: &str = "read_artifact";
@@ -1204,6 +1205,60 @@ use instead of web_fetch + file_write (which round-trips the entire body through
                         "run_id": { "type": "string", "description": "The workflow run UUID to cancel" }
                     },
                     "required": ["run_id"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::WORKFLOW_CREATE.to_string(),
+                description: "Create a new workflow and save it. The workflow appears in the dashboard and is available for workflow_run, workflow_start, and workflow_list. Use agent_find first to discover available agents for each step.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Unique workflow name. Only [A-Za-z0-9_-] allowed, max 64 chars. Used as the filename."
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "What this workflow does and when to use it."
+                        },
+                        "steps": {
+                            "type": "array",
+                            "description": "The workflow steps in execution order.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string", "description": "Step name for display and variable referencing." },
+                                    "agent": { "type": ["string", "object"], "description": "Agent name, UUID, or { \"type\": \"<template>\" } to auto-spawn from an agent type when no instance exists." },
+                                    "prompt_template": { "type": "string", "description": "The prompt sent to the agent. Use {{input}} for the previous step's output, {{var_name}} for named variables, and {{param}} for workflow input parameters." },
+                                    "depends_on": { "type": "array", "items": { "type": "string" }, "description": "Names of steps this step depends on. When set, steps execute in DAG order instead of sequentially." },
+                                    "output_var": { "type": "string", "description": "When set, this step's output is stored as a named variable accessible in later steps via {{name}}." },
+                                    "mode": { "type": "string", "enum": ["sequential", "fan_out", "collect", "conditional", "loop", "wait", "approval"], "description": "Execution mode. Default: sequential." },
+                                    "timeout_secs": { "type": "integer", "description": "Max seconds for this step. Default: 120." },
+                                    "error_mode": { "type": "string", "enum": ["fail", "skip", "retry"], "description": "What to do on failure. Default: fail." }
+                                },
+                                "required": ["name", "agent", "prompt_template"]
+                            }
+                        },
+                        "input_schema": {
+                            "type": "array",
+                            "description": "Declared input parameters so callers know what to pass in workflow_run.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "description": { "type": "string" },
+                                    "type": { "type": "string", "enum": ["string", "number", "boolean", "file", "image", "agent_id"] },
+                                    "required": { "type": "boolean" }
+                                },
+                                "required": ["name", "type"]
+                            }
+                        },
+                        "total_timeout_secs": {
+                            "type": "integer",
+                            "description": "Max wall-clock seconds for the entire workflow run."
+                        }
+                    },
+                    "required": ["name", "steps"]
                 }),
             },
             ToolDefinition {

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1180,7 +1180,7 @@ pub async fn execute_tool_raw(
         "goal_update" => tool_goal_update(input, *kernel),
 
         // Workflow tools.
-        "workflow_run" => tool_workflow_run(input, *kernel).await,
+        "workflow_run" => tool_workflow_run(input, *kernel, *caller_agent_id).await,
         "workflow_list" => tool_workflow_list(*kernel).await,
         "workflow_describe" => tool_workflow_describe(input, *kernel).await,
         "workflow_status" => tool_workflow_status(input, *kernel).await,

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -1128,6 +1128,7 @@ impl WorkflowRunner for DispatchCapture {
         &self,
         _workflow_id: &str,
         _input: &str,
+        _caller_agent_id: Option<&str>,
     ) -> Result<(String, String), librefang_kernel_handle::KernelOpError> {
         if self.deny_workflow_run {
             return Err(librefang_kernel_handle::KernelOpError::CapabilityDenied(
@@ -1577,7 +1578,7 @@ async fn workflow_run_depth_refusal_is_permission_denied_not_upstream() {
     let kernel: Arc<dyn KernelHandle> = denying;
     let input = serde_json::json!({ "workflow_id": "some-workflow" });
 
-    let err = super::workflow::tool_workflow_run(&input, Some(&kernel))
+    let err = super::workflow::tool_workflow_run(&input, Some(&kernel), None)
         .await
         .expect_err("a CapabilityDenied from the kernel must surface as an error");
     match &err {
@@ -1599,7 +1600,7 @@ async fn workflow_run_depth_refusal_is_permission_denied_not_upstream() {
     // Any other kernel failure still goes through `upstream` — the mapping is a narrow special case, not a blanket reclassification.
     let plain = Arc::new(DispatchCapture::default());
     let kernel: Arc<dyn KernelHandle> = plain;
-    let err = super::workflow::tool_workflow_run(&input, Some(&kernel))
+    let err = super::workflow::tool_workflow_run(&input, Some(&kernel), None)
         .await
         .expect_err("the default stub reports the engine unavailable");
     assert!(

--- a/crates/librefang-runtime/src/tool_runner/workflow.rs
+++ b/crates/librefang-runtime/src/tool_runner/workflow.rs
@@ -127,6 +127,7 @@ pub(super) fn build_workflow_run_result(
 pub(super) async fn tool_workflow_run(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
 ) -> ToolResult {
     let workflow_id = input["workflow_id"]
         .as_str()
@@ -147,7 +148,7 @@ pub(super) async fn tool_workflow_run(
     // Two reasons, the same ones spelled out in `tool_agent_send`: `Upstream` lifts to a 5xx-class `ToolExecution` that reads as a downstream crash to retry logic, and `PermissionDenied` classifies as `ToolExecutionStatus::Denied` — a soft failure — so a capped agent that keeps trying does not burn through `MAX_CONSECUTIVE_ALL_FAILED` and lose the turn to an abort.
     // Every other kernel failure stays `Upstream`.
     let (run_id, output) = kh
-        .run_workflow(workflow_id, &input_str)
+        .run_workflow(workflow_id, &input_str, caller_agent_id)
         .await
         .map_err(|e| match e {
             librefang_types::error::LibreFangError::CapabilityDenied(msg) => {


### PR DESCRIPTION
Closes #7714

> ⚠️ STACKED on #7715 (step agent types) — this branch carries its commit; it will be rebased on main once #7715 merges.

## Changes
- `WorkflowRun.owner_agent_id` persisted via migration v48; the caller of `workflow_run` / `workflow_start` / channel workflow commands threads its agent id through the trait surface; resume and operator-action paths copy the original run's owner.
- Template-spawned step agents record the owner as parent and bill to it (`billed_agent = parent.unwrap_or(agent_id)` in the usage record).
- `{ type = "x", fresh = true }` spawns a new random-id instance per run with a unique name tag (the registry is name-unique); the default keeps deterministic find-or-spawn.

## Verification
- `cargo check --workspace --lib` — green
- `cargo test -p librefang-kernel workflow_step_by_type` — 5/5 (spawn, reuse, missing, owner parent, fresh)
- `cargo test -p librefang-memory migration` — 39/39 (incl. v48 idempotence)
- `cargo clippy -p librefang-kernel -p librefang-api -p librefang-memory -p librefang-channels -p librefang-runtime --all-targets -- -D warnings` — clean