### PR TITLE
feat(slack): forward inbound files and images to the agent

### DIFF
--- a/changelog.d/added/7087-slack-inbound-attachments.md
+++ b/changelog.d/added/7087-slack-inbound-attachments.md
@@ -1,2 +1,2 @@
 Files and images uploaded into Slack now reach the agent instead of being dropped, so a member can hand over a campaign image or a clip in the channel where the work is happening and ask for something to be done with it.
-The bot token is pinned to Slack's own file hosts, and downloads are gated by a size cap, an extension allow-list and per-channel switches so a busy channel can opt out without disabling uploads everywhere (#7087) (@houko)
+The bot token is pinned to Slack's own file hosts, and downloads are gated by a size cap, an extension allow-list and per-channel switches so a busy channel can opt out without disabling uploads everywhere (#7812, #7087) (@houko)

--- a/changelog.d/added/7087-slack-inbound-attachments.md
+++ b/changelog.d/added/7087-slack-inbound-attachments.md
@@ -1,0 +1,2 @@
+Files and images uploaded into Slack now reach the agent instead of being dropped, so a member can hand over a campaign image or a clip in the channel where the work is happening and ask for something to be done with it.
+The bot token is pinned to Slack's own file hosts, and downloads are gated by a size cap, an extension allow-list and per-channel switches so a busy channel can opt out without disabling uploads everywhere (#7087) (@houko)

--- a/docs/architecture/sidecar-channels.md
+++ b/docs/architecture/sidecar-channels.md
@@ -154,6 +154,16 @@ Two dispatch details matter for a multi-step display:
   The two indicators have independent switches: `SLACK_REACTIONS` for the receipt and `SLACK_PROGRESS_CARD` for the card (#6730).
   The card's default follows `SLACK_REACTIONS`, so an operator who set `SLACK_REACTIONS=false` for silence keeps it, but either can now be turned off without the other.
 
+### Inbound attachments and `header_rules`
+
+An adapter whose platform serves media behind an authenticated URL forwards the URL, not the bytes, and declares `header_rules` in its `ready` event so the daemon can fetch it.
+The daemon's `fetch_headers_for` (`crates/librefang-channels/src/sidecar.rs`) exact-matches the request host against those rules and attaches nothing for a host that is not in them, which is what makes it safe to hand it a credential: a URL chosen by a platform user cannot pull the token along with it.
+Matrix uses this for MSC3916 media; the Slack sidecar uses it for `url_private_download` (#7087), pinning the rules — and its own acceptance check on every inbound file URL — to Slack's file hosts.
+
+Forwarding the URL rather than inlining bytes is not a size optimization.
+`download_media_blocks` in `bridge.rs` is what turns an inbound `Image` / `File` / `Voice` / `Audio` / `Video` URL into a vision image block, a saved document path, or an audio transcription; its match has no `FileData` arm, so an inbound `FileData` is rendered as a `[User sent a local file: …]` placeholder and its payload discarded.
+An adapter that inlines inbound bytes therefore delivers nothing the agent can act on.
+
 ## Supervision
 
 The supervisor owns the (re)spawn loop. State machine:

--- a/docs/src/app/integrations/channels/core/page.mdx
+++ b/docs/src/app/integrations/channels/core/page.mdx
@@ -144,6 +144,7 @@ common `[[sidecar_channels]]` fields documented under
 3. Go to **OAuth & Permissions** and add Bot Token Scopes:
    - `chat:write`
    - `files:write` (required for `File` / `FileData` attachments sent by agents)
+   - `files:read` (required to forward user-uploaded files and images to the agent)
    - `app_mentions:read`
    - `im:history`
    - `im:read`
@@ -176,6 +177,11 @@ SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_FORCE_FLAT_REPLIES = "false"   # set "true" to post replies as top-level messages
 # SLACK_REACTIONS = "true"             # set "false" to drop the 👀 / ✅ receipt
 # SLACK_PROGRESS_CARD = "true"         # set "false" to drop the task-progress card
+# SLACK_FILE_DOWNLOADS = "true"        # set "false" to stop forwarding user uploads to the agent
+# SLACK_FILE_MAX_BYTES = "10485760"    # inbound attachment size cap
+# SLACK_FILE_ALLOWED_EXTENSIONS = ""   # comma-separated allow-list; empty accepts every extension
+# SLACK_FILE_DOWNLOAD_CHANNELS = ""    # comma-separated channel IDs; empty means every channel
+# SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS = ""   # channel IDs that never accept uploads
 ```
 
 8. Restart the daemon.
@@ -183,6 +189,15 @@ SLACK_BOT_TOKEN = "xoxb-..."
 ### How It Works
 
 The Slack adapter uses Socket Mode, which establishes a WebSocket connection to Slack's servers. This avoids the need for a public webhook URL. The adapter receives events (app mentions, direct messages) and routes them to the configured agent. Text responses are posted via the `chat.postMessage` Web API. `File` and `FileData` responses use Slack's external upload flow and retain the same thread context. URL-backed files are downloaded only from public HTTP(S) targets and both URL-backed and inline files are capped at 10 MiB. When `threading = true`, replies are sent to the message's thread via `thread_ts`.
+
+### User Uploads
+
+A file or image dropped into a channel or DM reaches the agent as the message content, so the agent can look at the picture, transcribe the clip or read the document instead of being handed a URL it cannot open.
+Slack's private file URLs require the bot token, so the adapter declares a per-host authorization rule for Slack's own file hosts and the daemon downloads the file with it; the token is never attached to any other host, which matters because a workspace member can register a remote file pointing anywhere.
+One attachment per message is forwarded (the wire protocol carries one content value per message) and the attachment takes precedence over the message text, which rides along as its caption.
+Link-preview images are not followed — those belong to a URL somebody pasted, not to an upload.
+
+Four knobs gate it, all optional: `SLACK_FILE_DOWNLOADS` turns the whole feature off, `SLACK_FILE_MAX_BYTES` caps the size (10 MiB by default), `SLACK_FILE_ALLOWED_EXTENSIONS` restricts which extensions are accepted, and `SLACK_FILE_DOWNLOAD_CHANNELS` / `SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS` decide which channels participate — the pair a busy channel needs to opt out without disabling uploads everywhere.
 
 ### Processing-State Reactions
 

--- a/docs/src/app/zh/integrations/channels/core/page.mdx
+++ b/docs/src/app/zh/integrations/channels/core/page.mdx
@@ -130,6 +130,7 @@ Sidecar 自动处理 Gateway 重连、周期性心跳（首次心跳带 RFC 要�
 3. 前往 **OAuth & Permissions**，添加 Bot Token Scopes：
    - `chat:write`
    - `files:write`（Agent 发送 `File` / `FileData` 附件时必需）
+   - `files:read`（将用户上传的文件与图片转发给 Agent 时必需）
    - `app_mentions:read`
    - `im:history`
    - `im:read`
@@ -162,6 +163,11 @@ SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_FORCE_FLAT_REPLIES = "false"   # 设为 "true" 将回复以顶层消息发送
 # SLACK_REACTIONS = "true"             # 设为 "false" 关闭 👀 / ✅ 处理回执
 # SLACK_PROGRESS_CARD = "true"         # 设为 "false" 关闭多步任务进度卡片
+# SLACK_FILE_DOWNLOADS = "true"        # 设为 "false" 不再把用户上传转发给 Agent
+# SLACK_FILE_MAX_BYTES = "10485760"    # 入站附件大小上限
+# SLACK_FILE_ALLOWED_EXTENSIONS = ""   # 逗号分隔的扩展名白名单；留空表示接受所有扩展名
+# SLACK_FILE_DOWNLOAD_CHANNELS = ""    # 逗号分隔的频道 ID；留空表示所有频道
+# SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS = ""   # 永不接受上传的频道 ID
 ```
 
 8. 重启守护进程。
@@ -169,6 +175,15 @@ SLACK_BOT_TOKEN = "xoxb-..."
 ### 工作原理
 
 Slack 适配器使用 Socket Mode，通过 WebSocket 连接到 Slack 服务器。这避免了需要公网 Webhook URL 的问题。适配器接收事件（应用提及、私信）并路由到配置的 Agent。文本响应通过 `chat.postMessage` Web API 发送；`File` 与 `FileData` 响应使用 Slack external upload 流程，并保留同一 thread 上下文。URL 文件只会从公网 HTTP(S) 地址下载，URL 与内联文件均限制为 10 MiB。当 `threading = true` 时，回复通过 `thread_ts` 发送到消息所在的线程。
+
+### 用户上传的文件
+
+用户在频道或私信里发送的文件与图片会作为消息内容送达 Agent，Agent 可以直接看图、转写音频或阅读文档，而不是收到一个自己打不开的 URL。
+Slack 的私有文件 URL 必须携带 bot token 才能下载，因此适配器只为 Slack 自己的文件域名声明按主机生效的授权规则，由守护进程带着该 token 去下载；token 不会附加到任何其他主机上——这一点很重要，因为工作区成员可以注册指向任意地址的远程文件。
+每条消息只转发一个附件（协议中一条消息只承载一个内容值），并且附件优先于消息文本，文本作为附件的 caption 一同送出。
+链接预览里的图片不会被下载——那属于某人粘贴的 URL，而不是上传。
+
+四类开关全部可选：`SLACK_FILE_DOWNLOADS` 整体关闭该功能，`SLACK_FILE_MAX_BYTES` 限制大小（默认 10 MiB），`SLACK_FILE_ALLOWED_EXTENSIONS` 限定可接受的扩展名，`SLACK_FILE_DOWNLOAD_CHANNELS` / `SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS` 决定哪些频道参与——繁忙频道正是用后者单独退出，而不必在所有频道禁用上传。
 
 ### 处理状态反应（Reactions）
 

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -17,9 +17,29 @@ Behaviour parity with the Rust adapter:
   must be ACK'd by echoing back ``{"envelope_id": "..."}``.
 * **Event handling**: only ``message`` and ``app_mention`` types
   produce ``message`` events. Subtype filter: bare messages pass,
-  ``message_changed`` extracts ``event.message`` (edit), every other
-  subtype is dropped (joins, leaves, file_share, etc.). Self-skip on
+  ``message_changed`` extracts ``event.message`` (edit), ``file_share``
+  passes as an ordinary message carrying ``files`` (#7087), every other
+  subtype is dropped (joins, leaves, topic changes, etc.). Self-skip on
   ``bot_id`` present OR ``user == bot_user_id``.
+* **Inbound attachments** (#7087): a message's ``files`` array becomes an
+  ``Image`` / ``Video`` / ``Audio`` / ``File`` content variant carrying
+  ``url_private_download``, and the adapter declares ``header_rules`` so the
+  daemon fetches that URL with the bot token — Slack's private file URLs
+  302 to a login page without it.
+  The URL is forwarded rather than the bytes because the daemon's media
+  pipeline is what produces a vision image block, an audio transcription or
+  a saved document path; inbound ``FileData`` is rendered as a text
+  placeholder and its payload discarded, so inlining bytes would deliver
+  nothing.
+  One attachment per message (the wire carries one ``ChannelContent``), the
+  attachment outranks the message text including a slash command, and the
+  message text rides along as the caption for every variant that has one.
+  Policy knobs: ``SLACK_FILE_DOWNLOADS``, ``SLACK_FILE_MAX_BYTES``,
+  ``SLACK_FILE_ALLOWED_EXTENSIONS``, ``SLACK_FILE_DOWNLOAD_CHANNELS`` and
+  ``SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS``.
+  Link-unfurl ``attachments[].image_url`` is deliberately **not** followed:
+  it is preview metadata for a URL somebody pasted, not an upload, and
+  fetching it would point the daemon at an arbitrary host.
 * **Allowed channels**: empty list = allow all. When non-empty,
   channel must be in the list; DMs (``channel`` starts with ``D``)
   are exempt (the operator's per-user DM allowlist handles those).
@@ -56,6 +76,11 @@ Configure via ``[[sidecar_channels]]``::
     # SLACK_FORCE_FLAT_REPLIES = "false"
     # SLACK_REACTIONS = "true"
     # SLACK_PROGRESS_CARD = "true"
+    # SLACK_FILE_DOWNLOADS = "true"
+    # SLACK_FILE_MAX_BYTES = "10485760"
+    # SLACK_FILE_ALLOWED_EXTENSIONS = "png,jpg,pdf,mp4"
+    # SLACK_FILE_DOWNLOAD_CHANNELS = "C0123"
+    # SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS = "C0789"
     # SLACK_ACCOUNT_ID = "workspace-prod"
 
 Secrets via ``~/.librefang/secrets.env``: ``SLACK_APP_TOKEN`` (the
@@ -77,6 +102,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
@@ -113,6 +139,27 @@ MAX_BLOCKS_PER_MESSAGE = 50
 SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
 MAX_FILE_UPLOAD_BYTES = 10 * 1024 * 1024
+
+# Hosts that serve Slack's own `url_private` / `url_private_download` file
+# URLs. Inbound attachments are pinned to this set (#7087) and it is the
+# exact set declared in `header_rules`, so the bot token is only ever
+# attached to a fetch of a Slack-hosted file.
+#
+# `files.remote.add` lets any workspace member register a "file" whose
+# `url_private` points at a host of their choosing, and a link unfurl can
+# put an arbitrary `image_url` in `attachments`. Both reach this adapter
+# through an authentic Socket Mode envelope, so "the event came from Slack"
+# says nothing about who chose the URL — the host pin is what keeps a
+# member-chosen address from being fetched with the bot's credentials.
+SLACK_FILE_HOSTS = ("files.slack.com", "slack-files.com")
+
+# Slack `file.mode` values whose `url_private` no longer serves bytes.
+SLACK_UNFETCHABLE_FILE_MODES = frozenset({"tombstone", "hidden_by_limit"})
+
+# Default ceiling on an inbound attachment. Same 10 MiB as the outbound
+# upload cap so a round trip (user uploads, agent edits, agent posts back)
+# does not fail one direction with a size the other accepted.
+DEFAULT_INBOUND_FILE_MAX_BYTES = MAX_FILE_UPLOAD_BYTES
 
 INITIAL_BACKOFF_SECS = 1.0
 READ_TICK_SECS = 30.0
@@ -386,6 +433,196 @@ def parse_users_info(body: dict) -> tuple[Optional[str], Optional[str]]:
 
 
 # ---------------------------------------------------------------------------
+# Inbound attachments (#7087)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SlackFilePolicy:
+    """Resolved policy for inbound attachments.
+
+    ``enabled=False`` — the default when no policy is supplied — reproduces
+    the pre-#7087 behaviour of dropping every file-bearing message, so an
+    operator can turn the feature off without changing anything else.
+
+    ``channels`` is an allow-list (empty = every channel) and
+    ``excluded_channels`` a deny-list applied on top of it, which is the
+    ergonomic shape for the two things operators actually ask for: "only
+    this one channel accepts uploads" and "every channel except this busy
+    one".
+    """
+
+    enabled: bool = False
+    max_bytes: int = DEFAULT_INBOUND_FILE_MAX_BYTES
+    allowed_extensions: frozenset = frozenset()
+    channels: tuple = ()
+    excluded_channels: tuple = ()
+
+    def enabled_for(self, channel: str) -> bool:
+        """Whether attachments in ``channel`` should be forwarded to the agent."""
+        if not self.enabled:
+            return False
+        if channel in self.excluded_channels:
+            return False
+        return not self.channels or channel in self.channels
+
+    def extension_allowed(self, name: Any, filetype: Any) -> bool:
+        """Whether this file's extension passes the allow-list. An empty allow-list accepts everything."""
+        if not self.allowed_extensions:
+            return True
+        return _file_extension(name, filetype) in self.allowed_extensions
+
+
+def _file_extension(name: Any, filetype: Any) -> str:
+    """Lowercased extension for an inbound Slack file object.
+
+    The filename wins because it is what the agent's tools will see; Slack's
+    own ``filetype`` token is the fallback for uploads that arrive without a
+    usable name. Returns ``""`` when neither yields one, which a non-empty
+    allow-list then rejects.
+    """
+    head, dot, tail = _safe_filename(name).rpartition(".")
+    if dot and head and tail:
+        return tail.lower()
+    if isinstance(filetype, str):
+        return filetype.strip().lstrip(".").lower()
+    return ""
+
+
+def _is_slack_file_url(url: Any) -> bool:
+    """Whether ``url`` is an HTTPS URL served by one of Slack's own file hosts.
+
+    Userinfo is refused outright rather than ignored: ``https://files.slack.com@evil.example/x``
+    reads as a Slack URL to a human and resolves to ``evil.example``.
+    """
+    if not isinstance(url, str) or not url:
+        return False
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        host = parsed.hostname
+    except (TypeError, ValueError):
+        return False
+    if parsed.scheme != "https" or not host:
+        return False
+    if parsed.username is not None or parsed.password is not None:
+        return False
+    return host.rstrip(".").lower() in SLACK_FILE_HOSTS
+
+
+def _file_rejection(entry: Any, policy: SlackFilePolicy) -> Optional[str]:
+    """Return why this Slack file object must not be forwarded, or ``None`` when it passes policy."""
+    if not isinstance(entry, dict):
+        return "file entry is not an object"
+    mode = entry.get("mode")
+    if mode in SLACK_UNFETCHABLE_FILE_MODES:
+        # A deleted file, or one Slack has hidden behind a free-plan storage
+        # limit, still arrives with a `url_private` that no longer resolves.
+        # Refusing it here keeps a `[File download failed]` line out of the
+        # agent's prompt.
+        return f"file mode is {mode}"
+    url = entry.get("url_private_download") or entry.get("url_private")
+    if not isinstance(url, str) or not url:
+        return "file has neither url_private_download nor url_private"
+    if not _is_slack_file_url(url):
+        return "file URL is not served by a Slack file host"
+    if not policy.extension_allowed(
+        entry.get("name") or entry.get("title"), entry.get("filetype"),
+    ):
+        return "file extension is not in the allow-list"
+    size = entry.get("size")
+    if isinstance(size, int) and not isinstance(size, bool) and size > policy.max_bytes:
+        return f"file is {size} bytes, over the {policy.max_bytes} byte cap"
+    return None
+
+
+def _file_content(entry: dict, companion_text: str) -> dict[str, Any]:
+    """Map one policy-approved Slack file object onto a ``ChannelContent`` variant.
+
+    The URL is handed to the daemon rather than the bytes: the daemon's media
+    pipeline is what turns a URL into an image block for vision, a
+    transcription for audio, or a saved path for a document, and it attaches
+    the bot token for exactly the hosts this adapter declared in
+    ``header_rules``. Inlining bytes as ``FileData`` would not reach any of
+    that — the inbound side of the bridge renders ``FileData`` as a text
+    placeholder and discards the payload.
+    """
+    url = entry.get("url_private_download") or entry.get("url_private")
+    filename = _safe_filename(entry.get("name") or entry.get("title"))
+    raw_mime = entry.get("mimetype")
+    mimetype = raw_mime.strip() if isinstance(raw_mime, str) else ""
+    caption = companion_text or None
+    duration_seconds = 0
+    raw_ms = entry.get("duration_ms")
+    if isinstance(raw_ms, int) and not isinstance(raw_ms, bool) and raw_ms > 0:
+        duration_seconds = raw_ms // 1000
+
+    if mimetype.startswith("image/"):
+        return Content.image(url, caption=caption, mime_type=mimetype)
+    if mimetype.startswith("video/"):
+        return Content.video(url, caption=caption,
+                             duration_seconds=duration_seconds,
+                             filename=filename)
+    if mimetype.startswith("audio/"):
+        title = entry.get("title")
+        return Content.audio(url, caption=caption,
+                             duration_seconds=duration_seconds,
+                             title=title if isinstance(title, str) and title else None)
+    if companion_text:
+        # `ChannelContent::File` has no caption field, so the accompanying
+        # message text has nowhere to ride. Same limitation (and the same
+        # warning) as the discord sidecar's file attachments.
+        log.warn(
+            "slack file attachment has companion text that cannot be sent as a caption",
+            filename=filename,
+        )
+    return Content.file(url, filename)
+
+
+def parse_slack_files(
+    files: Any,
+    *,
+    channel: str,
+    companion_text: str,
+    policy: Optional[SlackFilePolicy],
+) -> Optional[dict[str, Any]]:
+    """Pick the first policy-approved attachment out of a message's ``files`` array.
+
+    Returns the ``ChannelContent`` for it, or ``None`` when downloads are off
+    for this channel, the array is absent, or nothing in it passes policy.
+
+    One attachment per message, matching the discord sidecar: the wire
+    protocol carries a single ``ChannelContent`` per message, so a
+    multi-file upload has to pick one. Extras are counted in a warning
+    rather than silently dropped.
+    """
+    if policy is None or not policy.enabled_for(channel):
+        return None
+    if not isinstance(files, list) or not files:
+        return None
+
+    chosen: Optional[dict] = None
+    rejected = 0
+    extra = 0
+    for entry in files:
+        reason = _file_rejection(entry, policy)
+        if reason is not None:
+            log.warn("slack inbound attachment rejected",
+                     channel=channel, reason=reason)
+            rejected += 1
+            continue
+        if chosen is None:
+            chosen = entry
+        else:
+            extra += 1
+    if chosen is None:
+        return None
+    if extra:
+        log.warn("slack forwarded only the first eligible attachment",
+                 channel=channel, ignored=extra, rejected=rejected)
+    return _file_content(chosen, companion_text)
+
+
+# ---------------------------------------------------------------------------
 # Inbound event parsing — port of crate::slack::parse_slack_event and
 # parse_slack_block_action. Pure functions so tests can exercise every
 # filter / variant without standing up the Socket Mode WS.
@@ -398,11 +635,15 @@ def parse_slack_event(
     bot_user_id: Optional[str],
     allowed_channels: list[str],
     account_id: Optional[str],
+    file_policy: Optional[SlackFilePolicy] = None,
 ) -> Optional[dict]:
-    """Mirror of the Rust ``parse_slack_event``.
+    """Mirror of the Rust ``parse_slack_event``, extended with inbound attachments.
 
     Returns the ``message`` event dict ready to ``emit``, or ``None``
     when the payload should be skipped.
+
+    ``file_policy`` defaults to ``None``, which drops every attachment and
+    leaves the pre-#7087 text-only behaviour untouched.
     """
     if not isinstance(event, dict):
         return None
@@ -417,11 +658,15 @@ def parse_slack_event(
             return None
         msg_data = inner
         is_edit = True
-    elif subtype is not None:
-        # Other subtypes (joins, leaves, file_share, …) are skipped —
+    elif subtype is not None and subtype != "file_share":
+        # Other subtypes (joins, leaves, topic changes, …) are skipped —
         # matches the Rust adapter precisely.
         return None
     else:
+        # `file_share` shares this arm: it is an ordinary message that also
+        # carries `files`, and dropping the whole subtype (#7087) discarded
+        # the user's upload before any content parsing ran. The attachment
+        # itself is still gated by `file_policy` below.
         msg_data = event
         is_edit = False
 
@@ -448,15 +693,31 @@ def parse_slack_event(
     ):
         return None
 
-    text = msg_data.get("text")
-    if not isinstance(text, str) or not text:
+    raw_text = msg_data.get("text")
+    text = raw_text if isinstance(raw_text, str) else ""
+
+    file_content = parse_slack_files(
+        msg_data.get("files"),
+        channel=channel,
+        companion_text=text,
+        policy=file_policy,
+    )
+    # An upload with no comment is a complete message; a text-only message
+    # with no text is not.
+    if file_content is None and not text:
         return None
 
     ts = (msg_data.get("ts") if is_edit else None) or event.get("ts") or "0"
     if not isinstance(ts, str):
         ts = str(ts)
 
-    if text.startswith("/"):
+    if file_content is not None:
+        # The attachment outranks the text, slash commands included: one
+        # message carries one `ChannelContent`, and the upload is the part
+        # the agent cannot reconstruct from the transcript. Same precedence
+        # as the discord sidecar.
+        content = file_content
+    elif text.startswith("/"):
         head, _, tail = text[1:].partition(" ")
         content = Content.command(head, tail.split() if tail else [])
     else:
@@ -676,6 +937,34 @@ class SlackAdapter(SidecarAdapter):
                   "bool",
                   placeholder="true",
                   advanced=True),
+            Field("SLACK_FILE_DOWNLOADS",
+                  "Forward user-uploaded files and images to the agent",
+                  "bool",
+                  placeholder="true",
+                  advanced=True),
+            Field("SLACK_FILE_MAX_BYTES",
+                  "Maximum inbound attachment size in bytes",
+                  "number",
+                  placeholder=str(DEFAULT_INBOUND_FILE_MAX_BYTES),
+                  advanced=True),
+            Field("SLACK_FILE_ALLOWED_EXTENSIONS",
+                  "Allowed attachment extensions (comma-separated, empty = "
+                  "allow all)",
+                  "list",
+                  placeholder="png, jpg, pdf, mp4",
+                  advanced=True),
+            Field("SLACK_FILE_DOWNLOAD_CHANNELS",
+                  "Channel IDs that accept attachments (comma-separated, "
+                  "empty = every channel)",
+                  "list",
+                  placeholder="C0123, C0456",
+                  advanced=True),
+            Field("SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS",
+                  "Channel IDs that never accept attachments "
+                  "(comma-separated)",
+                  "list",
+                  placeholder="C0789",
+                  advanced=True),
             Field("SLACK_ACCOUNT_ID",
                   "Account ID (multi-bot routing)",
                   "text",
@@ -724,6 +1013,55 @@ class SlackAdapter(SidecarAdapter):
         )
         acct = os.environ.get("SLACK_ACCOUNT_ID", "").strip()
         self.account_id = acct or None
+
+        # Inbound attachment policy (#7087).
+        max_bytes_raw = os.environ.get("SLACK_FILE_MAX_BYTES", "").strip()
+        try:
+            file_max_bytes = int(max_bytes_raw or DEFAULT_INBOUND_FILE_MAX_BYTES)
+        except (TypeError, ValueError):
+            log.error("SLACK_FILE_MAX_BYTES invalid (must be an integer)",
+                      value=max_bytes_raw)
+            raise SystemExit(2) from None
+        if file_max_bytes < 1:
+            log.warn("SLACK_FILE_MAX_BYTES < 1; using the default instead",
+                     requested=file_max_bytes,
+                     default=DEFAULT_INBOUND_FILE_MAX_BYTES)
+            file_max_bytes = DEFAULT_INBOUND_FILE_MAX_BYTES
+        self.file_policy = SlackFilePolicy(
+            enabled=_bool_env(
+                os.environ.get("SLACK_FILE_DOWNLOADS", ""), default=True,
+            ),
+            max_bytes=file_max_bytes,
+            allowed_extensions=frozenset(
+                ext.lstrip(".").lower()
+                for ext in _split_csv(
+                    os.environ.get("SLACK_FILE_ALLOWED_EXTENSIONS", ""),
+                )
+                if ext.strip(". ")
+            ),
+            channels=tuple(_split_csv(
+                os.environ.get("SLACK_FILE_DOWNLOAD_CHANNELS", ""),
+            )),
+            excluded_channels=tuple(_split_csv(
+                os.environ.get("SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS", ""),
+            )),
+        )
+        # `url_private_download` 302s to a login page without the bot token,
+        # so the daemon needs it to fetch what we forward. `header_rules` is
+        # the mechanism for that (matrix uses it for MSC3916 media): the
+        # daemon exact-matches the request host against these rules and
+        # attaches nothing for anything else, so the token cannot follow a
+        # member-chosen URL out of the workspace — see `fetch_headers_for` in
+        # `crates/librefang-channels/src/sidecar.rs`. The rules are only
+        # declared when attachment forwarding is on, so an operator who turns
+        # it off does not ship the token at all.
+        #
+        # Sorted so the ready event is byte-identical across runs.
+        if self.file_policy.enabled:
+            self.header_rules = [
+                (host, [["Authorization", f"Bearer {self.bot_token}"]])
+                for host in sorted(SLACK_FILE_HOSTS)
+            ]
 
         self.api_base = DEFAULT_API_BASE
         self.bot_user_id: Optional[str] = None
@@ -1219,6 +1557,7 @@ class SlackAdapter(SidecarAdapter):
                 bot_user_id=self.bot_user_id,
                 allowed_channels=self.allowed_channels,
                 account_id=self.account_id,
+                file_policy=self.file_policy,
             )
             if ev is None:
                 return

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -15,31 +15,14 @@ Behaviour parity with the Rust adapter:
   read JSON envelopes (``hello`` / ``events_api`` / ``interactive`` /
   ``disconnect``). Each ``events_api`` / ``interactive`` envelope
   must be ACK'd by echoing back ``{"envelope_id": "..."}``.
-* **Event handling**: only ``message`` and ``app_mention`` types
-  produce ``message`` events. Subtype filter: bare messages pass,
-  ``message_changed`` extracts ``event.message`` (edit), ``file_share``
-  passes as an ordinary message carrying ``files`` (#7087), every other
-  subtype is dropped (joins, leaves, topic changes, etc.). Self-skip on
-  ``bot_id`` present OR ``user == bot_user_id``.
-* **Inbound attachments** (#7087): a message's ``files`` array becomes an
-  ``Image`` / ``Video`` / ``Audio`` / ``File`` content variant carrying
-  ``url_private_download``, and the adapter declares ``header_rules`` so the
-  daemon fetches that URL with the bot token — Slack's private file URLs
-  302 to a login page without it.
-  The URL is forwarded rather than the bytes because the daemon's media
-  pipeline is what produces a vision image block, an audio transcription or
-  a saved document path; inbound ``FileData`` is rendered as a text
-  placeholder and its payload discarded, so inlining bytes would deliver
-  nothing.
-  One attachment per message (the wire carries one ``ChannelContent``), the
-  attachment outranks the message text including a slash command, and the
-  message text rides along as the caption for every variant that has one.
-  Policy knobs: ``SLACK_FILE_DOWNLOADS``, ``SLACK_FILE_MAX_BYTES``,
-  ``SLACK_FILE_ALLOWED_EXTENSIONS``, ``SLACK_FILE_DOWNLOAD_CHANNELS`` and
-  ``SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS``.
-  Link-unfurl ``attachments[].image_url`` is deliberately **not** followed:
-  it is preview metadata for a URL somebody pasted, not an upload, and
-  fetching it would point the daemon at an arbitrary host.
+* **Event handling**: only ``message`` and ``app_mention`` types produce ``message`` events.
+  Subtype filter: bare messages pass, ``message_changed`` extracts ``event.message`` (edit), ``file_share`` passes as an ordinary message carrying ``files`` (#7087), every other subtype is dropped (joins, leaves, topic changes, etc.).
+  Self-skip on ``bot_id`` present OR ``user == bot_user_id``.
+* **Inbound attachments** (#7087): a message's ``files`` array becomes an ``Image`` / ``Video`` / ``Audio`` / ``File`` content variant carrying ``url_private_download``, and the adapter declares ``header_rules`` so the daemon fetches that URL with the bot token — Slack's private file URLs 302 to a login page without it.
+  The URL is forwarded rather than the bytes because the daemon's media pipeline is what produces a vision image block, an audio transcription or a saved document path; inbound ``FileData`` is rendered as a text placeholder and its payload discarded, so inlining bytes would deliver nothing.
+  One attachment per message (the wire carries one ``ChannelContent``), the attachment outranks the message text including a slash command, and the message text rides along as the caption for every variant that has one.
+  Policy knobs: ``SLACK_FILE_DOWNLOADS``, ``SLACK_FILE_MAX_BYTES``, ``SLACK_FILE_ALLOWED_EXTENSIONS``, ``SLACK_FILE_DOWNLOAD_CHANNELS`` and ``SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS``.
+  Link-unfurl ``attachments[].image_url`` is deliberately **not** followed: it is preview metadata for a URL somebody pasted, not an upload, and fetching it would point the daemon at an arbitrary host.
 * **Allowed channels**: empty list = allow all. When non-empty,
   channel must be in the list; DMs (``channel`` starts with ``D``)
   are exempt (the operator's per-user DM allowlist handles those).
@@ -140,25 +123,18 @@ SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
 MAX_FILE_UPLOAD_BYTES = 10 * 1024 * 1024
 
-# Hosts that serve Slack's own `url_private` / `url_private_download` file
-# URLs. Inbound attachments are pinned to this set (#7087) and it is the
-# exact set declared in `header_rules`, so the bot token is only ever
-# attached to a fetch of a Slack-hosted file.
+# Hosts that serve Slack's own `url_private` / `url_private_download` file URLs.
+# Inbound attachments are pinned to this set (#7087) and it is the exact set declared in `header_rules`, so the bot token is only ever attached to a fetch of a Slack-hosted file.
 #
-# `files.remote.add` lets any workspace member register a "file" whose
-# `url_private` points at a host of their choosing, and a link unfurl can
-# put an arbitrary `image_url` in `attachments`. Both reach this adapter
-# through an authentic Socket Mode envelope, so "the event came from Slack"
-# says nothing about who chose the URL — the host pin is what keeps a
-# member-chosen address from being fetched with the bot's credentials.
+# `files.remote.add` lets any workspace member register a "file" whose `url_private` points at a host of their choosing, and a link unfurl can put an arbitrary `image_url` in `attachments`.
+# Both reach this adapter through an authentic Socket Mode envelope, so "the event came from Slack" says nothing about who chose the URL — the host pin is what keeps a member-chosen address from being fetched with the bot's credentials.
 SLACK_FILE_HOSTS = ("files.slack.com", "slack-files.com")
 
 # Slack `file.mode` values whose `url_private` no longer serves bytes.
 SLACK_UNFETCHABLE_FILE_MODES = frozenset({"tombstone", "hidden_by_limit"})
 
-# Default ceiling on an inbound attachment. Same 10 MiB as the outbound
-# upload cap so a round trip (user uploads, agent edits, agent posts back)
-# does not fail one direction with a size the other accepted.
+# Default ceiling on an inbound attachment.
+# Same 10 MiB as the outbound upload cap so a round trip (user uploads, agent edits, agent posts back) does not fail one direction with a size the other accepted.
 DEFAULT_INBOUND_FILE_MAX_BYTES = MAX_FILE_UPLOAD_BYTES
 
 INITIAL_BACKOFF_SECS = 1.0
@@ -441,15 +417,9 @@ def parse_users_info(body: dict) -> tuple[Optional[str], Optional[str]]:
 class SlackFilePolicy:
     """Resolved policy for inbound attachments.
 
-    ``enabled=False`` — the default when no policy is supplied — reproduces
-    the pre-#7087 behaviour of dropping every file-bearing message, so an
-    operator can turn the feature off without changing anything else.
+    ``enabled=False`` — the default when no policy is supplied — reproduces the pre-#7087 behaviour of dropping every file-bearing message, so an operator can turn the feature off without changing anything else.
 
-    ``channels`` is an allow-list (empty = every channel) and
-    ``excluded_channels`` a deny-list applied on top of it, which is the
-    ergonomic shape for the two things operators actually ask for: "only
-    this one channel accepts uploads" and "every channel except this busy
-    one".
+    ``channels`` is an allow-list (empty = every channel) and ``excluded_channels`` a deny-list applied on top of it, which is the ergonomic shape for the two things operators actually ask for: "only this one channel accepts uploads" and "every channel except this busy one".
     """
 
     enabled: bool = False
@@ -476,10 +446,8 @@ class SlackFilePolicy:
 def _file_extension(name: Any, filetype: Any) -> str:
     """Lowercased extension for an inbound Slack file object.
 
-    The filename wins because it is what the agent's tools will see; Slack's
-    own ``filetype`` token is the fallback for uploads that arrive without a
-    usable name. Returns ``""`` when neither yields one, which a non-empty
-    allow-list then rejects.
+    The filename wins because it is what the agent's tools will see; Slack's own ``filetype`` token is the fallback for uploads that arrive without a usable name.
+    Returns ``""`` when neither yields one, which a non-empty allow-list then rejects.
     """
     head, dot, tail = _safe_filename(name).rpartition(".")
     if dot and head and tail:
@@ -515,10 +483,8 @@ def _file_rejection(entry: Any, policy: SlackFilePolicy) -> Optional[str]:
         return "file entry is not an object"
     mode = entry.get("mode")
     if mode in SLACK_UNFETCHABLE_FILE_MODES:
-        # A deleted file, or one Slack has hidden behind a free-plan storage
-        # limit, still arrives with a `url_private` that no longer resolves.
-        # Refusing it here keeps a `[File download failed]` line out of the
-        # agent's prompt.
+        # A deleted file, or one Slack has hidden behind a free-plan storage limit, still arrives with a `url_private` that no longer resolves.
+        # Refusing it here keeps a `[File download failed]` line out of the agent's prompt.
         return f"file mode is {mode}"
     url = entry.get("url_private_download") or entry.get("url_private")
     if not isinstance(url, str) or not url:
@@ -538,13 +504,8 @@ def _file_rejection(entry: Any, policy: SlackFilePolicy) -> Optional[str]:
 def _file_content(entry: dict, companion_text: str) -> dict[str, Any]:
     """Map one policy-approved Slack file object onto a ``ChannelContent`` variant.
 
-    The URL is handed to the daemon rather than the bytes: the daemon's media
-    pipeline is what turns a URL into an image block for vision, a
-    transcription for audio, or a saved path for a document, and it attaches
-    the bot token for exactly the hosts this adapter declared in
-    ``header_rules``. Inlining bytes as ``FileData`` would not reach any of
-    that — the inbound side of the bridge renders ``FileData`` as a text
-    placeholder and discards the payload.
+    The URL is handed to the daemon rather than the bytes: the daemon's media pipeline is what turns a URL into an image block for vision, a transcription for audio, or a saved path for a document, and it attaches the bot token for exactly the hosts this adapter declared in ``header_rules``.
+    Inlining bytes as ``FileData`` would not reach any of that — the inbound side of the bridge renders ``FileData`` as a text placeholder and discards the payload.
     """
     url = entry.get("url_private_download") or entry.get("url_private")
     filename = _safe_filename(entry.get("name") or entry.get("title"))
@@ -568,9 +529,8 @@ def _file_content(entry: dict, companion_text: str) -> dict[str, Any]:
                              duration_seconds=duration_seconds,
                              title=title if isinstance(title, str) and title else None)
     if companion_text:
-        # `ChannelContent::File` has no caption field, so the accompanying
-        # message text has nowhere to ride. Same limitation (and the same
-        # warning) as the discord sidecar's file attachments.
+        # `ChannelContent::File` has no caption field, so the accompanying message text has nowhere to ride.
+        # Same limitation (and the same warning) as the discord sidecar's file attachments.
         log.warn(
             "slack file attachment has companion text that cannot be sent as a caption",
             filename=filename,
@@ -587,13 +547,10 @@ def parse_slack_files(
 ) -> Optional[dict[str, Any]]:
     """Pick the first policy-approved attachment out of a message's ``files`` array.
 
-    Returns the ``ChannelContent`` for it, or ``None`` when downloads are off
-    for this channel, the array is absent, or nothing in it passes policy.
+    Returns the ``ChannelContent`` for it, or ``None`` when downloads are off for this channel, the array is absent, or nothing in it passes policy.
 
-    One attachment per message, matching the discord sidecar: the wire
-    protocol carries a single ``ChannelContent`` per message, so a
-    multi-file upload has to pick one. Extras are counted in a warning
-    rather than silently dropped.
+    One attachment per message, matching the discord sidecar: the wire protocol carries a single ``ChannelContent`` per message, so a multi-file upload has to pick one.
+    Extras are counted in a warning rather than silently dropped.
     """
     if policy is None or not policy.enabled_for(channel):
         return None
@@ -642,8 +599,7 @@ def parse_slack_event(
     Returns the ``message`` event dict ready to ``emit``, or ``None``
     when the payload should be skipped.
 
-    ``file_policy`` defaults to ``None``, which drops every attachment and
-    leaves the pre-#7087 text-only behaviour untouched.
+    ``file_policy`` defaults to ``None``, which drops every attachment and leaves the pre-#7087 text-only behaviour untouched.
     """
     if not isinstance(event, dict):
         return None
@@ -659,14 +615,11 @@ def parse_slack_event(
         msg_data = inner
         is_edit = True
     elif subtype is not None and subtype != "file_share":
-        # Other subtypes (joins, leaves, topic changes, …) are skipped —
-        # matches the Rust adapter precisely.
+        # Other subtypes (joins, leaves, topic changes, …) are skipped — matches the Rust adapter precisely.
         return None
     else:
-        # `file_share` shares this arm: it is an ordinary message that also
-        # carries `files`, and dropping the whole subtype (#7087) discarded
-        # the user's upload before any content parsing ran. The attachment
-        # itself is still gated by `file_policy` below.
+        # `file_share` shares this arm: it is an ordinary message that also carries `files`, and dropping the whole subtype (#7087) discarded the user's upload before any content parsing ran.
+        # The attachment itself is still gated by `file_policy` below.
         msg_data = event
         is_edit = False
 
@@ -702,8 +655,7 @@ def parse_slack_event(
         companion_text=text,
         policy=file_policy,
     )
-    # An upload with no comment is a complete message; a text-only message
-    # with no text is not.
+    # An upload with no comment is a complete message; a text-only message with no text is not.
     if file_content is None and not text:
         return None
 
@@ -712,10 +664,8 @@ def parse_slack_event(
         ts = str(ts)
 
     if file_content is not None:
-        # The attachment outranks the text, slash commands included: one
-        # message carries one `ChannelContent`, and the upload is the part
-        # the agent cannot reconstruct from the transcript. Same precedence
-        # as the discord sidecar.
+        # The attachment outranks the text, slash commands included: one message carries one `ChannelContent`, and the upload is the part the agent cannot reconstruct from the transcript.
+        # Same precedence as the discord sidecar.
         content = file_content
     elif text.startswith("/"):
         head, _, tail = text[1:].partition(" ")
@@ -1046,15 +996,9 @@ class SlackAdapter(SidecarAdapter):
                 os.environ.get("SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS", ""),
             )),
         )
-        # `url_private_download` 302s to a login page without the bot token,
-        # so the daemon needs it to fetch what we forward. `header_rules` is
-        # the mechanism for that (matrix uses it for MSC3916 media): the
-        # daemon exact-matches the request host against these rules and
-        # attaches nothing for anything else, so the token cannot follow a
-        # member-chosen URL out of the workspace — see `fetch_headers_for` in
-        # `crates/librefang-channels/src/sidecar.rs`. The rules are only
-        # declared when attachment forwarding is on, so an operator who turns
-        # it off does not ship the token at all.
+        # `url_private_download` 302s to a login page without the bot token, so the daemon needs it to fetch what we forward.
+        # `header_rules` is the mechanism for that (matrix uses it for MSC3916 media): the daemon exact-matches the request host against these rules and attaches nothing for anything else, so the token cannot follow a member-chosen URL out of the workspace — see `fetch_headers_for` in `crates/librefang-channels/src/sidecar.rs`.
+        # The rules are only declared when attachment forwarding is on, so an operator who turns it off does not ship the token at all.
         #
         # Sorted so the ready event is byte-identical across runs.
         if self.file_policy.enabled:

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -37,6 +37,11 @@ def _adapter(**env):
         "SLACK_REACTIONS": "",
         "SLACK_PROGRESS_CARD": "",
         "SLACK_ACCOUNT_ID": "",
+        "SLACK_FILE_DOWNLOADS": "",
+        "SLACK_FILE_MAX_BYTES": "",
+        "SLACK_FILE_ALLOWED_EXTENSIONS": "",
+        "SLACK_FILE_DOWNLOAD_CHANNELS": "",
+        "SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS": "",
     }
     for k, v in defaults.items():
         os.environ[k] = env.get(k, v)
@@ -363,6 +368,415 @@ def test_parse_event_account_id_injected():
         bot_user_id="UBOT", allowed_channels=[], account_id="ws-prod",
     )
     assert ev["params"]["metadata"]["account_id"] == "ws-prod"
+
+
+# ---- inbound attachments (#7087) ----------------------------------
+
+
+_SLACK_IMAGE_URL = (
+    "https://files.slack.com/files-pri/T01-F01/download/campaign.png"
+)
+
+
+def _file(**overrides):
+    base = {
+        "id": "F01",
+        "name": "campaign.png",
+        "title": "campaign.png",
+        "mimetype": "image/png",
+        "filetype": "png",
+        "size": 2048,
+        "url_private": _SLACK_IMAGE_URL.replace("/download/", "/"),
+        "url_private_download": _SLACK_IMAGE_URL,
+    }
+    base.update(overrides)
+    return base
+
+
+def _file_evt(*, files=None, text="Post this to LinkedIn", **overrides):
+    base = {
+        "type": "message",
+        "subtype": "file_share",
+        "user": "U001",
+        "channel": "C01",
+        "text": text,
+        "ts": "1700000000.000001",
+        "files": [_file()] if files is None else files,
+    }
+    base.update(overrides)
+    return base
+
+
+def _policy(**overrides):
+    defaults = {"enabled": True}
+    defaults.update(overrides)
+    return sa.SlackFilePolicy(**defaults)
+
+
+def test_parse_event_file_share_emits_image_content():
+    ev = sa.parse_slack_event(
+        _file_evt(),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    )
+    assert ev is not None
+    assert ev["params"]["content"] == {
+        "Image": {
+            "url": _SLACK_IMAGE_URL,
+            "caption": "Post this to LinkedIn",
+            "mime_type": "image/png",
+        },
+    }
+    # Routing metadata is unchanged by the attachment path.
+    assert ev["params"]["user_id"] == "C01"
+    assert ev["params"]["message_id"] == "1700000000.000001"
+    assert ev["params"]["metadata"]["sender_user_id"] == "U001"
+
+
+def test_parse_event_file_share_dropped_without_a_policy():
+    """Default (no policy) keeps the pre-#7087 behaviour: file_share is discarded."""
+    assert sa.parse_slack_event(
+        _file_evt(text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+    ) is None
+
+
+def test_parse_event_file_share_with_no_comment_is_still_emitted():
+    ev = sa.parse_slack_event(
+        _file_evt(text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    )
+    assert ev is not None
+    assert ev["params"]["content"]["Image"]["caption"] is None
+
+
+def test_parse_event_file_share_video_and_audio_and_document_variants():
+    video = sa.parse_slack_event(
+        _file_evt(files=[_file(
+            name="review.mp4", mimetype="video/mp4", filetype="mp4",
+            duration_ms=90_500,
+        )], text="review this"),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    )
+    assert video["params"]["content"] == {
+        "Video": {
+            "url": _SLACK_IMAGE_URL,
+            "caption": "review this",
+            "duration_seconds": 90,
+            "filename": "review.mp4",
+        },
+    }
+
+    audio = sa.parse_slack_event(
+        _file_evt(files=[_file(
+            name="memo.m4a", title="Standup memo", mimetype="audio/mp4",
+            filetype="m4a", duration_ms=12_000,
+        )], text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    )
+    assert audio["params"]["content"] == {
+        "Audio": {
+            "url": _SLACK_IMAGE_URL,
+            "caption": None,
+            "duration_seconds": 12,
+            "title": "Standup memo",
+        },
+    }
+
+    document = sa.parse_slack_event(
+        _file_evt(files=[_file(
+            name="brief.pdf", mimetype="application/pdf", filetype="pdf",
+        )], text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    )
+    assert document["params"]["content"] == {
+        "File": {"url": _SLACK_IMAGE_URL, "filename": "brief.pdf"},
+    }
+
+
+def test_parse_event_file_share_oversize_is_rejected():
+    ev = sa.parse_slack_event(
+        _file_evt(files=[_file(size=64 * 1024 * 1024)], text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(max_bytes=1024),
+    )
+    assert ev is None
+
+
+def test_parse_event_file_share_oversize_keeps_the_companion_text():
+    """A rejected attachment must not swallow the message the user typed with it."""
+    ev = sa.parse_slack_event(
+        _file_evt(files=[_file(size=64 * 1024 * 1024)]),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(max_bytes=1024),
+    )
+    assert ev["params"]["content"] == {"Text": "Post this to LinkedIn"}
+
+
+def test_parse_event_file_share_disallowed_extension_is_rejected():
+    ev = sa.parse_slack_event(
+        _file_evt(files=[_file(name="payload.exe", filetype="exe",
+                               mimetype="application/octet-stream")],
+                  text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(allowed_extensions=frozenset({"png", "pdf"})),
+    )
+    assert ev is None
+
+
+def test_parse_event_file_share_allowed_extension_passes():
+    ev = sa.parse_slack_event(
+        _file_evt(text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(allowed_extensions=frozenset({"png", "pdf"})),
+    )
+    assert "Image" in ev["params"]["content"]
+
+
+def test_parse_event_file_share_extension_falls_back_to_filetype():
+    ev = sa.parse_slack_event(
+        _file_evt(files=[_file(name="screenshot", title="screenshot",
+                               filetype="png")], text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(allowed_extensions=frozenset({"png"})),
+    )
+    assert "Image" in ev["params"]["content"]
+
+
+def test_parse_event_file_share_download_switch_off_drops_the_file():
+    ev = sa.parse_slack_event(
+        _file_evt(text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(enabled=False),
+    )
+    assert ev is None
+
+
+def test_parse_event_file_share_per_channel_exclude_list():
+    policy = _policy(excluded_channels=("C01",))
+    assert sa.parse_slack_event(
+        _file_evt(text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=policy,
+    ) is None
+    # A different channel is unaffected by the exclusion.
+    assert sa.parse_slack_event(
+        _file_evt(channel="C02", text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=policy,
+    ) is not None
+
+
+def test_parse_event_file_share_per_channel_allow_list():
+    policy = _policy(channels=("C02",))
+    assert sa.parse_slack_event(
+        _file_evt(text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=policy,
+    ) is None
+    assert sa.parse_slack_event(
+        _file_evt(channel="C02", text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=policy,
+    ) is not None
+
+
+def test_parse_event_file_share_rejects_non_slack_host():
+    """A member-supplied `url_private` off Slack's file hosts is never forwarded."""
+    for url in (
+        "https://evil.example/files-pri/T01-F01/x.png",
+        "https://files.slack.com.evil.example/x.png",
+        "https://files.slack.com@evil.example/x.png",
+        "http://files.slack.com/x.png",
+    ):
+        ev = sa.parse_slack_event(
+            _file_evt(files=[_file(url_private=url,
+                                   url_private_download=url)], text=""),
+            bot_user_id="UBOT", allowed_channels=[], account_id=None,
+            file_policy=_policy(),
+        )
+        assert ev is None, url
+
+
+def test_parse_event_file_share_takes_first_eligible_and_skips_extras():
+    ev = sa.parse_slack_event(
+        _file_evt(files=[
+            _file(name="huge.png", size=99 * 1024 * 1024,
+                  url_private_download=_SLACK_IMAGE_URL + "?f=huge"),
+            _file(name="second.png",
+                  url_private_download=_SLACK_IMAGE_URL + "?f=second"),
+            _file(name="third.png",
+                  url_private_download=_SLACK_IMAGE_URL + "?f=third"),
+        ], text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(max_bytes=1024 * 1024),
+    )
+    # The oversize first entry is skipped, the next eligible one is
+    # forwarded, and the third is counted as an ignored extra.
+    assert ev["params"]["content"]["Image"]["url"] == (
+        _SLACK_IMAGE_URL + "?f=second"
+    )
+
+
+def test_parse_event_attachment_outranks_slash_command():
+    ev = sa.parse_slack_event(
+        _file_evt(text="/summarize please"),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    )
+    assert "Image" in ev["params"]["content"]
+    assert ev["params"]["content"]["Image"]["caption"] == "/summarize please"
+
+
+def test_parse_event_file_share_still_honours_self_skip_and_channel_filter():
+    assert sa.parse_slack_event(
+        _file_evt(user="UBOT", text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    ) is None
+    assert sa.parse_slack_event(
+        _file_evt(channel="C99", text=""),
+        bot_user_id="UBOT", allowed_channels=["C01"], account_id=None,
+        file_policy=_policy(),
+    ) is None
+
+
+def test_parse_event_other_subtypes_are_still_dropped():
+    assert sa.parse_slack_event(
+        {"type": "message", "subtype": "channel_join", "user": "U001",
+         "channel": "C01", "text": "joined", "ts": "1.0",
+         "files": [_file()]},
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    ) is None
+
+
+def test_parse_event_file_share_rejects_unfetchable_modes():
+    for mode in ("tombstone", "hidden_by_limit"):
+        assert sa.parse_slack_event(
+            _file_evt(files=[_file(mode=mode)], text=""),
+            bot_user_id="UBOT", allowed_channels=[], account_id=None,
+            file_policy=_policy(),
+        ) is None, mode
+    # A normal hosted file is unaffected by the mode check.
+    assert sa.parse_slack_event(
+        _file_evt(files=[_file(mode="hosted")], text=""),
+        bot_user_id="UBOT", allowed_channels=[], account_id=None,
+        file_policy=_policy(),
+    ) is not None
+
+
+def test_parse_slack_files_ignores_malformed_arrays():
+    for files in (None, {}, "campaign.png", [], [None], [{}], [{"name": "x"}]):
+        assert sa.parse_slack_files(
+            files, channel="C01", companion_text="", policy=_policy(),
+        ) is None
+
+
+def test_inbound_attachment_parsing_performs_no_http():
+    """Parsing hands the daemon a URL; the adapter itself never fetches inbound files."""
+    def _explode(*_a, **_k):
+        raise AssertionError("inbound parsing must not perform HTTP")
+
+    original_public = sa._public_http_request
+    original_request = sa._http_request
+    sa._public_http_request = _explode
+    sa._http_request = _explode
+    try:
+        ev = sa.parse_slack_event(
+            _file_evt(),
+            bot_user_id="UBOT", allowed_channels=[], account_id=None,
+            file_policy=_policy(),
+        )
+        assert "Image" in ev["params"]["content"]
+        assert sa.parse_slack_event(
+            _file_evt(text=""),
+            bot_user_id="UBOT", allowed_channels=[], account_id=None,
+            file_policy=_policy(enabled=False),
+        ) is None
+    finally:
+        sa._public_http_request = original_public
+        sa._http_request = original_request
+
+
+# ---- attachment policy env wiring ---------------------------------
+
+
+def test_file_policy_defaults():
+    a = _adapter()
+    assert a.file_policy.enabled is True
+    assert a.file_policy.max_bytes == sa.DEFAULT_INBOUND_FILE_MAX_BYTES
+    assert a.file_policy.allowed_extensions == frozenset()
+    assert a.file_policy.channels == ()
+    assert a.file_policy.excluded_channels == ()
+
+
+def test_file_policy_env_parsing():
+    a = _adapter(
+        SLACK_FILE_MAX_BYTES="4096",
+        SLACK_FILE_ALLOWED_EXTENSIONS=".PNG, jpg , ,pdf",
+        SLACK_FILE_DOWNLOAD_CHANNELS="C01, C02",
+        SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS="C09",
+    )
+    assert a.file_policy.max_bytes == 4096
+    assert a.file_policy.allowed_extensions == frozenset({"png", "jpg", "pdf"})
+    assert a.file_policy.channels == ("C01", "C02")
+    assert a.file_policy.excluded_channels == ("C09",)
+
+
+def test_file_max_bytes_non_integer_exits_2():
+    with pytest.raises(SystemExit) as e:
+        _adapter(SLACK_FILE_MAX_BYTES="ten megabytes")
+    assert e.value.code == 2
+
+
+def test_file_max_bytes_below_one_falls_back_to_default():
+    a = _adapter(SLACK_FILE_MAX_BYTES="0")
+    assert a.file_policy.max_bytes == sa.DEFAULT_INBOUND_FILE_MAX_BYTES
+
+
+def test_header_rules_pin_the_bot_token_to_slack_file_hosts():
+    a = _adapter()
+    assert a.header_rules == [
+        ("files.slack.com", [["Authorization", "Bearer xoxb-test-bot-token"]]),
+        ("slack-files.com", [["Authorization", "Bearer xoxb-test-bot-token"]]),
+    ]
+    # Every host the token is declared for is a Slack file host, so the
+    # daemon's exact-host `fetch_headers_for` match can never attach it to
+    # an attacker-named URL.
+    hosts = [host for host, _headers in a.header_rules]
+    assert hosts == sorted(sa.SLACK_FILE_HOSTS)
+    for host in hosts:
+        assert host == "slack-files.com" or host.endswith(".slack.com")
+
+
+def test_header_rules_absent_when_downloads_are_disabled():
+    """Switch the feature off and the bot token is not shipped to the daemon at all."""
+    a = _adapter(SLACK_FILE_DOWNLOADS="false")
+    assert a.file_policy.enabled is False
+    assert a.header_rules == []
+    assert "xoxb-test-bot-token" not in json.dumps(a.ready_event())
+
+
+def test_header_rules_surface_in_the_ready_event():
+    a = _adapter()
+    rules = a.ready_event()["params"]["header_rules"]
+    assert rules[0][0] == "files.slack.com"
+    assert rules[0][1] == [["Authorization", "Bearer xoxb-test-bot-token"]]
+
+
+def test_is_slack_file_url_host_pinning():
+    assert sa._is_slack_file_url(_SLACK_IMAGE_URL) is True
+    assert sa._is_slack_file_url("https://FILES.SLACK.COM./x.png") is True
+    assert sa._is_slack_file_url("https://slack-files.com/x.png") is True
+    assert sa._is_slack_file_url("https://evil.example/x.png") is False
+    assert sa._is_slack_file_url("https://slack.com/x.png") is False
+    assert sa._is_slack_file_url("") is False
+    assert sa._is_slack_file_url(None) is False
 
 
 # ---- parse_slack_block_action -------------------------------------


### PR DESCRIPTION
Closes #7087

The Slack sidecar was text-only on the inbound side. A message carrying an upload arrives with subtype `file_share`, and the subtype filter in `parse_slack_event` dropped every subtype other than `message_changed`, so the user's image or clip was discarded before any content parsing ran.

## Changes

- `sdk/python/librefang/sidecar/adapters/slack.py`
  - `file_share` now shares the bare-message arm; every other subtype is still dropped.
  - New `parse_slack_files` / `_file_content` map a message's `files` array onto `Content.image` / `Content.video` / `Content.audio` / `Content.file`, keyed on `mimetype`, carrying `url_private_download` and using the message text as the caption. `duration_ms` becomes `duration_seconds` for video / audio.
  - One attachment per message (the wire carries one `ChannelContent`), extras counted in a warning; the attachment outranks the message text including a slash command. Both match the discord sidecar's precedent.
  - An upload with no comment is now a complete message: the empty-text drop only applies when there is no eligible attachment.
  - `SlackFilePolicy` holds the gate: `SLACK_FILE_DOWNLOADS` (bool, default `true`), `SLACK_FILE_MAX_BYTES` (default 10 MiB, the same cap as the outbound upload path), `SLACK_FILE_ALLOWED_EXTENSIONS` (empty = allow all, matching the `SLACK_ALLOWED_CHANNELS` convention already in this file), and the `SLACK_FILE_DOWNLOAD_CHANNELS` allow-list / `SLACK_FILE_DOWNLOAD_EXCLUDE_CHANNELS` deny-list pair. A non-integer `SLACK_FILE_MAX_BYTES` exits 2, following the `TWITCH_RATE_LIMIT_*` precedent; a value below 1 falls back to the default with a warning.
  - Files whose `mode` is `tombstone` or `hidden_by_limit` are refused — their `url_private` no longer serves bytes, and letting the daemon try only puts a `[File download failed]` line in the prompt.
  - All five knobs are declared as `SCHEMA` fields so the dashboard renders them.

- **Credential handling.** `url_private_download` 302s to a login page without the bot token, so the daemon needs it. The adapter declares `header_rules` for Slack's own file hosts (`files.slack.com`, `slack-files.com`); the daemon's `fetch_headers_for` (`crates/librefang-channels/src/sidecar.rs`) exact-matches the request host against those rules and attaches nothing for any other host. `_is_slack_file_url` applies the same pin adapter-side, refusing non-HTTPS URLs and URLs carrying userinfo (`https://files.slack.com@evil.example/x` resolves to `evil.example`), so a file registered through `files.remote.add` with a member-chosen `url_private` is never forwarded at all. The rules are only declared when forwarding is enabled, so `SLACK_FILE_DOWNLOADS=false` does not ship the token to the daemon.

- **Why the URL and not the bytes.** `download_media_blocks` in `crates/librefang-channels/src/bridge.rs` is what turns an inbound `Image` / `File` / `Voice` / `Audio` / `Video` URL into a vision image block, an audio transcription or a saved document path. Its match has no `FileData` arm (`_ => None` at bridge.rs:5873), and the inbound text arm renders `FileData` as `[User sent a local file: …]` (bridge.rs:4412), so an adapter that inlines inbound bytes delivers a placeholder and discards the payload. Forwarding the URL with a host-pinned auth rule is the mechanism the matrix sidecar already uses for MSC3916 media, and it needs no kernel change.

- **Deliberately not followed:** link-unfurl `attachments[].image_url`. That is preview metadata for a URL somebody pasted, not an upload, and following it would point the daemon at an arbitrary host. Noted in the module docstring.

- Docs: architecture note on `header_rules` and why inbound `FileData` is a dead end (`docs/architecture/sidecar-channels.md`); a "User Uploads" section, the `files:read` scope and the five env vars in the en and zh channel pages.

- Changelog fragment: `changelog.d/added/7087-slack-inbound-attachments.md`.

## Verification

`cd sdk/python && python3 -m pytest tests -q` — 2044 passed (was 2016 before this branch; 28 new cases). This is the exact invocation of CI's `Python SDK Tests` job (`.github/workflows/ci.yml`, `working-directory: sdk/python`, `python -m pytest tests -q`).

`cd sdk/python && python3 -m pytest tests/test_slack_adapter.py -q` — 185 passed.

New tests in `sdk/python/tests/test_slack_adapter.py`, all against the pure `parse_slack_event` / `parse_slack_files` entry points:

- `test_parse_event_file_share_emits_image_content` — a `file_share` event produces `{"Image": {url, caption, mime_type}}` with routing metadata unchanged.
- `test_parse_event_file_share_video_and_audio_and_document_variants` — mimetype dispatch and `duration_ms` → `duration_seconds`.
- `test_parse_event_file_share_oversize_is_rejected`, `test_parse_event_file_share_oversize_keeps_the_companion_text` — the size cap, and proof a rejected attachment does not swallow the text the user typed with it.
- `test_parse_event_file_share_disallowed_extension_is_rejected`, `..._allowed_extension_passes`, `..._extension_falls_back_to_filetype`.
- `test_parse_event_file_share_download_switch_off_drops_the_file`, `..._per_channel_exclude_list`, `..._per_channel_allow_list`.
- `test_inbound_attachment_parsing_performs_no_http` — replaces `_public_http_request` and `_http_request` with a function that raises, then parses with the switch on and off: the adapter never fetches an inbound file itself.
- `test_parse_event_file_share_rejects_non_slack_host` — an attacker host, a suffix lookalike (`files.slack.com.evil.example`), the userinfo trick and plain HTTP are all refused.
- `test_header_rules_pin_the_bot_token_to_slack_file_hosts`, `test_header_rules_absent_when_downloads_are_disabled` (asserts the token string appears nowhere in the `ready` event), `test_header_rules_surface_in_the_ready_event`, `test_is_slack_file_url_host_pinning` — the token is declared only for Slack file hosts.
- `test_parse_event_file_share_dropped_without_a_policy`, `test_parse_event_other_subtypes_are_still_dropped`, `test_parse_event_file_share_still_honours_self_skip_and_channel_filter` — no behaviour change for callers that pass no policy, and the existing filters still apply.
- `test_file_policy_defaults`, `test_file_policy_env_parsing`, `test_file_max_bytes_non_integer_exits_2`, `test_file_max_bytes_below_one_falls_back_to_default`.

No cargo command was run: this branch touches no Rust source.

## Left out

- **Multi-file uploads deliver one attachment.** The wire protocol carries one `ChannelContent` per message; `Content.media_group` exists but the inbound bridge has no `MediaGroup` arm in `download_media_blocks`, so it would land as a `[Media group: N items]` placeholder. Extras are logged rather than silently dropped.
- **A non-media file loses its companion text.** `ChannelContent::File` has no caption field, so `Content.file` cannot carry the message. Warned at the boundary, same as the discord sidecar. Giving `File` a caption is a change to `crates/librefang-channels/src/types.rs` and every adapter that constructs it — a different crate, so it is not folded in here.
- **Attachments with an unknown `size`** (external files sometimes omit it) are accepted; the daemon's own `channels_download_max_bytes` still bounds the fetch.
