### PR TITLE
fix(dashboard): authenticate protected image loads

### DIFF
--- a/changelog.d/fixed/7738-authenticated-upload-images.md
+++ b/changelog.d/fixed/7738-authenticated-upload-images.md
@@ -1,1 +1,1 @@
-Fetch protected dashboard image assets with the configured API credential and render them through revocable object URLs, so uploads remain visible when API authentication is enabled (#7738) (@houko)
+Fetch protected dashboard image assets with the configured API credential and render them through revocable object URLs, so uploads remain visible when API authentication is enabled (#7801) (@houko)

--- a/changelog.d/fixed/7738-authenticated-upload-images.md
+++ b/changelog.d/fixed/7738-authenticated-upload-images.md
@@ -1,0 +1,1 @@
+Fetch protected dashboard image assets with the configured API credential and render them through revocable object URLs, so uploads remain visible when API authentication is enabled (#7738) (@houko)

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1179,6 +1179,23 @@ async function get<T>(path: string): Promise<T> {
   return (await response.json()) as T;
 }
 
+const AUTHENTICATED_IMAGE_PATH_RE = /^\/api\/(?:uploads|media\/artifacts)\/[A-Za-z0-9_-]+$/;
+
+export function isAuthenticatedImagePath(path: string): boolean {
+  return AUTHENTICATED_IMAGE_PATH_RE.test(path);
+}
+
+export async function fetchAuthenticatedImage(path: string, signal?: AbortSignal): Promise<Blob> {
+  if (!isAuthenticatedImagePath(path)) {
+    throw new Error("Authenticated image path is not allowed");
+  }
+  const response = await fetch(path, { headers: buildHeaders(), signal });
+  if (!response.ok) {
+    throw await parseError(response);
+  }
+  return response.blob();
+}
+
 async function post<T>(
   path: string,
   body: unknown,

--- a/crates/librefang-api/dashboard/src/components/AuthenticatedImage.tsx
+++ b/crates/librefang-api/dashboard/src/components/AuthenticatedImage.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState, type AnchorHTMLAttributes, type ImgHTMLAttributes } from "react";
+import { fetchAuthenticatedImage, isAuthenticatedImagePath } from "../api";
+
+interface AuthenticatedImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> {
+  src: string;
+  linkProps?: Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "children">;
+}
+
+export function AuthenticatedImage({ src, linkProps, ...imageProps }: AuthenticatedImageProps) {
+  const [resolvedSrc, setResolvedSrc] = useState<string | undefined>(() => isAuthenticatedImagePath(src) ? undefined : src);
+
+  useEffect(() => {
+    if (!isAuthenticatedImagePath(src)) {
+      setResolvedSrc(src);
+      return;
+    }
+
+    const controller = new AbortController();
+    let objectUrl: string | undefined;
+    setResolvedSrc(undefined);
+
+    void fetchAuthenticatedImage(src, controller.signal)
+      .then((blob) => {
+        if (controller.signal.aborted) return;
+        objectUrl = URL.createObjectURL(blob);
+        setResolvedSrc(objectUrl);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        setResolvedSrc(undefined);
+      });
+
+    return () => {
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
+  const image = <img {...imageProps} src={resolvedSrc} />;
+  if (!linkProps) return image;
+
+  return (
+    <a {...linkProps} href={resolvedSrc}>
+      {image}
+    </a>
+  );
+}

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
@@ -1,25 +1,65 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import { WorkflowStepImageGallery } from "./WorkflowStepImageGallery";
 import { extractImageRefs } from "../lib/workflowOutputImages";
 
 describe("WorkflowStepImageGallery", () => {
+  const fetchMock = vi.fn();
+  const createObjectURL = vi.fn(() => "blob:authenticated-image");
+  const revokeObjectURL = vi.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["image"], { type: "image/png" }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
   it("renders nothing when refs is empty", () => {
     const { container } = render(<WorkflowStepImageGallery refs={[]} />);
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders a single <img> for one image ref", () => {
+  it("fetches upload images with dashboard auth and renders an object URL", async () => {
+    sessionStorage.setItem("librefang-api-key", "dashboard-secret");
     const refs = extractImageRefs(
       JSON.stringify({ image_urls: ["/api/uploads/abc-1"] }),
     );
-    render(<WorkflowStepImageGallery refs={refs} />);
-    const imgs = screen.getAllByRole("img");
-    expect(imgs).toHaveLength(1);
-    expect(imgs[0]).toHaveAttribute("src", "/api/uploads/abc-1");
+    const { unmount } = render(<WorkflowStepImageGallery refs={refs} />);
+    const img = screen.getByRole("img");
+
+    await waitFor(() => {
+      expect(img).toHaveAttribute("src", "blob:authenticated-image");
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [path, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/api/uploads/abc-1");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer dashboard-secret");
+    expect(img.closest("a")).toHaveAttribute("href", "blob:authenticated-image");
+
+    unmount();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:authenticated-image");
   });
 
-  it("renders multiple <img>s as a gallery", () => {
+  it("renders multiple authenticated images as a gallery", async () => {
     const refs = extractImageRefs(
       JSON.stringify({
         image_urls: ["/api/uploads/a", "/api/uploads/b"],
@@ -28,10 +68,23 @@ describe("WorkflowStepImageGallery", () => {
     render(<WorkflowStepImageGallery refs={refs} />);
     const imgs = screen.getAllByRole("img");
     expect(imgs).toHaveLength(2);
-    expect(imgs.map((i) => i.getAttribute("src"))).toEqual([
-      "/api/uploads/a",
-      "/api/uploads/b",
-    ]);
+    await waitFor(() => {
+      expect(imgs.map((i) => i.getAttribute("src"))).toEqual([
+        "blob:authenticated-image",
+        "blob:authenticated-image",
+      ]);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves remote image URLs unchanged without sending dashboard credentials", () => {
+    const refs = extractImageRefs(
+      JSON.stringify({ image_urls: ["https://images.example.test/sunset.png"] }),
+    );
+    render(<WorkflowStepImageGallery refs={refs} />);
+
+    expect(screen.getByRole("img")).toHaveAttribute("src", "https://images.example.test/sunset.png");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("uses revised_prompt as alt text when present", () => {

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
@@ -1,10 +1,8 @@
-// Renders the images detected in a workflow step's output as a gallery.
-// Pure presentation — no fetch, no data access; the helper that produces
-// `refs` is in src/lib/workflowOutputImages.ts and is already URL-safety
-// checked, so we render `<img src={ref.src}>` directly.
+// Renders URL-safety-checked workflow images and authenticates protected same-origin API assets before exposing them to `<img>`.
 
 import type { ImageRef } from "../lib/workflowOutputImages";
 import { useTranslation } from "react-i18next";
+import { AuthenticatedImage } from "./AuthenticatedImage";
 
 interface Props {
   refs: ImageRef[];
@@ -23,23 +21,21 @@ export function WorkflowStepImageGallery({ refs, label }: Props) {
       )}
       <div className="flex flex-wrap gap-2">
         {refs.map((ref) => (
-          <a
+          <AuthenticatedImage
             key={ref.src}
-            href={ref.src}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[200px]"
-            title={ref.alt}
-          >
-            <img
-              src={ref.src}
-              alt={ref.alt || t("workflows.generated_image_alt", {
-                defaultValue: "generated image",
-              })}
-              loading="lazy"
-              className="block max-h-[200px] w-auto object-contain bg-main/30"
-            />
-          </a>
+            src={ref.src}
+            alt={ref.alt || t("workflows.generated_image_alt", {
+              defaultValue: "generated image",
+            })}
+            loading="lazy"
+            className="block max-h-[200px] w-auto object-contain bg-main/30"
+            linkProps={{
+              target: "_blank",
+              rel: "noopener noreferrer",
+              className: "block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[200px]",
+              title: ref.alt,
+            }}
+          />
         ))}
       </div>
     </div>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -40,6 +40,7 @@ import { ToolCallsPanel } from "../components/ui/ToolCallsPanel";
 import { filterVisible } from "../lib/hiddenModels";
 import { useVoiceInput } from "../lib/useVoiceInput";
 import { Typewriter_v2 } from "../components/Typewriter_v2";
+import { AuthenticatedImage } from "../components/AuthenticatedImage";
 import { useMathPlugins } from "../lib/hooks/useMathPlugins";
 import {
   useCreateAgentSession,
@@ -1401,19 +1402,17 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
               const isImage = !img.content_type || img.content_type.startsWith("image/");
               if (isImage) {
                 return (
-                  <a
+                  <AuthenticatedImage
                     key={img.file_id}
-                    href={src}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[240px]"
-                  >
-                    <img
-                      src={src}
-                      alt={img.filename || "attachment"}
-                      className="block max-h-[240px] w-auto object-contain bg-main/30"
-                    />
-                  </a>
+                    src={src}
+                    alt={img.filename || "attachment"}
+                    className="block max-h-[240px] w-auto object-contain bg-main/30"
+                    linkProps={{
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      className: "block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[240px]",
+                    }}
+                  />
                 );
               }
               const label = img.filename || img.file_id;
@@ -1567,7 +1566,7 @@ function AttachmentChip({ attachment, onRemove }: { attachment: PendingAttachmen
     }`}>
       <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-main/40">
         {isImage && imageSrc ? (
-          <img src={imageSrc} alt={attachment.filename} className="h-full w-full object-cover" />
+          <AuthenticatedImage src={imageSrc} alt={attachment.filename} className="h-full w-full object-cover" />
         ) : (
           <FileText className="h-4 w-4 text-text-dim" />
         )}

--- a/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MediaPage.tsx
@@ -21,6 +21,8 @@ import { Badge } from "../components/ui/Badge";
 import { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import { PageHeader } from "../components/ui/PageHeader";
+import { AuthenticatedImage } from "../components/AuthenticatedImage";
+import { isAuthenticatedImagePath } from "../api";
 import { useUIStore } from "../lib/store";
 import {
   Image as ImageIcon,
@@ -343,26 +345,36 @@ function ImagePanel({
             <p className="text-xs text-text-dim mb-3 italic">{t("media.revised_prompt")}: {result.revised_prompt}</p>
           )}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {result.images.map((img, i) => (
-              <a
-                key={i}
-                href={safeUrl(img.url) || undefined}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-xl overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors"
-              >
-                {img.url ? (
-                  <img src={img.url} alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })} className="w-full h-auto" />
-                ) : img.data_base64 && img.data_base64.length > MAX_BASE64_LENGTH ? (
+            {result.images.map((img, i) => {
+              const imageSrc = img.url && (isAuthenticatedImagePath(img.url) ? img.url : safeUrl(img.url));
+              if (imageSrc) {
+                return (
+                  <AuthenticatedImage
+                    key={i}
+                    src={imageSrc}
+                    alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })}
+                    className="w-full h-auto"
+                    linkProps={{
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      className: "block rounded-xl overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors",
+                    }}
+                  />
+                );
+              }
+              return (
+                <div key={i} className="block rounded-xl overflow-hidden border border-border-subtle">
+                  {img.data_base64 && img.data_base64.length > MAX_BASE64_LENGTH ? (
                   <div className="flex items-center gap-2 p-3 text-xs text-warning">
                     <AlertCircle className="w-4 h-4 shrink-0" />
                     <span>{t("media.image_too_large", { defaultValue: "Image too large to display" })}</span>
                   </div>
-                ) : (
-                  <img src={`data:image/png;base64,${img.data_base64}`} alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })} className="w-full h-auto" />
-                )}
-              </a>
-            ))}
+                  ) : (
+                    <img src={`data:image/png;base64,${img.data_base64}`} alt={t("media.generated_alt", { index: i + 1, defaultValue: "generated {{index}}" })} className="w-full h-auto" />
+                  )}
+                </div>
+              );
+            })}
           </div>
         </ResultBlock>
       )}


### PR DESCRIPTION
Closes #7738

## Summary

- Fetch protected `/api/uploads/<id>` and `/api/media/artifacts/<id>` images with the dashboard's existing API credential, then render revocable object URLs.
- Apply the authenticated renderer to chat history attachments, pending upload previews, workflow image galleries, and media generation results.
- Keep remote and data image URLs on the direct rendering path so dashboard credentials are never sent to external origins.
- Abort in-flight requests and revoke object URLs when an image changes or unmounts.

## Verification

- `pnpm test` — 122 files, 1187 tests passed.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` — 2049 modules transformed.
- Headless Chromium against the Vite development server — protected image requests carried `Bearer browser-secret`, image and link rendered the same blob URL, and the browser reported no console or page errors. The temporary harness was removed after verification.
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check`

## Out of scope

- Non-image attachment download links still require separate API-aware download handling. Anonymous access to uploads remains prohibited.
