### PR TITLE
fix(browser): fence preformatted blocks instead of folding them into prose

### DIFF
--- a/changelog.d/fixed/7822-browser-code-blocks.md
+++ b/changelog.d/fixed/7822-browser-code-blocks.md
@@ -1,0 +1,5 @@
+`browser_read_page` no longer folds code blocks into the prose around them.
+The walk had no branch for `pre`, so a listing fell through to the text-node branch, which trims every line: the text survived, but nothing separated it from the surrounding prose and its indentation was gone, which is what makes a compiler diagnostic unreadable.
+A `pre` is now taken as text rather than walked, and emitted as a fenced block carrying any `language-` or `lang-` class from the element or from an inner `code`.
+The fence is emitted for any `pre`, not only `pre > code`, because Python's documentation marks listings up as highlighted spans with no `code` element, the RFC series uses a bare `pre`, and so do diagnostics.
+Measured against pages loaded in a live browser, counting `pre` elements in the DOM against fenced blocks in the extraction: the Rust book 0 of 15 to 15, Python's tutorial 0 of 35 to 35, and the Rust Wikipedia article 0 of 29 to 29, with link counts identical before and after on every page (#7822) (@nevgenov)

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -1488,6 +1488,12 @@ const EXTRACT_CONTENT_JS_TEMPLATE: &str = r#"(() => {
         return text.replace(/⟨(\d+)⟩/g, '($1)');
     }
 
+    // Read a language hint out of a `language-rust` / `lang-rust` class, so the reader knows what it is looking at.
+    function codeLanguage(cls) {
+        const m = /(?:language|lang)-([A-Za-z0-9+#-]+)/.exec(cls || '');
+        return m ? m[1] : '';
+    }
+
     const lines = [];
     // Parallel to `lines`: whether that line is a bullet a nested `li` already emitted.
     // A list item folds its children onto one line, and it has to fold only its *own* text — re-folding a sub-list's bullets would put their `- ` markers mid-sentence.
@@ -1511,6 +1517,15 @@ const EXTRACT_CONTENT_JS_TEMPLATE: &str = r#"(() => {
             const heading = lines.splice(start).join(' ').replace(/\s+/g, ' ').trim();
             isBullet.splice(start);
             if (heading) emit('\n' + level + ' ' + heading);
+            return;
+        }
+        if (tag === 'pre') {
+            // A listing is the one place where the whitespace *is* the content, so it is taken as text rather than walked.
+            // Descending would trim every line in the text-node branch above and fold the block into the prose around it, which is what a compiler diagnostic or a Python session loses first.
+            // The fence is emitted for any `pre`, not only `pre > code`: Python's documentation, the RFC series and diagnostics all mark listings up with no `code` element anywhere.
+            const lang = codeLanguage(node.className) || codeLanguage((node.querySelector('code') || {}).className);
+            const body = plain(node.textContent.replace(/^\n+/, '').replace(/\n+$/, ''));
+            if (body) emit('\n```' + lang + '\n' + body + '\n```\n');
             return;
         }
         if (tag === 'a' && node.href && node.textContent.trim()) {
@@ -1981,6 +1996,52 @@ mod tests {
                 .expect("extraction script must return encoded JSON"),
         )
         .expect("extraction result must remain valid JSON")
+    }
+
+    /// A listing reaches the model fenced, with its whitespace and its language.
+    ///
+    /// The walk had no `pre` branch at all, so a listing fell through to the text-node branch, which trims every line: 15 of 15 blocks on a Rust book chapter and 35 of 35 on a Python tutorial arrived as prose with their indentation gone.
+    /// The fence is emitted for any `pre`, so the two shapes that carry no `code` element — Python's highlighted spans and a plain RFC listing — are covered as well as a highlighted one.
+    #[tokio::test]
+    async fn live_extraction_fences_preformatted_blocks() {
+        let Some(session) = live_browser_session().await else {
+            return;
+        };
+
+        load_html_fixture(
+            &session,
+            r##"<!doctype html><html><head><title>listings</title></head><body><main><p>Before.</p><pre class="playground"><code class="language-rust">fn main() {
+    let x = 1;
+}</code></pre><p>Between.</p><pre><span class="gp">&gt;&gt;&gt; </span>len(x)
+3</pre><p>After.</p></main></body></html>"##,
+        )
+        .await;
+        let extracted = extract_fixture(&session, 10_000).await;
+        let content = extracted["content"].as_str().unwrap();
+
+        assert!(
+            content.contains("```rust"),
+            "a language hint on the inner code element must reach the fence: {content}"
+        );
+        assert!(
+            content.contains("    let x = 1;"),
+            "indentation is the content of a listing and must survive: {content}"
+        );
+        assert!(
+            content.contains(">>> len(x)"),
+            "a listing with no code element must be fenced too: {content}"
+        );
+        assert_eq!(
+            content.matches("```").count(),
+            4,
+            "each listing must open and close exactly once: {content}"
+        );
+        for prose in ["Before.", "Between.", "After."] {
+            assert!(
+                content.contains(prose),
+                "prose around a listing must survive: {prose} missing from {content}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
`browser_read_page` loses every code block on a documentation page, the same way `web_fetch` does in #7821 — and for a different reason, in different code.

The walk in `EXTRACT_CONTENT_JS_TEMPLATE` has no branch for `pre`, so a listing falls through to the text-node branch, which trims every line. Measured against pages loaded in a live browser:

| page | `<pre>` in the DOM | fenced blocks before | after |
|---|---|---|---|
| Rust book | 15 | 0 | **15** |
| Python tutorial | 35 | 0 | **35** |
| Wikipedia (Rust) | 29 | 0 | **29** |
| Hacker News | 0 | 0 | 0 |

The text survives, but nothing separates it from the prose around it and its indentation is gone. A compiler diagnostic is the clearest loss, since the column markers that make it readable line up with nothing:

```
error[E0382]: borrow of moved value: `s1`
-->
src/main.rs:5:16
|
2 |     let s1 = String::from("hello");
  |         -- move occurs because `s1` has type `String`
```

## The change

A `pre` is taken as text rather than walked — descending is what trimmed it — and emitted as a fenced block, carrying any `language-` or `lang-` class from the element or from an inner `code`.

The fence is emitted for **any** `pre`, not only `pre > code`. Python's documentation marks listings up as highlighted spans with no `code` element anywhere, the RFC series uses a bare `<pre class="newpage">`, and so do diagnostics. Requiring `code` would leave all three exactly as they are today.

Link counts are identical before and after on every page measured, so the new branch takes nothing with it.

## Test

Added to the live-browser fixture harness from #7806, next to `live_extraction_preserves_structure_click_fallback_and_budget`, with a fixture carrying both shapes: a highlighted `pre > code` with a language class and a bare `pre` with no `code` element. It asserts the language reaches the fence, the indentation survives, both blocks are fenced exactly once, and the prose between them is untouched.

That harness needs a discoverable Chrome, which my machine does not have — both live tests fail here identically, including the pre-existing one on an unmodified `main` (`Chromium exited before printing DevTools URL`). I ran the same fixture through `chrome-headless-shell` over CDP by hand instead, and all five assertions hold:

```
Before.

```rust
fn main() {
    let x = 1;
}
```

Between.

```
>>> len(x)
3
```

After.
```

`2,295` tests pass otherwise; clippy `--all-targets` and fmt clean.

## Note

This is the same defect as #7821, fixed a second time because the two paths serialize independently — `web_fetch` parses an HTML string in Rust, the browser walks a live DOM in JS. They share nothing but `wrap_external_content`. Worth knowing, not worth blocking on: both fixes stand on their own.

Refs #6624
