### PR TITLE
ci: add concurrency groups to bookkeeping workflows

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -17,11 +17,13 @@ permissions:
   issues: write
   contents: read
 
-# The per-issue paths are safe to cancel: `area` recomputes labels from the current title and body, and `response-state` derives the awaiting-response / needs-attention pair from the triggering comment, so the newest event is the one whose answer should win.
+# The per-issue paths are safe to cancel WITHIN one event type: `area` recomputes labels from the current title and body, and `response-state` derives the awaiting-response / needs-attention pair from the triggering comment, so the newest event of the same kind is the one whose answer should win.
+# The event name is part of the group because the two paths run DIFFERENT jobs: `area` is gated on `github.event_name == 'issues'`, so an `issue_comment` run cancelling an in-flight `issues` run would drop the `area/*` labels permanently.
+# The `workflow_dispatch` backfill cannot repair that, because it only selects issues that have no labels at all and the comment run has already added one.
 # The `workflow_dispatch` backfill instead walks every unlabeled open issue, so it shares one constant group key and is never cancelled — a half-finished backfill leaves part of the backlog unlabeled with nothing to retrigger it.
 # Issue numbers are unique within the repository, so two different issues can never share a group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || 'backfill' }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || 'backfill' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -17,6 +17,13 @@ permissions:
   issues: write
   contents: read
 
+# The per-issue paths are safe to cancel: `area` recomputes labels from the current title and body, and `response-state` derives the awaiting-response / needs-attention pair from the triggering comment, so the newest event is the one whose answer should win.
+# The `workflow_dispatch` backfill instead walks every unlabeled open issue, so it shares one constant group key and is never cancelled — a half-finished backfill leaves part of the backlog unlabeled with nothing to retrigger it.
+# Issue numbers are unique within the repository, so two different issues can never share a group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || 'backfill' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   # ── Area labels based on title keywords ───────────────────────────
   area:

--- a/.github/workflows/issue-pr-link.yml
+++ b/.github/workflows/issue-pr-link.yml
@@ -13,6 +13,12 @@ permissions:
   issues: write
   pull-requests: read
 
+# Each run re-derives the linked-issue set from the PR body and the PR's current open/closed state, so the newest run converges on the correct `has-pr` labels whatever a cancelled predecessor had applied so far.
+# `pull_request_target` reports `github.ref` as the base branch for every PR, so the group keys on the PR number to stay collision-free across PRs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   link:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -16,6 +16,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# `actions/labeler` runs with `sync-labels: true`, so each run recomputes the complete area-label set from the PR's changed paths and the newest run supersedes the older one.
+# `pull_request_target` reports `github.ref` as the base branch (`refs/heads/main`) for every PR, so the group keys on the PR number instead — a ref-keyed group would let one PR's run cancel another's.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   # ── Area labels based on changed file paths ───────────────────────
   area:

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -33,7 +33,11 @@ permissions:
 # Key on the PR number, falling back to the check-suite head SHA and then the ref, and keep the event name in the group so a `check_suite` run can never cancel the main-push conflict sweep.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.ref }}
-  cancel-in-progress: true
+  # Only the per-PR paths cancel. The `push` and `workflow_dispatch` sweeps walk up to 100 open PRs
+  # with a retry delay per PR whose mergeability is still null, and a push to main is exactly what
+  # makes mergeability null repository-wide — so during a merge batch each further merge would abort
+  # the sweep that detects newly conflicting PRs. Same reasoning as stale-pr.yml's sweep.
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.event_name == 'check_suite' }}
 
 jobs:
   # ── Conflict detection ────────────────────────────────────────────

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -28,6 +28,13 @@ permissions:
   issues: write
   pull-requests: write
 
+# Every job here recomputes the full desired label set from the PR's current state, so a newer run's answer entirely supersedes an older one and cancelling the older run loses nothing.
+# `pull_request_target`, `check_suite` and `push` all report `github.ref` as a branch of this repository rather than as a PR ref, so keying the group on the ref alone would put every open PR in one bucket and let one PR's run cancel another's.
+# Key on the PR number, falling back to the check-suite head SHA and then the ref, and keep the event name in the group so a `check_suite` run can never cancel the main-push conflict sweep.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Conflict detection ────────────────────────────────────────────
   conflicts:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+# The title check is a pure function of the current PR title, so the newest run is the only one whose verdict matters.
+# `pull_request` events always carry a PR number, which is unique per PR and therefore cannot collide across PRs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-title:
     name: Validate PR title

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -13,6 +13,13 @@ on:
 permissions:
   pull-requests: write
 
+# Two paths with different safety properties share this workflow.
+# The `pull_request_target` path only removes `stale-pr` from the single PR that was pushed to, so it is idempotent and safe to cancel — the newer push repeats the same removal.
+# The `schedule` / `workflow_dispatch` path sweeps up to 100 open PRs and adds or removes a label one PR at a time, so cancelling it mid-flight would leave a partially swept repository; every sweep shares the constant `sweep` group key and is never cancelled, which makes two overlapping cron fires serialise instead of racing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -10,6 +10,13 @@ permissions:
   issues: write
   pull-requests: write
 
+# A greeting is a one-shot side effect, so this group never cancels: killing a run that has already posted, or dropping one that has not yet, is not something a later run repairs.
+# The group is per PR / issue rather than workflow-wide on purpose — GitHub keeps only one pending run per concurrency group and cancels any earlier pending one, so a single shared group would silently drop the greeting for every contributor who opened a PR while another greeting was still in flight.
+# PRs and issues share one number space within a repository, so the two triggers cannot collide on the same group key.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   welcome:
     runs-on: ubuntu-latest

--- a/changelog.d/fixed/7837-bookkeeping-workflow-concurrency.md
+++ b/changelog.d/fixed/7837-bookkeeping-workflow-concurrency.md
@@ -1,0 +1,3 @@
+Give the per-PR bookkeeping workflows cancelling concurrency groups, so a push no longer queues a full extra set of metadata runs that nothing supersedes.
+A sample of 100 queued runs found 64 were metadata bots rather than real CI, against a repository executing only three to four runs at a time — the labelers were directly starving the Rust build and test lanes of runner slots.
+Cancellation is decided per workflow rather than blanket-applied: the label and title reconcilers cancel because each run recomputes the full desired state, while the first-time-contributor greeting and the stale-PR sweep only serialise, because a half-posted comment or a half-finished sweep is worse than a redundant run (#7837) (@houko)


### PR DESCRIPTION
## Problem

The per-PR bookkeeping workflows have no `concurrency` block, so every push to a PR queues another full run and none of them supersedes the previous one.

Measured just now: a sample of 100 queued runs showed 64 of them were metadata bots rather than real CI — `PR Status Labels` 24, `PR Title` 12, `PR Labels` 11, `Welcome` 10, `Stale PR` 7.
The repository was executing only 3 to 4 runs concurrently at the time, so those redundant runs were directly starving the Rust build and test lanes of runner slots.
Confirmed absent before this change: `grep -c '^concurrency:'` returned 0 for `pr-status-labels.yml`, `pr-title.yml`, `pr-labels.yml`, `welcome.yml`, `stale-pr.yml` and `issue-pr-link.yml`.
For contrast, `ci.yml:15-17` already does this correctly for non-main refs, and `secret-scan.yml` / `dashboard-build.yml` use the same conditional-cancel shape.

## Changes

Seven top-level `concurrency` blocks, 46 added lines, 0 removed.
No other key in any file is touched.

| Workflow | Group expression | `cancel-in-progress` |
| --- | --- | --- |
| `pr-status-labels.yml` | `${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number \|\| github.event.check_suite.head_sha \|\| github.ref }}` | `true` |
| `pr-title.yml` | `${{ github.workflow }}-${{ github.event.pull_request.number }}` | `true` |
| `pr-labels.yml` | `${{ github.workflow }}-${{ github.event.pull_request.number }}` | `true` |
| `issue-pr-link.yml` | `${{ github.workflow }}-${{ github.event.pull_request.number }}` | `true` |
| `issue-labels.yml` | `${{ github.workflow }}-${{ github.event.issue.number \|\| 'backfill' }}` | `${{ github.event_name != 'workflow_dispatch' }}` |
| `stale-pr.yml` | `${{ github.workflow }}-${{ github.event.pull_request.number \|\| 'sweep' }}` | `${{ github.event_name == 'pull_request_target' }}` |
| `welcome.yml` | `${{ github.workflow }}-${{ github.event.pull_request.number \|\| github.event.issue.number }}` | `false` |

## Why the group keys cannot collide across PRs

None of these workflows can key on `github.ref`.
`pull_request_target` runs in the context of the base branch, so `github.ref` is `refs/heads/main` for **every** PR — a ref-keyed group would put all open PRs in one bucket and let one PR's run cancel another's.
`check_suite` reports the default branch the same way.
So every group keys on the PR number or the issue number, which GitHub allocates from a single per-repository number space: two different PRs, or a PR and an issue, can never share a key.

`pr-status-labels.yml` is the only mixed-trigger case that needs more than that.
It fires on `pull_request_target`, `push` to `main`, `check_suite` and `workflow_dispatch`, and the fallback chain resolves to a different identity for each: the PR number, the check-suite head SHA, or the ref.
`github.event_name` is part of the group so those identity spaces cannot alias — without it a `push` whose `github.sha` matched a `check_suite` head SHA would share a group, and a `check_suite` run could cancel the main-push conflict sweep, which is different work.

## Why `cancel-in-progress` differs per workflow

Cancelling is safe exactly when a run recomputes the full desired state and the newest answer therefore supersedes the older one completely.

**Cancel (`true`)**

- `pr-status-labels.yml` — all five jobs are pure label reconciliation. `conflicts`, `ci-status`, `size`, `docs-only` and `review-state` each re-read the PR (or all open PRs, on the `push` path) and converge the labels; nothing is written outside labels, no comment is posted. A later `push` scan covers the same or a larger PR set than the scan it cancels, and a later `check_suite` run for the same head SHA sees the same or more completed checks, so it strictly supersedes.
- `pr-title.yml` — `action-semantic-pull-request` is a pure function of the current title, and the check conclusion for the head SHA is overwritten by the newer run.
- `pr-labels.yml` — `actions/labeler` with `sync-labels: true` recomputes the complete area-label set from the changed paths.
- `issue-pr-link.yml` — each run re-derives the linked-issue set from the current PR body and the PR's open/closed state, so it converges on the right `has-pr` labels regardless of how far a cancelled predecessor got. Label add/remove on issues is the only effect; the PR is never closed or commented on.
- `issue-labels.yml`, per-issue paths — `area` recomputes labels from the current title/body, and `response-state` derives the `awaiting-response` / `needs-attention` pair from the triggering comment. Here cancelling is *more* correct than the status quo: with two comments arriving back to back, the newer run wins deterministically instead of racing the older one.

**Serialise only (`false`)**

- `welcome.yml` — the greeting is a one-shot comment. A cancelled run that already posted, or one dropped before posting, is not repaired by anything later, so this never cancels. It is also grouped **per PR / issue rather than workflow-wide** on purpose: GitHub keeps only one pending run per concurrency group and cancels any earlier pending one, so a single shared group would silently drop the greeting for every contributor who opened a PR while another greeting was in flight. That also means `Welcome`'s 10 runs in the sample are **not** redundancy — they are 10 distinct contributors, and concurrency is not the lever that reduces that count.
- `stale-pr.yml`, sweep path — `schedule` and `workflow_dispatch` walk up to 100 open PRs, adding or removing `stale-pr` one at a time. Killing that mid-flight leaves a partially swept repository, so all sweeps share the constant `sweep` key and serialise instead. Its `pull_request_target` path is different work — a single idempotent label removal on the pushed PR — so that path does cancel, expressed the same conditional way `ci.yml` and `secret-scan.yml` already do it.
- `issue-labels.yml`, backfill path — the `workflow_dispatch` backfill walks every unlabeled open issue; a half-finished backfill leaves part of the backlog unlabeled with nothing to retrigger it.

## Verification

No `cargo` or `pnpm` involved — YAML only.

- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` on all seven files: all parse, and `concurrency` appears in the top-level key list of each (`['name', True, 'permissions', 'concurrency', 'jobs']` — `True` is PyYAML reading the `on:` key as a boolean, which is expected).
- `grep -c '^concurrency:'` returns 1 for each of the seven files, so every block sits at column 0 as a sibling of `on:` / `jobs:`. `grep -n '^\s\+concurrency:'` shows only the three pre-existing job-level blocks in `discussion-to-issue.yml`, `pr-review-state-applier.yml` and `release.yml`, none of which this PR touches.
- `git diff --stat`: `7 files changed, 46 insertions(+)`. Zero deleted lines, and every hunk is an insertion before the `jobs:` key.
- `python3 scripts/check-changelog-attribution.py`: `OK: no changelog problems in scope`.

## Not touched

- `ci.yml` — its concurrency block is already correct and deliberately does not cancel on `main`.
- `dashboard-build.yml` — already has `concurrency` (`dashboard-build-${{ github.workflow }}-${{ github.ref }}`, cancelling only on `pull_request`), which is the same design as this PR.
- `stale.yml`, `issue-inactive.yml`, `auto-update-branches.yml`, `weekly-report.yml` and the other cron/release workflows — out of scope for this PR, which is limited to the per-item bookkeeping cluster measured above.

## Coordination

There is a separate open PR on `ci/job-timeout-caps` adding `timeout-minutes` to every job.
This PR's hunks are strictly the top-level `concurrency` block inserted before `jobs:`, and that PR's hunks are inside job bodies, so the two touch disjoint keys.
In the shortest files (`pr-title.yml`, `pr-labels.yml`, `welcome.yml`) the two insertion points are within three lines of each other, so a textual conflict is possible even though the changes are semantically independent — resolution there is "keep both".
