### PR TITLE
fix(api): preserve cron validation errors

### DIFF
--- a/changelog.d/fixed/7734-cron-validation-status.md
+++ b/changelog.d/fixed/7734-cron-validation-status.md
@@ -1,0 +1,1 @@
+Preserve scheduler validation errors when creating cron jobs through `POST /api/cron/jobs`, so rejected names and other caller-correctable fields return `400 invalid_input` with an actionable message while capacity and other internal failures remain scrubbed 500 responses (#7734) (@houko)

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -829,6 +829,34 @@ async fn cron_jobs_list_with_unknown_agent_id_is_empty() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn cron_job_create_rejected_name_returns_400() {
+    let h = boot().await;
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/cron/jobs",
+        Some(serde_json::json!({
+            "agent_id": uuid::Uuid::new_v4().to_string(),
+            "name": "daily — report",
+            "schedule": {"kind": "cron", "expr": "0 * * * *"},
+            "action": {"kind": "agent_turn", "message": "ping"},
+        })),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert_eq!(body["type"], "invalid_input", "{body:?}");
+    assert!(
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or_default()
+            .contains("name may only contain"),
+        "{body:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn cron_job_get_invalid_id_returns_400() {
     let h = boot().await;
     let (status, body) = get(&h, "/api/cron/jobs/garbage").await;

--- a/crates/librefang-kernel/src/kernel/handles/cron_control.rs
+++ b/crates/librefang-kernel/src/kernel/handles/cron_control.rs
@@ -85,11 +85,7 @@ impl kernel_handle::CronControl for LibreFangKernel {
             last_run: None,
         };
 
-        let id = self
-            .workflows
-            .cron_scheduler
-            .add_job(job, one_shot)
-            .map_err(|e| KernelOpError::Internal(e.to_string()))?;
+        let id = self.workflows.cron_scheduler.add_job(job, one_shot)?;
 
         // Persist after adding
         if let Err(e) = self.workflows.cron_scheduler.persist() {


### PR DESCRIPTION
## Summary

- Preserve `LibreFangError::InvalidInput` from the cron scheduler instead of wrapping every `add_job` failure as `Internal`.
- Keep real scheduler internal failures on the existing scrubbed 500 path.
- Add an HTTP integration regression test for a rejected cron name and a fixed changelog fragment.

Fixes #7734.

## Root cause

`CronScheduler::add_job` already distinguishes caller-correctable validation failures from internal failures, and `KernelOpError` is a re-export of that same structured error type. `cron_create` discarded the variant by converting every scheduler error to `KernelOpError::Internal`, so the centralized API mapper could only return 500.

## Verification

- Red before the fix: `cron_job_create_rejected_name_returns_400` received `500 internal_error`.
- `cargo test -p librefang-api --test workflows_routes_integration cron_job_create_rejected_name_returns_400 -- --exact --nocapture` — 1 passed.
- `cargo test -p librefang-api --test workflows_routes_integration` — 71 passed.
- `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.
- `python3 scripts/check-changelog-attribution.py --all-unreleased`.

## Out of scope

- The accepted cron-name character set is unchanged; this PR only corrects error classification.
