### PR TITLE
fix(registry): make a missing agent-templates directory loud

### DIFF
--- a/changelog.d/fixed/7851-registry-agents-dir-resolver.md
+++ b/changelog.d/fixed/7851-registry-agents-dir-resolver.md
@@ -1,0 +1,4 @@
+A registry checkout that arrives without an `agents/` directory no longer disables agent templates in silence.
+The three places that resolved that directory — the runtime's post-sync fan-out, the hands registry's `base = "<template>"` lookup, and the kernel router's hand scan — each open-coded its own existence check and skipped its entire block on a miss, so "the registry ships no templates" and "the sync produced a checkout this code cannot read" were indistinguishable from outside the process, and the 24h cache TTL kept the degraded state around.
+All three now share one resolver that logs at error level the first time a registry root fails to resolve, naming the path it tried, and reports again if the directory comes back and disappears a second time.
+(#7851) (@houko)

--- a/crates/librefang-hands/src/registry.rs
+++ b/crates/librefang-hands/src/registry.rs
@@ -87,14 +87,10 @@ struct HandTomlWrapper {
 }
 
 /// Resolve the agents registry directory from a home directory.
-/// Returns `Some(path)` if `{home_dir}/registry/agents/` exists and is a directory.
+///
+/// Delegates to [`librefang_types::registry_paths::resolve_agent_templates_dir`] so this lookup cannot drift from the runtime's fan-out and the kernel router's hand scan, and so a missing directory is reported at error level in one place rather than dropping `base = "<template>"` resolution silently (#7767).
 fn resolve_agents_dir(home_dir: &Path) -> Option<std::path::PathBuf> {
-    let dir = home_dir.join("registry").join("agents");
-    if dir.is_dir() {
-        Some(dir)
-    } else {
-        None
-    }
+    librefang_types::registry_paths::resolve_agent_templates_dir(&home_dir.join("registry"))
 }
 
 /// Parse a HAND.toml into a HandDefinition with its skill content attached.
@@ -1836,6 +1832,32 @@ fn check_option_available(provider_env: Option<&str>, binary: Option<&str>) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Hand `base = "<template>"` resolution must read the agent-templates directory through the shared resolver, so the missing-directory case is reported once at error level instead of silently failing the flat parse path (#7767).
+    #[test]
+    fn resolve_agents_dir_delegates_to_the_shared_resolver() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home_dir = tmp.path();
+        let registry_root = home_dir.join("registry");
+        std::fs::create_dir_all(registry_root.join("hands")).unwrap();
+
+        assert_eq!(resolve_agents_dir(home_dir), None);
+        assert_eq!(
+            resolve_agents_dir(home_dir),
+            librefang_types::registry_paths::resolve_agent_templates_dir(&registry_root),
+        );
+
+        std::fs::create_dir_all(registry_root.join("agents")).unwrap();
+
+        assert_eq!(
+            resolve_agents_dir(home_dir),
+            Some(registry_root.join("agents"))
+        );
+        assert_eq!(
+            resolve_agents_dir(home_dir),
+            librefang_types::registry_paths::resolve_agent_templates_dir(&registry_root),
+        );
+    }
 
     #[test]
     fn poisoned_activation_lock_recovers_and_activation_remains_usable() {

--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -247,6 +247,13 @@ fn build_hand_route_candidates(home_dir: Option<&Path>) -> Vec<HandRouteCandidat
     candidates
 }
 
+/// Resolve the registry's agent-templates directory for hand `base` resolution.
+///
+/// Delegates to [`librefang_types::registry_paths::resolve_agent_templates_dir`], the single resolver shared with the runtime's fan-out and the hands registry, so a missing directory is reported once at error level instead of quietly dropping every `base = "<template>"` hand out of routing (#7767).
+fn registry_agents_dir(home_dir: &Path) -> Option<PathBuf> {
+    librefang_types::registry_paths::resolve_agent_templates_dir(&home_dir.join("registry"))
+}
+
 fn load_hand_route_candidates(home_dir: &Path) -> Vec<HandRouteCandidate> {
     let mut seen = std::collections::HashSet::new();
     let mut candidates = Vec::new();
@@ -264,12 +271,8 @@ fn load_hand_route_candidates(home_dir: &Path) -> Vec<HandRouteCandidate> {
     // "requires agents registry directory" and emits a WARN on every
     // routing scan — and routing happens on every inbound message dispatch,
     // so the warning floods the log.
-    let agents_dir = home_dir.join("registry").join("agents");
-    let agents_dir_arg: Option<&Path> = if agents_dir.is_dir() {
-        Some(agents_dir.as_path())
-    } else {
-        None
-    };
+    let agents_dir = registry_agents_dir(home_dir);
+    let agents_dir_arg: Option<&Path> = agents_dir.as_deref();
 
     for hands_dir in &dirs {
         let Ok(entries) = fs::read_dir(hands_dir) else {
@@ -1171,6 +1174,32 @@ fn dedupe(values: Vec<String>) -> Vec<String> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// Routing must resolve the agent-templates directory through the shared resolver so it cannot drift from the runtime fan-out and the hands registry, and so its absence is reported rather than dropping every `base = "<template>"` hand from routing in silence (#7767).
+    #[test]
+    fn registry_agents_dir_delegates_to_the_shared_resolver() {
+        let tmp = tempdir().unwrap();
+        let home_dir = tmp.path();
+        let registry_root = home_dir.join("registry");
+        std::fs::create_dir_all(registry_root.join("hands")).unwrap();
+
+        assert_eq!(registry_agents_dir(home_dir), None);
+        assert_eq!(
+            registry_agents_dir(home_dir),
+            librefang_types::registry_paths::resolve_agent_templates_dir(&registry_root),
+        );
+
+        std::fs::create_dir_all(registry_root.join("agents")).unwrap();
+
+        assert_eq!(
+            registry_agents_dir(home_dir),
+            Some(registry_root.join("agents"))
+        );
+        assert_eq!(
+            registry_agents_dir(home_dir),
+            librefang_types::registry_paths::resolve_agent_templates_dir(&registry_root),
+        );
+    }
 
     #[test]
     fn poisoned_router_state_lock_recovers_and_remains_usable() {

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -238,9 +238,11 @@ fn fanout_registry_content(home_dir: &Path, registry_cache: &Path) {
         }
     }
 
-    // Pre-install agent templates from registry (e.g. hello-world)
-    let agents_src = registry_cache.join("agents");
-    if agents_src.exists() {
+    // Pre-install agent templates from registry (e.g. hello-world).
+    // The lookup goes through the shared resolver so a checkout without the directory is reported at error level rather than skipping this whole block in silence (#7767).
+    if let Some(agents_src) =
+        librefang_types::registry_paths::resolve_agent_templates_dir(registry_cache)
+    {
         let agents_dest = home_dir.join("workspaces").join("agents");
         if let Ok(entries) = std::fs::read_dir(&agents_src) {
             for entry in entries.flatten() {
@@ -894,6 +896,56 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The fan-out must reach the agent-template pre-install through the shared resolver, not its own `join("agents")`, so a missing directory is reported once rather than skipping the block in silence (#7767).
+    #[test]
+    fn fanout_agent_templates_goes_through_the_shared_resolver() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home_dir = tmp.path().join("home");
+        let registry_cache = home_dir.join("registry");
+        let template_src = registry_cache.join("agents").join("hello-world");
+        std::fs::create_dir_all(&template_src).unwrap();
+        std::fs::write(template_src.join("agent.toml"), "name = \"hello-world\"\n").unwrap();
+
+        assert_eq!(
+            librefang_types::registry_paths::resolve_agent_templates_dir(&registry_cache),
+            Some(registry_cache.join("agents")),
+            "the shared resolver is what the fan-out reads",
+        );
+
+        fanout_registry_content(&home_dir, &registry_cache);
+
+        assert!(
+            home_dir
+                .join("workspaces")
+                .join("agents")
+                .join("hello-world")
+                .join("agent.toml")
+                .exists(),
+            "a resolved agents directory pre-installs its templates",
+        );
+    }
+
+    #[test]
+    fn fanout_agent_templates_is_a_noop_when_the_agents_dir_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home_dir = tmp.path().join("home");
+        let registry_cache = home_dir.join("registry");
+        std::fs::create_dir_all(registry_cache.join("workflows")).unwrap();
+
+        assert_eq!(
+            librefang_types::registry_paths::resolve_agent_templates_dir(&registry_cache),
+            None,
+            "a checkout without `agents/` resolves to nothing, and the resolver reports it",
+        );
+
+        fanout_registry_content(&home_dir, &registry_cache);
+
+        assert!(
+            !home_dir.join("workspaces").join("agents").exists(),
+            "nothing is pre-installed when the directory cannot be resolved",
+        );
+    }
 
     #[test]
     fn poisoned_registry_sync_lock_recovers_and_remains_exclusive() {

--- a/crates/librefang-types/src/lib.rs
+++ b/crates/librefang-types/src/lib.rs
@@ -26,6 +26,7 @@ pub mod memory;
 pub mod message;
 pub mod model_catalog;
 pub mod oauth;
+pub mod registry_paths;
 pub mod registry_schema;
 pub mod scheduler;
 pub mod serde_compat;

--- a/crates/librefang-types/src/registry_paths.rs
+++ b/crates/librefang-types/src/registry_paths.rs
@@ -1,0 +1,141 @@
+//! Shared resolution of paths inside a registry checkout.
+//!
+//! The registry's agent-templates directory is read from three places — the runtime's post-sync fan-out, the hands registry's `base = "<template>"` resolution, and the kernel router's hand scan.
+//! Each used to open-code `join("agents")` plus an existence check and skip its whole block on a miss, so a checkout that arrived without the directory disabled agent templates with no error, no log, and no way to tell that state apart from "the registry ships no templates" (#7767).
+//! Routing all three through one resolver keeps them from drifting apart again and gives the miss a single place to be loud.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Directory name the registry checkout uses for agent templates.
+pub const AGENT_TEMPLATES_DIR_NAME: &str = "agents";
+
+/// Missing agent-template directories already reported at error level.
+///
+/// The router resolves this directory on every inbound message dispatch, so an unconditional log would flood rather than inform.
+/// Reporting is edge-triggered instead: a path is logged when it first fails to resolve and becomes eligible again only after it has resolved successfully, so a genuine recovery-then-regression is still reported.
+static REPORTED_MISSING: Mutex<BTreeSet<PathBuf>> = Mutex::new(BTreeSet::new());
+
+/// Resolve `<registry_root>/agents`, the directory holding the registry's agent templates.
+///
+/// `registry_root` is the registry checkout itself (`$LIBREFANG_HOME/registry`), not the LibreFang home directory.
+/// Returns `None` when the directory does not exist or is not a directory, logging at error level the first time a given path misses — callers treat the miss as "no agent templates", which is a degraded state an operator has to be able to see.
+pub fn resolve_agent_templates_dir(registry_root: &Path) -> Option<PathBuf> {
+    let dir = registry_root.join(AGENT_TEMPLATES_DIR_NAME);
+    if dir.is_dir() {
+        clear_missing_report(&dir);
+        return Some(dir);
+    }
+    report_missing(&dir);
+    None
+}
+
+/// Record a miss and log it if this path was not already known to be missing.
+///
+/// Returns whether the miss was reported, which is what the unit tests below assert on: the set membership is the record that the error line was emitted.
+fn report_missing(dir: &Path) -> bool {
+    let newly_missing = match REPORTED_MISSING.lock() {
+        Ok(mut reported) => reported.insert(dir.to_path_buf()),
+        // A poisoned lock means another thread panicked mid-report; logging again is strictly better than staying silent about a degraded registry.
+        Err(poisoned) => poisoned.into_inner().insert(dir.to_path_buf()),
+    };
+    if newly_missing {
+        tracing::error!(
+            path = %dir.display(),
+            "Registry checkout has no agent-templates directory — agent templates will not be pre-installed and hands declaring `base = \"<template>\"` will not resolve. Re-run `librefang init` to re-sync the registry.",
+        );
+    }
+    newly_missing
+}
+
+/// Forget a previously reported miss so a later regression is reported again.
+fn clear_missing_report(dir: &Path) {
+    match REPORTED_MISSING.lock() {
+        Ok(mut reported) => reported.remove(dir),
+        Err(poisoned) => poisoned.into_inner().remove(dir),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Whether `dir` is currently recorded as a reported miss.
+    ///
+    /// Reaching into the private static is deliberate: it is the same condition that gates the `tracing::error!` call, so asserting on it asserts the error-level signal fired without pulling a subscriber into this crate's dependency tree.
+    fn was_reported(dir: &Path) -> bool {
+        match REPORTED_MISSING.lock() {
+            Ok(reported) => reported.contains(dir),
+            Err(poisoned) => poisoned.into_inner().contains(dir),
+        }
+    }
+
+    #[test]
+    fn missing_agents_dir_returns_none_and_reports_at_error_level() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let expected = root.join("agents");
+
+        assert_eq!(resolve_agent_templates_dir(root), None);
+        assert!(
+            was_reported(&expected),
+            "a missing agent-templates directory must produce the error-level signal",
+        );
+    }
+
+    #[test]
+    fn repeated_misses_report_once_until_the_directory_comes_back() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let dir = root.join("agents");
+
+        assert!(report_missing(&dir), "the first miss is reported");
+        assert!(
+            !report_missing(&dir),
+            "a repeated miss is not reported again"
+        );
+
+        std::fs::create_dir_all(&dir).expect("create agents dir");
+        assert_eq!(resolve_agent_templates_dir(root), Some(dir.clone()));
+        assert!(
+            !was_reported(&dir),
+            "a successful resolution clears the reported miss",
+        );
+
+        std::fs::remove_dir_all(&dir).expect("remove agents dir");
+        assert_eq!(resolve_agent_templates_dir(root), None);
+        assert!(
+            was_reported(&dir),
+            "a regression after a recovery is reported again",
+        );
+    }
+
+    #[test]
+    fn present_agents_dir_resolves_without_reporting() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let dir = root.join("agents");
+        std::fs::create_dir_all(&dir).expect("create agents dir");
+
+        assert_eq!(resolve_agent_templates_dir(root), Some(dir.clone()));
+        assert!(
+            !was_reported(&dir),
+            "the normal case must not emit an error line",
+        );
+    }
+
+    #[test]
+    fn a_file_named_agents_is_treated_as_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let dir = root.join("agents");
+        std::fs::write(&dir, b"not a directory").expect("write agents file");
+
+        assert_eq!(resolve_agent_templates_dir(root), None);
+        assert!(
+            was_reported(&dir),
+            "a non-directory at the expected path is a miss, not a resolution",
+        );
+    }
+}


### PR DESCRIPTION
Closes #7767

## Credit

The analysis and the original approach here are @DaBlitzStein's, in #7768.
They filed the issue, traced all three call sites, and proposed the shared-resolver-plus-loud-log shape that this PR implements — that half of #7768 was never in dispute and I said so in my review.

This exists only because that review stalled: every commit #7768 has taken since the review is a `Merge branch 'main'`, and the silent-failure mode is worth closing rather than leaving open indefinitely.
I wrote the narrowed change myself rather than reusing the diff, so the deleted parts stay deleted, but the design is theirs.
Once this lands, #7768 can be closed as superseded — that is a recommendation for its author, not something I am doing.

## The problem

Three call sites resolved the registry's agent-templates directory, each with its own `join("agents")` plus an existence check, and each skipped its entire block on a miss with no log:

- `crates/librefang-runtime/src/registry_sync.rs` — `fanout_registry_content` had `if agents_src.exists() { … }` with no `else`, so the agent-template pre-install was skipped without a word.
- `crates/librefang-hands/src/registry.rs` — `resolve_agents_dir` returned `None` with no log.
- `crates/librefang-kernel-router/src/lib.rs` — `load_hand_route_candidates` set `agents_dir_arg = None` with no log.

"The registry ships no agent templates" and "the sync produced a checkout this code cannot read" were therefore indistinguishable from outside the process, and the checkout refreshes on a 24h TTL (`DEFAULT_CACHE_TTL_SECS`), so the degraded state persisted.
A fresh install ended up with no `hello-world`, and hands declaring `base = "<template>"` dropped out of routing — the latter surfacing only as a downstream per-hand parse warning that named the hand rather than the missing directory.

All three call sites were re-verified against `origin/main` at `c6db453d9` before the change.

## Changes

- New `librefang_types::registry_paths::resolve_agent_templates_dir(registry_root)`, the single resolver, returning `Option<PathBuf>` over `<registry_root>/agents`.
- The three call sites delegate to it. In the router the delegation goes through a named `registry_agents_dir(home_dir)` so it has something to test against; in the hands registry the existing private `resolve_agents_dir` becomes a one-line delegate; in the runtime the `exists()` check becomes the resolver's `is_dir()` check, which also stops a *file* named `agents` from entering the block and failing at `read_dir` instead.
- A miss logs at `tracing::error!` naming the path that was tried.

## Reporting is edge-triggered, not per-call

`load_hand_route_candidates` resolves this directory on **every inbound message dispatch** — the comment right above the old code says so, because a previous fix was needed for exactly that flooding shape.
An unconditional `error!` there would reintroduce it and teach operators to filter the line out.

So the resolver keeps a set of paths already reported and logs only on the transition into the missing state; a successful resolution clears the entry, so a genuine recovery-then-regression is reported again.
In daemon terms that is one error line per registry root per boot, plus one more if the directory disappears after coming back.

## Not included, deliberately

The `agent-types/` half of #7768 is left out, for the reason in my review on that PR: as written the preference returns early on `agent-types/` and makes `agents/` unreachable whenever `agent-types/` exists at all, even empty, so an interrupted sync or a stale-cache overlap would drop every `agents/`-only template at once.
There is no announced rename upstream, and a real dual layout needs merge semantics plus a regression with *unique* templates in each directory, not a preference.
For the same reason there is no new `agent-types/` fixture content and no change to the pinned registry fixture's README.

## On asserting the log without a new dependency

No `tracing-subscriber` dev-dependency is added.
The `tracing::error!` call is gated on the same `REPORTED_MISSING` insertion the tests assert against, and those tests live in the module itself, so they read the private static directly instead of capturing output through a subscriber.
That keeps `librefang-types`' dependency set unchanged while still asserting that the error path — not merely the `None` return — was taken.

## Verification

Commands run, with actual results:

- `cargo test -p librefang-types --lib registry_paths` — 4 passed: `missing_agents_dir_returns_none_and_reports_at_error_level`, `repeated_misses_report_once_until_the_directory_comes_back`, `present_agents_dir_resolves_without_reporting`, `a_file_named_agents_is_treated_as_missing`.
- `cargo test -p librefang-runtime --lib registry_sync::tests::fanout` — 2 passed: `fanout_agent_templates_goes_through_the_shared_resolver`, `fanout_agent_templates_is_a_noop_when_the_agents_dir_is_missing`.
- `cargo test -p librefang-hands --lib resolve_agents_dir` — 1 passed: `resolve_agents_dir_delegates_to_the_shared_resolver`.
- `cargo test -p librefang-kernel-router --lib registry_agents_dir` — 1 passed: `registry_agents_dir_delegates_to_the_shared_resolver`.
- `cargo clippy -- -D warnings`, clean, for `-p librefang-types --lib --tests`, `-p librefang-hands --lib --tests`, `-p librefang-runtime --lib`, `-p librefang-kernel-router --lib --tests`.
- `cargo fmt` run over the four crates.

Not run locally: `cargo clippy -p librefang-runtime --tests` and the workspace-wide lanes.
The build host hit its disk-space floor after the runs above, so those are left to CI rather than reported as passing.
No route or dashboard surface changes, so no `librefang-api` integration test applies.
