### PR TITLE
fix(test): unify API vault key initialization

### DIFF
--- a/changelog.d/fixed/7783-vault-test-key-race.md
+++ b/changelog.d/fixed/7783-vault-test-key-race.md
@@ -1,0 +1,1 @@
+API vault tests and `MockKernelBuilder` now share one process-wide vault-key initializer, preventing parallel `cargo test -p librefang-api --lib` runs from switching keys between vault initialization and unlock (#7783) (@houko)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3266,7 +3266,17 @@ mod tests {
         use librefang_types::approval::{ApprovalRequest, RiskLevel, SecondFactor};
         use totp_rs::{Algorithm, Builder as TotpBuilder, Secret};
 
+        // This test writes the credential vault through MockKernelBuilder. Pin the shared test-process key before the kernel is constructed so another parallel API test cannot switch resolution from the shared keyring fallback to the env-first path between init and unlock.
+        librefang_testing::ensure_test_vault_key();
+        let pinned_vault_key = std::env::var_os("LIBREFANG_VAULT_KEY")
+            .expect("the process-global vault key must be pinned before this test boots a kernel");
+
         let (kernel, _tmp) = MockKernelBuilder::new().build();
+        assert_eq!(
+            std::env::var_os("LIBREFANG_VAULT_KEY").as_ref(),
+            Some(&pinned_vault_key),
+            "building the mock kernel must not replace the process-global vault key",
+        );
         let mut policy = kernel.approvals().policy();
         policy.second_factor = SecondFactor::Totp;
         policy.totp_tools = vec!["shell_exec".to_string()];

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -196,41 +196,6 @@ mod atomic_write_tests {
     }
 }
 
-/// One owner for the process-global `LIBREFANG_VAULT_KEY` that this crate's tests pin.
-///
-/// The vault master key is resolved from an environment variable, so it is process-global state that every test in the binary shares.
-/// `cargo test` runs the whole crate's tests as threads in one process, so two tests that pin *different* keys race: whichever writes last wins, and the vault the loser already wrote can no longer be decrypted — surfacing as `Crypto("Decryption failed: aead::Error")` in whichever test happens to lose.
-///
-/// That is not hypothetical. `server.rs`'s TOTP-lockout tests pinned one key while `routes/mcp_auth.rs`'s flow-cleanup test pinned 32 zero bytes, each under its own `Once` and each believing it was the only writer.
-/// Under `cargo test -p librefang-api --lib` the pair failed roughly one run in two, and CI never caught it because nextest gives every test its own process.
-///
-/// So the key lives here, exactly once, and both call [`pin_vault_key`].
-/// Anything else in this crate that needs a usable vault must do the same rather than setting the variable itself.
-#[cfg(test)]
-pub(crate) mod test_vault {
-    /// Syntactically-valid master key: base64 of exactly 32 bytes, so it decodes to the `[u8; 32]` the vault expects rather than failing key resolution.
-    /// (32 ASCII characters would *not* work — see the `LIBREFANG_VAULT_KEY` note in CLAUDE.md.)
-    pub(crate) const TEST_VAULT_KEY: &str = "dGVzdC12YXVsdC1rZXktZm9yLXRvdHAtbG9ja291dHM=";
-
-    /// Pin the vault master key for this process, idempotently.
-    ///
-    /// `resolve_master_key` (`crates/librefang-extensions/src/vault.rs`) reads `LIBREFANG_VAULT_KEY` first and otherwise falls back to a store shared beyond any single test's tempdir, so leaving it unset lets `init()` and a later resolution settle on different keys.
-    /// Setting it takes the documented env-first branch, making the two agree by construction.
-    ///
-    /// Set once and never removed: unsetting it on drop would reopen the race for whichever test is still running.
-    pub(crate) fn pin_vault_key() {
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| {
-            // SAFETY: the `Once` makes this the only writer in the process —
-            // which now holds, because this function is the crate's only
-            // writer of this variable.
-            unsafe {
-                std::env::set_var("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY);
-            }
-        });
-    }
-}
-
 #[cfg(windows)]
 pub mod acp_pipe;
 #[cfg(unix)]

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -1845,9 +1845,9 @@ mod tests {
     #[test]
     fn flow_vault_cleanup_removes_all_per_flow_keys_on_drop() {
         // Vault crypto needs a 32-byte key.
-        // Pin it through the crate's single owner rather than setting the variable here: `server.rs`'s TOTP-lockout tests pin one too, and under `cargo test` (one process, tests as threads) two different keys race — whoever writes last wins and the loser's freshly written vault no longer decrypts, which is how this test came to fail with `Decryption failed: aead::Error` while passing in isolation.
+        // Pin it through the shared test helper rather than setting the variable here: `server.rs`'s TOTP-lockout tests and MockKernelBuilder use it too, and under `cargo test` (one process, tests as threads) two different keys race — whoever writes last wins and the loser's freshly written vault no longer decrypts, which is how this test came to fail with `Decryption failed: aead::Error` while passing in isolation.
         // nextest hides it by giving every test its own process, so CI never saw it.
-        crate::test_vault::pin_vault_key();
+        librefang_testing::ensure_test_vault_key();
         let home = std::env::temp_dir().join(format!("lf-vault-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&home).unwrap();
         let provider = KernelOAuthProvider::new(home.clone());

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -3963,8 +3963,8 @@ mod dashboard_login_totp_lockout_tests {
     /// Each gets its own `home_dir` tempdir, but the *key* does not come from there: `resolve_master_key` (crates/librefang-extensions/src/vault.rs) reads `LIBREFANG_VAULT_KEY` and otherwise falls back to a store that is shared beyond the test's tempdir.
     /// With neither pinned, `init()` and a later `resolve_master_key()` can settle on different keys and the freshly written vault fails to decrypt — the failure is which test loses the race, not which test is wrong, which is why CI showed a different one failing on each lane (`Test / Unit (lib+bin)` blamed the new test, `Test / Ubuntu (shard 1/4)` the pre-existing one).
     ///
-    /// The key and the `Once` live in `crate::test_vault` rather than here, so this module cannot become a second writer of the variable competing with another test module's key — which is exactly the bug that made `routes::mcp_auth::tests::flow_vault_cleanup_removes_all_per_flow_keys_on_drop` fail under `cargo test`. See that module's doc-comment.
-    use crate::test_vault::pin_vault_key;
+    /// The key and the `Once` live in `librefang-testing` rather than here, so API tests and `MockKernelBuilder` cannot become competing writers with different values — which is exactly the bug that made `routes::mcp_auth::tests::flow_vault_cleanup_removes_all_per_flow_keys_on_drop` fail under `cargo test`. See that module's doc-comment.
+    use librefang_testing::ensure_test_vault_key;
 
     /// Produce `count` 6-digit codes that are guaranteed NOT to match the
     /// enrolled secret in the current TOTP window (or the adjacent windows a
@@ -4034,7 +4034,7 @@ mod dashboard_login_totp_lockout_tests {
     /// keep returning "Invalid TOTP code" forever.
     #[tokio::test(flavor = "multi_thread")]
     async fn dashboard_login_locks_out_after_repeated_wrong_totp_codes() {
-        pin_vault_key();
+        ensure_test_vault_key();
         let tmp = tempfile::tempdir().expect("temp dir");
         librefang_kernel::registry_sync::seed_registry_fixture_for_tests(tmp.path());
         let mut config = KernelConfig {
@@ -4114,7 +4114,7 @@ mod dashboard_login_totp_lockout_tests {
     async fn dashboard_login_fails_closed_when_totp_claim_persistence_fails() {
         use totp_rs::{Algorithm, Builder as TotpBuilder, Secret};
 
-        pin_vault_key();
+        ensure_test_vault_key();
         let tmp = tempfile::tempdir().expect("temp dir");
         librefang_kernel::registry_sync::seed_registry_fixture_for_tests(tmp.path());
         let mut config = KernelConfig {

--- a/crates/librefang-testing/src/lib.rs
+++ b/crates/librefang-testing/src/lib.rs
@@ -16,7 +16,9 @@ pub mod test_app;
 
 pub use helpers::{assert_json_error, assert_json_ok, test_request};
 pub use mock_driver::{FailingLlmDriver, MockLlmDriver};
-pub use mock_kernel::{test_catalog_baseline, CatalogSeed, MockKernelBuilder};
+pub use mock_kernel::{
+    ensure_test_vault_key, test_catalog_baseline, CatalogSeed, MockKernelBuilder,
+};
 pub use test_app::TestAppState;
 
 #[cfg(test)]

--- a/crates/librefang-testing/src/mock_kernel.rs
+++ b/crates/librefang-testing/src/mock_kernel.rs
@@ -66,26 +66,20 @@ pub fn test_catalog_baseline() -> CatalogSeed {
     (providers, models)
 }
 
-/// Pin a deterministic vault master key for the test process the first
-/// time a mock kernel is built. Without this, parallel integration tests
-/// race on the process-shared `<data_local_dir>/librefang/.keyring` file
-/// (or OS keyring entry): one test's `init()` overwrites another's master
-/// key, and the loser's later `vault_get`/`vault_set` calls open a fresh
-/// `CredentialVault` whose `resolve_master_key` then loads the wrong key
-/// and fails to decrypt its own vault file (TOTP test flake on CI).
+/// Pin a deterministic vault master key for the test process before any kernel or vault is constructed.
+///
+/// Without this, parallel tests race on the process-shared `<data_local_dir>/librefang/.keyring` file (or OS keyring entry): one test's `init()` overwrites another's master key, and the loser's later `vault_get`/`vault_set` calls open a fresh `CredentialVault` whose `resolve_master_key` then loads the wrong key and fails to decrypt its own vault file.
+///
+/// This function is the single test-process owner of `LIBREFANG_VAULT_KEY`. Tests that access a vault directly must call it before doing so; `MockKernelBuilder::build` calls it automatically. An externally supplied key is preserved.
 ///
 /// 32 zero bytes, base64-encoded — value is irrelevant, only stability is.
 static VAULT_KEY_INIT: Once = Once::new();
 const TEST_VAULT_KEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
-fn ensure_test_vault_key() {
+pub fn ensure_test_vault_key() {
     VAULT_KEY_INIT.call_once(|| {
         if std::env::var_os("LIBREFANG_VAULT_KEY").is_none() {
-            // SAFETY: only runs once, before any kernel is booted in this
-            // process — no other thread can be reading the env at this point
-            // because all paths into the vault go through MockKernelBuilder
-            // (or `LibreFangKernel::boot_with_config`, which the builder
-            // owns the entry to).
+            // SAFETY: the shared Once makes this the only test helper that writes the variable, and callers invoke it before constructing a kernel or vault.
             std::env::set_var("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY_B64);
         }
     });


### PR DESCRIPTION
## Summary

- Export one process-wide vault-key initializer from `librefang-testing` and use it from both `MockKernelBuilder` and every vault-touching API lib test.
- Pin the key before the channel approval replay test constructs its kernel, then verify that kernel construction does not replace the pinned value.
- Remove the API crate's independent `Once` and key so the test process has one writer while preserving an externally supplied key.

## Root cause

The API crate and its `librefang-testing` dev dependency each owned a separate `Once` and wrote a different `LIBREFANG_VAULT_KEY`. Their check-then-set sequences could interleave, so adding the missing channel test pin alone did not eliminate the race and an exact-value assertion could still fail randomly. Sharing the test-infrastructure initializer removes the competing writer structurally.

## Verification

- `env -u LIBREFANG_VAULT_KEY cargo test -p librefang-api --lib channel_bridge::tests::channel_approval_rejects_replayed_totp_code -- --exact --nocapture` — 1 passed.
- `env -u LIBREFANG_VAULT_KEY cargo test -p librefang-api --lib` — 1030 passed.
- `env -u LIBREFANG_VAULT_KEY cargo test -p librefang-testing` — 14 unit tests and 4 doc-tests passed; 4 doc-tests ignored.
- `cargo clippy -p librefang-testing -p librefang-api --lib --tests -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `python3 scripts/check-changelog-attribution.py --all-unreleased` — passed.

## Out of scope

None.

Closes #7783
