### PR TITLE
fix(browser): build authenticated websocket handshake

### DIFF
--- a/changelog.d/fixed/7737-cdp-auth-websocket-handshake.md
+++ b/changelog.d/fixed/7737-cdp-auth-websocket-handshake.md
@@ -1,1 +1,1 @@
-Build authenticated CDP WebSocket requests through tungstenite's handshake generator before adding the bearer token, so token-protected browser endpoints receive the required upgrade headers (#7737) (@houko)
+Build authenticated CDP WebSocket requests through tungstenite's handshake generator before adding the bearer token, so token-protected browser endpoints receive the required upgrade headers (#7802) (@houko)

--- a/changelog.d/fixed/7737-cdp-auth-websocket-handshake.md
+++ b/changelog.d/fixed/7737-cdp-auth-websocket-handshake.md
@@ -1,0 +1,1 @@
+Build authenticated CDP WebSocket requests through tungstenite's handshake generator before adding the bearer token, so token-protected browser endpoints receive the required upgrade headers (#7737) (@houko)

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::{oneshot, Mutex};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tracing::{debug, info, warn};
 
@@ -659,10 +660,13 @@ impl BrowserSession {
         auth_token: Option<&str>,
     ) -> Result<CdpConnection, String> {
         if let Some(token) = auth_token {
-            let req = http::Request::get(ws_url)
-                .header("Authorization", format!("Bearer {token}"))
-                .body(())
+            let mut req = ws_url
+                .into_client_request()
                 .map_err(|e| format!("Failed to build CDP auth request: {e}"))?;
+            let authorization = http::HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| format!("Failed to build CDP auth request: {e}"))?;
+            req.headers_mut()
+                .insert(http::header::AUTHORIZATION, authorization);
             let (stream, _) = tokio::time::timeout(
                 Duration::from_secs(CDP_CONNECT_TIMEOUT_SECS),
                 tokio_tungstenite::connect_async(req),
@@ -2898,6 +2902,42 @@ mod tests {
         });
 
         (format!("ws://127.0.0.1:{port}/"), seen)
+    }
+
+    #[tokio::test]
+    async fn connect_with_auth_sends_a_complete_websocket_handshake() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("ws://{}/", listener.local_addr().unwrap());
+        let (headers_tx, headers_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            #[allow(clippy::result_large_err)]
+            let capture_headers =
+                move |request: &http::Request<()>, response: http::Response<()>| {
+                    let authorization = request
+                        .headers()
+                        .get(http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .map(str::to_owned);
+                    let websocket_key_present = request.headers().contains_key("Sec-WebSocket-Key");
+                    headers_tx
+                        .send((authorization, websocket_key_present))
+                        .unwrap();
+                    Ok(response)
+                };
+            tokio_tungstenite::accept_hdr_async(stream, capture_headers)
+                .await
+                .unwrap();
+        });
+
+        let connection = BrowserSession::connect_with_auth(&url, Some("test-token"))
+            .await
+            .expect("authenticated CDP WebSocket handshake should succeed");
+        let (authorization, websocket_key_present) = headers_rx.await.unwrap();
+        assert_eq!(authorization.as_deref(), Some("Bearer test-token"));
+        assert!(websocket_key_present);
+        drop(connection);
+        server.await.unwrap();
     }
 
     /// A page-level endpoint must behave exactly as it did before the handshake existed.


### PR DESCRIPTION
Closes #7737

## Summary

- Build authenticated CDP WebSocket requests through tungstenite's `IntoClientRequest` implementation so the standard upgrade headers and `Sec-WebSocket-Key` are generated before adding the bearer token.
- Preserve the existing unauthenticated connection, timeout, and error mapping behavior.
- Add a real local WebSocket handshake regression test that captures the authorization header and verifies a generated WebSocket key reached the server.

## Verification

- Red test before the fix: `connect_with_auth_sends_a_complete_websocket_handshake` failed with `Missing, duplicated or incorrect header sec-websocket-key`.
- `cargo test -p librefang-runtime browser::tests::connect_with_auth_sends_a_complete_websocket_handshake --lib -- --exact` — 1 passed.
- `cargo test -p librefang-runtime browser::tests --lib` — 54 passed.
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-changelog-attribution.py --all-unreleased`
- `git diff --check`

## Full crate test note

- `cargo test -p librefang-runtime --lib` completed with 2292 passed, 2 ignored, and the unrelated `agent_context::tests::poisoned_cache_lock_recovers_cached_context` parallel global-lock flake failing. The same test passed 1/1 when rerun in isolation.

## Out of scope

- No CDP discovery, target lifecycle, or browser command behavior changed.
