### PR TITLE
fix(goals): expose actionable goal ids in prompts

### DIFF
--- a/changelog.d/fixed/7732-goal-id-prompt.md
+++ b/changelog.d/fixed/7732-goal-id-prompt.md
@@ -1,0 +1,1 @@
+Include each assigned goal's UUID in the Active Goals system-prompt section so agents can call `goal_update` with an actionable identifier (#7732) (@houko)

--- a/changelog.d/fixed/7732-goal-id-prompt.md
+++ b/changelog.d/fixed/7732-goal-id-prompt.md
@@ -1,1 +1,1 @@
-Include each assigned goal's UUID in the Active Goals system-prompt section so agents can call `goal_update` with an actionable identifier (#7732) (@houko)
+Include each assigned goal's UUID in the Active Goals system-prompt section so agents can call `goal_update` with an actionable identifier (#7804) (@houko)

--- a/crates/librefang-kernel/src/kernel/handles/goal_control.rs
+++ b/crates/librefang-kernel/src/kernel/handles/goal_control.rs
@@ -125,6 +125,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn goal_update_uses_stored_id_representation_verbatim() {
+        let goal_id = "B5264016-E9CC-4FD1-83C6-D13626B404DC";
+        let goals = vec![serde_json::json!({
+            "id": goal_id,
+            "status": "pending",
+            "progress": 0,
+        })];
+
+        let (_, updated) =
+            apply_goal_update(goals, goal_id, Some("in_progress"), Some(25)).unwrap();
+
+        assert_eq!(updated["id"], goal_id);
+        assert_eq!(updated["status"], "in_progress");
+        assert_eq!(updated["progress"], 25);
+    }
+
+    #[test]
     fn absent_goal_store_is_typed_not_found() {
         let error = decode_goal_store(None, "goal-123").unwrap_err();
 

--- a/crates/librefang-kernel/src/kernel/prompt_context.rs
+++ b/crates/librefang-kernel/src/kernel/prompt_context.rs
@@ -14,7 +14,8 @@
 
 use std::path::Path;
 
-use librefang_types::agent::AgentId;
+use librefang_runtime::prompt_builder::ActiveGoalPrompt;
+use librefang_types::{agent::AgentId, goal::GoalId};
 
 use super::*;
 
@@ -31,6 +32,17 @@ fn goal_is_active_for_agent(goal: &serde_json::Value, agent_id: AgentId) -> bool
         .as_str()
         .and_then(|stored| stored.trim().parse::<AgentId>().ok())
         == Some(agent_id)
+}
+
+fn active_goal_for_prompt(goal: &serde_json::Value) -> Option<ActiveGoalPrompt> {
+    let id = goal["id"].as_str()?;
+    id.parse::<GoalId>().ok()?;
+    Some(ActiveGoalPrompt {
+        id: id.to_string(),
+        title: goal["title"].as_str().unwrap_or("").to_string(),
+        status: goal["status"].as_str().unwrap_or("pending").to_string(),
+        progress: goal_progress_for_prompt(goal),
+    })
 }
 
 impl LibreFangKernel {
@@ -129,8 +141,8 @@ impl LibreFangKernel {
         metadata
     }
 
-    /// Load active goals assigned to the agent as (title, status, progress) tuples for injection into its system prompt. Unassigned goals remain visible in management APIs but are not agent work.
-    pub(crate) fn active_goals_for_prompt(&self, agent_id: AgentId) -> Vec<(String, String, u8)> {
+    /// Load active goals assigned to the agent for injection into its system prompt. Unassigned goals remain visible in management APIs but are not agent work.
+    pub(crate) fn active_goals_for_prompt(&self, agent_id: AgentId) -> Vec<ActiveGoalPrompt> {
         let shared_id = shared_memory_agent_id();
         let goals: Vec<serde_json::Value> = match self
             .memory
@@ -143,12 +155,7 @@ impl LibreFangKernel {
         goals
             .into_iter()
             .filter(|goal| goal_is_active_for_agent(goal, agent_id))
-            .map(|g| {
-                let title = g["title"].as_str().unwrap_or("").to_string();
-                let status = g["status"].as_str().unwrap_or("pending").to_string();
-                let progress = goal_progress_for_prompt(&g);
-                (title, status, progress)
-            })
+            .filter_map(|goal| active_goal_for_prompt(&goal))
             .collect()
     }
 
@@ -412,6 +419,30 @@ mod goal_prompt_tests {
 
         assert_eq!(visible_to_a, vec!["owned by A"]);
         assert_eq!(visible_to_b, vec!["owned by B"]);
+    }
+
+    #[test]
+    fn prompt_goal_preserves_valid_id_and_rejects_unusable_ids() {
+        let goal_id: GoalId = "b5264016-e9cc-4fd1-83c6-d13626b404dc".parse().unwrap();
+        let stored_id = goal_id.to_string().to_uppercase();
+        let valid = serde_json::json!({
+            "id": stored_id,
+            "title": "owned goal",
+            "status": "in_progress",
+            "progress": 140,
+        });
+
+        let prompt_goal = active_goal_for_prompt(&valid).unwrap();
+        assert_eq!(prompt_goal.id, stored_id);
+        assert_eq!(prompt_goal.title, "owned goal");
+        assert_eq!(prompt_goal.status, "in_progress");
+        assert_eq!(prompt_goal.progress, 100);
+
+        assert!(active_goal_for_prompt(&serde_json::json!({"title": "missing id"})).is_none());
+        assert!(active_goal_for_prompt(
+            &serde_json::json!({"id": "not-a-uuid", "title": "malformed id"})
+        )
+        .is_none());
     }
 }
 

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -5,7 +5,6 @@
 //! with a single, testable, ordered prompt builder.
 
 use crate::str_utils::safe_truncate_str;
-
 // ---------------------------------------------------------------------------
 // Skill prompt context budget
 // ---------------------------------------------------------------------------
@@ -119,6 +118,15 @@ pub fn sanitize_for_prompt(s: &str, max_chars: usize) -> String {
 /// Aliases the single source of truth `librefang_types::text::INVISIBLE_FORMAT_CHARS` so this set and the skill verifier's set cannot drift apart.
 pub(crate) const INVISIBLE_PROMPT_CHARS: &[char] = librefang_types::text::INVISIBLE_FORMAT_CHARS;
 
+/// An active goal exposed to an agent through its system prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveGoalPrompt {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub progress: u8,
+}
+
 /// All the context needed to build a system prompt for an agent.
 #[derive(Debug, Clone, Default)]
 pub struct PromptContext {
@@ -200,9 +208,8 @@ pub struct PromptContext {
     pub peer_agents: Vec<(String, String, String)>,
     /// Current date/time string for temporal awareness.
     pub current_date: Option<String>,
-    /// Active goals (pending/in_progress) for the agent. Each entry is a
-    /// (title, status, progress%) tuple.
-    pub active_goals: Vec<(String, String, u8)>,
+    /// Active goals (pending/in_progress) assigned to the agent.
+    pub active_goals: Vec<ActiveGoalPrompt>,
     /// Current on-disk `context.md` content for the agent (see `agent_context`).
     ///
     /// Read per-turn by the kernel so external writers (cron jobs, integrations)
@@ -1046,13 +1053,16 @@ fn build_channel_section(
 }
 
 /// Build the active goals section (Section 7.6).
-fn build_goals_section(goals: &[(String, String, u8)]) -> String {
+fn build_goals_section(goals: &[ActiveGoalPrompt]) -> String {
     let mut out = String::from(
         "## Active Goals\n\
          You are working toward these goals. Use the `goal_update` tool to report progress.\n",
     );
-    for (title, status, progress) in goals {
-        out.push_str(&format!("- [{status} {progress}%] {title}\n"));
+    for goal in goals {
+        out.push_str(&format!(
+            "- [{} {}%] {} (goal_id: {})\n",
+            goal.status, goal.progress, goal.title, goal.id
+        ));
     }
     out
 }

--- a/crates/librefang-runtime/src/prompt_builder/tests.rs
+++ b/crates/librefang-runtime/src/prompt_builder/tests.rs
@@ -721,14 +721,26 @@ fn test_capitalize() {
 #[test]
 fn test_goals_section_present_when_active() {
     let mut ctx = basic_ctx();
+    let goal_id = "C4D180E1-2F32-4585-A0A1-1C63435E62BB";
     ctx.active_goals = vec![
-        ("Ship v1.0".to_string(), "in_progress".to_string(), 40),
-        ("Write docs".to_string(), "pending".to_string(), 0),
+        ActiveGoalPrompt {
+            id: goal_id.to_string(),
+            title: "Ship v1.0".to_string(),
+            status: "in_progress".to_string(),
+            progress: 40,
+        },
+        ActiveGoalPrompt {
+            id: "968a4794-775b-4938-9a37-2eb7dc945ec5".to_string(),
+            title: "Write docs".to_string(),
+            status: "pending".to_string(),
+            progress: 0,
+        },
     ];
     let prompt = build_system_prompt(&ctx);
     assert!(prompt.contains("## Active Goals"));
     assert!(prompt.contains("[in_progress 40%] Ship v1.0"));
     assert!(prompt.contains("[pending 0%] Write docs"));
+    assert!(prompt.contains(&format!("goal_id: {goal_id}")));
     assert!(prompt.contains("goal_update"));
 }
 
@@ -743,7 +755,12 @@ fn test_goals_section_omitted_when_empty() {
 fn test_goals_section_present_for_subagents() {
     let mut ctx = basic_ctx();
     ctx.is_subagent = true;
-    ctx.active_goals = vec![("Sub-task".to_string(), "in_progress".to_string(), 50)];
+    ctx.active_goals = vec![ActiveGoalPrompt {
+        id: "46c7e82a-434f-4f58-a95f-6fc45d56aa67".to_string(),
+        title: "Sub-task".to_string(),
+        status: "in_progress".to_string(),
+        progress: 50,
+    }];
     let prompt = build_system_prompt(&ctx);
     // Goals should still be visible to subagents
     assert!(prompt.contains("## Active Goals"));

--- a/crates/librefang-runtime/src/silent_response.rs
+++ b/crates/librefang-runtime/src/silent_response.rs
@@ -859,7 +859,12 @@ mod tests {
             tools_md: Some("tools".to_string()),
             peer_agents: vec![("peer".to_string(), "Idle".to_string(), "haiku".to_string())],
             current_date: Some("Friday, 2026-05-16".to_string()),
-            active_goals: vec![("goal".to_string(), "in_progress".to_string(), 50)],
+            active_goals: vec![crate::prompt_builder::ActiveGoalPrompt {
+                id: "cc016c43-b781-4434-aeb7-f87d56af1522".to_string(),
+                title: "goal".to_string(),
+                status: "in_progress".to_string(),
+                progress: 50,
+            }],
             context_md: Some("ctx-md".to_string()),
             dynamic_sections: vec![crate::hooks::DynamicSection {
                 provider: "test".to_string(),


### PR DESCRIPTION
Closes #7732

## Changes

- Carry each valid stored goal ID into `ActiveGoalPrompt` and render it beside the assigned goal so `goal_update` has an actionable identifier.
- Preserve the stored UUID representation byte-for-byte in the prompt and in `goal_update` lookup, while excluding missing, malformed, or whitespace-wrapped IDs that could not be copied back successfully.
- Keep assignment and active-status filtering from #7800 intact across normal execution, channel messaging, and silent-response prompt construction.
- Add projection, rendering, and update-path regression tests, plus the changelog fragment.

## Verification

- `cargo test -p librefang-kernel prompt_context::goal_prompt_tests --lib` — 2 passed.
- `cargo test -p librefang-kernel kernel::handles::goal_control::tests --lib` — 5 passed.
- `cargo test -p librefang-runtime prompt_builder --lib` — 84 passed.
- `cargo clippy -p librefang-kernel -p librefang-runtime --all-targets -- -D warnings` — passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.
- `python3 scripts/check-changelog-attribution.py --all-unreleased` — passed.

## Out of scope

- This does not add the optional `goal_list` or `goal_create` tools proposed in the issue; the existing assigned-goal prompt and `goal_update` contract are made internally complete.
