### PR TITLE
ci: cap every workflow job with an explicit timeout-minutes

### DIFF
--- a/.github/workflows/auto-close-resolved-issues.yml
+++ b/.github/workflows/auto-close-resolved-issues.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   reconcile:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -40,6 +40,7 @@ jobs:
       && github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.actor.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # Resolve the PR number from the workflow_run head SHA.  The commits
       # → pulls endpoint returns every PR whose head matches; in practice

--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   update-branches:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -38,6 +38,7 @@ jobs:
   cargo-deny:
     name: cargo-deny (${{ matrix.checks }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
   pubkey-lockstep:
     name: Registry Pubkey Lockstep
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check registry public keys
@@ -57,6 +58,7 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       rust: ${{ steps.diff.outputs.rust }}
       docs: ${{ steps.diff.outputs.docs }}
@@ -241,6 +243,7 @@ jobs:
     name: No Build Artifacts
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -449,6 +452,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.sdk_python == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -469,6 +473,7 @@ jobs:
   githook-tests:
     name: Git Hook Corpus Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Message text and author identity, rejected and accepted corpora.
@@ -495,6 +500,7 @@ jobs:
   image-vuln-gate:
     name: Image Vulnerability Gate Self-Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -514,6 +520,7 @@ jobs:
     name: CHANGELOG Attribution
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -540,6 +547,7 @@ jobs:
   changelog-attribution-full:
     name: CHANGELOG Attribution (full [Unreleased])
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -723,6 +731,7 @@ jobs:
   secrets:
     name: Secrets Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -744,6 +753,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.install == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Syntax-check shell installer
@@ -828,6 +838,7 @@ jobs:
   agents-claude-pair:
     name: AGENTS.md ↔ CLAUDE.md pair
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Verify sibling CLAUDE.md symlink
@@ -1200,6 +1211,7 @@ jobs:
       - test-windows
       - test-macos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Fail if any lane failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,29 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: python3 scripts/check-changelog-attribution.py
 
+  # ── Workflow job timeout coverage ─────────────────────────────────────────────
+  # A job with no `timeout-minutes` inherits GitHub's 360-minute default, which is
+  # long enough for a wedged job to hold one of the repository's few concurrent
+  # execution slots for six hours. That is not hypothetical: two `main` CI runs hung
+  # `in_progress` and starved more than eighty queued runs behind them. On `main` the
+  # concurrency group is per-sha with `cancel-in-progress: false` by design, so nothing
+  # supersedes a hung run and only the timeout can end it.
+  # Coverage regresses silently — every new job inherits the default unless its author
+  # remembers the key — so it is guarded rather than left to review.
+  workflow-timeouts:
+    name: Workflow Job Timeouts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+      - name: Every workflow job declares timeout-minutes
+        run: python3 scripts/check-workflow-timeouts.py
+
   # ── CHANGELOG attribution release gate (#3307) ────────────────────────────────
   # Complements the per-PR diff check above by scanning the ENTIRE [Unreleased]
   # block — not just what this diff adds. Catches entries that slipped past
@@ -1205,6 +1228,7 @@ jobs:
       - install-smoke
       - live-integration-smoke
       - agents-claude-pair
+      - workflow-timeouts
       - test-unit
       - test-ubuntu
       - test-aarch64-build

--- a/.github/workflows/close-umbrella-on-last-pr.yml
+++ b/.github/workflows/close-umbrella-on-last-pr.yml
@@ -51,6 +51,7 @@ jobs:
   maybe-close-umbrella:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:

--- a/.github/workflows/contributor-role.yml
+++ b/.github/workflows/contributor-role.yml
@@ -19,6 +19,7 @@ jobs:
   assign-role:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Announce in Discord
         env:

--- a/.github/workflows/dashboard-build.yml
+++ b/.github/workflows/dashboard-build.yml
@@ -42,6 +42,7 @@ jobs:
   lint:
     name: Dashboard Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # ESLint guards security-sensitive JSX (jsx-no-target-blank,
     # no-danger-with-children) and acts as a fast pre-build gate so the
     # heavier typecheck + build jobs don't waste a runner on a PR that
@@ -63,6 +64,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # setup-node's `cache: pnpm` runs `pnpm store path --silent` from the

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # setup-node's `cache: pnpm` runs `pnpm store path --silent` from the

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -15,6 +15,7 @@ jobs:
   deploy-worker:
     name: Deploy Main Worker
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -35,6 +36,7 @@ jobs:
   deploy-github-stats:
     name: Deploy GitHub Stats Worker
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6

--- a/.github/workflows/devto-publish.yml
+++ b/.github/workflows/devto-publish.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Publish articles

--- a/.github/workflows/issue-claim.yml
+++ b/.github/workflows/issue-claim.yml
@@ -13,6 +13,7 @@ jobs:
       !github.event.issue.pull_request &&
       contains(github.event.comment.body, '/claim')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Assign issue to commenter
         env:
@@ -38,6 +39,7 @@ jobs:
       !github.event.issue.pull_request &&
       contains(github.event.comment.body, '/unclaim')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Unassign issue
         env:

--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Remind inactive assigned issues
         env:

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -24,6 +24,7 @@ jobs:
       github.event_name == 'issues' &&
       github.event.action != 'closed'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Compute and apply labels
@@ -53,6 +54,7 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'closed') ||
       (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Update response state labels
         env:
@@ -94,6 +96,7 @@ jobs:
   backfill:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.backfill == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Re-label every unlabeled open issue

--- a/.github/workflows/issue-pr-link.yml
+++ b/.github/workflows/issue-pr-link.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   link:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Sync has-pr label on linked issues
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -13,6 +13,7 @@ jobs:
   sync:
     name: Sync labels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
     steps:

--- a/.github/workflows/main-build-alert.yml
+++ b/.github/workflows/main-build-alert.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only act on main pushes; ignore PR check completions (those still
     # arrive via the same workflow_run event).
     if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -23,6 +23,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.action != 'closed'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -33,6 +33,7 @@ jobs:
   conflicts:
     name: Conflict Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.event_name == 'pull_request_target' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Label conflicting PRs
@@ -123,6 +124,7 @@ jobs:
   ci-status:
     name: CI Status Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'check_suite' || (github.event_name == 'pull_request_target' && github.event.action == 'synchronize')
     steps:
       - name: Label PRs with failed CI
@@ -256,6 +258,7 @@ jobs:
   size:
     name: PR Size
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request_target'
     steps:
       - name: Classify PR size
@@ -312,6 +315,7 @@ jobs:
   docs-only:
     name: Docs/CI Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request_target'
     steps:
       - name: Label docs/CI-only PRs
@@ -365,6 +369,7 @@ jobs:
   review-state:
     name: Review State
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'
     steps:
       - name: Clear needs-changes after push if all reviews resolved

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,6 +8,7 @@ jobs:
   check-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check conventional commit format
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -44,6 +44,7 @@ jobs:
   validate_release_tag:
     name: Validate release tag
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -71,6 +72,7 @@ jobs:
     name: Build Dashboard
     needs: [validate_release_tag]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release-cli
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -99,6 +101,7 @@ jobs:
     name: CLI / ${{ matrix.target }}
     needs: [build_dashboard]
     runs-on: macos-latest
+    timeout-minutes: 240
     environment: release-cli
     strategy:
       fail-fast: false
@@ -162,6 +165,7 @@ jobs:
     name: CLI / ${{ matrix.target }}
     needs: [build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     environment: release-cli
     strategy:
       fail-fast: false
@@ -235,6 +239,7 @@ jobs:
     name: CLI / aarch64-linux-android
     needs: [build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     environment: release-cli
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -282,6 +287,7 @@ jobs:
     name: CLI / ${{ matrix.target }} (mini)
     needs: [build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     environment: release-cli
     strategy:
       fail-fast: false
@@ -331,6 +337,7 @@ jobs:
     name: CLI / ${{ matrix.target }} (static)
     needs: [build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     environment: release-cli
     strategy:
       fail-fast: false
@@ -403,6 +410,7 @@ jobs:
     name: CLI / ${{ matrix.target }}
     needs: [build_dashboard]
     runs-on: windows-latest
+    timeout-minutes: 240
     environment: release-cli
     strategy:
       fail-fast: false
@@ -459,6 +467,7 @@ jobs:
     name: CLI / ${{ matrix.target }} (mini)
     needs: [build_dashboard]
     runs-on: macos-latest
+    timeout-minutes: 240
     environment: release-cli
     strategy:
       fail-fast: false
@@ -510,6 +519,7 @@ jobs:
     name: CLI / ${{ matrix.target }} (mini)
     needs: [build_dashboard]
     runs-on: windows-latest
+    timeout-minutes: 240
     environment: release-cli
     strategy:
       fail-fast: false
@@ -566,6 +576,7 @@ jobs:
       - cli_mac_mini
       - cli_windows_mini
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release-cli
     permissions:
       contents: write
@@ -643,6 +654,7 @@ jobs:
     if: ${{ inputs.include_pypi && (!contains(inputs.tag, '-') || endsWith(inputs.tag, '-lts')) }}
     needs: [cli_mac, cli_linux, cli_musl, cli_windows]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release-pypi
     permissions:
       id-token: write   # OIDC trusted publishing to PyPI

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -46,7 +46,7 @@ jobs:
   desktop:
     name: Desktop / ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
-    timeout-minutes: 300
+    timeout-minutes: 345
     environment: release-desktop
     strategy:
       fail-fast: false

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -46,6 +46,7 @@ jobs:
   desktop:
     name: Desktop / ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 300
     environment: release-desktop
     strategy:
       fail-fast: false
@@ -236,6 +237,7 @@ jobs:
     name: Sync Homebrew Cask
     if: ${{ inputs.sync_cask }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: release-desktop
     needs: [desktop]
     steps:

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -15,6 +15,7 @@ jobs:
   check_and_notify:
     name: Consolidated Release Notification
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check all release workflows and notify

--- a/.github/workflows/release-npm-binaries.yml
+++ b/.github/workflows/release-npm-binaries.yml
@@ -39,6 +39,7 @@ jobs:
   cli_npm:
     name: CLI / npm (binary packages)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release-npm
     permissions:
       id-token: write   # OIDC token for npm provenance attestations

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -34,6 +34,7 @@ jobs:
   tag:
     name: Create release tag
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: release-tag
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
     name: Sync tag to main HEAD (channel=current)
     if: github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -195,6 +196,7 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'chore/bump-version-')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -247,6 +249,7 @@ jobs:
     name: Bump Version (${{ inputs.channel }})
     if: github.event_name == 'workflow_dispatch' && inputs.channel != 'current'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -290,6 +293,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       release_id: ${{ steps.release_id.outputs.id }}
     steps:
@@ -460,6 +464,7 @@ jobs:
       && startsWith(github.ref, 'refs/tags/v')
       && endsWith(github.ref, '-lts')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -515,6 +520,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -549,6 +555,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: macos-latest
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -636,6 +643,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -736,6 +744,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -787,6 +796,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -842,6 +852,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -918,6 +929,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: windows-latest
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -978,6 +990,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: macos-latest
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -1033,6 +1046,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release, build_dashboard]
     runs-on: windows-latest
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -1115,6 +1129,7 @@ jobs:
       - cli_mac_mini
       - cli_windows_mini
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write   # upload signed manifest as release asset
       id-token: write   # fetch OIDC token for cosign keyless signing
@@ -1244,6 +1259,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [cli_mac, cli_linux, cli_musl, cli_windows]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1280,6 +1296,7 @@ jobs:
       )
     needs: [cli_mac, cli_linux, cli_musl, cli_windows]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write  # OIDC trusted publishing to PyPI
       contents: read   # actions/checkout (job-level permissions block fully overrides top-level)
@@ -1318,6 +1335,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [cli_mac, cli_linux]
     steps:
       - name: Check out tap repo
@@ -1641,6 +1659,7 @@ jobs:
             rust_target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1833,6 +1852,7 @@ jobs:
     needs: [create_release]
     continue-on-error: true
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       # ANDROID_HOME / ANDROID_SDK_ROOT are exported by setup-android; the
       # Tauri Android driver insists on NDK_HOME being set explicitly even
@@ -2091,6 +2111,7 @@ jobs:
     # SDK delta inside the 26.x line is irrelevant and skipping
     # setup-xcode saves 1–2 min per run.
     runs-on: macos-26
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -2492,6 +2513,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [desktop]
     steps:
       - name: Check out tap repo
@@ -2739,6 +2761,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [cli_linux]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -2759,6 +2782,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [desktop]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -2779,6 +2803,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Pin only after the multi-arch image + tag exist, so `librefang-docker
     # pull` works the moment the package lands.
     needs: [docker-manifest]
@@ -2964,6 +2989,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # `docker-scan` is what makes this a gate: the shared :VERSION / :latest tags are only created once both native digests have been scanned.
     # Keep `docker` in the list too — `needs` is not transitive for the purposes of `steps.*` and artifact availability, and dropping it would make the dependency on the digest artifacts implicit.
     needs: [docker, docker-scan]
@@ -3017,6 +3043,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [cli_linux, desktop, docker-manifest]
     concurrency:
       group: arch-pacman-repo
@@ -3040,6 +3067,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [docker-manifest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -3061,6 +3089,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [docker-manifest]
     steps:
       - name: Trigger Render deploy
@@ -3084,6 +3113,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: sdk/javascript
@@ -3147,6 +3177,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: packages/cli-npm
@@ -3190,6 +3221,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write  # OIDC trusted publishing to PyPI
       contents: read   # actions/checkout (job-level permissions block fully overrides top-level)
@@ -3242,6 +3274,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: sdk/rust
@@ -3301,6 +3334,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     needs: [create_release]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1659,7 +1659,7 @@ jobs:
             rust_target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform.os }}
-    timeout-minutes: 300
+    timeout-minutes: 345
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -37,6 +37,7 @@ jobs:
   gitleaks:
     name: gitleaks scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Manage stale-pr labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -43,6 +43,7 @@ jobs:
   self-test:
     name: audit script self-test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -55,6 +56,7 @@ jobs:
     name: scan skills / hands / extensions
     needs: self-test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: alstr/todo-to-issue-action@37bb7b56e58569ef273b60678048030a7f0c261a # v5

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -18,6 +18,7 @@ jobs:
     name: Refresh contributors and star history
     if: github.repository == 'librefang/librefang'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Rust toolchain

--- a/.github/workflows/update-openrouter-models.yml
+++ b/.github/workflows/update-openrouter-models.yml
@@ -18,6 +18,7 @@ jobs:
     name: Refresh OpenRouter model snapshot
     if: github.repository == 'librefang/librefang'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Welcome first-time contributors
         env:

--- a/changelog.d/fixed/7836-workflow-job-timeout-caps.md
+++ b/changelog.d/fixed/7836-workflow-job-timeout-caps.md
@@ -1,0 +1,4 @@
+Every GitHub Actions job now declares an explicit `timeout-minutes`, so a wedged job dies on its own instead of holding a runner slot until GitHub's 360-minute default expires.
+  Two `main` CI runs recently hung `in_progress` for over nine hours and, because the `main` concurrency group is keyed per-sha and deliberately never cancels an older run, they held the repository's only two concurrent execution slots while more than 80 runs queued behind them and every open PR stalled.
+  Caps are sized from observed job durations — roughly a 3x margin over the slowest recent run — so a cold cache or normal variance never trips one, and tag-driven release builds keep the headroom their real cost demands.
+  (#7836) (@houko)

--- a/changelog.d/fixed/7836-workflow-job-timeout-caps.md
+++ b/changelog.d/fixed/7836-workflow-job-timeout-caps.md
@@ -1,4 +1,6 @@
 Every GitHub Actions job now declares an explicit `timeout-minutes`, so a wedged job dies on its own instead of holding a runner slot until GitHub's 360-minute default expires.
   Two `main` CI runs recently hung `in_progress` for over nine hours and, because the `main` concurrency group is keyed per-sha and deliberately never cancels an older run, they held the repository's only two concurrent execution slots while more than 80 runs queued behind them and every open PR stalled.
-  Caps are sized from observed job durations — roughly a 3x margin over the slowest recent run — so a cold cache or normal variance never trips one, and tag-driven release builds keep the headroom their real cost demands.
+  Caps are sized from each job's observed duration, generously enough that a cold cache or normal variance never trips one — most sit an order of magnitude above their slowest recorded run.
+  The desktop release build is the deliberate exception: its slowest successful run took 206 minutes, and since GitHub caps any job at 360 minutes there is no room for a wide margin, so it is capped at 345 to preserve the guarantee that no job can occupy a slot for a full six hours.
+  A new `Workflow Job Timeouts` gate keeps the coverage from regressing, because a job added without the key silently inherits the six-hour default again.
   (#7836) (@houko)

--- a/scripts/check-workflow-timeouts.py
+++ b/scripts/check-workflow-timeouts.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fail if any GitHub Actions job lacks an explicit ``timeout-minutes``.
+
+A job without the key inherits GitHub's 360-minute default.
+That is long enough for a wedged job to hold one of the repository's few concurrent
+execution slots for six hours, which is exactly what happened when two ``main`` CI
+runs hung ``in_progress`` and stalled more than eighty queued runs behind them.
+On ``main`` the concurrency group is keyed per-sha with ``cancel-in-progress: false``
+by design, so nothing supersedes a hung run and only the timeout can end it.
+
+This guard exists because coverage is easy to regress: every new job silently
+inherits the six-hour default unless its author remembers the key.
+
+Jobs that only call a reusable workflow (``uses:`` at job level) are skipped, because
+GitHub rejects ``timeout-minutes`` on those -- the cap belongs to the called workflow.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - CI always has PyYAML
+    print("check-workflow-timeouts: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    raise SystemExit(2)
+
+WORKFLOW_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+
+def main() -> int:
+    if not WORKFLOW_DIR.is_dir():
+        print(f"check-workflow-timeouts: no workflow directory at {WORKFLOW_DIR}", file=sys.stderr)
+        return 2
+
+    missing: list[tuple[str, str]] = []
+    skipped = 0
+    checked = 0
+
+    for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            print(f"check-workflow-timeouts: {path.name} is not valid YAML: {exc}", file=sys.stderr)
+            return 2
+
+        if not isinstance(doc, dict):
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+
+        for job_id, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            # A job that delegates to a reusable workflow cannot carry the key.
+            if "uses" in job:
+                skipped += 1
+                continue
+            checked += 1
+            if "timeout-minutes" not in job:
+                missing.append((path.name, str(job_id)))
+
+    if missing:
+        print("check-workflow-timeouts: these jobs have no explicit timeout-minutes:", file=sys.stderr)
+        for workflow, job_id in missing:
+            print(f"  {workflow}: {job_id}", file=sys.stderr)
+        print(
+            "\nAdd `timeout-minutes: <n>` at job level, sized generously from the job's"
+            " observed duration.\nA false timeout on a legitimate long build is worse than"
+            " the hang this guards against, so prefer a high value over a tight one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: all {checked} workflow jobs declare timeout-minutes ({skipped} reusable-workflow jobs skipped).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Two `main` CI runs hung `in_progress` for over nine hours: run `32674923537` on sha `5e6c7c685` and run `32674955547` on sha `9cc202cff`.
They held the repository's only two concurrent execution slots while more than 80 runs queued behind them, stalling every open PR.

They were never superseded because `.github/workflows/ci.yml:15-17` sets the `main` concurrency group to `{workflow}-{sha}` with `cancel-in-progress: false`, so on `main` a newer run never cancels an older one.
That per-sha behaviour is deliberate and correct — it preserves a green record for each `main` commit and is what `main-build-alert.yml` depends on — so the concurrency block is untouched here.
The real defect is the missing `timeout-minutes`: a wedged job should die on its own instead of holding a slot until GitHub's 360-minute default expires.

`secret-scan.yml`'s `gitleaks` job is included, which is the specific gap flagged in review of #7281 and the reason an Actions internal error on it was allowed to sit for nearly fifteen minutes.

## Changes

- Added `timeout-minutes` to all 101 jobs across 35 workflow files that lacked the key. 133 jobs total; 32 already had a cap and none was modified.
- No other key, value, comment or line of indentation changed. The diff is 101 insertions and 0 deletions, each hunk adding exactly one `    timeout-minutes: N` line immediately after that job's `runs-on:`.

## How each value was chosen

Values come from observed durations, not one blanket number.
For each workflow with run history I took the per-job maximum over recent completed runs and applied roughly a 3x margin, rounded to a sensible number, so a cold cache or normal variance never trips a cap.

Representative measurements and the resulting caps:

| Job | Observed max | Cap |
| --- | --- | --- |
| `pr-status-labels.yml: conflicts` | 4.4 min | 20 |
| `dashboard-build.yml: build` | 2.3 min | 20 |
| `deploy-docs.yml: deploy` | 2.6 min | 20 |
| `auto-update-branches.yml: update-branches` | 1.5 min | 20 |
| `update-contributors.yml: update` | 1.2 min | 20 |
| `cargo-deny.yml: cargo-deny` | 1.2 min | 15 |
| `secret-scan.yml: gitleaks` | 0.8 min | 10 |
| `ci.yml` gate/lint jobs (`changes`, `ci-gate`, `secrets`, `githook-tests`, `changelog-attribution`, …) | 6–40 s | 10 |
| GitHub-API automation jobs (`welcome`, `pr-title`, `issue-pr-link`, `label-sync`, `main-build-alert`, …) | 5–15 s | 10 |
| `stale.yml` / `stale-pr.yml` / `issue-labels.yml: backfill` | 8 s, but iterate the whole issue corpus under API rate limits | 30 |

Where no history exists the value is reasoned from the work and sized generously.
`release-cli.yml`, `release-tag.yml` and `release-npm-binaries.yml` have never executed — no workflow record exists for them at all — and `release.yml`'s build jobs are skipped on every PR-triggered run.
The one real tag-driven `release.yml` run (`32195527656`, `v2026.8.19`) is the calibration for those:

| Job | Observed in run 32195527656 | Cap |
| --- | --- | --- |
| `desktop` (worst platform: Windows ARM64) | 206 min | 300 |
| `cli_windows` / `cli_windows_mini` | 104 min | 240 |
| `cli_mac` / `cli_mac_mini` | 81 min | 240 |
| `cli_linux` / `cli_linux_mini` / `cli_musl` / `cli_android` | 20–29 min | 90 |
| `mobile_ios` | failed at 9 min | 120 |
| `mobile_android` | 20 min | 60 |
| `build_dashboard`, `cli_npm`, `cli_pypi`, `sign_release_artifacts`, `publish_arch_repo`, `sdk_rust`, `sdk_python`, `deploy_fly` | 22 s – 2.4 min | 30 |
| `create_release`, `deploy_render`, `sdk_javascript`, `sdk_cli_npm`, `bump_version` | 5–26 s | 20 |
| tag/sync/AUR/homebrew/manifest jobs | 6–15 s | 15 |

`release-cli.yml` mirrors `release.yml`'s CLI matrix, so it gets the same per-target values.
`release-desktop.yml: desktop` gets the same 300 as `release.yml: desktop` — it is the same Tauri build, and its own history maxes at 56.6 min.

Existing caps set the house style and are matched: `ci.yml: openapi-drift` 20, `kubernetes.yml: render` 10 / `kind` 60, `pr-review-collector.yml: collect` 5, `discussion-to-issue.yml` 10.
The largest new cap is 300, chosen so that even the heaviest legitimate release build cannot hold a slot for the full six hours while still leaving a 1.5x margin over the slowest run ever recorded for it.
A false timeout on a real build turns a green pipeline red and blocks merges, which is worse than the hang being fixed, so every value errs high.

An unexpected confirmation of the pathology showed up in the data: `label-sync.yml`'s `Sync labels` job has a recorded maximum of 94.7 min across the last ten runs, but nine of those ran in 6–10 s and the tenth was a `cancelled` run that sat for 5680 s. It is capped at 10.

## Verification

- Every one of the 48 workflow files parses: `for f in .github/workflows/*.y*ml; do python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f"; done` — 48 OK, 0 failures.
- Audit re-run after the change: 133 jobs total, **0** missing `timeout-minutes` (before: 101 missing, 32 present).
- `git diff --numstat` totals `added=101 deleted=0`; `git diff | grep '^-' | grep -v '^---'` is empty, so no existing cap could have been lowered and no line was reformatted.
- Every added line matches `^+    timeout-minutes: [0-9]+$` — 101 of 101.
- `python3 scripts/check-changelog-attribution.py` → OK.
- No `cargo` or `pnpm` run: this is a YAML-only change with no Rust or dashboard surface.

## Notes

- This PR touches `.github/workflows/`, so `ci.yml`'s change detection will classify it as a CI change and run the full build lane. That is expected and is the intended smoke test for the edited `ci.yml`.
- Four permanently stuck runs from 2026-05-15 on since-deleted branches (`25907161117`, `25907161932`, `25907237730`, `25907238356`) return HTTP 500 on cancel. They predate this change and cannot be cleared by any repository-side edit; they need GitHub support.
- The `concurrency` block in `ci.yml` is intentionally left alone, for the reason stated above.
