### PR TITLE
fix(api): apply provider-only agent config updates

### DIFF
--- a/changelog.d/fixed/7765-provider-only-agent-patch.md
+++ b/changelog.d/fixed/7765-provider-only-agent-patch.md
@@ -1,0 +1,1 @@
+Provider-only `PATCH /api/agents/{id}/config` requests now preserve the current model while applying and persisting the new provider instead of returning 200 without changing the agent (#7765) (@houko)

--- a/changelog.d/fixed/7765-provider-only-agent-patch.md
+++ b/changelog.d/fixed/7765-provider-only-agent-patch.md
@@ -1,1 +1,1 @@
-Provider-only `PATCH /api/agents/{id}/config` requests now preserve the current model while applying and persisting the new provider instead of returning 200 without changing the agent (#7765) (@houko)
+Provider-only `PATCH /api/agents/{id}/config` requests now preserve the current model while applying and persisting the new provider instead of returning 200 without changing the agent (#7796) (@houko)

--- a/crates/librefang-api/src/routes/agents/config.rs
+++ b/crates/librefang-api/src/routes/agents/config.rs
@@ -877,8 +877,10 @@ pub async fn patch_agent_config(
         }
     }
 
-    // Update model/provider through set_agent_model so provider-change semantics (prefix stripping, canonical-session cleanup, and stale per-agent credential/base URL removal) are applied uniformly. Bypassing it was the root cause of #2380.
-    // A provider-only PATCH keeps the stored model. Ignoring that shape returned 200 without changing anything (#7765).
+    // Update model/provider through set_agent_model so provider-change semantics (prefix stripping, canonical-session cleanup, and stale per-agent credential/base URL removal) are applied uniformly.
+    // Bypassing it was the root cause of #2380.
+    // A provider-only PATCH keeps the stored model.
+    // Ignoring that shape returned 200 without changing anything (#7765).
     let requested_model = req.model.as_deref().filter(|model| !model.is_empty());
     let explicit_provider = req
         .provider

--- a/crates/librefang-api/src/routes/agents/config.rs
+++ b/crates/librefang-api/src/routes/agents/config.rs
@@ -877,26 +877,35 @@ pub async fn patch_agent_config(
         }
     }
 
-    // Update model/provider — always go through set_agent_model so that
-    // provider-change semantics (prefix stripping, canonical-session cleanup,
-    // and clearing of stale per-agent api_key_env / base_url overrides) are
-    // applied uniformly. Bypassing it via update_model_and_provider was the
-    // root cause of #2380: switching to a non-default provider via the
-    // dashboard left stale CLOUDVERSE_API_KEY / cloudverse base_url on the
-    // manifest, so the new provider's request was sent to the old URL with
-    // the old credentials and rejected with "Missing Authentication header".
-    if let Some(ref new_model) = req.model {
-        if !new_model.is_empty() {
-            let explicit_provider = req.provider.as_deref().filter(|p| !p.is_empty());
-            if let Err(e) = state
-                .kernel
-                .set_agent_model(agent_id, new_model, explicit_provider)
-            {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": scrub_500(&e, &t)})),
-                );
-            }
+    // Update model/provider through set_agent_model so provider-change semantics (prefix stripping, canonical-session cleanup, and stale per-agent credential/base URL removal) are applied uniformly. Bypassing it was the root cause of #2380.
+    // A provider-only PATCH keeps the stored model. Ignoring that shape returned 200 without changing anything (#7765).
+    let requested_model = req.model.as_deref().filter(|model| !model.is_empty());
+    let explicit_provider = req
+        .provider
+        .as_deref()
+        .filter(|provider| !provider.is_empty());
+    if requested_model.is_some() || explicit_provider.is_some() {
+        let model = match requested_model {
+            Some(model) => model.to_string(),
+            None => match state.kernel.agent_registry().get(agent_id) {
+                Some(entry) => entry.manifest.model.model,
+                None => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
+                    );
+                }
+            },
+        };
+        if let Err(e) = state
+            .kernel
+            .set_agent_model(agent_id, &model, explicit_provider)
+        {
+            let status = kernel_err_to_status(&e);
+            return (
+                status,
+                Json(serde_json::json!({"error": kernel_err_body(status, &e, &t)})),
+            );
         }
     }
 

--- a/crates/librefang-api/src/routes/agents/mod.rs
+++ b/crates/librefang-api/src/routes/agents/mod.rs
@@ -1927,6 +1927,83 @@ mod monitoring_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn patch_agent_config_provider_only_preserves_model_and_persists() {
+        let (state, _tmp) = monitoring_test_app_state();
+        let manifest = AgentManifest {
+            name: "patch-provider-only".to_string(),
+            model: librefang_types::agent::ModelConfig {
+                provider: "openai".to_string(),
+                model: "gpt-4.1".to_string(),
+                api_key_env: Some("OLD_PROVIDER_API_KEY".to_string()),
+                base_url: Some("https://old-provider.invalid/v1".to_string()),
+                ..Default::default()
+            },
+            ..AgentManifest::default()
+        };
+        let agent_id = state.kernel.spawn_agent_typed(manifest).unwrap();
+        let request = serde_json::from_value(serde_json::json!({"provider": "litellm"})).unwrap();
+
+        let (status, body) = json_response(
+            patch_agent_config(
+                State(state.clone()),
+                Path(agent_id.to_string()),
+                None,
+                Json(request),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "response: {body}");
+        let entry = state.kernel.agent_registry().get(agent_id).unwrap();
+        assert_eq!(entry.manifest.model.model, "gpt-4.1");
+        assert_eq!(entry.manifest.model.provider, "litellm");
+        assert_eq!(entry.manifest.model.api_key_env, None);
+        assert_eq!(entry.manifest.model.base_url, None);
+
+        let persisted = state
+            .kernel
+            .memory_substrate()
+            .load_agent(agent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.manifest.model.model, "gpt-4.1");
+        assert_eq!(persisted.manifest.model.provider, "litellm");
+        assert_eq!(persisted.manifest.model.api_key_env, None);
+        assert_eq!(persisted.manifest.model.base_url, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn patch_agent_config_model_and_provider_shapes_return_not_found_consistently() {
+        let (state, _tmp) = monitoring_test_app_state();
+        let missing_id = AgentId::new();
+
+        for payload in [
+            serde_json::json!({"provider": "litellm"}),
+            serde_json::json!({"model": "gpt-4.1"}),
+            serde_json::json!({"model": "gpt-4.1", "provider": "litellm"}),
+        ] {
+            let request = serde_json::from_value(payload.clone()).unwrap();
+            let (status, body) = json_response(
+                patch_agent_config(
+                    State(state.clone()),
+                    Path(missing_id.to_string()),
+                    None,
+                    Json(request),
+                )
+                .await,
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "payload {payload} returned {body}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_patch_agent_updates_nested_capabilities_mcp_servers_and_persists() {
         let (state, _tmp) = monitoring_test_app_state();
         let manifest = AgentManifest {


### PR DESCRIPTION
## Summary

- Apply a non-empty provider from `PATCH /api/agents/{id}/config` even when the request omits the model, using the agent's stored model as the unchanged half of the update.
- Keep all model/provider changes on `set_agent_model`, preserving provider-prefix normalization, stale credential/base URL cleanup, persistence, and canonical-session invalidation.
- Map typed kernel errors consistently so provider-only, model-only, and combined requests all return 404 for an unknown agent, including a concurrent deletion after the provider-only pre-read.

## Root cause

The handler nested provider handling inside the non-empty model branch. A provider-only request therefore returned 200 without calling the kernel or changing any state, even though the request schema accepted the field.

## Verification

- The new provider-only regression test failed before the fix because the response was 200 while the stored provider remained `openai`.
- The unknown-agent regression test failed before typed error mapping because a model-only request returned 500 while a provider-only request returned 404.
- `cargo test -p librefang-api --lib routes::agents::monitoring_tests::patch_agent_config_ -- --nocapture` — 2 passed.
- `cargo test -p librefang-api --lib routes::agents::monitoring_tests` — 13 passed.
- `cargo clippy -p librefang-api --lib --tests -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `python3 scripts/check-changelog-attribution.py --all-unreleased` — passed.

## Out of scope

- Sensitive request-body debug logging remains unchanged; adding it requires a separate redaction contract.
- The full API lib suite was not repeated on this branch because `main` still contains the known vault-key race fixed separately by #7793; the affected agents module and both new regression paths were run directly.

Closes #7765
