### PR TITLE
fix(channels): scope /think to its conversation and make it execute

### DIFF
--- a/changelog.d/fixed/7140-think-conversation-scope.md
+++ b/changelog.d/fixed/7140-think-conversation-scope.md
@@ -1,4 +1,4 @@
 Channel `/think` now takes effect, and takes effect only where it was typed.
 It previously stored a preference nothing ever read, so the next turn ran exactly as before while the reply said the setting had been applied; the toggle now rides the turn as a per-call thinking override on the streaming, non-streaming and image send paths.
 The preference is keyed by the conversation — channel, bot account, chat, agent — rather than by the agent alone, so one Telegram group turning extended thinking on no longer changes the reasoning mode, and the token bill, of every other chat the same agent serves.
-An unrecognised argument such as `/think of` is rejected instead of being read as "off" (#PR) (@houko)
+An unrecognised argument such as `/think of` is rejected instead of being read as "off" (#7854) (@houko)

--- a/changelog.d/fixed/7140-think-conversation-scope.md
+++ b/changelog.d/fixed/7140-think-conversation-scope.md
@@ -1,0 +1,4 @@
+Channel `/think` now takes effect, and takes effect only where it was typed.
+It previously stored a preference nothing ever read, so the next turn ran exactly as before while the reply said the setting had been applied; the toggle now rides the turn as a per-call thinking override on the streaming, non-streaming and image send paths.
+The preference is keyed by the conversation — channel, bot account, chat, agent — rather than by the agent alone, so one Telegram group turning extended thinking on no longer changes the reasoning mode, and the token bill, of every other chat the same agent serves.
+An unrecognised argument such as `/think of` is rejected instead of being read as "off" (#PR) (@houko)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -623,23 +623,16 @@ pub struct KernelBridgeAdapter {
     started_at: Instant,
     /// `/think` preference per `(agent, conversation)` (#7140).
     ///
-    /// Keyed by the conversation the command was typed in, never by the agent
-    /// alone: one agent routinely serves many chats, so an agent-keyed
-    /// preference would push one user's reasoning mode — and its token cost —
-    /// onto everybody else's turns.
+    /// Keyed by the conversation the command was typed in, never by the agent alone: one agent routinely serves many chats, so an agent-keyed preference would push one user's reasoning mode — and its token cost — onto everybody else's turns.
     ///
-    /// Deliberately in-memory. A `/think` toggle is a per-chat convenience,
-    /// not durable configuration; after a daemon restart every conversation
-    /// falls back to the agent's `[thinking]` manifest / global default, which
-    /// is the same state a chat starts in.
+    /// Deliberately in-memory. A `/think` toggle is a per-chat convenience, not durable configuration; after a daemon restart every conversation falls back to the agent's `[thinking]` manifest / global default, which is the same state a chat starts in.
     thinking_prefs: dashmap::DashMap<(AgentId, ConversationScope), bool>,
 }
 
 impl KernelBridgeAdapter {
     /// Build an adapter over `kernel` with an empty preference store.
     ///
-    /// Every construction site goes through this rather than a struct literal
-    /// so adding per-adapter state cannot leave one call site behind.
+    /// Every construction site goes through this rather than a struct literal so adding per-adapter state cannot leave one call site behind.
     pub fn new(kernel: Arc<dyn KernelApi>) -> Self {
         Self {
             kernel,
@@ -650,22 +643,15 @@ impl KernelBridgeAdapter {
 
     /// The per-turn thinking override to apply to a message from `sender`.
     ///
-    /// `None` — no `/think` was issued in this conversation, so the agent
-    /// manifest / global `[thinking]` default stands untouched. This is the
-    /// read half of `set_thinking`; both sides derive the key the same way, so
-    /// a preference set in one chat is invisible to every other chat and to
-    /// every other agent.
+    /// `None` — no `/think` was issued in this conversation, so the agent manifest / global `[thinking]` default stands untouched. This is the read half of `set_thinking`; both sides derive the key the same way, so a preference set in one chat is invisible to every other chat and to every other agent.
     fn thinking_override_for(&self, agent_id: AgentId, sender: &SenderContext) -> Option<bool> {
         let scope = ConversationScope::from_sender(sender);
         self.thinking_prefs.get(&(agent_id, scope)).map(|v| *v)
     }
 
-    /// `true` only when the catalog positively reports that this agent's
-    /// configured model has no extended-thinking mode.
+    /// `true` only when the catalog positively reports that this agent's configured model has no extended-thinking mode.
     ///
-    /// An agent left on the empty / `"default"` model, or on an id the catalog
-    /// does not carry, returns `false`: the honest answer there is silence,
-    /// not a guess in either direction.
+    /// An agent left on the empty / `"default"` model, or on an id the catalog does not carry, returns `false`: the honest answer there is silence, not a guess in either direction.
     fn model_rejects_thinking(&self, agent_id: AgentId) -> bool {
         let Some(entry) = self.kernel.agent_registry().get(agent_id) else {
             return false;
@@ -3437,8 +3423,7 @@ mod tests {
         );
     }
 
-    /// A `SenderContext` for one conversation, shaped the way
-    /// `build_sender_context` shapes it on the message path.
+    /// A `SenderContext` for one conversation, shaped the way `build_sender_context` shapes it on the message path.
     fn sender_in(account: Option<&str>, chat: &str) -> SenderContext {
         SenderContext {
             channel: "telegram".to_string(),
@@ -3449,12 +3434,7 @@ mod tests {
         }
     }
 
-    /// Injection-site guard for #7140. `/think` promises the user a per-chat
-    /// setting, and `KernelBridgeAdapter` is where that promise is kept: the
-    /// store is written by `set_thinking` and read by every send path. Keying
-    /// it by `agent_id` alone compiles, passes every command-path test, and
-    /// silently pushes one chat's reasoning mode (and token bill) onto every
-    /// other chat the agent serves — the same shape as the #7605 memory leak.
+    /// Injection-site guard for #7140. `/think` promises the user a per-chat setting, and `KernelBridgeAdapter` is where that promise is kept: the store is written by `set_thinking` and read by every send path. Keying it by `agent_id` alone compiles, passes every command-path test, and silently pushes one chat's reasoning mode (and token bill) onto every other chat the agent serves — the same shape as the #7605 memory leak.
     #[tokio::test(flavor = "multi_thread")]
     async fn think_preference_is_isolated_per_conversation() {
         use librefang_testing::MockKernelBuilder;
@@ -3522,10 +3502,7 @@ mod tests {
         );
     }
 
-    /// The command path builds the scope from `session_scope` parts, the
-    /// message path from a `SenderContext`. If the two ever disagree, a
-    /// `/think` write lands under a key no send path will ever read, and the
-    /// command goes back to acking without acting.
+    /// The command path builds the scope from `session_scope` parts, the message path from a `SenderContext`. If the two ever disagree, a `/think` write lands under a key no send path will ever read, and the command goes back to acking without acting.
     #[test]
     fn conversation_scope_agrees_across_the_command_and_message_paths() {
         assert_eq!(

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -7,7 +7,7 @@ use crate::workflow::{StepAgent, WorkflowId};
 use librefang_channels::bridge::{BridgeManager, ChannelBridgeHandle};
 use librefang_channels::router::AgentRouter;
 use librefang_channels::sidecar::SidecarAdapter;
-use librefang_channels::types::{ChannelAdapter, SenderContext};
+use librefang_channels::types::{ChannelAdapter, ConversationScope, SenderContext};
 
 fn is_safe_manifest_name(name: &str) -> bool {
     if name.contains(['/', '\\']) {
@@ -621,6 +621,65 @@ where
 pub struct KernelBridgeAdapter {
     kernel: Arc<dyn KernelApi>,
     started_at: Instant,
+    /// `/think` preference per `(agent, conversation)` (#7140).
+    ///
+    /// Keyed by the conversation the command was typed in, never by the agent
+    /// alone: one agent routinely serves many chats, so an agent-keyed
+    /// preference would push one user's reasoning mode — and its token cost —
+    /// onto everybody else's turns.
+    ///
+    /// Deliberately in-memory. A `/think` toggle is a per-chat convenience,
+    /// not durable configuration; after a daemon restart every conversation
+    /// falls back to the agent's `[thinking]` manifest / global default, which
+    /// is the same state a chat starts in.
+    thinking_prefs: dashmap::DashMap<(AgentId, ConversationScope), bool>,
+}
+
+impl KernelBridgeAdapter {
+    /// Build an adapter over `kernel` with an empty preference store.
+    ///
+    /// Every construction site goes through this rather than a struct literal
+    /// so adding per-adapter state cannot leave one call site behind.
+    pub fn new(kernel: Arc<dyn KernelApi>) -> Self {
+        Self {
+            kernel,
+            started_at: Instant::now(),
+            thinking_prefs: dashmap::DashMap::new(),
+        }
+    }
+
+    /// The per-turn thinking override to apply to a message from `sender`.
+    ///
+    /// `None` — no `/think` was issued in this conversation, so the agent
+    /// manifest / global `[thinking]` default stands untouched. This is the
+    /// read half of `set_thinking`; both sides derive the key the same way, so
+    /// a preference set in one chat is invisible to every other chat and to
+    /// every other agent.
+    fn thinking_override_for(&self, agent_id: AgentId, sender: &SenderContext) -> Option<bool> {
+        let scope = ConversationScope::from_sender(sender);
+        self.thinking_prefs.get(&(agent_id, scope)).map(|v| *v)
+    }
+
+    /// `true` only when the catalog positively reports that this agent's
+    /// configured model has no extended-thinking mode.
+    ///
+    /// An agent left on the empty / `"default"` model, or on an id the catalog
+    /// does not carry, returns `false`: the honest answer there is silence,
+    /// not a guess in either direction.
+    fn model_rejects_thinking(&self, agent_id: AgentId) -> bool {
+        let Some(entry) = self.kernel.agent_registry().get(agent_id) else {
+            return false;
+        };
+        let model = entry.manifest.model.model.as_str();
+        if model.is_empty() || model == "default" {
+            return false;
+        }
+        let catalog = self.kernel.model_catalog_ref().load();
+        catalog
+            .find_model_for_manifest(entry.manifest.model.provider.as_str(), model)
+            .map(|m| !catalog.effective_capabilities(m).supports_thinking)
+            .unwrap_or(false)
+    }
 }
 
 /// Compose the message returned to a channel user when `/approve <id>`
@@ -800,14 +859,17 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .map(|e| e.manifest.show_progress)
             .unwrap_or(true);
         let language = self.kernel.config_snapshot().language.clone();
+        let thinking = self.thinking_override_for(agent_id, sender);
         let (event_rx, kernel_handle) = self
             .kernel
             .clone()
-            .send_message_streaming_with_sender_context_and_routing(
+            .send_message_streaming_with_sender_context_routing_thinking_and_session(
                 agent_id,
                 message,
                 None,
                 sender.clone(),
+                thinking,
+                None,
             )
             .await
             .map_err(|e| format!("{e}"))?;
@@ -839,14 +901,17 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .map(|e| e.manifest.show_progress)
             .unwrap_or(true);
         let language = self.kernel.config_snapshot().language.clone();
+        let thinking = self.thinking_override_for(agent_id, sender);
         let (event_rx, kernel_handle) = self
             .kernel
             .clone()
-            .send_message_streaming_with_sender_context_and_routing(
+            .send_message_streaming_with_sender_context_routing_thinking_and_session(
                 agent_id,
                 message,
                 None,
                 sender.clone(),
+                thinking,
+                None,
             )
             .await
             .map_err(|e| format!("{e}"))?;
@@ -867,7 +932,12 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
     ) -> Result<String, String> {
         let result = self
             .kernel
-            .send_message_with_sender_context(agent_id, message, sender.clone())
+            .send_message_with_sender_context(
+                agent_id,
+                message,
+                sender.clone(),
+                self.thinking_override_for(agent_id, sender),
+            )
             .await
             .map_err(|e| format!("{e}"))?;
         if result.silent {
@@ -898,7 +968,13 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         };
         let result = self
             .kernel
-            .send_message_with_blocks_and_sender(agent_id, &text, blocks, sender.clone())
+            .send_message_with_blocks_and_sender(
+                agent_id,
+                &text,
+                blocks,
+                sender.clone(),
+                self.thinking_override_for(agent_id, sender),
+            )
             .await
             .map_err(|e| format!("{e}"))?;
         if result.silent {
@@ -1918,12 +1994,24 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         Ok(msg)
     }
 
-    async fn set_thinking(&self, _agent_id: AgentId, on: bool) -> Result<String, String> {
-        // Future-ready: stores preference but doesn't affect model behavior yet
+    async fn set_thinking(
+        &self,
+        agent_id: AgentId,
+        on: bool,
+        scope: &ConversationScope,
+    ) -> Result<String, String> {
+        self.thinking_prefs.insert((agent_id, scope.clone()), on);
         let state = if on { "enabled" } else { "disabled" };
-        Ok(format!(
-            "Extended thinking {state}. (This will take effect when supported by the model.)"
-        ))
+        let mut msg =
+            format!("Extended thinking {state} for this chat. Other chats are unaffected.");
+        // Only warn when the catalog positively knows this model cannot think.
+        // An unset / "default" / unrecognised model resolves to no entry, and
+        // guessing there would produce exactly the false statement this
+        // command is being fixed for.
+        if on && self.model_rejects_thinking(agent_id) {
+            msg.push_str("\nNote: this agent's model has no extended-thinking mode, so turns will run as usual until you switch models.");
+        }
+        Ok(msg)
     }
 
     async fn classify_reply_intent(
@@ -2698,10 +2786,7 @@ pub async fn start_channel_bridge_with_config(
         .collect();
     librefang_channels::sidecar::warn_secret_prefix_collisions(&sidecar_names);
 
-    let handle = KernelBridgeAdapter {
-        kernel: kernel.clone(),
-        started_at: Instant::now(),
-    };
+    let handle = KernelBridgeAdapter::new(kernel.clone());
 
     // (adapter, default_agent_name, account_id) — `account_id` is the
     // sidecar's config `name`, which qualifies the per-bot routing key
@@ -2851,10 +2936,8 @@ pub async fn start_channel_bridge_with_config(
     }
     router.load_broadcast(kernel.broadcast_ref().clone());
 
-    let bridge_handle: Arc<dyn ChannelBridgeHandle> = Arc::new(KernelBridgeAdapter {
-        kernel: kernel.clone(),
-        started_at: Instant::now(),
-    });
+    let bridge_handle: Arc<dyn ChannelBridgeHandle> =
+        Arc::new(KernelBridgeAdapter::new(kernel.clone()));
     let router = Arc::new(router);
     // Create message journal for crash recovery
     let data_dir = std::path::PathBuf::from(
@@ -3332,10 +3415,7 @@ mod tests {
             .submit_manual_request(second)
             .expect("submit second approval");
 
-        let adapter = KernelBridgeAdapter {
-            kernel: kernel.clone(),
-            started_at: Instant::now(),
-        };
+        let adapter = KernelBridgeAdapter::new(kernel.clone());
         let first_message = adapter
             .resolve_approval_text(&first_id.to_string(), true, Some(&code), "channel-user")
             .await;
@@ -3354,6 +3434,110 @@ mod tests {
         assert!(
             kernel.approvals().get_pending(second_id).is_some(),
             "replayed code must not resolve the second request"
+        );
+    }
+
+    /// A `SenderContext` for one conversation, shaped the way
+    /// `build_sender_context` shapes it on the message path.
+    fn sender_in(account: Option<&str>, chat: &str) -> SenderContext {
+        SenderContext {
+            channel: "telegram".to_string(),
+            chat_id: Some(chat.to_string()),
+            account_id: account.map(str::to_string),
+            user_id: "member-1".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Injection-site guard for #7140. `/think` promises the user a per-chat
+    /// setting, and `KernelBridgeAdapter` is where that promise is kept: the
+    /// store is written by `set_thinking` and read by every send path. Keying
+    /// it by `agent_id` alone compiles, passes every command-path test, and
+    /// silently pushes one chat's reasoning mode (and token bill) onto every
+    /// other chat the agent serves — the same shape as the #7605 memory leak.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn think_preference_is_isolated_per_conversation() {
+        use librefang_testing::MockKernelBuilder;
+
+        let (kernel, _tmp) = MockKernelBuilder::new().build();
+        let agent = kernel
+            .agent_registry()
+            .find_by_name("assistant")
+            .expect("default assistant agent should exist after boot")
+            .id;
+        let other_agent = AgentId::new();
+        let adapter = KernelBridgeAdapter::new(kernel.clone());
+
+        let chat_a = ConversationScope::new("telegram", Some("bot-a"), Some("chat-a"));
+        let chat_b = ConversationScope::new("telegram", Some("bot-a"), Some("chat-b"));
+
+        // Nobody has configured anything: every conversation keeps the
+        // agent/global `[thinking]` default, which `None` means.
+        assert_eq!(
+            adapter.thinking_override_for(agent, &sender_in(Some("bot-a"), "chat-a")),
+            None,
+            "an unconfigured conversation must not force thinking either way"
+        );
+
+        adapter
+            .set_thinking(agent, true, &chat_a)
+            .await
+            .expect("set_thinking");
+
+        // Round trip: what was set in chat A is what chat A reads back.
+        assert_eq!(
+            adapter.thinking_override_for(agent, &sender_in(Some("bot-a"), "chat-a")),
+            Some(true),
+        );
+        // …and chat B, same agent, same bot, is untouched.
+        assert_eq!(
+            adapter.thinking_override_for(agent, &sender_in(Some("bot-a"), "chat-b")),
+            None,
+            "/think in one chat must not reach another chat on the same agent",
+        );
+        // …as is the same chat id reached through a second bot account.
+        assert_eq!(
+            adapter.thinking_override_for(agent, &sender_in(Some("bot-b"), "chat-a")),
+            None,
+            "/think must not cross bot accounts",
+        );
+        // …as is a different agent entirely.
+        assert_eq!(
+            adapter.thinking_override_for(other_agent, &sender_in(Some("bot-a"), "chat-a")),
+            None,
+        );
+
+        // The opposite toggle in chat B leaves chat A's `on` standing.
+        adapter
+            .set_thinking(agent, false, &chat_b)
+            .await
+            .expect("set_thinking");
+        assert_eq!(
+            adapter.thinking_override_for(agent, &sender_in(Some("bot-a"), "chat-a")),
+            Some(true),
+        );
+        assert_eq!(
+            adapter.thinking_override_for(agent, &sender_in(Some("bot-a"), "chat-b")),
+            Some(false),
+        );
+    }
+
+    /// The command path builds the scope from `session_scope` parts, the
+    /// message path from a `SenderContext`. If the two ever disagree, a
+    /// `/think` write lands under a key no send path will ever read, and the
+    /// command goes back to acking without acting.
+    #[test]
+    fn conversation_scope_agrees_across_the_command_and_message_paths() {
+        assert_eq!(
+            ConversationScope::from_sender(&sender_in(Some("bot-a"), "chat-a")),
+            ConversationScope::new("telegram", Some("bot-a"), Some("chat-a")),
+        );
+        // Absent and empty are the same conversation, not two.
+        let mut blank = sender_in(None, "chat-a");
+        blank.account_id = Some(String::new());
+        assert_eq!(
+            ConversationScope::from_sender(&blank),
+            ConversationScope::new("telegram", None, Some("chat-a")),
         );
     }
 
@@ -3379,10 +3563,7 @@ mod tests {
             .expect("default assistant agent should exist after boot")
             .id;
 
-        let adapter = KernelBridgeAdapter {
-            kernel: kernel.clone(),
-            started_at: Instant::now(),
-        };
+        let adapter = KernelBridgeAdapter::new(kernel.clone());
 
         // No binding of either level yet -> both fall through (None).
         assert_eq!(

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -249,12 +249,7 @@ pub trait ChannelBridgeHandle: Send + Sync {
 
     /// Toggle extended thinking for one conversation on `agent_id`.
     ///
-    /// `scope` is the conversation the command was typed in, not the agent:
-    /// one agent commonly serves many chats across many channel accounts, and
-    /// `/think` acks say "for this chat", so the preference must be stored and
-    /// read back per conversation (#7140). Implementations that key it by
-    /// `agent_id` alone leak one user's reasoning mode — and its cost — into
-    /// every other conversation the agent serves.
+    /// `scope` is the conversation the command was typed in, not the agent: one agent commonly serves many chats across many channel accounts, and `/think` acks say "for this chat", so the preference must be stored and read back per conversation (#7140). Implementations that key it by `agent_id` alone leak one user's reasoning mode — and its cost — into every other conversation the agent serves.
     async fn set_thinking(
         &self,
         _agent_id: AgentId,
@@ -7079,9 +7074,7 @@ async fn handle_command(
             }
         }
         "think" => {
-            // Bare `/think` means "on"; anything that is not a recognised
-            // on/off word is a typo, and silently reading it as "off" is how
-            // `/think of` used to disable thinking while acking success.
+            // Bare `/think` means "on"; anything that is not a recognised on/off word is a typo, and silently reading it as "off" is how `/think of` used to disable thinking while acking success.
             let on = match args.first().map(|a| a.to_ascii_lowercase()).as_deref() {
                 None | Some("on") | Some("true") | Some("enable") | Some("enabled") => true,
                 Some("off") | Some("false") | Some("disable") | Some("disabled") => false,
@@ -7092,9 +7085,7 @@ async fn handle_command(
             let agent_id = resolve_for_command();
             match agent_id {
                 Some(aid) => {
-                    // Same (channel, chat_id) pair `/new` resets and the next
-                    // inbound turn resolves its session from, plus the account
-                    // dimension — see `ConversationScope` (#7140).
+                    // Same (channel, chat_id) pair `/new` resets and the next inbound turn resolves its session from, plus the account dimension — see `ConversationScope` (#7140).
                     let (ch, chat) =
                         session_scope(channel_type, &sender.platform_id, sender_user_id);
                     let scope =
@@ -7565,9 +7556,7 @@ mod tests {
         }
     }
 
-    /// Records every `/think` toggle with the conversation scope it arrived
-    /// with, so a test can assert the command path passes the conversation
-    /// identity down instead of the bare agent id (#7140).
+    /// Records every `/think` toggle with the conversation scope it arrived with, so a test can assert the command path passes the conversation identity down instead of the bare agent id (#7140).
     struct ThinkRecorderHandle {
         agents: Mutex<Vec<(AgentId, String)>>,
         calls: Mutex<Vec<(AgentId, bool, crate::types::ConversationScope)>>,
@@ -8337,10 +8326,7 @@ mod tests {
         );
     }
 
-    /// Regression for #7140: `/think` acks say "for this chat", so the
-    /// command path must hand `set_thinking` the conversation it was typed in.
-    /// One agent commonly serves many Telegram chats; passing the bare agent
-    /// id is what made one user's toggle rewrite everybody else's turns.
+    /// Regression for #7140: `/think` acks say "for this chat", so the command path must hand `set_thinking` the conversation it was typed in. One agent commonly serves many Telegram chats; passing the bare agent id is what made one user's toggle rewrite everybody else's turns.
     #[tokio::test]
     async fn think_command_carries_the_conversation_scope() {
         let agent = AgentId::new();
@@ -8414,8 +8400,7 @@ mod tests {
         );
     }
 
-    /// The same chat reached through two different bot accounts is two
-    /// conversations, so `/think` in one must not carry into the other (#7140).
+    /// The same chat reached through two different bot accounts is two conversations, so `/think` in one must not carry into the other (#7140).
     #[tokio::test]
     async fn think_command_scope_separates_bot_accounts() {
         let agent = AgentId::new();
@@ -8457,9 +8442,7 @@ mod tests {
         );
     }
 
-    /// `/think of` is a typo, not "off". Reading an unrecognised argument as
-    /// `false` disabled thinking while acking success — the confirmation-without-
-    /// action class this issue is about (#7140).
+    /// `/think of` is a typo, not "off". Reading an unrecognised argument as `false` disabled thinking while acking success — the confirmation-without-action class this issue is about (#7140).
     #[tokio::test]
     async fn think_command_rejects_an_unknown_argument() {
         let agent = AgentId::new();

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -247,8 +247,20 @@ pub trait ChannelBridgeHandle: Send + Sync {
         Err("Not implemented".to_string())
     }
 
-    /// Toggle extended thinking mode for an agent.
-    async fn set_thinking(&self, _agent_id: AgentId, _on: bool) -> Result<String, String> {
+    /// Toggle extended thinking for one conversation on `agent_id`.
+    ///
+    /// `scope` is the conversation the command was typed in, not the agent:
+    /// one agent commonly serves many chats across many channel accounts, and
+    /// `/think` acks say "for this chat", so the preference must be stored and
+    /// read back per conversation (#7140). Implementations that key it by
+    /// `agent_id` alone leak one user's reasoning mode — and its cost — into
+    /// every other conversation the agent serves.
+    async fn set_thinking(
+        &self,
+        _agent_id: AgentId,
+        _on: bool,
+        _scope: &crate::types::ConversationScope,
+    ) -> Result<String, String> {
         Ok("Extended thinking preference saved.".to_string())
     }
 
@@ -7067,12 +7079,28 @@ async fn handle_command(
             }
         }
         "think" => {
+            // Bare `/think` means "on"; anything that is not a recognised
+            // on/off word is a typo, and silently reading it as "off" is how
+            // `/think of` used to disable thinking while acking success.
+            let on = match args.first().map(|a| a.to_ascii_lowercase()).as_deref() {
+                None | Some("on") | Some("true") | Some("enable") | Some("enabled") => true,
+                Some("off") | Some("false") | Some("disable") | Some("disabled") => false,
+                Some(other) => {
+                    return format!("Unknown argument '{other}'. Usage: /think [on|off]");
+                }
+            };
             let agent_id = resolve_for_command();
             match agent_id {
                 Some(aid) => {
-                    let on = args.first().map(|a| a == "on").unwrap_or(true);
+                    // Same (channel, chat_id) pair `/new` resets and the next
+                    // inbound turn resolves its session from, plus the account
+                    // dimension — see `ConversationScope` (#7140).
+                    let (ch, chat) =
+                        session_scope(channel_type, &sender.platform_id, sender_user_id);
+                    let scope =
+                        crate::types::ConversationScope::new(ch, account_id, chat.as_deref());
                     handle
-                        .set_thinking(aid, on)
+                        .set_thinking(aid, on, &scope)
                         .await
                         .unwrap_or_else(|e| format!("Error: {e}"))
                 }
@@ -7531,6 +7559,55 @@ mod tests {
         }
         async fn spawn_agent_by_name(&self, _manifest_name: &str) -> Result<AgentId, String> {
             Err("spawn not implemented in mock".to_string())
+        }
+        fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {
+            // Test mock: no event bus to forward to.
+        }
+    }
+
+    /// Records every `/think` toggle with the conversation scope it arrived
+    /// with, so a test can assert the command path passes the conversation
+    /// identity down instead of the bare agent id (#7140).
+    struct ThinkRecorderHandle {
+        agents: Mutex<Vec<(AgentId, String)>>,
+        calls: Mutex<Vec<(AgentId, bool, crate::types::ConversationScope)>>,
+    }
+
+    impl ThinkRecorderHandle {
+        fn new(agents: Vec<(AgentId, String)>) -> Self {
+            Self {
+                agents: Mutex::new(agents),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ChannelBridgeHandle for ThinkRecorderHandle {
+        async fn send_message(&self, _agent_id: AgentId, message: &str) -> Result<String, String> {
+            Ok(format!("Echo: {message}"))
+        }
+        async fn find_agent_by_name(&self, name: &str) -> Result<Option<AgentId>, String> {
+            let agents = self.agents.lock().unwrap();
+            Ok(agents.iter().find(|(_, n)| n == name).map(|(id, _)| *id))
+        }
+        async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+            Ok(self.agents.lock().unwrap().clone())
+        }
+        async fn spawn_agent_by_name(&self, _manifest_name: &str) -> Result<AgentId, String> {
+            Err("spawn not implemented in mock".to_string())
+        }
+        async fn set_thinking(
+            &self,
+            agent_id: AgentId,
+            on: bool,
+            scope: &crate::types::ConversationScope,
+        ) -> Result<String, String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((agent_id, on, scope.clone()));
+            Ok("ok".to_string())
         }
         fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {
             // Test mock: no event bus to forward to.
@@ -8258,6 +8335,181 @@ mod tests {
             "/model must route per-account; got {:?}",
             calls,
         );
+    }
+
+    /// Regression for #7140: `/think` acks say "for this chat", so the
+    /// command path must hand `set_thinking` the conversation it was typed in.
+    /// One agent commonly serves many Telegram chats; passing the bare agent
+    /// id is what made one user's toggle rewrite everybody else's turns.
+    #[tokio::test]
+    async fn think_command_carries_the_conversation_scope() {
+        let agent = AgentId::new();
+        let recorder = Arc::new(ThinkRecorderHandle::new(vec![(
+            agent,
+            "shared-agent".to_string(),
+        )]));
+        let handle: Arc<dyn ChannelBridgeHandle> = recorder.clone();
+        let router = Arc::new(AgentRouter::new());
+        router.set_channel_default("telegram:bot-a".to_string(), agent);
+
+        // Two distinct chats served by the same agent through the same bot.
+        let chat_one = ChannelUser {
+            platform_id: "chat-1".to_string(),
+            display_name: "Group One".to_string(),
+            librefang_user: None,
+        };
+        let chat_two = ChannelUser {
+            platform_id: "chat-2".to_string(),
+            display_name: "Group Two".to_string(),
+            librefang_user: None,
+        };
+
+        let on = handle_command(
+            "think",
+            &["on".to_string()],
+            &handle,
+            &router,
+            &chat_one,
+            &ChannelType::Telegram,
+            Some("bot-a"),
+            None,
+            "member-1",
+        )
+        .await;
+        assert_eq!(on, "ok");
+
+        let off = handle_command(
+            "think",
+            &["off".to_string()],
+            &handle,
+            &router,
+            &chat_two,
+            &ChannelType::Telegram,
+            Some("bot-a"),
+            None,
+            "member-2",
+        )
+        .await;
+        assert_eq!(off, "ok");
+
+        let calls = recorder.calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 2, "both toggles must reach the handle");
+        assert_eq!(calls[0].0, agent);
+        assert_eq!(calls[1].0, agent, "same agent serves both chats");
+        assert!(calls[0].1, "/think on");
+        assert!(!calls[1].1, "/think off");
+        assert_ne!(
+            calls[0].2, calls[1].2,
+            "two chats on one agent must produce different scopes, or the \
+             second toggle overwrites the first"
+        );
+
+        // The scope is the same (channel, chat_id) pair `/new` resets, plus
+        // the account — so `set_thinking` and the message path agree on the key.
+        let (channel, chat) =
+            session_scope(&ChannelType::Telegram, &chat_one.platform_id, "member-1");
+        assert_eq!(
+            calls[0].2,
+            crate::types::ConversationScope::new(channel, Some("bot-a"), chat.as_deref()),
+        );
+    }
+
+    /// The same chat reached through two different bot accounts is two
+    /// conversations, so `/think` in one must not carry into the other (#7140).
+    #[tokio::test]
+    async fn think_command_scope_separates_bot_accounts() {
+        let agent = AgentId::new();
+        let recorder = Arc::new(ThinkRecorderHandle::new(vec![(
+            agent,
+            "shared-agent".to_string(),
+        )]));
+        let handle: Arc<dyn ChannelBridgeHandle> = recorder.clone();
+        let router = Arc::new(AgentRouter::new());
+        router.set_channel_default("telegram:bot-a".to_string(), agent);
+        router.set_channel_default("telegram:bot-b".to_string(), agent);
+
+        let chat = ChannelUser {
+            platform_id: "chat-1".to_string(),
+            display_name: "Group One".to_string(),
+            librefang_user: None,
+        };
+
+        for account in ["bot-a", "bot-b"] {
+            handle_command(
+                "think",
+                &["on".to_string()],
+                &handle,
+                &router,
+                &chat,
+                &ChannelType::Telegram,
+                Some(account),
+                None,
+                "member-1",
+            )
+            .await;
+        }
+
+        let calls = recorder.calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 2);
+        assert_ne!(
+            calls[0].2, calls[1].2,
+            "one chat id under two bot accounts must not collapse to one scope"
+        );
+    }
+
+    /// `/think of` is a typo, not "off". Reading an unrecognised argument as
+    /// `false` disabled thinking while acking success — the confirmation-without-
+    /// action class this issue is about (#7140).
+    #[tokio::test]
+    async fn think_command_rejects_an_unknown_argument() {
+        let agent = AgentId::new();
+        let recorder = Arc::new(ThinkRecorderHandle::new(vec![(
+            agent,
+            "shared-agent".to_string(),
+        )]));
+        let handle: Arc<dyn ChannelBridgeHandle> = recorder.clone();
+        let router = Arc::new(AgentRouter::new());
+        router.set_channel_default("telegram:bot-a".to_string(), agent);
+
+        let chat = ChannelUser {
+            platform_id: "chat-1".to_string(),
+            display_name: "Group One".to_string(),
+            librefang_user: None,
+        };
+
+        let result = handle_command(
+            "think",
+            &["of".to_string()],
+            &handle,
+            &router,
+            &chat,
+            &ChannelType::Telegram,
+            Some("bot-a"),
+            None,
+            "member-1",
+        )
+        .await;
+        assert!(result.contains("Usage: /think [on|off]"), "got: {result}");
+        assert!(
+            recorder.calls.lock().unwrap().is_empty(),
+            "a typo must not silently toggle anything"
+        );
+
+        // Bare `/think` still means "on".
+        let result = handle_command(
+            "think",
+            &[],
+            &handle,
+            &router,
+            &chat,
+            &ChannelType::Telegram,
+            Some("bot-a"),
+            None,
+            "member-1",
+        )
+        .await;
+        assert_eq!(result, "ok");
+        assert!(recorder.calls.lock().unwrap()[0].1);
     }
 
     /// Regression test for #5672 Layer B: `/agent` in bot-a must NOT

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -444,6 +444,62 @@ pub struct SenderContext {
     pub is_internal_system: bool,
 }
 
+/// Conversation identity a per-chat channel preference is keyed by.
+///
+/// `channel` and `chat_id` are exactly the pair the bridge feeds into
+/// `SessionId::for_sender_scope`, so a preference stored against this scope
+/// covers the same conversation slice `/new` resets and no wider.
+/// `account_id` is the one dimension the derived session id does not carry:
+/// two sidecar instances of the same channel type (two Telegram bots) can
+/// serve the same chat, and a preference set through one must not follow the
+/// other.
+///
+/// Constructed from the `SenderContext` on the message path and from
+/// `session_scope` plus the inbound `account_id` on the command path, so both
+/// sides land on the same key for the same conversation (#7140).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ConversationScope {
+    /// Sanitized channel name (`telegram`, `whatsapp`, `ext-cron`, …).
+    pub channel: String,
+    /// Sidecar instance name, when the channel is multi-account.
+    pub account_id: Option<String>,
+    /// Chat / group / DM id within the channel.
+    pub chat_id: Option<String>,
+}
+
+impl ConversationScope {
+    /// Build the scope of the conversation a `SenderContext` came from.
+    ///
+    /// Empty strings collapse to `None` so an adapter that sends `""` and one
+    /// that omits the field entirely do not split one conversation into two
+    /// scopes.
+    pub fn from_sender(sender: &SenderContext) -> Self {
+        Self {
+            channel: sender.channel.clone(),
+            account_id: non_empty(sender.account_id.as_deref()),
+            chat_id: non_empty(sender.chat_id.as_deref()),
+        }
+    }
+
+    /// Build a scope from the parts the command path has on hand.
+    pub fn new(
+        channel: impl Into<String>,
+        account_id: Option<&str>,
+        chat_id: Option<&str>,
+    ) -> Self {
+        Self {
+            channel: channel.into(),
+            account_id: non_empty(account_id),
+            chat_id: non_empty(chat_id),
+        }
+    }
+}
+
+/// `Some(trimmed)` for a non-empty string, `None` otherwise.
+fn non_empty(value: Option<&str>) -> Option<String> {
+    value.filter(|v| !v.is_empty()).map(str::to_string)
+}
+
 /// Reference to a participant in a group chat.
 ///
 /// Minimal shape required by the §C addressee guard. Full roster persistence

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -446,17 +446,9 @@ pub struct SenderContext {
 
 /// Conversation identity a per-chat channel preference is keyed by.
 ///
-/// `channel` and `chat_id` are exactly the pair the bridge feeds into
-/// `SessionId::for_sender_scope`, so a preference stored against this scope
-/// covers the same conversation slice `/new` resets and no wider.
-/// `account_id` is the one dimension the derived session id does not carry:
-/// two sidecar instances of the same channel type (two Telegram bots) can
-/// serve the same chat, and a preference set through one must not follow the
-/// other.
+/// `channel` and `chat_id` are exactly the pair the bridge feeds into `SessionId::for_sender_scope`, so a preference stored against this scope covers the same conversation slice `/new` resets and no wider. `account_id` is the one dimension the derived session id does not carry: two sidecar instances of the same channel type (two Telegram bots) can serve the same chat, and a preference set through one must not follow the other.
 ///
-/// Constructed from the `SenderContext` on the message path and from
-/// `session_scope` plus the inbound `account_id` on the command path, so both
-/// sides land on the same key for the same conversation (#7140).
+/// Constructed from the `SenderContext` on the message path and from `session_scope` plus the inbound `account_id` on the command path, so both sides land on the same key for the same conversation (#7140).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConversationScope {
     /// Sanitized channel name (`telegram`, `whatsapp`, `ext-cron`, …).
@@ -470,9 +462,7 @@ pub struct ConversationScope {
 impl ConversationScope {
     /// Build the scope of the conversation a `SenderContext` came from.
     ///
-    /// Empty strings collapse to `None` so an adapter that sends `""` and one
-    /// that omits the field entirely do not split one conversation into two
-    /// scopes.
+    /// Empty strings collapse to `None` so an adapter that sends `""` and one that omits the field entirely do not split one conversation into two scopes.
     pub fn from_sender(sender: &SenderContext) -> Self {
         Self {
             channel: sender.channel.clone(),

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -135,12 +135,16 @@ impl LibreFangKernel {
     }
 
     /// Send a multimodal message with sender identity context from a channel.
+    ///
+    /// `thinking_override` follows [`Self::send_message_with_thinking_override`]:
+    /// the channel bridge resolves it per conversation from `/think` (#7140).
     pub async fn send_message_with_blocks_and_sender(
         &self,
         agent_id: AgentId,
         message: &str,
         blocks: Vec<librefang_types::message::ContentBlock>,
         sender: &SenderContext,
+        thinking_override: Option<bool>,
     ) -> KernelResult<AgentLoopResult> {
         self.send_message_full(
             agent_id,
@@ -149,7 +153,7 @@ impl LibreFangKernel {
             Some(blocks),
             Some(sender),
             None,
-            None,
+            thinking_override,
             None,
         )
         .await
@@ -1762,22 +1766,6 @@ impl LibreFangKernel {
             loop_opts,
             owner,
         )
-    }
-
-    /// Sender-aware streaming entry point for channel bridges.
-    pub async fn send_message_streaming_with_sender_context_and_routing(
-        self: &Arc<Self>,
-        agent_id: AgentId,
-        message: &str,
-        kernel_handle: Option<Arc<dyn KernelHandle>>,
-        sender: &SenderContext,
-    ) -> KernelResult<(
-        tokio::sync::mpsc::Receiver<StreamEvent>,
-        tokio::task::JoinHandle<KernelResult<AgentLoopResult>>,
-    )> {
-        let handle = kernel_handle.unwrap_or_else(|| self.kernel_handle());
-        self.send_message_streaming_resolved(agent_id, message, handle, Some(sender), None, None)
-            .await
     }
 
     /// Streaming entry point with per-call deep-thinking override.

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -136,8 +136,7 @@ impl LibreFangKernel {
 
     /// Send a multimodal message with sender identity context from a channel.
     ///
-    /// `thinking_override` follows [`Self::send_message_with_thinking_override`]:
-    /// the channel bridge resolves it per conversation from `/think` (#7140).
+    /// `thinking_override` follows [`Self::send_message_with_thinking_override`]: the channel bridge resolves it per conversation from `/think` (#7140).
     pub async fn send_message_with_blocks_and_sender(
         &self,
         agent_id: AgentId,

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -717,10 +717,7 @@ pub trait KernelApi: KernelHandle + Send + Sync {
         message: &str,
         blocks: Vec<librefang_types::message::ContentBlock>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
-    /// `thinking_override` carries the conversation's `/think` preference
-    /// (`None` = agent/global default). Channel turns resolve it per
-    /// conversation, so it has to ride the send call rather than be read off
-    /// the agent (#7140).
+    /// `thinking_override` carries the conversation's `/think` preference (`None` = agent/global default). Channel turns resolve it per conversation, so it has to ride the send call rather than be read off the agent (#7140).
     async fn send_message_with_sender_context(
         &self,
         agent_id: AgentId,
@@ -728,8 +725,7 @@ pub trait KernelApi: KernelHandle + Send + Sync {
         sender: librefang_channels::types::SenderContext,
         thinking_override: Option<bool>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
-    /// Multimodal counterpart of [`KernelApi::send_message_with_sender_context`];
-    /// `thinking_override` has the same per-conversation meaning.
+    /// Multimodal counterpart of [`KernelApi::send_message_with_sender_context`]; `thinking_override` has the same per-conversation meaning.
     async fn send_message_with_blocks_and_sender(
         &self,
         agent_id: AgentId,

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -717,29 +717,27 @@ pub trait KernelApi: KernelHandle + Send + Sync {
         message: &str,
         blocks: Vec<librefang_types::message::ContentBlock>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    /// `thinking_override` carries the conversation's `/think` preference
+    /// (`None` = agent/global default). Channel turns resolve it per
+    /// conversation, so it has to ride the send call rather than be read off
+    /// the agent (#7140).
     async fn send_message_with_sender_context(
         &self,
         agent_id: AgentId,
         message: &str,
         sender: librefang_channels::types::SenderContext,
+        thinking_override: Option<bool>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    /// Multimodal counterpart of [`KernelApi::send_message_with_sender_context`];
+    /// `thinking_override` has the same per-conversation meaning.
     async fn send_message_with_blocks_and_sender(
         &self,
         agent_id: AgentId,
         message: &str,
         blocks: Vec<librefang_types::message::ContentBlock>,
         sender: librefang_channels::types::SenderContext,
+        thinking_override: Option<bool>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
-    async fn send_message_streaming_with_sender_context_and_routing(
-        self: Arc<Self>,
-        agent_id: AgentId,
-        message: &str,
-        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
-        sender: librefang_channels::types::SenderContext,
-    ) -> KernelResult<(
-        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
-        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
-    )>;
 
     // ====================================================================
     // Test-only / boot-only kernel ops surfaced for integration tests
@@ -1661,8 +1659,16 @@ impl KernelApi for LibreFangKernel {
         agent_id: AgentId,
         message: &str,
         sender: librefang_channels::types::SenderContext,
+        thinking_override: Option<bool>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
-        Self::send_message_with_sender_context(self, agent_id, message, &sender).await
+        Self::send_message_with_sender_context_and_thinking(
+            self,
+            agent_id,
+            message,
+            &sender,
+            thinking_override,
+        )
+        .await
     }
     async fn send_message_with_blocks_and_sender(
         &self,
@@ -1670,25 +1676,15 @@ impl KernelApi for LibreFangKernel {
         message: &str,
         blocks: Vec<librefang_types::message::ContentBlock>,
         sender: librefang_channels::types::SenderContext,
+        thinking_override: Option<bool>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
-        Self::send_message_with_blocks_and_sender(self, agent_id, message, blocks, &sender).await
-    }
-    async fn send_message_streaming_with_sender_context_and_routing(
-        self: Arc<Self>,
-        agent_id: AgentId,
-        message: &str,
-        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
-        sender: librefang_channels::types::SenderContext,
-    ) -> KernelResult<(
-        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
-        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
-    )> {
-        LibreFangKernel::send_message_streaming_with_sender_context_and_routing(
-            &self,
+        Self::send_message_with_blocks_and_sender(
+            self,
             agent_id,
             message,
-            kernel_handle,
+            blocks,
             &sender,
+            thinking_override,
         )
         .await
     }


### PR DESCRIPTION
Implements the change requested on **#7159** by @DaBlitzStein, which has been blocked on my `CHANGES_REQUESTED` review since 2026-08-22 with only merge commits since.
The analysis in #7159 and its original approach are theirs — the `/think` stub, the per-turn thinking override as the mechanism, and the reading of #7140 root cause 2 all come from that PR and from the issue triage.
This is the smaller version of the same idea rather than a copy of that diff, written so the review item can land while #7159 is stalled.
**Recommendation only:** #7159 should be closed as superseded once this merges — the routing half of it is already on `main` through #7701, and the `/think` half is here.
I have not touched that PR.

## What was on `main`

I checked before writing anything, and the premise needed correcting: **there is no `/think` implementation on `main` to adjust.**
`KernelBridgeAdapter::set_thinking` (`crates/librefang-api/src/channel_bridge.rs`) took `_agent_id`, stored nothing, and returned "Extended thinking {state}. (This will take effect when supported by the model.)".
There is no `thinking_prefs` field, no per-conversation key, and no read path anywhere.
So this PR implements the behaviour rather than re-keying an existing one — and the cross-conversation leak my review described is a property the implementation had to be designed not to have, not a bug being removed.

## Changes

- `ConversationScope` (`crates/librefang-channels/src/types.rs`) — the conversation identity a per-chat channel preference is keyed by: sanitized channel, sidecar account id, chat id.
  `from_sender` builds it on the message path, `new` on the command path, and empty strings collapse to `None` on both so one conversation cannot split into two keys.
  The `(channel, chat_id)` pair is exactly what `session_scope` feeds into `SessionId::for_sender_scope`, so a `/think` covers the slice `/new` resets rather than a parallel notion of "conversation" invented for this feature.
  `account_id` is the one dimension the derived session id does not carry, and two Telegram bots can serve the same chat.
- `ChannelBridgeHandle::set_thinking` now takes that scope; the `/think` arm in `crates/librefang-channels/src/bridge.rs` builds it from `session_scope` plus the inbound `account_id`.
- `KernelBridgeAdapter` stores the preference in a `DashMap<(AgentId, ConversationScope), bool>` and reads it back in `thinking_override_for`, which now feeds the per-call thinking override on all four sender-aware send paths: `send_message_with_sender`, `send_message_with_blocks_and_sender` (images), and both streaming variants.
  The kernel already accepted `thinking_override` on every one of these — `apply_thinking_override` in `manifest_helpers.rs` is the existing mechanism — so nothing new was invented kernel-side.
  The store is deliberately in-memory: a `/think` toggle is a per-chat convenience, and after a restart each chat falls back to the agent's `[thinking]` default, which is the state a chat starts in.
- `KernelApi::send_message_with_sender_context` / `send_message_with_blocks_and_sender` gained the `thinking_override` parameter; `send_message_streaming_with_sender_context_and_routing` was removed from the trait and the kernel because `…_routing_thinking_and_session` supersedes it exactly and it had no remaining caller.
- `KernelBridgeAdapter::new` replaces four struct literals, so a future field cannot leave a construction site behind.
- `/think of` (and any other unrecognised argument) is rejected with usage instead of being read as "off" — silently disabling thinking while acking success is the same confirmation-without-action class this issue is about.
- `/think on` appends a caveat when the model catalog positively reports the agent's model has no extended-thinking mode. An unset, `"default"`, or unknown model says nothing, because guessing there re-creates the false confirmation.

## Verification

- `cargo check -p librefang-api --tests` — clean.
- `cargo test -p librefang-channels --lib think_command` — 3 passed:
  - `think_command_carries_the_conversation_scope` — two chats on one agent produce two different scopes, and the scope equals the `session_scope`-derived one.
  - `think_command_scope_separates_bot_accounts` — one chat id under two bot accounts stays two conversations.
  - `think_command_rejects_an_unknown_argument` — `/think of` toggles nothing; bare `/think` still means on.
- `cargo test -p librefang-api --lib think_preference conversation_scope_agrees` — 2 passed:
  - `think_preference_is_isolated_per_conversation` — round trip in chat A; chat B, a second bot account, and a second agent all still read `None`; the opposite toggle in chat B leaves chat A's setting standing. This is the injection-site guard: an `agent_id`-keyed store passes every command-path test and fails only this one.
  - `conversation_scope_agrees_across_the_command_and_message_paths` — the write key and the read key are the same, or a `/think` lands under a key no send path reads.
- No integration test under `crates/librefang-api/tests/` — this adds no route and changes no router wiring; the adapter is reached from the channel bridge, and the two unit suites cover the write side and the read side.
- Clippy and the full workspace build are left to CI: the local disk hit its floor during the test runs.

## Scope

Refs #7140, not "Closes" — root cause 1 of that issue (sidecar SDK version skew) is #7848, still open.
This PR is root cause 2 only.
