### PR TITLE
fix(skills): map a webpage-serving marketplace to 503 across every hub handler

### DIFF
--- a/changelog.d/fixed/7387-marketplace-unavailable-mapping.md
+++ b/changelog.d/fixed/7387-marketplace-unavailable-mapping.md
@@ -1,0 +1,6 @@
+A skill marketplace whose API host is retired while its CDN keeps serving answers `200 OK` with the site's single-page-app shell for every path, and the daemon used to pass that HTML to `serde_json` and surface the parser's `expected value at line 1 column 1` as the whole explanation.
+  Every ClawHub, ClawHub China mirror and Skillhub read now recognises a leading `<` — through a UTF-8 BOM, which CDN-fronted origins prepend often enough to matter — as "this hub is serving a webpage" and reports `503 Service Unavailable` with the operation and URL named.
+  The uniformity is the fix: skill detail previously answered `404`, asserting a skill does not exist when the hub never answered as a marketplace at all, and install answered `500`, whose body is scrubbed before it leaves the process, discarding the one message an operator could act on.
+  A truncated or corrupted body stays a network error, because that one is worth a retry and this one is not.
+  Each hub's endpoints are also overridable now, so a mirror can be adopted without recompiling; Skillhub takes three variables because it is three hosts, and setting only the API base would leave browse and install still aimed at the dead one.
+  (#PR) (@houko)

--- a/changelog.d/fixed/7387-marketplace-unavailable-mapping.md
+++ b/changelog.d/fixed/7387-marketplace-unavailable-mapping.md
@@ -3,4 +3,4 @@ A skill marketplace whose API host is retired while its CDN keeps serving answer
   The uniformity is the fix: skill detail previously answered `404`, asserting a skill does not exist when the hub never answered as a marketplace at all, and install answered `500`, whose body is scrubbed before it leaves the process, discarding the one message an operator could act on.
   A truncated or corrupted body stays a network error, because that one is worth a retry and this one is not.
   Each hub's endpoints are also overridable now, so a mirror can be adopted without recompiling; Skillhub takes three variables because it is three hosts, and setting only the API base would leave browse and install still aimed at the dead one.
-  (#PR) (@houko)
+  (#7856) (@houko)

--- a/crates/librefang-api/src/routes/skills/clawhub.rs
+++ b/crates/librefang-api/src/routes/skills/clawhub.rs
@@ -79,6 +79,26 @@ mod provenance_tests {
     }
 }
 
+/// Fetch the first source file a ClawHub-family hub actually has for `slug`.
+///
+/// Returns `Err` only when the hub is not serving marketplace data at all.
+/// Every candidate name is fetched from the same host, so once that host answers with its webpage instead of a file, walking to the next name just re-reads the same page — and the old `if let Ok` chain then reported the result as "no source code found", a `404` about the skill for a fault in the hub (#7387).
+/// Any other per-file failure keeps the original try-the-next-name behaviour and still ends as that `404` when none of the three exist.
+async fn fetch_skill_source(
+    client: &librefang_skills::clawhub::ClawHubClient,
+    slug: &str,
+) -> Result<Option<(String, String)>, librefang_skills::SkillError> {
+    for filename in ["SKILL.md", "package.json", "skill.toml"] {
+        match client.get_file(slug, filename).await {
+            Ok(content) if !content.is_empty() => return Ok(Some((filename.to_string(), content))),
+            Ok(_) => continue,
+            Err(error) if is_marketplace_unavailable(&error) => return Err(error),
+            Err(_) => continue,
+        }
+    }
+    Ok(None)
+}
+
 // ---------------------------------------------------------------------------
 // ClawHub (OpenClaw ecosystem) endpoints
 // ---------------------------------------------------------------------------
@@ -154,11 +174,7 @@ pub async fn clawhub_search(
         Err(e) => {
             let msg = format!("{e}");
             tracing::warn!("ClawHub search failed: {msg}");
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::BAD_GATEWAY
-            };
+            let status = marketplace_error_status(&e, StatusCode::BAD_GATEWAY);
             (
                 status,
                 Json(serde_json::json!({"items": [], "next_cursor": null, "error": msg})),
@@ -233,11 +249,7 @@ pub async fn clawhub_browse(
         Err(e) => {
             let msg = format!("{e}");
             tracing::warn!("ClawHub browse failed: {msg}");
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::BAD_GATEWAY
-            };
+            let status = marketplace_error_status(&e, StatusCode::BAD_GATEWAY);
             (
                 status,
                 Json(serde_json::json!({"items": [], "next_cursor": null, "error": msg})),
@@ -312,11 +324,9 @@ pub async fn clawhub_skill_detail(
             )
         }
         Err(e) => {
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::NOT_FOUND
-            };
+            // `404` is only honest for a slug the hub says it does not have.
+            // When the hub itself is not answering as a marketplace, saying "not found" invents a fact about the skill (#7387).
+            let status = marketplace_error_status(&e, StatusCode::NOT_FOUND);
             (status, Json(serde_json::json!({"error": format!("{e}")})))
         }
     }
@@ -342,24 +352,20 @@ pub async fn clawhub_skill_code(
     let client = librefang_skills::clawhub::ClawHubClient::new(cache_dir);
 
     // Try to fetch SKILL.md first, then fallback to package.json
-    let mut code = String::new();
-    let mut filename = String::new();
-
-    if let Ok(content) = client.get_file(&slug, "SKILL.md").await {
-        code = content;
-        filename = "SKILL.md".to_string();
-    } else if let Ok(content) = client.get_file(&slug, "package.json").await {
-        code = content;
-        filename = "package.json".to_string();
-    } else if let Ok(content) = client.get_file(&slug, "skill.toml").await {
-        code = content;
-        filename = "skill.toml".to_string();
-    }
-
-    if code.is_empty() {
-        return ApiErrorResponse::not_found("No source code found for this skill")
-            .into_json_tuple();
-    }
+    let (filename, code) = match fetch_skill_source(&client, &slug).await {
+        Ok(Some(found)) => found,
+        Ok(None) => {
+            return ApiErrorResponse::not_found("No source code found for this skill")
+                .into_json_tuple()
+        }
+        Err(error) => {
+            tracing::warn!("ClawHub skill code fetch failed: {error}");
+            return (
+                marketplace_error_status(&error, StatusCode::BAD_GATEWAY),
+                Json(serde_json::json!({"error": format!("{error}")})),
+            );
+        }
+    };
 
     (
         StatusCode::OK,
@@ -489,12 +495,16 @@ pub async fn clawhub_install(
             let msg = format!("{e}");
             let status = if matches!(e, librefang_skills::SkillError::SecurityBlocked(_)) {
                 StatusCode::FORBIDDEN
-            } else if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else if matches!(e, librefang_skills::SkillError::Network(_)) {
-                StatusCode::BAD_GATEWAY
             } else {
-                StatusCode::INTERNAL_SERVER_ERROR
+                // A dead marketplace used to fall through to the `500`, whose body is then scrubbed to "Internal server error" — the one case where the operator most needs the text (#7387).
+                marketplace_error_status(
+                    &e,
+                    if matches!(e, librefang_skills::SkillError::Network(_)) {
+                        StatusCode::BAD_GATEWAY
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    },
+                )
             };
             tracing::warn!("ClawHub install failed: {msg}");
             // 4xx / 502 echo the actionable SkillError (security
@@ -537,7 +547,8 @@ pub async fn clawhub_cn_search(
     }
 
     let cache_dir = state.kernel.home_dir().join(".cache").join("clawhub-cn");
-    let client = librefang_skills::clawhub::ClawHubClient::with_url(CLAWHUB_CN_BASE_URL, cache_dir);
+    let client =
+        librefang_skills::clawhub::ClawHubClient::with_url(&clawhub_cn_base_url(), cache_dir);
 
     match client.search(&query, limit).await {
         Ok(results) => {
@@ -564,11 +575,7 @@ pub async fn clawhub_cn_search(
         Err(e) => {
             let msg = format!("{e}");
             tracing::warn!("ClawHub CN search failed: {msg}");
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::BAD_GATEWAY
-            };
+            let status = marketplace_error_status(&e, StatusCode::BAD_GATEWAY);
             (
                 status,
                 Json(serde_json::json!({"items": [], "next_cursor": null, "error": msg})),
@@ -605,7 +612,8 @@ pub async fn clawhub_cn_browse(
     }
 
     let cache_dir = state.kernel.home_dir().join(".cache").join("clawhub-cn");
-    let client = librefang_skills::clawhub::ClawHubClient::with_url(CLAWHUB_CN_BASE_URL, cache_dir);
+    let client =
+        librefang_skills::clawhub::ClawHubClient::with_url(&clawhub_cn_base_url(), cache_dir);
 
     match client.browse(sort, limit, cursor).await {
         Ok(results) => {
@@ -626,11 +634,7 @@ pub async fn clawhub_cn_browse(
         Err(e) => {
             let msg = format!("{e}");
             tracing::warn!("ClawHub CN browse failed: {msg}");
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::BAD_GATEWAY
-            };
+            let status = marketplace_error_status(&e, StatusCode::BAD_GATEWAY);
             (
                 status,
                 Json(serde_json::json!({"items": [], "next_cursor": null, "error": msg})),
@@ -645,7 +649,8 @@ pub async fn clawhub_cn_skill_detail(
     Path(slug): Path<String>,
 ) -> impl IntoResponse {
     let cache_dir = state.kernel.home_dir().join(".cache").join("clawhub-cn");
-    let client = librefang_skills::clawhub::ClawHubClient::with_url(CLAWHUB_CN_BASE_URL, cache_dir);
+    let client =
+        librefang_skills::clawhub::ClawHubClient::with_url(&clawhub_cn_base_url(), cache_dir);
 
     let skills_dir = state.kernel.home_dir().join("skills");
     let is_installed = client.is_installed(&slug, &skills_dir);
@@ -693,11 +698,9 @@ pub async fn clawhub_cn_skill_detail(
             )
         }
         Err(e) => {
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::NOT_FOUND
-            };
+            // `404` is only honest for a slug the hub says it does not have.
+            // When the hub itself is not answering as a marketplace, saying "not found" invents a fact about the skill (#7387).
+            let status = marketplace_error_status(&e, StatusCode::NOT_FOUND);
             (status, Json(serde_json::json!({"error": format!("{e}")})))
         }
     }
@@ -709,26 +712,23 @@ pub async fn clawhub_cn_skill_code(
     Path(slug): Path<String>,
 ) -> impl IntoResponse {
     let cache_dir = state.kernel.home_dir().join(".cache").join("clawhub-cn");
-    let client = librefang_skills::clawhub::ClawHubClient::with_url(CLAWHUB_CN_BASE_URL, cache_dir);
+    let client =
+        librefang_skills::clawhub::ClawHubClient::with_url(&clawhub_cn_base_url(), cache_dir);
 
-    let mut code = String::new();
-    let mut filename = String::new();
-
-    if let Ok(content) = client.get_file(&slug, "SKILL.md").await {
-        code = content;
-        filename = "SKILL.md".to_string();
-    } else if let Ok(content) = client.get_file(&slug, "package.json").await {
-        code = content;
-        filename = "package.json".to_string();
-    } else if let Ok(content) = client.get_file(&slug, "skill.toml").await {
-        code = content;
-        filename = "skill.toml".to_string();
-    }
-
-    if code.is_empty() {
-        return ApiErrorResponse::not_found("No source code found for this skill")
-            .into_json_tuple();
-    }
+    let (filename, code) = match fetch_skill_source(&client, &slug).await {
+        Ok(Some(found)) => found,
+        Ok(None) => {
+            return ApiErrorResponse::not_found("No source code found for this skill")
+                .into_json_tuple()
+        }
+        Err(error) => {
+            tracing::warn!("ClawHub skill code fetch failed: {error}");
+            return (
+                marketplace_error_status(&error, StatusCode::BAD_GATEWAY),
+                Json(serde_json::json!({"error": format!("{error}")})),
+            );
+        }
+    };
 
     (
         StatusCode::OK,
@@ -774,7 +774,8 @@ pub async fn clawhub_cn_install(
     };
 
     let cache_dir = state.kernel.home_dir().join(".cache").join("clawhub-cn");
-    let client = librefang_skills::clawhub::ClawHubClient::with_url(CLAWHUB_CN_BASE_URL, cache_dir);
+    let client =
+        librefang_skills::clawhub::ClawHubClient::with_url(&clawhub_cn_base_url(), cache_dir);
 
     if client.is_installed(&req.slug, &skills_dir) {
         return (
@@ -837,12 +838,16 @@ pub async fn clawhub_cn_install(
             let msg = format!("{e}");
             let status = if matches!(e, librefang_skills::SkillError::SecurityBlocked(_)) {
                 StatusCode::FORBIDDEN
-            } else if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else if matches!(e, librefang_skills::SkillError::Network(_)) {
-                StatusCode::BAD_GATEWAY
             } else {
-                StatusCode::INTERNAL_SERVER_ERROR
+                // A dead marketplace used to fall through to the `500`, whose body is then scrubbed to "Internal server error" — the one case where the operator most needs the text (#7387).
+                marketplace_error_status(
+                    &e,
+                    if matches!(e, librefang_skills::SkillError::Network(_)) {
+                        StatusCode::BAD_GATEWAY
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    },
+                )
             };
             tracing::warn!("ClawHub CN install failed: {msg}");
             // See ClawHub install above: 500 catch-all scrubbed

--- a/crates/librefang-api/src/routes/skills/mod.rs
+++ b/crates/librefang-api/src/routes/skills/mod.rs
@@ -437,11 +437,7 @@ const ENV_CLAWHUB_CN_URL: &str = "LIBREFANG_CLAWHUB_CN_URL";
 ///
 /// Read per request rather than cached in a `OnceLock` so a restart is enough to move off a dead mirror, matching how the ClawHub and Skillhub clients resolve their own overrides.
 fn clawhub_cn_base_url() -> String {
-    std::env::var(ENV_CLAWHUB_CN_URL)
-        .ok()
-        .map(|value| value.trim().trim_end_matches('/').to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| CLAWHUB_CN_BASE_URL.to_string())
+    librefang_skills::clawhub::env_url_or(ENV_CLAWHUB_CN_URL, CLAWHUB_CN_BASE_URL)
 }
 
 /// Check whether a SkillError represents a ClawHub rate-limit (429).

--- a/crates/librefang-api/src/routes/skills/mod.rs
+++ b/crates/librefang-api/src/routes/skills/mod.rs
@@ -430,9 +430,48 @@ fn parse_skill_md_frontmatter(content: &str) -> Option<SkillMdFrontmatter> {
 // ---------------------------------------------------------------------------
 const CLAWHUB_CN_BASE_URL: &str = "https://mirror-cn.clawhub.com/api/v1";
 
+/// Environment variable that repoints the ClawHub China mirror handlers.
+const ENV_CLAWHUB_CN_URL: &str = "LIBREFANG_CLAWHUB_CN_URL";
+
+/// The ClawHub China mirror base URL these handlers should use.
+///
+/// Read per request rather than cached in a `OnceLock` so a restart is enough to move off a dead mirror, matching how the ClawHub and Skillhub clients resolve their own overrides.
+fn clawhub_cn_base_url() -> String {
+    std::env::var(ENV_CLAWHUB_CN_URL)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| CLAWHUB_CN_BASE_URL.to_string())
+}
+
 /// Check whether a SkillError represents a ClawHub rate-limit (429).
 fn is_clawhub_rate_limit(err: &librefang_skills::SkillError) -> bool {
     matches!(err, librefang_skills::SkillError::RateLimited(_))
+}
+
+/// Check whether a SkillError means the marketplace answered but is not serving marketplace data.
+fn is_marketplace_unavailable(err: &librefang_skills::SkillError) -> bool {
+    matches!(err, librefang_skills::SkillError::MarketplaceUnavailable(_))
+}
+
+/// Map a marketplace error to an HTTP status, uniformly across every hub and every operation.
+///
+/// `fallback` is the status the handler used before this classification existed — `502` for the read endpoints, `404` for detail, `500` for install — and stays in force for every error that is not one of the two the caller can act on.
+///
+/// `503 Service Unavailable` is the answer for [`SkillError::MarketplaceUnavailable`] because the condition is exactly what that status describes: the daemon is healthy, the request was well-formed, the upstream is temporarily not a marketplace.
+/// It also has to be the *same* answer everywhere. A `404` from detail told the reader the skill does not exist, and a scrubbed `500` from install told them the daemon broke; both are wrong in the same way, and both sent the dashboard down a different render path for one underlying fault.
+/// The dashboard's `isMarketplaceUnavailable` (#7846) already accepts `502` alongside `503` and renders one offline state for either, so a handler that still returns its old `502` degrades gracefully rather than regressing — but detail and install, which returned neither, needed this to reach that state at all.
+fn marketplace_error_status(
+    err: &librefang_skills::SkillError,
+    fallback: StatusCode,
+) -> StatusCode {
+    if is_marketplace_unavailable(err) {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else if is_clawhub_rate_limit(err) {
+        StatusCode::TOO_MANY_REQUESTS
+    } else {
+        fallback
+    }
 }
 
 /// Convert a browse entry (nested stats/tags) to a flat JSON object for the frontend.

--- a/crates/librefang-api/src/routes/skills/skillhub.rs
+++ b/crates/librefang-api/src/routes/skills/skillhub.rs
@@ -60,11 +60,7 @@ pub async fn skillhub_search(
         Err(e) => {
             let msg = format!("{e}");
             tracing::warn!("Skillhub search failed: {msg}");
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::BAD_GATEWAY
-            };
+            let status = marketplace_error_status(&e, StatusCode::BAD_GATEWAY);
             (
                 status,
                 Json(serde_json::json!({"items": [], "next_cursor": null, "error": msg})),
@@ -125,7 +121,7 @@ pub async fn skillhub_browse(
             let msg = format!("{e}");
             tracing::warn!("Skillhub browse failed: {msg}");
             (
-                StatusCode::BAD_GATEWAY,
+                marketplace_error_status(&e, StatusCode::BAD_GATEWAY),
                 Json(serde_json::json!({"items": [], "error": msg})),
             )
         }
@@ -193,11 +189,9 @@ pub async fn skillhub_skill_detail(
             )
         }
         Err(e) => {
-            let status = if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else {
-                StatusCode::NOT_FOUND
-            };
+            // `404` is only honest for a slug the hub says it does not have.
+            // When the hub itself is not answering as a marketplace, saying "not found" invents a fact about the skill (#7387).
+            let status = marketplace_error_status(&e, StatusCode::NOT_FOUND);
             (status, Json(serde_json::json!({"error": format!("{e}")})))
         }
     }
@@ -293,12 +287,16 @@ pub async fn skillhub_install(
             let msg = format!("{e}");
             let status = if matches!(e, librefang_skills::SkillError::SecurityBlocked(_)) {
                 StatusCode::FORBIDDEN
-            } else if is_clawhub_rate_limit(&e) {
-                StatusCode::TOO_MANY_REQUESTS
-            } else if matches!(e, librefang_skills::SkillError::Network(_)) {
-                StatusCode::BAD_GATEWAY
             } else {
-                StatusCode::INTERNAL_SERVER_ERROR
+                // A dead marketplace used to fall through to the `500`, whose body is then scrubbed to "Internal server error" — the one case where the operator most needs the text (#7387).
+                marketplace_error_status(
+                    &e,
+                    if matches!(e, librefang_skills::SkillError::Network(_)) {
+                        StatusCode::BAD_GATEWAY
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    },
+                )
             };
             tracing::warn!("Skillhub install failed: {msg}");
             // See ClawHub install above: 500 catch-all scrubbed

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -795,3 +795,222 @@ async fn skills_propose_without_token_returns_401() {
         "401 error should mention GitHub token: {body:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// A marketplace that answers 200 with its webpage (#7387)
+// ---------------------------------------------------------------------------
+//
+// The failure this covers is not a hub that is down — a down hub already
+// produced a sensible upstream error. It is a hub whose API host has been
+// retired while the CDN in front of it kept answering, so every path now
+// returns `200 OK` with the marketing single-page-app shell. `serde_json` then
+// complains about the leading `<`, and that complaint used to reach the reader
+// as the whole explanation: a `502` on search and browse, a `404` on detail
+// that falsely said the skill did not exist, and a `500` on install whose body
+// was scrubbed to "Internal server error".
+//
+// Every handler below drives exactly that upstream response and asserts the one
+// answer they now share: `503 Service Unavailable`, with the actionable text
+// intact. The point of testing all of them rather than one is that the previous
+// attempt at this fix mapped only the Skillhub routes, leaving the shared
+// `ClawHubClient`'s eight ClawHub and ClawHub CN handlers translating the new
+// condition into their old, wrong statuses.
+
+/// The shell a dead marketplace serves, complete with the UTF-8 BOM that a
+/// CDN-fronted origin tends to prepend. The BOM is deliberate: it is not ASCII
+/// whitespace, so a markup detector that skips only whitespace before looking
+/// for `<` misses this exact body — the most common real-world shape.
+const MARKETPLACE_SPA_SHELL: &str = "\u{feff}<!doctype html>\n<html><head><title>Skill Hub</title></head>\n<body><div id=\"app\"></div></body></html>\n";
+
+/// Base URL of a process-wide server that answers every request with
+/// [`MARKETPLACE_SPA_SHELL`], with the marketplace URL overrides already
+/// pointed at it.
+///
+/// Process-wide, and initialised exactly once, because the handlers resolve
+/// their hub URLs from the environment and the environment is shared by every
+/// test in this binary. One server started once means those variables are
+/// written a single time, to a single set of values, before any test reads
+/// them. No other test in this file touches a remote hub.
+///
+/// The listener runs on its own thread with its own runtime rather than on the
+/// calling test's. `#[tokio::test]` builds a fresh runtime per test and drops it
+/// at the end of that test, which would take a `tokio::spawn`-ed accept loop
+/// down with it — every later test would then hit a closed port, and a refused
+/// connection is a `Network` error that the client retries with backoff, so the
+/// suite hangs for tens of seconds instead of failing.
+fn dead_marketplace() -> &'static str {
+    use std::io::{Read, Write};
+    use std::sync::OnceLock;
+
+    static SERVER: OnceLock<String> = OnceLock::new();
+
+    SERVER.get_or_init(|| {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stub marketplace");
+        let address = listener.local_addr().expect("stub marketplace address");
+
+        std::thread::spawn(move || {
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: text/html; charset=utf-8\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n{}",
+                MARKETPLACE_SPA_SHELL.len(),
+                MARKETPLACE_SPA_SHELL
+            );
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let response = response.clone();
+                std::thread::spawn(move || {
+                    // Read only until the blank line that ends the request head;
+                    // reading to EOF would block on a client waiting for us.
+                    let mut request = Vec::new();
+                    let mut byte = [0_u8; 1];
+                    while stream.read_exact(&mut byte).is_ok() {
+                        request.push(byte[0]);
+                        if request.ends_with(b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                    let _ = stream.shutdown(std::net::Shutdown::Both);
+                });
+            }
+        });
+
+        let base = format!("http://{address}");
+        std::env::set_var("LIBREFANG_CLAWHUB_URL", format!("{base}/api/v1"));
+        std::env::set_var("LIBREFANG_CLAWHUB_CN_URL", format!("{base}/api/v1"));
+        std::env::set_var("LIBREFANG_SKILLHUB_URL", format!("{base}/api/v1"));
+        std::env::set_var(
+            "LIBREFANG_SKILLHUB_INDEX_URL",
+            format!("{base}/skills.json"),
+        );
+        std::env::set_var("LIBREFANG_SKILLHUB_COS_URL", base.clone());
+        base
+    })
+}
+
+/// Drive one route against the dead marketplace and assert the shared answer.
+async fn assert_marketplace_unavailable(
+    method: Method,
+    path: &str,
+    body: Option<serde_json::Value>,
+) {
+    dead_marketplace();
+    let h = boot().await;
+    let (status, json) = json_request(&h, method, path, body).await;
+
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{path} should report the hub as unavailable, got {status} with {json}"
+    );
+
+    let error = json["error"].as_str().unwrap_or_default();
+    assert!(
+        error.starts_with("Marketplace unavailable:"),
+        "{path} should name the condition, got {error:?}"
+    );
+    assert!(
+        error.contains("webpage instead of"),
+        "{path} should say what the hub served, got {error:?}"
+    );
+    // The scrub that blanks a 500 body must not swallow the one message an
+    // operator can act on.
+    assert_ne!(
+        error, "Internal server error",
+        "{path} scrubbed its message"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_search_reports_a_webpage_serving_hub_as_unavailable() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub/search?q=rust", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_browse_reports_a_webpage_serving_hub_as_unavailable() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub/browse?limit=5", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_detail_reports_unavailable_rather_than_not_found() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub/skill/example-skill", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_skill_code_reports_unavailable_rather_than_not_found() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub/skill/example-skill/code", None)
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_install_reports_unavailable_rather_than_a_scrubbed_500() {
+    assert_marketplace_unavailable(
+        Method::POST,
+        "/api/clawhub/install",
+        Some(serde_json::json!({"slug": "example-skill"})),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_cn_search_reports_a_webpage_serving_hub_as_unavailable() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub-cn/search?q=rust", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_cn_browse_reports_a_webpage_serving_hub_as_unavailable() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub-cn/browse?limit=5", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_cn_detail_reports_unavailable_rather_than_not_found() {
+    assert_marketplace_unavailable(Method::GET, "/api/clawhub-cn/skill/example-skill", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_cn_skill_code_reports_unavailable_rather_than_not_found() {
+    assert_marketplace_unavailable(
+        Method::GET,
+        "/api/clawhub-cn/skill/example-skill/code",
+        None,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clawhub_cn_install_reports_unavailable_rather_than_a_scrubbed_500() {
+    assert_marketplace_unavailable(
+        Method::POST,
+        "/api/clawhub-cn/install",
+        Some(serde_json::json!({"slug": "example-skill"})),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skillhub_search_reports_a_webpage_serving_hub_as_unavailable() {
+    assert_marketplace_unavailable(Method::GET, "/api/skillhub/search?q=rust", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skillhub_browse_reports_a_webpage_serving_hub_as_unavailable() {
+    assert_marketplace_unavailable(Method::GET, "/api/skillhub/browse?limit=5", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skillhub_detail_reports_unavailable_rather_than_not_found() {
+    assert_marketplace_unavailable(Method::GET, "/api/skillhub/skill/example-skill", None).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skillhub_install_reports_unavailable_rather_than_a_scrubbed_500() {
+    assert_marketplace_unavailable(
+        Method::POST,
+        "/api/skillhub/install",
+        Some(serde_json::json!({"slug": "example-skill"})),
+    )
+    .await;
+}

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -19,6 +19,23 @@ use sha2::{Digest, Sha256};
 use std::path::{Component, Path, PathBuf};
 use tracing::{debug, info, warn};
 
+/// Official ClawHub API base URL.
+pub const DEFAULT_CLAWHUB_URL: &str = "https://clawhub.ai/api/v1";
+
+/// Environment variable that repoints [`ClawHubClient::new`] at a ClawHub mirror.
+pub const ENV_CLAWHUB_URL: &str = "LIBREFANG_CLAWHUB_URL";
+
+/// Read a marketplace URL override from the environment, falling back to `default`.
+///
+/// An unset variable and one set to whitespace are treated alike: a blank override in a shell profile or compose file is an operator mistake, not a request to fetch from the empty string.
+pub(crate) fn env_url_or(var: &str, default: &str) -> String {
+    std::env::var(var)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
 // ---------------------------------------------------------------------------
 // Retry constants for ClawHub API rate-limit handling
 // ---------------------------------------------------------------------------
@@ -264,11 +281,14 @@ pub struct ClawHubClient {
 }
 
 impl ClawHubClient {
-    /// Create a new ClawHub client with default settings.
+    /// Create a new ClawHub client pointed at the configured ClawHub API.
     ///
-    /// Uses the official ClawHub API at `https://clawhub.ai/api/v1`.
+    /// Defaults to the official API at [`DEFAULT_CLAWHUB_URL`]; `LIBREFANG_CLAWHUB_URL` overrides it so an operator can move to a mirror without recompiling when the official host stops answering with JSON.
     pub fn new(cache_dir: PathBuf) -> Self {
-        Self::with_url("https://clawhub.ai/api/v1", cache_dir)
+        Self::with_url(
+            &crate::clawhub::env_url_or(ENV_CLAWHUB_URL, DEFAULT_CLAWHUB_URL),
+            cache_dir,
+        )
     }
 
     /// Create a ClawHub client with a custom API URL.
@@ -412,13 +432,11 @@ impl ClawHubClient {
         );
 
         let response = self.get_with_retry(&url, "ClawHub search").await?;
+        let body = response.bytes().await.map_err(|e| {
+            SkillError::Network(format!("Failed to read ClawHub search response: {e}"))
+        })?;
 
-        let results: ClawHubSearchResponse = response
-            .json()
-            .await
-            .map_err(|e| SkillError::Network(format!("Failed to parse ClawHub response: {e}")))?;
-
-        Ok(results)
+        crate::parse_marketplace_json::<ClawHubSearchResponse>("ClawHub search", &url, &body)
     }
 
     /// Browse skills by sort order (trending, downloads, stars, etc.).
@@ -442,13 +460,11 @@ impl ClawHubClient {
         }
 
         let response = self.get_with_retry(&url, "ClawHub browse").await?;
+        let body = response.bytes().await.map_err(|e| {
+            SkillError::Network(format!("Failed to read ClawHub browse response: {e}"))
+        })?;
 
-        let results: ClawHubBrowseResponse = response
-            .json()
-            .await
-            .map_err(|e| SkillError::Network(format!("Failed to parse ClawHub browse: {e}")))?;
-
-        Ok(results)
+        crate::parse_marketplace_json::<ClawHubBrowseResponse>("ClawHub browse", &url, &body)
     }
 
     /// Get detailed info about a specific skill.
@@ -460,13 +476,11 @@ impl ClawHubClient {
         let url = format!("{}/skills/{}", self.base_url, urlencoded(slug));
 
         let response = self.get_with_retry(&url, "ClawHub skill detail").await?;
+        let body = response.bytes().await.map_err(|e| {
+            SkillError::Network(format!("Failed to read ClawHub detail response: {e}"))
+        })?;
 
-        let detail: ClawHubSkillDetail = response
-            .json()
-            .await
-            .map_err(|e| SkillError::Network(format!("Failed to parse ClawHub detail: {e}")))?;
-
-        Ok(detail)
+        crate::parse_marketplace_json::<ClawHubSkillDetail>("ClawHub skill detail", &url, &body)
     }
 
     /// Helper: extract the version string from a browse entry.
@@ -497,6 +511,14 @@ impl ClawHubClient {
             .text()
             .await
             .map_err(|e| SkillError::Network(format!("Failed to read ClawHub file: {e}")))?;
+
+        // A hub serving its SPA shell answers `200` here too, and the caller would happily display that HTML as the skill's source.
+        // None of the three files this endpoint is asked for — `SKILL.md`, `package.json`, `skill.toml` — begins with `<`, so the same marker that identifies a dead JSON endpoint identifies a dead file endpoint.
+        if crate::looks_like_markup(text.as_bytes()) {
+            return Err(SkillError::MarketplaceUnavailable(format!(
+                "ClawHub file fetch at {url} answered with a webpage instead of {path} — the marketplace is unreachable or has moved. Skill source cannot be shown until it returns; skills already installed locally are unaffected."
+            )));
+        }
 
         Ok(text)
     }

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -28,7 +28,7 @@ pub const ENV_CLAWHUB_URL: &str = "LIBREFANG_CLAWHUB_URL";
 /// Read a marketplace URL override from the environment, falling back to `default`.
 ///
 /// An unset variable and one set to whitespace are treated alike: a blank override in a shell profile or compose file is an operator mistake, not a request to fetch from the empty string.
-pub(crate) fn env_url_or(var: &str, default: &str) -> String {
+pub fn env_url_or(var: &str, default: &str) -> String {
     std::env::var(var)
         .ok()
         .map(|value| value.trim().trim_end_matches('/').to_string())

--- a/crates/librefang-skills/src/lib.rs
+++ b/crates/librefang-skills/src/lib.rs
@@ -65,6 +65,45 @@ pub enum SkillError {
     YamlParse(String),
     #[error("Security blocked: {0}")]
     SecurityBlocked(String),
+    /// The marketplace answered the request, but with something other than the data it promises.
+    ///
+    /// In practice this is a hub whose API host has gone away and now serves its own single-page-app shell (or an interception portal's login page) with `200 OK` for every path.
+    /// It is deliberately distinct from [`SkillError::Network`]: the request succeeded, the hub is simply not a marketplace any more, and the fix is operator-side (point at a mirror, or wait) rather than a retry.
+    #[error("Marketplace unavailable: {0}")]
+    MarketplaceUnavailable(String),
+}
+
+/// True when `body` is a markup document (an HTML page, an XML error envelope) rather than JSON.
+///
+/// A JSON value never begins with `<` — the eight JSON grammar starts are `{`, `[`, `"`, `-`, a digit, `t`, `f` and `n` — so a leading `<` separates "the marketplace is serving its webpage" from "the JSON is genuinely malformed" without guessing.
+/// A UTF-8 BOM is skipped before the scan: `0xEF 0xBB 0xBF` is not ASCII whitespace, and CDN-fronted origins prepend one often enough that ignoring it would send the most common real-world shape down the parser path this function exists to avoid.
+pub fn looks_like_markup(body: &[u8]) -> bool {
+    let body = body.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(body);
+    matches!(
+        body.iter().find(|byte| !byte.is_ascii_whitespace()),
+        Some(b'<')
+    )
+}
+
+/// Parse a marketplace response body, separating "this hub is not answering with JSON at all" from "this JSON is malformed".
+///
+/// Every remote marketplace read in this crate goes through here so the two conditions cannot diverge per endpoint: a `MarketplaceUnavailable` from search must mean the same thing as one from install, because the HTTP layer maps them to one status and the dashboard renders them as one offline state.
+/// `context` names the operation ("ClawHub search"), `url` is the address that answered, and both appear in the message so an operator can see which of several configured hubs died.
+pub fn parse_marketplace_json<T: serde::de::DeserializeOwned>(
+    context: &str,
+    url: &str,
+    body: &[u8],
+) -> Result<T, SkillError> {
+    if looks_like_markup(body) {
+        return Err(SkillError::MarketplaceUnavailable(format!(
+            "{context} at {url} answered with a webpage instead of JSON — the marketplace is unreachable or has moved. Searching, browsing and installing from it are unavailable until it returns; skills already installed locally are unaffected."
+        )));
+    }
+    serde_json::from_slice(body).map_err(|error| {
+        SkillError::Network(format!(
+            "Failed to parse {context} response from {url}: {error}"
+        ))
+    })
 }
 
 /// The runtime type for a skill.
@@ -528,5 +567,91 @@ custom_key = "custom_value"
             reparsed.config.get("custom_key").and_then(|v| v.as_str()),
             Some("custom_value")
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Marketplace-serves-a-webpage detection (#7387)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn markup_is_recognised_through_leading_whitespace_and_a_bom() {
+        assert!(looks_like_markup(b"<!doctype html>"));
+        assert!(looks_like_markup(b"  \n\t<html><body>hi</body></html>"));
+        // A CDN-fronted origin prepends a UTF-8 BOM often enough that missing it
+        // would let the most common real shape reach the parser.
+        assert!(looks_like_markup("\u{feff}<!doctype html>".as_bytes()));
+        assert!(looks_like_markup(
+            "\u{feff}\n  <html><head><title>Skill Hub</title></head></html>".as_bytes()
+        ));
+        assert!(looks_like_markup(b"<?xml version=\"1.0\"?><Error/>"));
+    }
+
+    #[test]
+    fn json_is_never_mistaken_for_markup() {
+        // Every start the JSON grammar allows, plus a BOM-prefixed object.
+        for body in [
+            "{\"skills\":[]}",
+            "  [1, 2, 3]",
+            "\"a string\"",
+            "-1.5",
+            "42",
+            "true",
+            "false",
+            "null",
+            "\u{feff}{\"skills\":[]}",
+        ] {
+            assert!(
+                !looks_like_markup(body.as_bytes()),
+                "{body:?} is JSON, not markup"
+            );
+        }
+        assert!(!looks_like_markup(b""));
+        assert!(!looks_like_markup(b"   "));
+    }
+
+    #[test]
+    fn a_webpage_body_becomes_marketplace_unavailable_naming_the_hub() {
+        let error = parse_marketplace_json::<serde_json::Value>(
+            "ClawHub search",
+            "https://clawhub.example/api/v1/search?q=rust",
+            b"<!doctype html><html></html>",
+        )
+        .expect_err("a webpage is not a search response");
+
+        let message = error.to_string();
+        assert!(
+            matches!(error, SkillError::MarketplaceUnavailable(_)),
+            "got {error:?}"
+        );
+        assert!(message.contains("ClawHub search"), "{message}");
+        assert!(message.contains("clawhub.example"), "{message}");
+        assert!(message.contains("webpage instead of JSON"), "{message}");
+    }
+
+    #[test]
+    fn genuinely_malformed_json_stays_a_network_error() {
+        // The distinction is the whole point: a truncated or corrupted body is a
+        // transport-level fault worth retrying, and reporting it as a dead
+        // marketplace would send operators looking for a mirror that they do not
+        // need.
+        let error = parse_marketplace_json::<serde_json::Value>(
+            "ClawHub browse",
+            "https://clawhub.example/api/v1/skills",
+            b"{\"skills\": [{\"slug\": \"rus",
+        )
+        .expect_err("a truncated body is not parseable");
+
+        assert!(matches!(error, SkillError::Network(_)), "got {error:?}");
+    }
+
+    #[test]
+    fn well_formed_json_still_parses() {
+        let value: serde_json::Value = parse_marketplace_json(
+            "Skillhub index",
+            "https://skillhub.example/skills.json",
+            b"{\"total\": 1}",
+        )
+        .expect("valid JSON parses");
+        assert_eq!(value["total"], 1);
     }
 }

--- a/crates/librefang-skills/src/skillhub.rs
+++ b/crates/librefang-skills/src/skillhub.rs
@@ -21,12 +21,22 @@ use tracing::{info, warn};
 /// Default Skillhub API base URL.
 pub const DEFAULT_SKILLHUB_URL: &str = "https://skillhub.tencent.com/api/v1";
 
-/// Static skills index URL (Tencent COS).
-const SKILLHUB_INDEX_URL: &str =
+/// Default static skills index URL (Tencent COS).
+pub const DEFAULT_SKILLHUB_INDEX_URL: &str =
     "https://skillhub-1388575217.cos.ap-guangzhou.myqcloud.com/skills.json";
 
-/// COS accelerate base URL for skill zip downloads.
-const SKILLHUB_COS_BASE: &str = "https://skillhub-1388575217.cos.accelerate.myqcloud.com";
+/// Default COS accelerate base URL for skill zip downloads.
+pub const DEFAULT_SKILLHUB_COS_BASE: &str =
+    "https://skillhub-1388575217.cos.accelerate.myqcloud.com";
+
+/// Environment variable for the Skillhub API base — search and skill detail.
+pub const ENV_SKILLHUB_URL: &str = "LIBREFANG_SKILLHUB_URL";
+
+/// Environment variable for the static skills index — browse, and the version lookup that install starts from.
+pub const ENV_SKILLHUB_INDEX_URL: &str = "LIBREFANG_SKILLHUB_INDEX_URL";
+
+/// Environment variable for the object-storage base that skill archives are downloaded from.
+pub const ENV_SKILLHUB_COS_URL: &str = "LIBREFANG_SKILLHUB_COS_URL";
 
 fn atomic_write_manifest(path: &Path, contents: &[u8]) -> Result<(), SkillError> {
     use std::io::Write;
@@ -202,6 +212,10 @@ pub struct SkillhubClient {
     http: reqwest::Client,
     /// Base API URL (e.g. `https://skillhub.tencent.com/api/v1`).
     base_url: String,
+    /// Static skills index URL — the source for browse and for the version install resolves.
+    index_url: String,
+    /// Object-storage base that skill archives are downloaded from.
+    cos_base: String,
 }
 
 impl SkillhubClient {
@@ -215,13 +229,24 @@ impl SkillhubClient {
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
                 .expect("HTTP client build"),
-            base_url: base_url.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            index_url: crate::clawhub::env_url_or(
+                ENV_SKILLHUB_INDEX_URL,
+                DEFAULT_SKILLHUB_INDEX_URL,
+            ),
+            cos_base: crate::clawhub::env_url_or(ENV_SKILLHUB_COS_URL, DEFAULT_SKILLHUB_COS_BASE),
         }
     }
 
-    /// Create a Skillhub client with the default URL.
+    /// Create a Skillhub client from the configured Skillhub endpoints.
+    ///
+    /// Skillhub is not one host: search and detail come from the API base, browse and install's version lookup come from a static index, and archives come from object storage.
+    /// All three are overridable — `LIBREFANG_SKILLHUB_URL`, `LIBREFANG_SKILLHUB_INDEX_URL`, `LIBREFANG_SKILLHUB_COS_URL` — because pointing only the API base at a mirror would leave browse and install still aimed at the dead host, which is the opposite of the recovery an override is for.
     pub fn with_defaults(cache_dir: PathBuf) -> Self {
-        Self::new(DEFAULT_SKILLHUB_URL, cache_dir)
+        Self::new(
+            &crate::clawhub::env_url_or(ENV_SKILLHUB_URL, DEFAULT_SKILLHUB_URL),
+            cache_dir,
+        )
     }
 
     // -- Delegated to ClawHubClient (compatible APIs) -----------------------
@@ -263,6 +288,15 @@ impl SkillhubClient {
         let body = resp.bytes().await.map_err(|e| {
             SkillError::Network(format!("Failed to read Skillhub search response: {e}"))
         })?;
+
+        // Markup first: both parses below fail on an HTML body, and the second one's
+        // `serde_json` complaint is exactly the cryptic "expected value at line 1 column 1"
+        // this check exists to replace (#7387).
+        if crate::looks_like_markup(&body) {
+            return Err(SkillError::MarketplaceUnavailable(format!(
+                "Skillhub search at {url} answered with a webpage instead of JSON — the marketplace is unreachable or has moved. Searching, browsing and installing from it are unavailable until it returns; skills already installed locally are unaffected."
+            )));
+        }
 
         // Try SkillHub-native format first (snake_case, `skills` or `results` key).
         // We parse this first because ClawHubSearchResponse with serde(default)
@@ -315,8 +349,9 @@ impl SkillhubClient {
         // Step 1: Look up the version from the static index
         let index_resp = self
             .http
-            .get(SKILLHUB_INDEX_URL)
+            .get(&self.index_url)
             .header("User-Agent", "LibreFang/0.1")
+            .header("Accept", "application/json")
             .send()
             .await
             .map_err(|e| SkillError::Network(format!("Skillhub index fetch failed: {e}")))?;
@@ -326,10 +361,12 @@ impl SkillhubClient {
                 index_resp.status()
             )));
         }
-        let index: SkillhubIndexResponse = index_resp
-            .json()
+        let index_body = index_resp
+            .bytes()
             .await
-            .map_err(|e| SkillError::Network(format!("Skillhub index parse error: {e}")))?;
+            .map_err(|e| SkillError::Network(format!("Failed to read Skillhub index: {e}")))?;
+        let index: SkillhubIndexResponse =
+            crate::parse_marketplace_json("Skillhub index", &self.index_url, &index_body)?;
 
         let entry = index
             .skills
@@ -341,7 +378,7 @@ impl SkillhubClient {
         let version = &entry.version;
 
         // Step 2: Download zip from COS
-        let cos_url = format!("{SKILLHUB_COS_BASE}/skills/{slug}/{version}.zip",);
+        let cos_url = format!("{}/skills/{slug}/{version}.zip", self.cos_base);
         info!(slug, version = %version, "Downloading skill from Skillhub COS");
 
         let dl_resp = self
@@ -408,8 +445,9 @@ impl SkillhubClient {
     ) -> Result<SkillhubIndexResponse, SkillError> {
         let resp = self
             .http
-            .get(SKILLHUB_INDEX_URL)
+            .get(&self.index_url)
             .header("User-Agent", "LibreFang/0.1")
+            .header("Accept", "application/json")
             .send()
             .await
             .map_err(|e| SkillError::Network(format!("Skillhub index fetch failed: {e}")))?;
@@ -421,10 +459,12 @@ impl SkillhubClient {
             )));
         }
 
-        let mut data: SkillhubIndexResponse = resp
-            .json()
+        let body = resp
+            .bytes()
             .await
-            .map_err(|e| SkillError::Network(format!("Skillhub index parse error: {e}")))?;
+            .map_err(|e| SkillError::Network(format!("Failed to read Skillhub index: {e}")))?;
+        let mut data: SkillhubIndexResponse =
+            crate::parse_marketplace_json("Skillhub index", &self.index_url, &body)?;
 
         // Client-side sort
         match sort {

--- a/docs/operations/skill-marketplaces.md
+++ b/docs/operations/skill-marketplaces.md
@@ -1,0 +1,59 @@
+# Skill marketplaces: when a hub stops answering with JSON
+
+LibreFang reads skills from four remote hubs — ClawHub, the ClawHub China mirror, Skillhub, and the FangHub registry (which is a local checkout, not an HTTP API, and is not covered here).
+This page is about one specific way the first three fail, because it does not look like a failure from the outside.
+
+## The failure
+
+A hub's API host is retired while the CDN in front of it keeps serving.
+Every path then answers `200 OK` with the marketing single-page-app shell instead of the JSON the path used to return.
+Nothing times out and nothing returns an error status, so the daemon happily hands the body to `serde_json`, which reports `expected value at line 1 column 1` — a parser's complaint about a `<`, offered to the reader as the entire explanation for why the Skills page is empty.
+
+The daemon separates this from a genuinely malformed body.
+A JSON document never begins with `<`, so a leading `<` — after an optional UTF-8 BOM and any whitespace — identifies "this is a webpage" without guessing.
+That check lives in `librefang_skills::looks_like_markup`, and every remote marketplace read goes through `librefang_skills::parse_marketplace_json`, which turns it into `SkillError::MarketplaceUnavailable`.
+A truncated or corrupted body stays `SkillError::Network`, because that one is worth a retry and this one is not.
+
+## What you see
+
+Every marketplace endpoint answers `503 Service Unavailable` with the condition spelled out, naming the operation and the URL that answered:
+
+```
+GET /api/clawhub/search        503   Marketplace unavailable: ClawHub search at … answered with a webpage instead of JSON …
+GET /api/clawhub/browse        503
+GET /api/clawhub/skill/{slug}  503
+GET /api/clawhub/skill/{slug}/code
+                               503
+POST /api/clawhub/install      503
+```
+
+and identically for `/api/clawhub-cn/…` and `/api/skillhub/…`.
+
+One status for all of them is the point.
+Detail used to answer `404`, which told the reader the skill does not exist — a claim the daemon is in no position to make when the hub never answered as a marketplace.
+Install used to answer `500`, whose body is then scrubbed to `Internal server error` before it leaves the process, discarding the one message an operator could act on.
+
+The dashboard renders `503` (and `502`, for a daemon that predates this) as a single offline state for the hub rather than a load error with a parser transcript under it.
+
+Skills already installed on disk are unaffected: nothing about a dead hub touches local execution, and `librefang skill install` from a local path keeps working.
+
+## Pointing at a mirror
+
+Each hub's endpoints are overridable, so a mirror can be adopted without recompiling.
+Set these before starting the daemon; they are read when a client is constructed, so a restart is enough.
+
+| Variable | Default | Feeds |
+| --- | --- | --- |
+| `LIBREFANG_CLAWHUB_URL` | `https://clawhub.ai/api/v1` | ClawHub search, browse, detail, source, install |
+| `LIBREFANG_CLAWHUB_CN_URL` | `https://mirror-cn.clawhub.com/api/v1` | The same five endpoints on the China mirror |
+| `LIBREFANG_SKILLHUB_URL` | `https://skillhub.tencent.com/api/v1` | Skillhub search and detail |
+| `LIBREFANG_SKILLHUB_INDEX_URL` | `https://skillhub-1388575217.cos.ap-guangzhou.myqcloud.com/skills.json` | Skillhub browse, and the version lookup install starts from |
+| `LIBREFANG_SKILLHUB_COS_URL` | `https://skillhub-1388575217.cos.accelerate.myqcloud.com` | Skillhub archive downloads |
+
+Skillhub needs three because it is three hosts: an API, a static index, and object storage.
+Overriding only the API base leaves browse and install still aimed at the dead host, which is the opposite of what an override is for — so a Skillhub mirror means setting all three, or none.
+
+A variable set to whitespace is treated as unset rather than as a request to fetch from the empty string.
+Trailing slashes are trimmed.
+
+No replacement host for any of the three defaults has been verified, so LibreFang ships the original URLs and leaves the choice of mirror to you.


### PR DESCRIPTION
Closes #7387.

## Credit

The analysis and the approach here are @DaBlitzStein's, from #7748.
Detecting a leading `<` as the marker that separates "this hub is serving its webpage" from "this JSON is malformed", giving that condition its own `SkillError` variant rather than folding it into `Network`, mapping it to `503`, and making the base URL overridable so a mirror can be adopted without recompiling — all four ideas are theirs, and this PR reuses all four.
The verification that `skillhub.tencent.com` 301s to an SPA with no JSON endpoint anywhere behind it is theirs too, and is what made a graceful-degradation fix the right one instead of a URL swap.

This exists because the review on #7748 stalled: the CHANGES_REQUESTED review of 2026-08-22 is still unaddressed at `58c7d20`, and every commit since has been a bare `Merge branch 'main'`.
Rather than keep the issue open I wrote the change myself, from scratch rather than by copying the diff, so the review items are addressed at the design level rather than patched on.
**I'd recommend closing #7748 as superseded** — that is a recommendation, not an action; I have not touched the PR.

## Premise check

`looks_like_markup`, `SkillError::MarketplaceUnavailable` and `LIBREFANG_SKILLHUB_URL` are **absent from `main`** — I grepped `origin/main` at `3bb418ea6` before writing.
The only thing on `main` with the name is the dashboard's `isMarketplaceUnavailable` helper in `src/lib/http/errors.ts`, from the merged UI half (#7846).
So this is an implementation of the issue, not an adjustment of existing code.

## How this fits with #7846

`#7846` shipped the UI half: the Skills page renders an offline state for a dead hub instead of a load error with a parser transcript under it, and its `isMarketplaceUnavailable` accepts `502` **and** `503`.
This PR makes the backend produce `503` for the condition, which is the status that helper's doc comment was written against.
The `502` half of that predicate stays meaningful: it is what an older daemon returns on search and browse, so a dashboard from this release still degrades correctly against one.
Detail and install, which returned neither `502` nor `503`, could not reach that offline state at all before this change.

## Changes

**Detection — `crates/librefang-skills/src/lib.rs`**

- `looks_like_markup(&[u8])`: skips a UTF-8 BOM, then ASCII whitespace, then reports whether the first byte is `<`.
  No JSON document can start with `<`, so the separation needs no heuristics.
  The BOM skip is one of the review items on #7748: `0xEF` is not ASCII whitespace, so whitespace-only skipping misses the most common CDN-fronted shape.
- `SkillError::MarketplaceUnavailable(String)`, deliberately distinct from `Network`: the request succeeded, the hub is simply not a marketplace, and the response is operator-side rather than a retry.
- `parse_marketplace_json(context, url, body)`: the single boundary every remote marketplace read goes through, so the classification cannot drift per endpoint.
  Names the operation and the URL that answered, so an operator with several hubs configured can see which one died.

**Detection sites — `clawhub.rs`, `skillhub.rs`**

- `ClawHubClient::search` / `browse` / `get_skill` now read bytes and parse through the shared boundary.
- `ClawHubClient::get_file` rejects a markup body too. None of the three names it fetches — `SKILL.md`, `package.json`, `skill.toml` — can begin with `<`, and without this the source viewer renders the hub's SPA shell as the skill's source.
- `SkillhubClient::search` checks before either of its two parse attempts; `browse` and `install`'s index fetch go through the shared boundary.
- ClawHub install and Skillhub install are covered without a check on the archive download: both fetch JSON first (skill detail, static index), so a webpage-serving hub is caught before any bytes are downloaded.

**Mapping — `crates/librefang-api/src/routes/skills/`**

One `marketplace_error_status(err, fallback)` helper, applied at **all fourteen** handlers that reach a hub. This is the standing review item, and a partial mapping is what the review rejected:

| | search | browse | detail | source | install |
| --- | --- | --- | --- | --- | --- |
| `/api/clawhub` | 502 → 503 | 502 → 503 | **404 → 503** | **404 → 503** | **500 → 503** |
| `/api/clawhub-cn` | 502 → 503 | 502 → 503 | **404 → 503** | **404 → 503** | **500 → 503** |
| `/api/skillhub` | 502 → 503 | 502 → 503 | **404 → 503** | n/a | **500 → 503** |

The bold cells are the ones that were actively misleading. `404` on detail asserts the skill does not exist, a claim the daemon cannot make when the hub never answered as a marketplace. `500` on install is scrubbed to `"Internal server error"` on the way out, discarding the one message an operator could act on — precisely the case where they need it.
`/api/skillhub/skill/{slug}/code` is a static 404 with no network call, so there is nothing to map.

The source-code handlers needed more than a status swap: their `if let Ok` chain walked to the next filename on failure and ended at "no source code found". Every candidate comes from the same host, so once it is serving its webpage the next name just re-reads the same page. `fetch_skill_source` returns `Err` for that one condition and keeps try-the-next-name for everything else.

**Mirror contract — the second review item**

#7748's `LIBREFANG_SKILLHUB_URL` reached search and delegated detail only; browse and install still hard-coded the index and COS URLs, so the error text promised a recovery the code could not deliver. Rather than narrow the promise, all of it is configurable now:

| Variable | Feeds |
| --- | --- |
| `LIBREFANG_CLAWHUB_URL` | ClawHub search, browse, detail, source, install |
| `LIBREFANG_CLAWHUB_CN_URL` | the same five on the China mirror |
| `LIBREFANG_SKILLHUB_URL` | Skillhub search and detail |
| `LIBREFANG_SKILLHUB_INDEX_URL` | Skillhub browse, and install's version lookup |
| `LIBREFANG_SKILLHUB_COS_URL` | Skillhub archive downloads |

Skillhub takes three because it is three hosts. Blank values are treated as unset; trailing slashes are trimmed.
No replacement host for any default has been verified, so the shipped defaults are unchanged — this is suggested fix 2 from the issue, with suggested fix 1 reduced to a config change if a JSON contract ever reappears.

**Docs** — `docs/operations/skill-marketplaces.md`: the failure mode, the status contract, and the override table.

## Verification

- `cargo test -p librefang-api --test skills_routes_test` — 38 passed, including **14 new route-level tests**, one per affected handler.
  Each boots the real router via `TestAppState` and drives a genuine `200 OK` + `text/html` upstream response through it, asserting `503` and that the message survives the install scrub.
  The stub's body carries a UTF-8 BOM, so the BOM review item is covered end-to-end and not only in a unit test.
  The stub listens on its own thread with its own runtime: `#[tokio::test]` drops its runtime per test, and a `tokio::spawn`-ed accept loop would die with the first test, leaving later ones retrying a refused connection with backoff.
- `cargo test -p librefang-skills --lib` — 256 passed, including 5 new cases: markup through whitespace and a BOM, every JSON grammar start rejected as markup, the error naming the hub, **a truncated body staying a `Network` error**, and valid JSON still parsing.
- `cargo clippy -p librefang-skills -p librefang-api --lib --tests -- -D warnings` — clean.
- `cargo fmt --all`; `scripts/check-changelog-attribution.py` — clean.
- No dashboard change, so no locale or `pnpm run build` work in scope here; the UI side is already on `main` via #7846.

## Deferred

Nothing.
