### PR TITLE
fix(kernel): scope prompt goals to assigned agent

### DIFF
--- a/changelog.d/fixed/7733-unassigned-goal-prompt.md
+++ b/changelog.d/fixed/7733-unassigned-goal-prompt.md
@@ -1,1 +1,1 @@
-Keep unassigned goals in the management backlog without injecting them into every agent's active-goals prompt, and require prompt goal filtering to name the target agent explicitly (#7733) (@houko)
+Keep unassigned goals in the management backlog without injecting them into every agent's active-goals prompt, and require prompt goal filtering to name the target agent explicitly (#7800) (@houko)

--- a/changelog.d/fixed/7733-unassigned-goal-prompt.md
+++ b/changelog.d/fixed/7733-unassigned-goal-prompt.md
@@ -1,0 +1,1 @@
+Keep unassigned goals in the management backlog without injecting them into every agent's active-goals prompt, and require prompt goal filtering to name the target agent explicitly (#7733) (@houko)

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -848,7 +848,7 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                active_goals: self.active_goals_for_prompt(Some(agent_id)),
+                active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,
             };

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -624,7 +624,7 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                active_goals: self.active_goals_for_prompt(Some(agent_id)),
+                active_goals: self.active_goals_for_prompt(agent_id),
                 is_group: false,
                 was_mentioned: false,
                 context_md,
@@ -2668,7 +2668,7 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                active_goals: self.active_goals_for_prompt(Some(agent_id)),
+                active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,
             };

--- a/crates/librefang-kernel/src/kernel/prompt_context.rs
+++ b/crates/librefang-kernel/src/kernel/prompt_context.rs
@@ -22,6 +22,17 @@ fn goal_progress_for_prompt(goal: &serde_json::Value) -> u8 {
     goal["progress"].as_u64().unwrap_or(0).min(100) as u8
 }
 
+fn goal_is_active_for_agent(goal: &serde_json::Value, agent_id: AgentId) -> bool {
+    let status = goal["status"].as_str().unwrap_or("");
+    if status != "pending" && status != "in_progress" {
+        return false;
+    }
+    goal["agent_id"]
+        .as_str()
+        .and_then(|stored| stored.trim().parse::<AgentId>().ok())
+        == Some(agent_id)
+}
+
 impl LibreFangKernel {
     /// Get cached workspace metadata (workspace context + identity files) for
     /// an agent's workspace, rebuilding if the cache entry has expired.
@@ -118,12 +129,8 @@ impl LibreFangKernel {
         metadata
     }
 
-    /// Load active goals (pending/in_progress) as (title, status, progress) tuples
-    /// for injection into the agent system prompt.
-    pub(crate) fn active_goals_for_prompt(
-        &self,
-        agent_id: Option<AgentId>,
-    ) -> Vec<(String, String, u8)> {
+    /// Load active goals assigned to the agent as (title, status, progress) tuples for injection into its system prompt. Unassigned goals remain visible in management APIs but are not agent work.
+    pub(crate) fn active_goals_for_prompt(&self, agent_id: AgentId) -> Vec<(String, String, u8)> {
         let shared_id = shared_memory_agent_id();
         let goals: Vec<serde_json::Value> = match self
             .memory
@@ -135,23 +142,7 @@ impl LibreFangKernel {
         };
         goals
             .into_iter()
-            .filter(|g| {
-                let status = g["status"].as_str().unwrap_or("");
-                let is_active = status == "pending" || status == "in_progress";
-                if !is_active {
-                    return false;
-                }
-                match agent_id {
-                    Some(aid) => {
-                        // Include goals assigned to this agent OR unassigned goals
-                        match g["agent_id"].as_str() {
-                            Some(gid) => gid == aid.to_string(),
-                            None => true,
-                        }
-                    }
-                    None => true,
-                }
-            })
+            .filter(|goal| goal_is_active_for_agent(goal, agent_id))
             .map(|g| {
                 let title = g["title"].as_str().unwrap_or("").to_string();
                 let status = g["status"].as_str().unwrap_or("pending").to_string();
@@ -389,6 +380,38 @@ impl LibreFangKernel {
             ));
         }
         context_parts.join("\n\n")
+    }
+}
+
+#[cfg(test)]
+mod goal_prompt_tests {
+    use super::*;
+
+    #[test]
+    fn agent_prompt_excludes_unassigned_and_other_agent_goals() {
+        let agent_a = AgentId::new();
+        let agent_b = AgentId::new();
+        let goals = [
+            serde_json::json!({"title": "owned by A", "status": "pending", "agent_id": agent_a.to_string().to_uppercase()}),
+            serde_json::json!({"title": "owned by B", "status": "in_progress", "agent_id": agent_b.0.simple().to_string()}),
+            serde_json::json!({"title": "unassigned", "status": "pending"}),
+            serde_json::json!({"title": "malformed", "status": "pending", "agent_id": "not-a-uuid"}),
+            serde_json::json!({"title": "completed A", "status": "completed", "agent_id": agent_a.to_string()}),
+        ];
+
+        let visible_to_a: Vec<_> = goals
+            .iter()
+            .filter(|goal| goal_is_active_for_agent(goal, agent_a))
+            .map(|goal| goal["title"].as_str().unwrap())
+            .collect();
+        let visible_to_b: Vec<_> = goals
+            .iter()
+            .filter(|goal| goal_is_active_for_agent(goal, agent_b))
+            .map(|goal| goal["title"].as_str().unwrap())
+            .collect();
+
+        assert_eq!(visible_to_a, vec!["owned by A"]);
+        assert_eq!(visible_to_b, vec!["owned by B"]);
     }
 }
 


### PR DESCRIPTION
Closes #7733

## Summary

- exclude unassigned goals from agent-specific Active Goals prompt sections
- require `active_goals_for_prompt` to receive a concrete `AgentId`
- parse stored UUIDs before matching so accepted uppercase and non-hyphenated representations continue to work
- keep unassigned goals available through management APIs and assignment flows

## Verification

- reproduced the regression with an agent seeing both its assigned goal and an unassigned goal
- reproduced the UUID compatibility edge case where raw string comparison omitted an uppercase assigned UUID
- `cargo test -p librefang-kernel --lib kernel::prompt_context::goal_prompt_tests::agent_prompt_excludes_unassigned_and_other_agent_goals`
- `cargo test -p librefang-kernel --lib` (1481 passed, 1 ignored)
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`

## Out of scope

- Dashboard template application and goal CRUD remain unchanged; template goals stay unassigned until an operator assigns them.
