### PR TITLE
feat(backup): restore onto an existing system — keep the target's config, choose components

### DIFF
--- a/changelog.d/added/7830-selective-restore.md
+++ b/changelog.d/added/7830-selective-restore.md
@@ -1,0 +1,4 @@
+`POST /api/restore` accepts `keep_config` and `components`, so an archive can be restored onto a machine that is already running instead of only onto an empty one.
+Restore was all-or-nothing and overwrote `config.toml`, which transplanted the source host's API key, bind port and paths onto the target — so cloning a working setup meant repairing the clone by hand, and recovering one deleted cron job meant rolling agents, workspaces and the database back to the moment of the backup.
+`keep_config` skips `config.toml` (clone mode) and is evaluated before the component filter; `components` limits the restore to the classification `create_backup` already writes into `manifest.json`, with unrecognised entries always restored so archive metadata is never dropped.
+The dashboard's restore control exposes both (#7830, #7831) (@DaBlitzStein)

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3142,8 +3142,15 @@ export async function createBackup(): Promise<{ filename?: string; path?: string
   return post<{ filename?: string; path?: string; size_bytes?: number; components?: string[]; created_at?: string }>("/api/backup", {});
 }
 
-export async function restoreBackup(filename: string): Promise<{ restored_files?: number; errors?: string[]; message?: string }> {
-  return post<{ restored_files?: number; errors?: string[]; message?: string }>("/api/restore", { filename });
+export async function restoreBackup(
+  filename: string,
+  options?: { keepConfig?: boolean; components?: string[] },
+): Promise<{ restored_files?: number; errors?: string[]; message?: string }> {
+  return post<{ restored_files?: number; errors?: string[]; message?: string }>("/api/restore", {
+    filename,
+    keep_config: options?.keepConfig,
+    components: options?.components,
+  });
 }
 
 export async function deleteBackup(filename: string): Promise<{ deleted?: string }> {

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
@@ -84,7 +84,7 @@ describe("useRestoreBackup", () => {
 
     const { result } = renderHook(() => useRestoreBackup(), { wrapper });
 
-    result.current.mutate("backup-1");
+    result.current.mutate({ filename: "backup-1" });
     await vi.waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalled();
     });

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime.ts
@@ -55,7 +55,8 @@ export function useCreateBackup() {
 export function useRestoreBackup() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: restoreBackup,
+    mutationFn: (vars: { filename: string; keepConfig?: boolean; components?: string[] }) =>
+      restoreBackup(vars.filename, { keepConfig: vars.keepConfig, components: vars.components }),
     onSuccess: () => {
       qc.invalidateQueries();
     },

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1932,7 +1932,8 @@
     "subagent_lane_help": "Spawned child agents (agent_send)",
     "trigger_lane_help": "Event-trigger dispatches (TaskPosted, MessageReceived, …)",
     "default_per_agent_help": "Per-agent fallback when manifest omits max_concurrent_invocations",
-    "audit_anchor": "anchor"
+    "audit_anchor": "anchor",
+    "restore_keep_config": "Keep my config (clone mode)"
   },
   "telemetry": {
     "badge": "Observability",

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -1932,7 +1932,8 @@
     "subagent_lane_help": "생성된 하위 에이전트(agent_send)",
     "trigger_lane_help": "이벤트 트리거 전달(TaskPosted, MessageReceived, …)",
     "default_per_agent_help": "매니페스트가 max_concurrent_invocations를 생략하는 경우 에이전트별 대체",
-    "audit_anchor": "기준점"
+    "audit_anchor": "기준점",
+    "restore_keep_config": "내 구성 유지 (복제 모드)"
   },
   "telemetry": {
     "badge": "관찰 가능성",

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -1934,7 +1934,8 @@
     "subagent_lane_help": "Uruchomione agenty potomne (agent_send)",
     "trigger_lane_help": "Wysyłanie wyzwalaczy zdarzeń (TaskPosted, MessageReceived, …)",
     "default_per_agent_help": "Domyślna wartość dla agenta, gdy manifest pomija max_concurrent_invocations",
-    "audit_anchor": "kotwica"
+    "audit_anchor": "kotwica",
+    "restore_keep_config": "Zachowaj moją konfigurację (tryb klonowania)"
   },
   "telemetry": {
     "badge": "Obserwowalność",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -1934,7 +1934,8 @@
     "main_lane_help": "Повідомлення користувача, передані з каналів",
     "queue_concurrency": "Ліміти черг і типовий ліміт агента",
     "subagent_lane_help": "Породжені дочірні агенти (agent_send)",
-    "trigger_lane_help": "Dispatch тригерів подій (TaskPosted, MessageReceived, …)"
+    "trigger_lane_help": "Dispatch тригерів подій (TaskPosted, MessageReceived, …)",
+    "restore_keep_config": "Зберегти мою конфігурацію (режим клону)"
   },
   "telemetry": {
     "badge": "Спостережуваність",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1932,7 +1932,8 @@
     "subagent_lane_help": "生成的子智能体（agent_send）",
     "trigger_lane_help": "事件触发分发（TaskPosted、MessageReceived、…）",
     "default_per_agent_help": "当清单省略 max_concurrent_invocations 时的每智能体 fallback",
-    "audit_anchor": "锚点"
+    "audit_anchor": "锚点",
+    "restore_keep_config": "保留我的配置（克隆模式）"
   },
   "logs": {
     "title": "日志",

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
@@ -381,6 +381,6 @@ describe("RuntimePage", () => {
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: "runtime.restore" }));
     fireEvent.click(screen.getByRole("button", { name: "runtime.restore_confirm" }));
-    expect(mutateAsync).toHaveBeenCalledWith("backup-1.tar.gz");
+    expect(mutateAsync).toHaveBeenCalledWith({ filename: "backup-1.tar.gz", keepConfig: false, components: [] });
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -50,6 +50,8 @@ const OK_STATUSES = new Set(["ok", "pass", "healthy"]);
 type BackupConfirmState = {
   type: "restore" | "delete";
   filename: string;
+  keepConfig: boolean;
+  components: string[];
 };
 
 function formatUptime(seconds?: number): string {
@@ -103,6 +105,11 @@ export function RuntimePage() {
   const addToast = useUIStore((s) => s.addToast);
   const [showShutdownConfirm, setShowShutdownConfirm] = useState(false);
   const [backupConfirm, setBackupConfirm] = useState<BackupConfirmState | null>(null);
+
+  // Which components a restore is allowed to touch. Empty = restore all.
+  const [restoreKeepConfig, setRestoreKeepConfig] = useState(false);
+  const [restoreComponents, setRestoreComponents] = useState<string[]>([]);
+  const BACKUP_COMPONENTS = ["config", "cron_jobs", "hand_state", "custom_models", "agents", "skills", "workflows", "data"];
   const [reloadResult, setReloadResult] = useState<ReloadConfigResult | null>(null);
   const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -747,7 +754,7 @@ export function RuntimePage() {
                       <button
                         onClick={() => {
                           if (b.filename) {
-                            setBackupConfirm({ type: "restore", filename: b.filename });
+                            setBackupConfirm({ type: "restore", filename: b.filename, keepConfig: restoreKeepConfig, components: restoreComponents });
                           }
                         }}
                         className="text-brand hover:text-brand/80 text-[10px] font-bold shrink-0"
@@ -758,7 +765,7 @@ export function RuntimePage() {
                       <button
                         onClick={() => {
                           if (b.filename) {
-                            setBackupConfirm({ type: "delete", filename: b.filename });
+                            setBackupConfirm({ type: "delete", filename: b.filename, keepConfig: false, components: [] });
                           }
                         }}
                         className="text-error hover:text-error/80 shrink-0"
@@ -843,6 +850,35 @@ export function RuntimePage() {
         onClose={() => setShowShutdownConfirm(false)}
       />
 
+      {/* Restore options: keep the target's own config, and/or limit the
+           restore to chosen components. */}
+      <div className="flex flex-wrap items-center gap-3 text-xs mt-2">
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={restoreKeepConfig}
+            onChange={(e) => setRestoreKeepConfig(e.target.checked)}
+          />
+          {t("runtime.restore_keep_config", { defaultValue: "Keep my config (clone mode)" })}
+        </label>
+        {BACKUP_COMPONENTS.map((c) => (
+          <label key={c} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={restoreComponents.includes(c)}
+              onChange={(e) =>
+                setRestoreComponents(
+                  e.target.checked
+                    ? [...restoreComponents, c]
+                    : restoreComponents.filter((x) => x !== c),
+                )
+              }
+            />
+            <span className="text-text-dim">{c}</span>
+          </label>
+        ))}
+      </div>
+
       {/* Restore Confirm Dialog */}
       <ConfirmDialog
         isOpen={backupConfirm?.type === "restore"}
@@ -852,7 +888,11 @@ export function RuntimePage() {
         tone="destructive"
         onConfirm={async () => {
           if (backupConfirm?.type === "restore") {
-            await restoreMutation.mutateAsync(backupConfirm.filename);
+            await restoreMutation.mutateAsync({
+              filename: backupConfirm.filename,
+              keepConfig: backupConfirm.keepConfig,
+              components: backupConfirm.components,
+            });
           }
         }}
         onClose={() => setBackupConfirm(null)}

--- a/crates/librefang-api/src/routes/backup.rs
+++ b/crates/librefang-api/src/routes/backup.rs
@@ -528,6 +528,8 @@ struct RestoreOutcome {
 fn restore_backup_blocking(
     backup_path: std::path::PathBuf,
     home_dir: std::path::PathBuf,
+    keep_config: bool,
+    components: Option<Vec<String>>,
 ) -> Result<RestoreOutcome, RestoreError> {
     let file = std::fs::File::open(&backup_path).map_err(|e| RestoreError::Open(e.to_string()))?;
     let mut archive =
@@ -572,6 +574,40 @@ fn restore_backup_blocking(
 
         if entry_name.to_string_lossy() == "manifest.json" {
             continue;
+        }
+
+        // Component of this entry, or None when not classifiable.
+        let name_str = entry_name.to_string_lossy();
+        let component: Option<&str> = if name_str == "config.toml" {
+            Some("config")
+        } else if name_str == "data/cron_jobs.json" {
+            Some("cron_jobs")
+        } else if name_str == "data/hand_state.json" {
+            Some("hand_state")
+        } else if name_str == "data/custom_models.json" {
+            Some("custom_models")
+        } else if name_str.starts_with("agents/") {
+            Some("agents")
+        } else if name_str.starts_with("skills/") {
+            Some("skills")
+        } else if name_str.starts_with("workflows/") {
+            Some("workflows")
+        } else if name_str.starts_with("data/") {
+            Some("data")
+        } else {
+            None
+        };
+        if keep_config && component == Some("config") {
+            continue;
+        }
+        if let Some(selected) = &components {
+            match component {
+                Some(c) if selected.iter().any(|s| s == c) => {}
+                // Classified but not selected: skip. Unclassified entries
+                // (manifest-adjacent metadata) always restore.
+                Some(_) => continue,
+                None => {}
+            }
         }
 
         let target = home_dir.join(&entry_name);
@@ -643,6 +679,21 @@ pub async fn restore_backup(
             .into_json_tuple();
     }
 
+    // Selective restore: `keep_config` skips config.toml (clone mode — the
+    // target keeps its own key, port and paths), and `components` limits the
+    // restore to the named components ("config", "cron_jobs", "hand_state",
+    // "custom_models", "agents", "skills", "workflows", "data").
+    let keep_config = req
+        .get("keep_config")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let components: Option<Vec<String>> =
+        req.get("components").and_then(|v| v.as_array()).map(|a| {
+            a.iter()
+                .filter_map(|c| c.as_str().map(str::to_string))
+                .collect()
+        });
+
     let home_dir = state.kernel.home_dir().to_path_buf();
     let backups_dir = home_dir.join("backups");
     let backup_path = match find_backup_path(&backups_dir, &filename) {
@@ -671,8 +722,10 @@ pub async fn restore_backup(
     // Dispatch the blocking open + decompress + write loop onto a blocking
     // thread so it does not stall the axum/tokio worker (refs
     // blocking-fs-on-executor).
-    let result =
-        tokio::task::spawn_blocking(move || restore_backup_blocking(backup_path, home_dir)).await;
+    let result = tokio::task::spawn_blocking(move || {
+        restore_backup_blocking(backup_path, home_dir, keep_config, components)
+    })
+    .await;
 
     let outcome = match result {
         Ok(Ok(o)) => o,

--- a/crates/librefang-api/tests/pairing_backup_extra_test.rs
+++ b/crates/librefang-api/tests/pairing_backup_extra_test.rs
@@ -426,3 +426,106 @@ async fn restore_returns_404_when_archive_missing() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+// ---------------------------------------------------------------------------
+// /api/restore (POST) — selective restore onto an existing system.
+//
+// `keep_config` and `components` are what make a backup restorable onto a
+// machine that is already running: clone mode keeps the target's own key,
+// port and paths, and the component list keeps a restore from dragging in
+// state the operator did not ask for. Both are decided inside the extraction
+// loop, so the only honest assertion is on the files that end up on disk.
+// ---------------------------------------------------------------------------
+
+/// Seed the kernel home with one file per component the classifier
+/// recognises, so a round-trip can distinguish "restored", "skipped by
+/// keep_config" and "skipped by the component filter".
+fn seed_home(home: &std::path::Path) {
+    std::fs::write(home.join("config.toml"), b"origin = \"backup\"\n").expect("write config.toml");
+    std::fs::create_dir_all(home.join("data")).expect("mkdir data");
+    std::fs::write(
+        home.join("data").join("cron_jobs.json"),
+        b"[\"from-backup\"]",
+    )
+    .expect("write cron_jobs.json");
+    std::fs::create_dir_all(home.join("skills")).expect("mkdir skills");
+    std::fs::write(home.join("skills").join("from-backup.md"), b"# skill")
+        .expect("write skills entry");
+}
+
+async fn create_backup_of_seeded_home(h: &Harness) -> String {
+    seed_home(h.state.kernel.home_dir());
+    let (status, body) = json_post(h, "/api/backup", serde_json::json!({})).await;
+    assert_eq!(status, StatusCode::OK, "backup failed: {body:?}");
+    body["filename"]
+        .as_str()
+        .expect("filename present in create_backup response")
+        .to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_without_options_writes_every_component_back() {
+    let h = boot(true).await;
+    let filename = create_backup_of_seeded_home(&h).await;
+    let home = h.state.kernel.home_dir().to_path_buf();
+
+    // Diverge the live system from the archive.
+    std::fs::write(home.join("config.toml"), b"origin = \"local\"\n").expect("overwrite config");
+    std::fs::remove_file(home.join("data").join("cron_jobs.json")).expect("remove cron_jobs");
+    std::fs::remove_file(home.join("skills").join("from-backup.md")).expect("remove skill");
+
+    let (status, body) = json_post(
+        &h,
+        "/api/restore",
+        serde_json::json!({"filename": filename}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "restore failed: {body:?}");
+
+    assert_eq!(
+        std::fs::read_to_string(home.join("config.toml")).expect("config.toml back"),
+        "origin = \"backup\"\n",
+        "a restore with no options must overwrite config.toml"
+    );
+    assert!(home.join("data").join("cron_jobs.json").exists());
+    assert!(home.join("skills").join("from-backup.md").exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_honours_keep_config_and_the_component_selection() {
+    let h = boot(true).await;
+    let filename = create_backup_of_seeded_home(&h).await;
+    let home = h.state.kernel.home_dir().to_path_buf();
+
+    std::fs::write(home.join("config.toml"), b"origin = \"local\"\n").expect("overwrite config");
+    std::fs::remove_file(home.join("data").join("cron_jobs.json")).expect("remove cron_jobs");
+    std::fs::remove_file(home.join("skills").join("from-backup.md")).expect("remove skill");
+
+    // `config` is selected *and* `keep_config` is set, so the skip is
+    // attributable to clone mode rather than to the component filter.
+    let (status, body) = json_post(
+        &h,
+        "/api/restore",
+        serde_json::json!({
+            "filename": filename,
+            "keep_config": true,
+            "components": ["config", "cron_jobs"],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "restore failed: {body:?}");
+
+    assert_eq!(
+        std::fs::read_to_string(home.join("config.toml")).expect("config.toml still there"),
+        "origin = \"local\"\n",
+        "keep_config must leave the target's own config.toml untouched"
+    );
+    assert!(
+        home.join("data").join("cron_jobs.json").exists(),
+        "a selected component must be restored"
+    );
+    assert!(
+        !home.join("skills").join("from-backup.md").exists(),
+        "a classified component that was not selected must be skipped"
+    );
+}


### PR DESCRIPTION
Closes #7830.

## What this does

`POST /api/restore` gains two optional fields, both defaulting to today's all-or-nothing behaviour:

- `keep_config` (bool) — skip `config.toml` during extraction, so the target keeps its own API key, bind port and paths.
  This is what makes an archive usable as a clone source instead of an identity transplant.
- `components` (array of string) — restore only the named components: `config`, `cron_jobs`, `hand_state`, `custom_models`, `agents`, `skills`, `workflows`, `data`.
  The same classification `create_backup` already writes into `manifest.json` and `GET /api/backups` already reports per archive.

Both are decided inside the extraction loop in `restore_backup_blocking`, so an entry that is skipped is never written at all rather than written and rolled back.

Entries the classifier does not recognise always restore, so archive metadata is never dropped by a narrow selection.
`keep_config` is evaluated before `components`, so clone mode holds even if the caller also lists `config`.

The dashboard's restore flow passes both through: a "Keep my config" toggle and a component checklist sit with the backup list, and `useRestoreBackup` now takes `{ filename, keepConfig, components }` instead of a bare filename.

## Verification

Two new `#[tokio::test]` cases in `crates/librefang-api/tests/pairing_backup_extra_test.rs`, both round-tripping a seeded kernel home through `POST /api/backup` and `POST /api/restore` and asserting on the files that end up on disk:

- `restore_without_options_writes_every_component_back` — the default path is unchanged: `config.toml` is overwritten and every seeded component comes back.
- `restore_honours_keep_config_and_the_component_selection` — `config` is listed in `components` *and* `keep_config` is set, so the untouched `config.toml` is attributable to clone mode and not to the filter; the selected `cron_jobs` entry is restored, and a classified-but-unselected `skills` entry is not.

That file's header previously said a happy-path round-trip was out of reach for the mock kernel; these two cases show it is reachable by seeding the home first, and they are the first happy-path coverage `/api/restore` has had.

Dashboard: `RuntimePage.test.tsx` and `runtime-skills.test.tsx` updated for the new mutation signature.

## Not included

`POST /api/restore` keeps its `JsonObject` request body, so there is no OpenAPI schema change and no SDK regeneration.

The CLI and TUI surfaces for this are not in this PR; the TUI side follows separately.
