### PR TITLE
fix(api): accept the daemon's own literal-IP origin on the agent WebSocket

### DIFF
--- a/changelog.d/fixed/7777-ws-own-origin-literal-ip.md
+++ b/changelog.d/fixed/7777-ws-own-origin-literal-ip.md
@@ -1,0 +1,6 @@
+A daemon that is not on loopback now accepts the WebSocket from the dashboard it serves itself.
+`validate_ws_origin` auto-allowed only `localhost` / `127.0.0.1` / `::1` on the listen port, so a daemon bound to `0.0.0.0:4545` and opened at `http://192.168.1.161:4545` answered every agent-chat upgrade with a 403 and silently dropped every agent reply — the product's primary flow, broken out of the box on any non-loopback deployment.
+The implicit allow now also covers an origin naming the same **literal IP address and port** the request was itself addressed to.
+It is restricted to IP literals deliberately: the `Host` header is derived from whatever URL the page dialled rather than from anything the daemon asserted, so matching `Host` and `Origin` on a *hostname* proves only that the page came from a name that currently resolves here, which is exactly what DNS rebinding arranges — and treating that as same-origin would hand any rebound attacker page a socket and defeat the cross-site hijacking guard from #3731.
+An IP literal has no name in the middle to rebind, so for the two sides to match the page must have been served by whatever answers on that address and port.
+Deployments reached through a hostname, including anything behind a TLS-terminating proxy, continue to list their public origin in the top-level `cors_origin` (#7850) (@houko)

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
-use url::Url;
+use url::{Host, Url};
 
 // ---------------------------------------------------------------------------
 // Verbose Level
@@ -202,8 +202,17 @@ pub fn ws_bearer_protocol(headers: &HeaderMap) -> Option<String> {
 }
 
 /// Validates the WebSocket `Origin` header against allowed origins.
-/// Returns Ok(()) if: (a) no Origin header (non-browser client), or (b) Origin matches.
-/// Returns Err(reason) if Origin is present but doesn't match any allowed origin.
+///
+/// Returns `Ok(())` when any of these hold, in order:
+///
+/// 1. No `Origin` header at all — a non-browser client (curl, a native app), which cannot be driven cross-site.
+/// 2. A loopback origin (`localhost` / `127.0.0.1` / `::1`) on the listen port.
+/// 3. The origin names the same **literal IP address and port** as this request's own `Host` header — see `origin_is_self`.
+///    A hostname never satisfies this rule, however exactly it matches; hostname and TLS-proxy deployments list their public origin in `cors_origin` instead.
+/// 4. `extra_origins` contains `"*"` and `allow_remote` is set.
+/// 5. `extra_origins` contains an entry whose scheme, host and port all match the origin.
+///
+/// Returns `Err(reason)` if an `Origin` is present and none of the above match.
 pub fn validate_ws_origin(
     headers: &HeaderMap,
     listen_port: Option<u16>,
@@ -220,15 +229,16 @@ pub fn validate_ws_origin(
     let origin_host = parsed
         .host_str()
         .ok_or_else(|| format!("Origin missing host: {origin}"))?;
+    let parsed_host = parsed
+        .host()
+        .ok_or_else(|| format!("Origin missing host: {origin}"))?;
     if origin_scheme != "http" && origin_scheme != "https" {
         return Err(format!("Origin {origin} not in allowed list"));
     }
 
-    let origin_port = if origin_scheme == "https" {
-        parsed.port().unwrap_or(443)
-    } else {
-        parsed.port().unwrap_or(80)
-    };
+    let origin_port = parsed
+        .port()
+        .unwrap_or_else(|| default_port_for_scheme(origin_scheme));
 
     // Only loopback hosts (localhost / 127.0.0.1 / ::1) on the same port
     // are auto-allowed. Fail closed when listen_port is unknown — otherwise
@@ -240,6 +250,11 @@ pub fn validate_ws_origin(
                 return Ok(());
             }
         }
+    }
+
+    // The daemon's own non-loopback address, reached directly by IP (#7777).
+    if origin_is_self(headers, &parsed_host, origin_port, origin_scheme) {
+        return Ok(());
     }
 
     // Wildcard "*" means allow all origins — only permitted when allow_remote is true.
@@ -256,11 +271,9 @@ pub fn validate_ws_origin(
         let extra_host = extra_parsed
             .host_str()
             .ok_or_else(|| format!("Origin missing host in allowed origin: {extra}"))?;
-        let extra_port = if extra_scheme == "https" {
-            extra_parsed.port().unwrap_or(443)
-        } else {
-            extra_parsed.port().unwrap_or(80)
-        };
+        let extra_port = extra_parsed
+            .port()
+            .unwrap_or_else(|| default_port_for_scheme(extra_scheme));
 
         let normalized_extra_host = normalize_origin_host(extra_host);
 
@@ -280,6 +293,65 @@ fn normalize_origin_host(host: &str) -> &str {
         "localhost" | "127.0.0.1" | "::1" | "[::1]" => "localhost",
         _ => host,
     }
+}
+
+/// The default port a scheme implies when the URL or `Host` header omits one.
+fn default_port_for_scheme(scheme: &str) -> u16 {
+    if scheme == "https" {
+        443
+    } else {
+        80
+    }
+}
+
+/// Whether the `Origin` names the same **literal IP address** and port that this request was itself addressed to.
+///
+/// This is the rule that lets a daemon on `0.0.0.0:4545`, opened at `http://192.168.1.161:4545`, accept its own dashboard's WebSocket (#7777).
+///
+/// The implicit allow is restricted to IP literals on purpose, and the restriction is the entire security content of this function.
+/// `Host` is not something the daemon asserted — it is derived from whatever URL the page dialled, and the page chooses that URL.
+/// So `Host == Origin` on a *hostname* proves only that the page came from a name that currently resolves to this address, which is precisely what DNS rebinding arranges: an attacker serves a page from `attacker.example`, rebinds that name to the daemon's loopback or LAN address, and the browser then sends `Host: attacker.example:4545` beside `Origin: http://attacker.example:4545` with nothing forged.
+/// Treating that pair as proof of same-origin would hand any such page a WebSocket and defeat the cross-site hijacking guard from #3731.
+///
+/// An IP literal has no name in the middle to rebind.
+/// For the two sides to match, the page must have been served by whatever answers on that address and port — which, since this request arrived there, is this daemon.
+///
+/// Deployments reached through a hostname or a TLS-terminating proxy are therefore not covered here and must list their public origin in `cors_origin`.
+/// The scheme is not compared, because `Host` carries none and behind a TLS terminator the browser's `https` cannot be reconstructed from the plaintext hop; the origin's scheme only supplies the default port when `Host` omits one.
+/// `X-Forwarded-Host` is deliberately ignored — it is attacker-controlled unless the peer is a verified proxy, and this function has no view of the peer.
+fn origin_is_self(
+    headers: &HeaderMap,
+    origin_host: &Host<&str>,
+    origin_port: u16,
+    origin_scheme: &str,
+) -> bool {
+    // A hostname origin is never self-evident, so there is nothing to compare against.
+    if !matches!(origin_host, Host::Ipv4(_) | Host::Ipv6(_)) {
+        return false;
+    }
+
+    let Some(host_header) = headers.get("host").and_then(|value| value.to_str().ok()) else {
+        return false;
+    };
+
+    // `Host` is `host[:port]` with no scheme; borrow the origin's to parse it,
+    // which also normalises `192.168.1.5` / `[fd00::1]` the same way the origin
+    // was normalised so the comparison is on addresses rather than on spelling.
+    let Ok(self_url) = Url::parse(&format!("{origin_scheme}://{host_header}")) else {
+        return false;
+    };
+    let Some(self_host) = self_url.host() else {
+        return false;
+    };
+    if !matches!(self_host, Host::Ipv4(_) | Host::Ipv6(_)) {
+        return false;
+    }
+
+    let self_port = self_url
+        .port()
+        .unwrap_or_else(|| default_port_for_scheme(origin_scheme));
+
+    self_host == *origin_host && self_port == origin_port
 }
 
 // ---------------------------------------------------------------------------
@@ -2621,6 +2693,18 @@ mod tests {
         );
     }
 
+    /// The header pair a real browser sends on a WebSocket handshake.
+    ///
+    /// `Origin` is the page's, `Host` is the authority from the URL the page
+    /// dialled. Tests that set only `Origin` cannot exercise the self-origin rule
+    /// at all, because it returns early when `Host` is absent.
+    fn browser_headers(origin: &str, host: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", origin.parse().unwrap());
+        headers.insert("host", host.parse().unwrap());
+        headers
+    }
+
     #[test]
     fn validate_ws_origin_missing_origin_allowed() {
         let headers = HeaderMap::new();
@@ -2662,19 +2746,32 @@ mod tests {
     }
 
     #[test]
-    fn validate_ws_origin_lan_ip_same_port_rejected() {
-        // LAN IP with matching port should be rejected without explicit allowed_origins.
-        let mut headers = HeaderMap::new();
-        headers.insert("origin", "http://192.168.1.5:4545".parse().unwrap());
+    fn validate_ws_origin_lan_ip_addressed_to_a_different_host_rejected() {
+        // A LAN IP origin is not blanket-allowed just because its port matches the
+        // listen port: it is allowed only when the request was itself addressed to
+        // that same address. Here the browser dialled 10.0.0.7 and the page came
+        // from 192.168.1.5, which is a cross-site request.
+        //
+        // The `host` header is what makes this test mean anything. Without it
+        // `origin_is_self` returns early and the assertion passes for a reason no
+        // real browser ever produces, since every browser sends `Host`.
+        let mut headers = browser_headers("http://192.168.1.5:4545", "10.0.0.7:4545");
         let result = validate_ws_origin(&headers, Some(4545), &[], false);
         assert!(result.is_err());
+
+        // Same origin, no `Host` at all: still rejected, so the rule fails closed
+        // rather than treating an absent header as a match.
+        headers.remove("host");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_err());
     }
 
     #[test]
     fn validate_ws_origin_arbitrary_host_same_port_rejected() {
-        // Any hostname with matching port is rejected without explicit allowed_origins.
-        let mut headers = HeaderMap::new();
-        headers.insert("origin", "http://myserver.local:8080".parse().unwrap());
+        // Any hostname with matching port is rejected without explicit allowed_origins,
+        // and it stays rejected when the request's own `Host` header names that same
+        // hostname — which is the pairing a real browser sends and the one an attacker
+        // gets for free from DNS rebinding.
+        let headers = browser_headers("http://myserver.local:8080", "myserver.local:8080");
         let result = validate_ws_origin(&headers, Some(8080), &[], false);
         assert!(result.is_err());
     }
@@ -2772,6 +2869,107 @@ mod tests {
         headers.insert("origin", "not-a-url".parse().unwrap());
         let result = validate_ws_origin(&headers, Some(4545), &["*".to_string()], true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_ws_origin_accepts_the_servers_own_lan_origin() {
+        // The reported defect from #7777, reduced: a daemon bound to 0.0.0.0:4545
+        // and opened at http://192.168.1.161:4545 must accept its own dashboard's
+        // socket with nothing configured.
+        let headers = browser_headers("http://192.168.1.161:4545", "192.168.1.161:4545");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_ok());
+    }
+
+    #[test]
+    fn validate_ws_origin_self_rule_matches_ipv6_literal_host() {
+        // Both sides go through `Url`, so the comparison is on the parsed address
+        // and the bracket/zero-compression spelling does not have to agree.
+        let headers = browser_headers("http://[fd00::1]:4545", "[fd00:0:0:0:0:0:0:1]:4545");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_ok());
+    }
+
+    #[test]
+    fn validate_ws_origin_self_rule_holds_on_a_port_other_than_listen_port() {
+        // Port-mapped or proxied to a different external port: the rule compares the
+        // origin against the request's own `Host`, not against `listen_port`.
+        let headers = browser_headers("http://192.168.1.161:8443", "192.168.1.161:8443");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_ok());
+    }
+
+    #[test]
+    fn validate_ws_origin_self_rule_bridges_a_portless_host_header() {
+        // `Host` omits the port on the scheme default, so the origin's scheme supplies it.
+        let headers = browser_headers("https://192.168.1.161", "192.168.1.161");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_ok());
+    }
+
+    #[test]
+    fn validate_ws_origin_self_rule_requires_the_same_port() {
+        let headers = browser_headers("http://192.168.1.161:4545", "192.168.1.161:9999");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_err());
+    }
+
+    #[test]
+    fn validate_ws_origin_rebound_hostname_rejected_unless_explicitly_allowed() {
+        // The DNS-rebinding case, and the reason the implicit allow is restricted to
+        // IP literals. The attacker serves a page from a name they own, rebinds that
+        // name to this daemon's address, and the browser then sends matching `Host`
+        // and `Origin` with nothing forged. Equality here is not evidence that this
+        // daemon served the page, so it must not open the socket.
+        let headers = browser_headers("http://attacker.example:4545", "attacker.example:4545");
+        assert!(
+            validate_ws_origin(&headers, Some(4545), &[], false).is_err(),
+            "matching Host and Origin on a hostname must not imply same-origin"
+        );
+
+        // The escape hatch for a legitimate hostname deployment: list it.
+        assert!(validate_ws_origin(
+            &headers,
+            Some(4545),
+            &["http://attacker.example:4545".to_string()],
+            false,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_ws_origin_tls_proxy_hostname_requires_explicit_cors_origin() {
+        // A dashboard behind a TLS terminator is a hostname deployment and is not
+        // covered by the self rule, however exactly `Host` and `Origin` agree.
+        // Nothing distinguishes it from the rebinding case above at this layer, so
+        // the operator names the origin instead.
+        let headers = browser_headers("https://dash.example.com", "dash.example.com");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_err());
+        assert!(validate_ws_origin(
+            &headers,
+            Some(4545),
+            &["https://dash.example.com".to_string()],
+            false,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_ws_origin_cross_site_origin_carrying_our_host_rejected() {
+        // The #3731 guard: a cross-site page reaching this daemon sends its own
+        // Origin next to our Host, so the two differ and the self rule declines.
+        let headers = browser_headers("http://evil.example", "192.168.1.161:4545");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_err());
+    }
+
+    #[test]
+    fn validate_ws_origin_self_rule_ignores_x_forwarded_host() {
+        // `X-Forwarded-Host` is attacker-controlled unless the peer is a verified
+        // proxy, and this function has no view of the peer.
+        let mut headers = browser_headers("http://192.168.1.161:4545", "10.0.0.7:4545");
+        headers.insert("x-forwarded-host", "192.168.1.161:4545".parse().unwrap());
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_err());
+    }
+
+    #[test]
+    fn validate_ws_origin_self_rule_ignores_a_malformed_host_header() {
+        let headers = browser_headers("http://192.168.1.161:4545", "not a host::");
+        assert!(validate_ws_origin(&headers, Some(4545), &[], false).is_err());
     }
 
     #[test]

--- a/crates/librefang-api/tests/ws_origin_validation_test.rs
+++ b/crates/librefang-api/tests/ws_origin_validation_test.rs
@@ -1,0 +1,199 @@
+//! `Origin` validation on the agent-chat WebSocket upgrade (#7777).
+//!
+//! These run against a real axum router over a raw socket, because the rule
+//! under test reads two headers — `Origin` and `Host` — and only one of them is
+//! under a normal HTTP client's control. `Host` is set by the client library
+//! from the address it dialled, so a test that wants to say "the browser dialled
+//! 192.168.1.161:4545" while actually connecting to a loopback ephemeral port
+//! has to write the request bytes itself. That divergence is not an artifact of
+//! the test: it is exactly the shape of the real deployment, where the daemon
+//! binds `0.0.0.0` and the browser addresses one particular interface.
+//!
+//! Raw TCP also keeps `axum::extract::WebSocketUpgrade` happy — it answers 426
+//! before the handler body runs unless `Connection`, `Upgrade`,
+//! `Sec-WebSocket-Version` and `Sec-WebSocket-Key` are all intact, and a
+//! general-purpose client manages `Connection` itself.
+
+use axum::routing::get;
+use axum::Router;
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use std::net::SocketAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// The address the operator in #7777 reaches the dashboard on.
+const SERVER_HOST: &str = "192.168.1.161:4545";
+
+/// A syntactically invalid agent id, so a *passing* origin check lands on a
+/// status one step later with no agent fixture and no waiting.
+///
+/// `impl FromStr for AgentId` is `Uuid::parse_str` with no fallback, so this
+/// never reaches the existence lookup and returns 400 rather than 404. The
+/// discriminator every assertion below turns on is therefore 403 (origin
+/// refused) versus 400 (origin accepted, then the id rejected).
+const UNPARSEABLE_AGENT_ID: &str = "not-a-uuid";
+
+const ORIGIN_ACCEPTED: u16 = 400;
+const ORIGIN_REFUSED: u16 = 403;
+
+struct TestServer {
+    addr: SocketAddr,
+    state: std::sync::Arc<librefang_api::routes::AppState>,
+    _test: TestAppState,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.state.kernel.shutdown();
+    }
+}
+
+/// Boot a daemon with no auth configured and the given `cors_origin` list.
+///
+/// No credential is deliberate: it makes the loopback no-auth branch pass so
+/// every status below is the origin check's verdict and not an auth failure,
+/// and it is the shipped default the reporter was running.
+///
+/// `api_listen` is `0.0.0.0:4545` — the deployment from the issue. The socket
+/// still binds an ephemeral loopback port; `api_listen` only feeds the
+/// `listen_port` argument, which is what the loopback rule consults.
+async fn start(cors_origin: Vec<String>) -> TestServer {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(move |cfg| {
+        cfg.api_key = String::new();
+        cfg.api_key_hash = String::new();
+        cfg.api_listen = "0.0.0.0:4545".to_string();
+        cfg.cors_origin = cors_origin;
+    }));
+    let state = test.state.clone();
+    state.kernel.clone().set_self_handle();
+
+    let app = Router::new()
+        .route("/api/agents/{id}/ws", get(librefang_api::ws::agent_ws))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    TestServer {
+        addr,
+        state,
+        _test: test,
+    }
+}
+
+/// Perform a handshake with an explicit `Host` and `Origin`, return the status.
+async fn handshake(server: &TestServer, host: &str, origin: &str) -> u16 {
+    let mut stream = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect to test server");
+    let request = format!(
+        "GET /api/agents/{UNPARSEABLE_AGENT_ID}/ws HTTP/1.1\r\n\
+         Host: {host}\r\n\
+         Origin: {origin}\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write handshake");
+    let mut buf = [0u8; 256];
+    let read = stream.read(&mut buf).await.expect("read response");
+    let head = String::from_utf8_lossy(&buf[..read]);
+    let status_line = head.lines().next().unwrap_or_default().to_string();
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("no status code in response: {status_line:?}"))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn server_own_lan_origin_is_accepted_with_no_allowed_origins_configured() {
+    // The reported failure from #7777: the daemon refuses the dashboard it
+    // served. The browser fetched the page from this very address, so `Host`
+    // and `Origin` are the same IP literal and port.
+    let server = start(Vec::new()).await;
+    assert_eq!(
+        handshake(&server, SERVER_HOST, &format!("http://{SERVER_HOST}")).await,
+        ORIGIN_ACCEPTED,
+        "a dashboard served by this daemon over its own LAN address must not be \
+         rejected by it"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_rebound_hostname_with_matching_host_and_origin_is_rejected() {
+    // The reason the implicit allow is restricted to IP literals, exercised
+    // end-to-end rather than only at the unit boundary. An attacker who serves
+    // a page from a name they own and rebinds that name to this daemon's
+    // address produces matching `Host` and `Origin` with nothing forged, so
+    // equality alone cannot be allowed to open the socket.
+    let server = start(Vec::new()).await;
+    assert_eq!(
+        handshake(
+            &server,
+            "attacker.example:4545",
+            "http://attacker.example:4545"
+        )
+        .await,
+        ORIGIN_REFUSED,
+        "matching Host and Origin on a hostname is not evidence that this daemon \
+         served the page"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_hostname_deployment_is_accepted_once_its_origin_is_listed() {
+    // The supported path for hostname and TLS-proxy deployments, and the reason
+    // the rejection above is a narrowing rather than a removal of the feature.
+    let server = start(vec!["https://dash.example.com".to_string()]).await;
+    assert_eq!(
+        handshake(&server, "dash.example.com", "https://dash.example.com").await,
+        ORIGIN_ACCEPTED,
+        "cors_origin must remain the escape hatch for a hostname deployment"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_cross_site_origin_reaching_the_same_host_is_still_rejected() {
+    // The #3731 cross-site WebSocket hijacking guard: a page on another origin
+    // reaching this daemon sends its own `Origin` beside our `Host`.
+    let server = start(Vec::new()).await;
+    assert_eq!(
+        handshake(&server, SERVER_HOST, "http://evil.example").await,
+        ORIGIN_REFUSED
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_lan_origin_the_request_was_not_addressed_to_is_rejected() {
+    // The self rule compares against the address the browser actually dialled,
+    // so one LAN IP does not vouch for another.
+    let server = start(Vec::new()).await;
+    assert_eq!(
+        handshake(&server, "10.0.0.7:4545", &format!("http://{SERVER_HOST}")).await,
+        ORIGIN_REFUSED
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn loopback_origin_on_the_listen_port_is_still_accepted() {
+    // The pre-existing rule, unaffected by the self rule and reached before it.
+    let server = start(Vec::new()).await;
+    assert_eq!(
+        handshake(&server, "localhost:4545", "http://localhost:4545").await,
+        ORIGIN_ACCEPTED
+    );
+}

--- a/docs/src/app/operations/troubleshooting/page.mdx
+++ b/docs/src/app/operations/troubleshooting/page.mdx
@@ -440,15 +440,22 @@ curl -H "Authorization: Bearer your-api-key" http://127.0.0.1:4545/api/agents
 rate_limit_per_second = 20  # Increase if needed
 ```
 
-### CORS errors from browser
+### CORS errors from browser, or a 403 on the agent WebSocket
 
-**Cause**: Trying to access API from a different origin.
+**Cause**: Trying to access the API from an origin the daemon does not recognise.
 
-**Fix**: Add your origin to CORS config:
+**Fix**: Add your origin to `cors_origin`, which is a **top-level** key — not a member of `[api]`, and singular:
 ```toml
-[api]
-cors_origins = ["http://localhost:5173", "https://your-app.com"]
+cors_origin = ["http://localhost:5173", "https://your-app.com"]
 ```
+
+The same list governs the agent-chat WebSocket, which additionally accepts two origins without configuration: loopback on the listen port, and the literal IP address and port the request was itself addressed to (so a daemon on `0.0.0.0:4545` opened at `http://192.168.1.161:4545` serves its own dashboard).
+A daemon reached through a **hostname** — including anything behind a TLS-terminating proxy — has to be listed here, because a hostname that resolves to this address is not evidence that this daemon served the page.
+
+<Note>
+`allowed_origins` is a different setting: it belongs to `[terminal]` and feeds the terminal route only.
+Setting it under `[api]` does nothing at all, because `config.toml` has no `[api]` table.
+</Note>
 
 ### WebSocket disconnects
 

--- a/docs/src/app/zh/operations/troubleshooting/page.mdx
+++ b/docs/src/app/zh/operations/troubleshooting/page.mdx
@@ -440,15 +440,22 @@ curl -H "Authorization: Bearer your-api-key" http://127.0.0.1:4545/api/agents
 rate_limit_per_second = 20  # Increase if needed
 ```
 
-### 浏览器中出现 CORS 错误
+### 浏览器中出现 CORS 错误，或 Agent WebSocket 返回 403
 
-**原因**：尝试从不同的源访问 API。
+**原因**：尝试从守护进程无法识别的源访问 API。
 
-**解决方案**：在 CORS 配置中添加你的源：
+**解决方案**：将你的源添加到 `cors_origin`。该键位于**顶层**，不属于 `[api]`，且为单数形式：
 ```toml
-[api]
-cors_origins = ["http://localhost:5173", "https://your-app.com"]
+cors_origin = ["http://localhost:5173", "https://your-app.com"]
 ```
+
+同一份列表也适用于 Agent 聊天 WebSocket。无需配置即可放行的源只有两类：监听端口上的回环地址，以及请求本身所指向的**字面 IP 地址**和端口（因此绑定在 `0.0.0.0:4545` 的守护进程通过 `http://192.168.1.161:4545` 打开时，可以正常提供自己的仪表盘）。
+通过**主机名**访问的守护进程（包括位于 TLS 终结代理之后的部署）必须在此列出，因为“某个主机名解析到本机地址”并不能证明页面是由本守护进程提供的。
+
+<Note>
+`allowed_origins` 是另一个设置：它属于 `[terminal]`，仅作用于终端路由。
+把它写在 `[api]` 下不会有任何效果，因为 `config.toml` 中并不存在 `[api]` 这个表。
+</Note>
 
 ### WebSocket 断开连接
 


### PR DESCRIPTION
Implements the narrowing I asked for in my review of #7779, so the underlying defect stops waiting on that thread.

## Credit

The analysis and the original approach here are **@DaBlitzStein's**, in **#7779**.
That PR diagnosed #7777 correctly — the auto-allow covered only loopback, so a daemon serving its own dashboard over a LAN address rejected its own socket — and proposed the self-origin rule this PR ships, including the `Host`-vs-`Origin` port comparison and the default-port bridge for a portless `Host`, both of which are reused as designed.
I left a CHANGES_REQUESTED review on one point, every commit since has been a bare `Merge branch 'main'`, and the bug is a first-run breakage on every non-loopback deployment, so I am implementing the narrowed version directly rather than leaving it parked.

**Recommendation, not an action:** once this lands, #7779 can be closed as superseded. I have not closed, labelled, or commented on it, and I have not pushed to that branch — that call is the author's and the maintainer's.

## What the review asked for, and why

The one point of disagreement was the implicit allow accepting a matching **hostname**.
`Host` is not something the daemon asserts — it is derived from whatever URL the page dialled, and the page chooses that URL.
So matching `Host` and `Origin` on a hostname proves only that the page came from a name that *currently resolves* to this address, which is precisely what DNS rebinding arranges: an attacker serves a page from `attacker.example`, rebinds that name to the daemon's loopback or LAN address, and the browser then sends `Host: attacker.example:4545` beside `Origin: http://attacker.example:4545` with nothing forged.
Accepting that pair defeats the cross-site WebSocket hijacking guard from #3731.

An IP literal has no name in the middle to rebind: for the two sides to match, the page must have been served by whatever answers on that address and port, which — since the request arrived there — is this daemon.
That keeps the reported LAN case working at no cost to the guard.

This is a narrowing of the **proposed** behaviour, not of shipped behaviour: `main` today has no self-origin rule at all, so nothing an operator relies on gets stricter.

## Changes

- `crates/librefang-api/src/ws.rs` — new `origin_is_self`, consulted after the loopback rule.
  It takes the origin's `url::Host` (the caller already holds the parsed `Url`) rather than a `&str`, and requires **both** that value and the `Host`-header side to be `Host::Ipv4(_) | Host::Ipv6(_)` before comparing.
  Going through `url::Host` on both sides also means the comparison is on parsed addresses, so `[fd00::1]` and `[fd00:0:0:0:0:0:0:1]` match and no ad-hoc string normalisation is needed.
- Port comparison is against the request's own `Host`, not `listen_port`, so a port-mapped or externally-proxied deployment still works; the origin's scheme supplies the default port when `Host` omits one.
  The scheme itself is not compared, because `Host` carries none.
- `X-Forwarded-Host` is ignored — it is attacker-controlled unless the peer is a verified proxy, and this function has no view of the peer. Pinned by a test.
- Extracted `default_port_for_scheme` and used it for the three places in this function that inlined `if https { 443 } else { 80 }`.
- Rewrote the `validate_ws_origin` doc comment into the ordered rule list it actually implements, and documented the rebinding reasoning on `origin_is_self` itself.
- `docs/src/app/operations/troubleshooting/page.mdx` and its `zh` mirror — the documented remedy for this exact 403 said `[api] cors_origins`, which is the wrong table *and* the wrong key (`config.toml` has no `[api]` table; the key is the top-level singular `cors_origin`).
  Corrected, with the WebSocket's two unconfigured allowances stated and a note that `allowed_origins` is a different setting belonging to `[terminal]`.
  Fixed here rather than deferred because it is the workaround an operator hitting this PR's rejection path is sent to.

## Behaviour change worth calling out

A daemon reached through a **hostname**, including anything behind a TLS-terminating proxy, is not covered by the implicit allow and must list its public origin in `cors_origin`.
That is already the documented answer for the `X-Forwarded-Host` case, so it is the same rule rather than a new burden — but it is the deliberate difference from #7779, which would have accepted such an origin with nothing configured.

## Tests

The two existing unit tests that look like they cover this did not: `validate_ws_origin_lan_ip_same_port_rejected` and `validate_ws_origin_arbitrary_host_same_port_rejected` set only `origin`, so `origin_is_self` returns early at the `Host` guard before comparing anything, and a real browser always sends `Host`. Both now set it, via a new `browser_headers` helper.

- `validate_ws_origin_lan_ip_same_port_rejected` → `validate_ws_origin_lan_ip_addressed_to_a_different_host_rejected`. Renamed because its premise genuinely changes: a LAN IP whose `Host` matches is now *accepted*, which is the fix. It pins the cross-site shape (browser dialled `10.0.0.7`, page came from `192.168.1.5`) plus the no-`Host` fail-closed path.
- `validate_ws_origin_arbitrary_host_same_port_rejected` keeps its name and gets stronger: with a *matching* `Host` it is now the rebinding case, and still `Err`.

New unit tests in `ws::tests`: `validate_ws_origin_accepts_the_servers_own_lan_origin` (the reported case), `..._self_rule_matches_ipv6_literal_host`, `..._self_rule_holds_on_a_port_other_than_listen_port`, `..._self_rule_bridges_a_portless_host_header`, `..._self_rule_requires_the_same_port`, `..._rebound_hostname_rejected_unless_explicitly_allowed`, `..._tls_proxy_hostname_requires_explicit_cors_origin`, `..._cross_site_origin_carrying_our_host_rejected`, `..._self_rule_ignores_x_forwarded_host`, `..._self_rule_ignores_a_malformed_host_header`.

New `crates/librefang-api/tests/ws_origin_validation_test.rs` — 6 `#[tokio::test]`s against a real axum router, raw-socket handshakes so `Host` and `Origin` are both under the test's control (an HTTP client sets `Host` from the address it dialled, and the whole point is that those differ): `server_own_lan_origin_is_accepted_with_no_allowed_origins_configured`, `a_rebound_hostname_with_matching_host_and_origin_is_rejected`, `a_hostname_deployment_is_accepted_once_its_origin_is_listed`, `a_cross_site_origin_reaching_the_same_host_is_still_rejected`, `a_lan_origin_the_request_was_not_addressed_to_is_rejected`, `loopback_origin_on_the_listen_port_is_still_accepted`.

Both integration tests were confirmed load-bearing by negative control rather than by assumption:

- Forcing `origin_is_self` to `false` fails `server_own_lan_origin_is_accepted_with_no_allowed_origins_configured` with `left: 403, right: 400` — so it pins the fix.
- Removing the two `Host::Ipv4 | Host::Ipv6` guards (i.e. the behaviour as proposed) fails `a_rebound_hostname_with_matching_host_and_origin_is_rejected` with `left: 400, right: 403` — so it pins the narrowing, and reproduces the bypass end-to-end.

## Verification

```
cargo check -p librefang-api --lib                             clean
cargo test  -p librefang-api --lib                             1053 passed, 0 failed
cargo test  -p librefang-api --lib ws_origin                   31 passed
cargo test  -p librefang-api --test ws_origin_validation_test  6 passed
cargo fmt   -p librefang-api -- --check                        clean
python3 scripts/check-changelog-attribution.py                 OK
```

**Not run locally: `cargo clippy`.** The build host was down to 12 GiB free after the test runs and a clippy pass rebuilds the dependency graph under a separate fingerprint, so I stopped rather than risk filling the disk. Relying on CI for that gate.

## Scope — this does not close #7777

`Refs #7777` rather than `Closes`, deliberately. Of that issue's four "Expected" bullets:

- *Own origin accepted* — met for literal IPs, **deliberately declined for hostnames** per the reasoning above. The issue asks for it unconditionally; that is the one ask I am consciously not granting.
- *Concrete allow list still rejects everything outside it* — already true, and now pinned by tests.
- *`cors_origin = ["*"]` works on the WebSocket* — **not addressed here.** The agent-chat route still derives `allow_remote` from `LIBREFANG_ALLOW_NO_AUTH`, so a wildcard is still ignored on this route. #7779 fixes this; I left it out on purpose, because widening origin acceptance does not belong in the same PR as narrowing it, and it wants its own review.
- *Rejection names the effective list and its config key* — **not addressed here.** Also #7779's, and worth taking from there.

So #7777 should stay open after this merges. The two unaddressed bullets are the parts of #7779 I would like to see land on their own, and they are a straightforward lift from that branch.
