### PR TITLE
feat(media): make transcription and image understanding declarable capabilities

### DIFF
--- a/changelog.d/added/7823-media-understanding-capabilities.md
+++ b/changelog.d/added/7823-media-understanding-capabilities.md
@@ -1,0 +1,3 @@
+`MediaCapability` gains `SpeechToText` and `ImageUnderstanding`, so a provider can declare that it transcribes audio or describes images the same way it already declares that it generates them.
+Understanding was the only half of media with no capability value, which is why its provider selection lives in two hand-written env-var ladders in `media_understanding.rs` instead of resolving through the driver registry like generation does — with no fallback when the first provider holding a key is the broken one.
+This is the type-level prerequisite; drivers declaring the new capabilities, and routing a capability the agent's own model lacks to a provider that has it, follow separately (#7824) (@DaBlitzStein)

--- a/crates/librefang-types/src/media.rs
+++ b/crates/librefang-types/src/media.rs
@@ -564,6 +564,16 @@ pub enum MediaCapability {
     TextToSpeech,
     VideoGeneration,
     MusicGeneration,
+    /// Turning speech into text. Understanding, not generation — but it is a
+    /// media capability a provider either has or lacks, and leaving it out
+    /// meant transcription providers could not be discovered from the
+    /// registry like every other one and were picked from a hardcoded env-var
+    /// cascade instead.
+    SpeechToText,
+    /// Describing an image. Same reasoning as `SpeechToText`: this is the
+    /// capability that decides whether an attached image reaches the model
+    /// or gets replaced by a note about a file path.
+    ImageUnderstanding,
 }
 
 impl std::fmt::Display for MediaCapability {
@@ -573,6 +583,8 @@ impl std::fmt::Display for MediaCapability {
             MediaCapability::TextToSpeech => write!(f, "text_to_speech"),
             MediaCapability::VideoGeneration => write!(f, "video_generation"),
             MediaCapability::MusicGeneration => write!(f, "music_generation"),
+            MediaCapability::SpeechToText => write!(f, "speech_to_text"),
+            MediaCapability::ImageUnderstanding => write!(f, "image_understanding"),
         }
     }
 }


### PR DESCRIPTION
Closes #7823.

## What this does

`MediaCapability` enumerated only generation — `ImageGeneration`, `TextToSpeech`, `VideoGeneration`, `MusicGeneration` — so a provider that transcribes audio or describes an image had no way to declare it.
This adds the two missing variants and their `Display` arms.

- `SpeechToText`
- `ImageUnderstanding`

## Why the type is the blocker

Generation resolves through the driver registry: a `MediaDriver` declares `capabilities()` and `MediaDriverRegistry::detect_for_capability` returns the first *configured* provider that declares the one asked for — discovery with a fallback, driven by data.

Understanding cannot use that path, because there is no capability value to pass in.
`crates/librefang-runtime-media/src/media_understanding.rs` instead resolves the provider through two hand-written env-var ladders, `detect_vision_provider()` and `detect_audio_provider()`, that live outside the catalog, stop at the first key they find, and have no fallback when that provider is the broken one.

Adding a provider's STT support today means editing an `if` ladder rather than declaring a fact about the provider.
Answering "which of my providers can describe an image?" is impossible, because the answer is not represented anywhere — the underlying shape of the silent rot #6538 documented.

The variants are what make that question expressible.

## Scope

Deliberately type-only.

The follow-on work — drivers declaring the new capabilities, and `media_understanding.rs` resolving through `detect_for_capability` instead of the cascades — is a behavioural change to provider selection that deserves its own review, and it has somewhere to land only once these variants exist.
Routing a capability the agent's own model lacks to a provider that has it depends on the same prerequisite.

## Verification

- `MediaCapability` is `#[non_exhaustive]`, so adding variants is not a breaking change for downstream matchers.
- Every in-tree use is `contains(&cap)` or an explicit `vec![…]` construction (`openai.rs`, `gemini.rs`, `minimax.rs`, `google_tts.rs`, `elevenlabs.rs`, `lib.rs`); the only exhaustive `match` is the `Display` impl in the same file, and this PR extends it.
- No generated-artifact drift: `MediaCapability` does not appear in `openapi.json` or the SDKs, so no codegen refresh is needed.
- No behaviour change, so no new test: nothing constructs or consumes the new variants yet. The existing `capabilities()` assertions in the driver tests are unaffected — they assert on the generation variants only.
