### PR TITLE
feat(workflows): add workflow_create with an atomic name reservation

### DIFF
--- a/changelog.d/added/6934-workflow-create-tool.md
+++ b/changelog.d/added/6934-workflow-create-tool.md
@@ -1,0 +1,3 @@
+Agents can now define a workflow during a conversation with the new `workflow_create` tool, instead of workflow authoring being reachable only from the dashboard canvas, the CLI, or the HTTP API.
+A workflow an agent writes is registered immediately and outlives the turn, so the next `workflow_run` — from that agent or any other — can reach it.
+Names stay unique: the check and the registration are one atomic operation inside the engine, so two agents proposing the same name concurrently cannot both succeed and leave a workflow that name-based lookup resolves to at random (#7857) (@houko)

--- a/crates/librefang-kernel-handle/src/workflow_runner.rs
+++ b/crates/librefang-kernel-handle/src/workflow_runner.rs
@@ -291,6 +291,36 @@ pub trait WorkflowRunner: Send + Sync {
         Err(KernelOpError::unavailable("Workflow engine"))
     }
 
+    /// Create and register a new workflow from an agent-authored spec (#6934).
+    ///
+    /// `spec` is the tool payload as received — `{ name, description, steps[], input_schema?, total_timeout_secs? }`.
+    /// It is passed through as JSON rather than as a typed struct because the workflow types live in
+    /// `librefang-kernel`, which the runtime cannot depend on; the kernel deserializes it into its own `Workflow`
+    /// so the wire shape can never drift from the struct the engine executes.
+    ///
+    /// Note that this is **not** the `POST /api/workflows` body: that endpoint has its own hand-written parser over
+    /// different field names (`agent_id` / `agent_name` / `prompt`), while this path deserializes the canonical
+    /// workflow shape (`agent` / `prompt_template`) — the same one `*.workflow.toml` files use.
+    ///
+    /// Every check lives on the kernel side of this boundary — name legality, resource caps, `Workflow::validate()`,
+    /// and the uniqueness of the name — because the caller is an LLM and a JSON-schema constraint is advice it is
+    /// free to ignore.
+    ///
+    /// `caller_agent_id` is recorded on the registration log line so a workflow an agent synthesized can be traced
+    /// back to the turn that produced it. It is a trace, not an authorization gate: no ownership model exists for
+    /// workflows yet, and inventing one here would put the policy in the wrong layer.
+    ///
+    /// Errors: `InvalidInput` for a spec that cannot become a valid workflow, `Conflict` when the name is already
+    /// registered, `Unavailable` when no workflow engine is wired.
+    async fn create_workflow(
+        &self,
+        spec: &serde_json::Value,
+        caller_agent_id: Option<&str>,
+    ) -> Result<WorkflowSummary, KernelOpError> {
+        let _ = (spec, caller_agent_id);
+        Err(KernelOpError::unavailable("Workflow engine"))
+    }
+
     /// Cancel a running or paused workflow run by its UUID string.
     /// Returns `Ok(())` on success, or an error describing why cancellation
     /// failed (not found, already in a terminal state, etc.).

--- a/crates/librefang-kernel-handle/src/workflow_runner.rs
+++ b/crates/librefang-kernel-handle/src/workflow_runner.rs
@@ -294,24 +294,16 @@ pub trait WorkflowRunner: Send + Sync {
     /// Create and register a new workflow from an agent-authored spec (#6934).
     ///
     /// `spec` is the tool payload as received — `{ name, description, steps[], input_schema?, total_timeout_secs? }`.
-    /// It is passed through as JSON rather than as a typed struct because the workflow types live in
-    /// `librefang-kernel`, which the runtime cannot depend on; the kernel deserializes it into its own `Workflow`
-    /// so the wire shape can never drift from the struct the engine executes.
+    /// It is passed through as JSON rather than as a typed struct because the workflow types live in `librefang-kernel`, which the runtime cannot depend on; the kernel deserializes it into its own `Workflow` so the wire shape can never drift from the struct the engine executes.
     ///
-    /// Note that this is **not** the `POST /api/workflows` body: that endpoint has its own hand-written parser over
-    /// different field names (`agent_id` / `agent_name` / `prompt`), while this path deserializes the canonical
-    /// workflow shape (`agent` / `prompt_template`) — the same one `*.workflow.toml` files use.
+    /// Note that this is **not** the `POST /api/workflows` body: that endpoint has its own hand-written parser over different field names (`agent_id` / `agent_name` / `prompt`), while this path deserializes the canonical workflow shape (`agent` / `prompt_template`) — the same one `*.workflow.toml` files use.
     ///
-    /// Every check lives on the kernel side of this boundary — name legality, resource caps, `Workflow::validate()`,
-    /// and the uniqueness of the name — because the caller is an LLM and a JSON-schema constraint is advice it is
-    /// free to ignore.
+    /// Every check lives on the kernel side of this boundary — name legality, resource caps, `Workflow::validate()`, and the uniqueness of the name — because the caller is an LLM and a JSON-schema constraint is advice it is free to ignore.
     ///
-    /// `caller_agent_id` is recorded on the registration log line so a workflow an agent synthesized can be traced
-    /// back to the turn that produced it. It is a trace, not an authorization gate: no ownership model exists for
-    /// workflows yet, and inventing one here would put the policy in the wrong layer.
+    /// `caller_agent_id` is recorded on the registration log line so a workflow an agent synthesized can be traced back to the turn that produced it.
+    /// It is a trace, not an authorization gate: no ownership model exists for workflows yet, and inventing one here would put the policy in the wrong layer.
     ///
-    /// Errors: `InvalidInput` for a spec that cannot become a valid workflow, `Conflict` when the name is already
-    /// registered, `Unavailable` when no workflow engine is wired.
+    /// Errors: `InvalidInput` for a spec that cannot become a valid workflow, `Conflict` when the name is already registered, `Unavailable` when no workflow engine is wired.
     async fn create_workflow(
         &self,
         spec: &serde_json::Value,

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -36,6 +36,184 @@ fn placeholder_regex() -> &'static regex::Regex {
     })
 }
 
+/// Upper bound on the number of steps an agent may put in one workflow.
+///
+/// `workflow_create` takes LLM-authored input, so every ceiling here is enforced rather than merely advertised — a
+/// JSON-schema `maxItems` is advice the calling model is free to ignore. The tool schema publishes the same numbers
+/// so a model is never told one ceiling and rejected at another.
+pub(crate) const MAX_CREATED_WORKFLOW_STEPS: usize = 50;
+
+/// Upper bound on a single step's `timeout_secs` in an agent-created workflow (1 hour).
+pub(crate) const MAX_CREATED_STEP_TIMEOUT_SECS: u64 = 3_600;
+
+/// Upper bound on an agent-created workflow's `total_timeout_secs` (24 hours).
+pub(crate) const MAX_CREATED_TOTAL_TIMEOUT_SECS: u64 = 86_400;
+
+/// Upper bound on the length of an agent-supplied workflow name.
+pub(crate) const MAX_CREATED_WORKFLOW_NAME_LEN: usize = 64;
+
+/// Does this workflow advertise input parameters an agent can discover?
+///
+/// True when an explicit `[[input_schema]]` block was authored **or** any step's `prompt_template` carries a
+/// `{{var}}` placeholder — the auto-detect fallback, which mirrors `Workflow::to_template()` so the discovery
+/// surface reads the same for both authoring styles (#4982 — gap 2).
+fn has_discoverable_input_schema(workflow: &crate::workflow::Workflow) -> bool {
+    let has_explicit = workflow
+        .input_schema
+        .as_ref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    has_explicit
+        || workflow
+            .steps
+            .iter()
+            .any(|s| s.prompt_template.contains("{{") && s.prompt_template.contains("}}"))
+}
+
+/// Build the `WorkflowSummary` the trait boundary hands back for a workflow.
+fn summarize_workflow(workflow: &crate::workflow::Workflow) -> kernel_handle::WorkflowSummary {
+    kernel_handle::WorkflowSummary::new(
+        workflow.id.0.to_string(),
+        workflow.name.clone(),
+        workflow.description.clone(),
+        workflow.steps.len(),
+        has_discoverable_input_schema(workflow),
+    )
+}
+
+/// The agent-authored payload `workflow_create` accepts.
+///
+/// Deliberately a `Deserialize` over the canonical [`crate::workflow::WorkflowStep`] /
+/// [`crate::workflow::WorkflowInputParam`] types rather than a hand-written `Value` walk: the tool's accepted shape
+/// is then the struct the engine executes, by construction, and cannot drift from it the way the `POST
+/// /api/workflows` parser has. It also means an input parameter's `param_type` is the key the struct actually reads
+/// — the same spelling `workflow_describe` reports back — so a described workflow round-trips.
+#[derive(serde::Deserialize)]
+struct WorkflowCreateSpec {
+    name: String,
+    #[serde(default)]
+    description: String,
+    steps: Vec<crate::workflow::WorkflowStep>,
+    #[serde(default)]
+    total_timeout_secs: Option<u64>,
+    #[serde(default)]
+    input_schema: Option<Vec<crate::workflow::WorkflowInputParam>>,
+}
+
+/// Validate an agent-supplied workflow name.
+///
+/// `[A-Za-z0-9_-]`, 1–[`MAX_CREATED_WORKFLOW_NAME_LEN`] chars. The name never reaches the filesystem — persistence
+/// is keyed by id (`<uuid>.workflow.json`) — so this is not a traversal guard. It exists because the name is how
+/// agents address the workflow afterwards and it lands verbatim in prompt text: control characters, newlines and
+/// leading/trailing whitespace all produce a workflow that is awkward or impossible to name back.
+fn validate_created_workflow_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name.chars().count() > MAX_CREATED_WORKFLOW_NAME_LEN {
+        return Err(format!(
+            "workflow name must be 1-{MAX_CREATED_WORKFLOW_NAME_LEN} characters, got {}",
+            name.chars().count()
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(format!(
+            "workflow name '{name}' must use only letters, digits, '_' and '-'"
+        ));
+    }
+    Ok(())
+}
+
+/// Turn an agent-authored spec into a registrable [`crate::workflow::Workflow`], or explain why it cannot be one.
+///
+/// Pulled out of the trait method as a free function so every rejection branch is unit-testable without booting a
+/// kernel — the branches are the whole security surface of an always-available, LLM-driven creation tool.
+///
+/// The returned `Err` is relayed to the model verbatim, so each one names the offending field and the limit it
+/// broke; a model that cannot see which ceiling it hit retries the same payload.
+fn build_created_workflow(spec: &serde_json::Value) -> Result<crate::workflow::Workflow, String> {
+    use crate::workflow::{Workflow, WorkflowId};
+
+    let spec: WorkflowCreateSpec = serde_json::from_value(spec.clone())
+        .map_err(|e| format!("not a valid workflow definition: {e}"))?;
+
+    validate_created_workflow_name(&spec.name)?;
+
+    if spec.steps.is_empty() {
+        return Err("a workflow needs at least one step".to_string());
+    }
+    if spec.steps.len() > MAX_CREATED_WORKFLOW_STEPS {
+        return Err(format!(
+            "a workflow may declare at most {MAX_CREATED_WORKFLOW_STEPS} steps, got {}",
+            spec.steps.len()
+        ));
+    }
+
+    let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for step in &spec.steps {
+        if step.name.is_empty() {
+            return Err("every step needs a non-empty 'name'".to_string());
+        }
+        if !seen.insert(step.name.as_str()) {
+            return Err(format!(
+                "step name '{}' is used twice — step names address dependencies, so they must be unique",
+                step.name
+            ));
+        }
+        if step.timeout_secs > MAX_CREATED_STEP_TIMEOUT_SECS {
+            return Err(format!(
+                "step '{}' timeout_secs={} exceeds the {MAX_CREATED_STEP_TIMEOUT_SECS}s per-step ceiling",
+                step.name, step.timeout_secs
+            ));
+        }
+    }
+    // Dependencies are checked in a second pass so a step may depend on one declared after it — DAG execution is
+    // topological, not positional, and rejecting a forward reference would forbid a legal workflow.
+    for step in &spec.steps {
+        for dep in &step.depends_on {
+            if !seen.contains(dep.as_str()) {
+                return Err(format!(
+                    "step '{}' depends on '{dep}', which is not a step in this workflow",
+                    step.name
+                ));
+            }
+        }
+    }
+
+    if let Some(total) = spec.total_timeout_secs {
+        if total > MAX_CREATED_TOTAL_TIMEOUT_SECS {
+            return Err(format!(
+                "total_timeout_secs={total} exceeds the {MAX_CREATED_TOTAL_TIMEOUT_SECS}s per-workflow ceiling"
+            ));
+        }
+    }
+
+    let workflow = Workflow {
+        id: WorkflowId::new(),
+        name: spec.name,
+        description: spec.description,
+        steps: spec.steps,
+        created_at: chrono::Utc::now(),
+        layout: None,
+        total_timeout_secs: spec.total_timeout_secs,
+        input_schema: spec.input_schema,
+    };
+
+    // The same semantic pass `POST /api/workflows` and the canvas run: empty Transform code, unparseable Tera
+    // templates, zero / over-cap Wait durations, operator nodes wired into a DAG.
+    let errs = workflow.validate();
+    if !errs.is_empty() {
+        let detail = errs
+            .iter()
+            .map(|(step, reason)| format!("step '{step}': {reason}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(detail);
+    }
+
+    Ok(workflow)
+}
+
 #[async_trait::async_trait]
 impl kernel_handle::WorkflowRunner for LibreFangKernel {
     async fn run_workflow(
@@ -85,31 +263,7 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
             .list_workflows()
             .await
             .into_iter()
-            .map(|w| {
-                // `has_input_schema` is true when either an explicit
-                // `[[input_schema]]` block was authored on the workflow
-                // OR any step's prompt_template references at least one
-                // `{{var}}` placeholder (auto-detect path). The fallback
-                // mirrors `Workflow::to_template()` so the discovery
-                // surface stays consistent across both authoring styles
-                // (#4982 — gap 2).
-                let has_explicit = w
-                    .input_schema
-                    .as_ref()
-                    .map(|s| !s.is_empty())
-                    .unwrap_or(false);
-                let has_auto = !has_explicit
-                    && w.steps.iter().any(|s| {
-                        s.prompt_template.contains("{{") && s.prompt_template.contains("}}")
-                    });
-                kernel_handle::WorkflowSummary::new(
-                    w.id.0.to_string(),
-                    w.name,
-                    w.description,
-                    w.steps.len(),
-                    has_explicit || has_auto,
-                )
-            })
+            .map(|w| summarize_workflow(&w))
             .collect();
         // Sort by name for deterministic prompt output (#3298).
         summaries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -486,6 +640,42 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
         Ok(run_id.0.to_string())
     }
 
+    async fn create_workflow(
+        &self,
+        spec: &serde_json::Value,
+        caller_agent_id: Option<&str>,
+    ) -> Result<kernel_handle::WorkflowSummary, kernel_handle::KernelOpError> {
+        use kernel_handle::KernelOpError;
+
+        let workflow = build_created_workflow(spec).map_err(KernelOpError::InvalidInput)?;
+        // Built before the move into the engine; the engine returns only the id.
+        let summary = summarize_workflow(&workflow);
+        let name = workflow.name.clone();
+
+        // `register_unique_name`, not `list_workflows()`-then-`register()`: the name check and the insert have to be
+        // one operation or two agents creating the same name concurrently both win, and name-based lookup then
+        // resolves to whichever duplicate the registry iterator reaches first (#6934).
+        let id = self
+            .workflows
+            .engine
+            .register_unique_name(workflow)
+            .await
+            .map_err(|taken| KernelOpError::Conflict(taken.to_string()))?;
+
+        // Provenance trace, not an authorization gate: workflows have no ownership model, and an agent-authored one
+        // is executable by any agent the moment it is registered. Logging who asked for it is what makes that
+        // reviewable after the fact.
+        tracing::info!(
+            workflow_id = %id,
+            workflow_name = %name,
+            caller_agent_id = caller_agent_id.unwrap_or("<unattributed>"),
+            step_count = summary.step_count,
+            "Agent created a workflow"
+        );
+
+        Ok(summary)
+    }
+
     async fn cancel_workflow_run(&self, run_id: &str) -> Result<(), kernel_handle::KernelOpError> {
         use crate::workflow::{CancelRunError, WorkflowRunId};
         use kernel_handle::KernelOpError;
@@ -518,6 +708,224 @@ mod tests {
     /// the PR explicitly locks in. If you need to change the format,
     /// announce it in the changelog under a breaking-change bullet and
     /// update this assertion.
+    /// A minimal spec that `build_created_workflow` accepts, as JSON, so each
+    /// test below can mutate exactly the field it is about.
+    fn spec(steps: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "name": "nightly-report",
+            "description": "summarise the day",
+            "steps": steps,
+        })
+    }
+
+    fn one_step() -> serde_json::Value {
+        serde_json::json!([{
+            "name": "write",
+            "agent": "writer",
+            "prompt_template": "Summarise {{input}}",
+        }])
+    }
+
+    #[test]
+    fn build_created_workflow_accepts_a_minimal_spec() {
+        let wf = build_created_workflow(&spec(one_step())).expect("minimal spec is valid");
+        assert_eq!(wf.name, "nightly-report");
+        assert_eq!(wf.steps.len(), 1);
+        // Bare-string `agent` is the documented shorthand for by-name routing.
+        assert!(matches!(
+            &wf.steps[0].agent,
+            crate::workflow::StepAgent::ByName { name } if name == "writer"
+        ));
+        // Serde defaults fill the fields the model left out, rather than a
+        // hand-written parser inventing its own.
+        assert_eq!(wf.steps[0].timeout_secs, 120);
+        assert!(matches!(
+            wf.steps[0].mode,
+            crate::workflow::StepMode::Sequential
+        ));
+    }
+
+    /// The input-parameter key is `param_type` — the spelling
+    /// `WorkflowInputParam` deserializes and `workflow_describe` reports — so a
+    /// described workflow round-trips back through creation with its declared
+    /// types intact.
+    #[test]
+    fn build_created_workflow_preserves_declared_param_types() {
+        let mut s = spec(one_step());
+        s["input_schema"] = serde_json::json!([
+            { "name": "cover", "param_type": "image", "required": false },
+            { "name": "topic" },
+        ]);
+        let wf = build_created_workflow(&s).expect("input schema is valid");
+        let schema = wf.input_schema.expect("input_schema survives");
+        assert_eq!(schema[0].param_type, "image");
+        assert!(!schema[0].required);
+        // Defaults apply to the parameter the model under-specified.
+        assert_eq!(schema[1].param_type, "string");
+        assert!(schema[1].required);
+    }
+
+    #[test]
+    fn build_created_workflow_rejects_a_spec_without_steps() {
+        let err = build_created_workflow(&spec(serde_json::json!([])))
+            .expect_err("a stepless workflow can never run");
+        assert!(err.contains("at least one step"), "{err}");
+    }
+
+    #[test]
+    fn build_created_workflow_rejects_a_step_without_an_agent() {
+        let s = spec(serde_json::json!([{ "name": "write", "prompt_template": "go" }]));
+        let err = build_created_workflow(&s).expect_err("a step needs an agent");
+        assert!(err.contains("not a valid workflow definition"), "{err}");
+    }
+
+    /// The ceiling is inclusive: exactly `MAX_CREATED_WORKFLOW_STEPS` steps is
+    /// a legal workflow, one more is not. Pinned in one test so a future edit
+    /// cannot quietly move the boundary by one.
+    #[test]
+    fn build_created_workflow_caps_the_step_count() {
+        let steps = |n: usize| {
+            serde_json::Value::Array(
+                (0..n)
+                    .map(|i| {
+                        serde_json::json!({
+                            "name": format!("step-{i}"),
+                            "agent": "writer",
+                            "prompt_template": "go",
+                        })
+                    })
+                    .collect(),
+            )
+        };
+        assert!(build_created_workflow(&spec(steps(MAX_CREATED_WORKFLOW_STEPS))).is_ok());
+        let err = build_created_workflow(&spec(steps(MAX_CREATED_WORKFLOW_STEPS + 1)))
+            .expect_err("one step over the ceiling must be rejected");
+        assert!(
+            err.contains(&MAX_CREATED_WORKFLOW_STEPS.to_string()),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn build_created_workflow_caps_both_timeouts() {
+        let mut s = spec(serde_json::json!([{
+            "name": "write",
+            "agent": "writer",
+            "prompt_template": "go",
+            "timeout_secs": MAX_CREATED_STEP_TIMEOUT_SECS + 1,
+        }]));
+        let err = build_created_workflow(&s).expect_err("step timeout over the ceiling");
+        assert!(err.contains("per-step ceiling"), "{err}");
+
+        s = spec(one_step());
+        s["total_timeout_secs"] = serde_json::json!(MAX_CREATED_TOTAL_TIMEOUT_SECS + 1);
+        let err = build_created_workflow(&s).expect_err("total timeout over the ceiling");
+        assert!(err.contains("per-workflow ceiling"), "{err}");
+    }
+
+    /// Step names address dependencies, so a duplicate makes `depends_on`
+    /// ambiguous and an unknown target makes it unsatisfiable — both produce a
+    /// workflow that cannot run, and both are cheap to catch at creation.
+    #[test]
+    fn build_created_workflow_rejects_broken_step_dependencies() {
+        let dup = spec(serde_json::json!([
+            { "name": "write", "agent": "writer", "prompt_template": "a" },
+            { "name": "write", "agent": "writer", "prompt_template": "b" },
+        ]));
+        let err = build_created_workflow(&dup).expect_err("duplicate step names");
+        assert!(err.contains("used twice"), "{err}");
+
+        let dangling = spec(serde_json::json!([{
+            "name": "write",
+            "agent": "writer",
+            "prompt_template": "a",
+            "depends_on": ["research"],
+        }]));
+        let err = build_created_workflow(&dangling).expect_err("unknown dependency");
+        assert!(err.contains("not a step in this workflow"), "{err}");
+    }
+
+    /// A dependency on a step declared later is legal — DAG execution is
+    /// topological, not positional.
+    #[test]
+    fn build_created_workflow_allows_a_forward_dependency() {
+        let s = spec(serde_json::json!([
+            { "name": "publish", "agent": "writer", "prompt_template": "a", "depends_on": ["research"] },
+            { "name": "research", "agent": "analyst", "prompt_template": "b" },
+        ]));
+        assert!(build_created_workflow(&s).is_ok());
+    }
+
+    #[test]
+    fn created_workflow_names_are_constrained() {
+        assert!(validate_created_workflow_name("nightly-report").is_ok());
+        assert!(validate_created_workflow_name("report_v2").is_ok());
+        assert!(validate_created_workflow_name("").is_err());
+        assert!(validate_created_workflow_name("../../etc/passwd").is_err());
+        assert!(validate_created_workflow_name("has space").is_err());
+        assert!(validate_created_workflow_name("line\nbreak").is_err());
+        assert!(validate_created_workflow_name(&"a".repeat(MAX_CREATED_WORKFLOW_NAME_LEN)).is_ok());
+        assert!(
+            validate_created_workflow_name(&"a".repeat(MAX_CREATED_WORKFLOW_NAME_LEN + 1)).is_err()
+        );
+    }
+
+    /// The semantic pass `POST /api/workflows` runs must run here too — an
+    /// agent-authored operator node is exactly as unrunnable as a hand-written
+    /// one.
+    #[test]
+    fn build_created_workflow_runs_the_shared_semantic_validation() {
+        let s = spec(serde_json::json!([{
+            "name": "pause",
+            "agent": "writer",
+            "prompt_template": "",
+            "mode": { "wait": { "duration_secs": 0 } },
+        }]));
+        let err = build_created_workflow(&s).expect_err("a zero-second wait is rejected");
+        assert!(err.contains("wait.duration_secs"), "{err}");
+    }
+
+    /// The ceilings the tool schema advertises must be the ceilings this module
+    /// enforces.
+    ///
+    /// They live in two crates — the schema in `librefang-runtime`, the limits
+    /// here — so nothing but a test keeps them in step, and a model told one
+    /// number and rejected at another burns a turn discovering the difference.
+    /// The kernel is the only place both are visible.
+    #[test]
+    fn the_tool_schema_advertises_the_ceilings_this_module_enforces() {
+        let defs = librefang_runtime::tool_runner::builtin_tool_definitions();
+        let schema = &defs
+            .iter()
+            .find(|d| d.name == "workflow_create")
+            .expect("workflow_create must be a builtin tool")
+            .input_schema;
+
+        assert_eq!(
+            schema["properties"]["steps"]["maxItems"].as_u64(),
+            Some(MAX_CREATED_WORKFLOW_STEPS as u64),
+            "advertised step ceiling must match the enforced one"
+        );
+        assert_eq!(
+            schema["properties"]["steps"]["items"]["properties"]["timeout_secs"]["maximum"]
+                .as_u64(),
+            Some(MAX_CREATED_STEP_TIMEOUT_SECS),
+            "advertised per-step timeout ceiling must match the enforced one"
+        );
+        assert_eq!(
+            schema["properties"]["total_timeout_secs"]["maximum"].as_u64(),
+            Some(MAX_CREATED_TOTAL_TIMEOUT_SECS),
+            "advertised total timeout ceiling must match the enforced one"
+        );
+        let name_doc = schema["properties"]["name"]["description"]
+            .as_str()
+            .expect("the name property must be documented");
+        assert!(
+            name_doc.contains(&format!("1-{MAX_CREATED_WORKFLOW_NAME_LEN}")),
+            "the name length rule must be advertised as enforced, got: {name_doc}"
+        );
+    }
+
     #[test]
     fn workflow_timeout_text_format_is_stable() {
         assert_eq!(

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -38,9 +38,8 @@ fn placeholder_regex() -> &'static regex::Regex {
 
 /// Upper bound on the number of steps an agent may put in one workflow.
 ///
-/// `workflow_create` takes LLM-authored input, so every ceiling here is enforced rather than merely advertised — a
-/// JSON-schema `maxItems` is advice the calling model is free to ignore. The tool schema publishes the same numbers
-/// so a model is never told one ceiling and rejected at another.
+/// `workflow_create` takes LLM-authored input, so every ceiling here is enforced rather than merely advertised — a JSON-schema `maxItems` is advice the calling model is free to ignore.
+/// The tool schema publishes the same numbers so a model is never told one ceiling and rejected at another.
 pub(crate) const MAX_CREATED_WORKFLOW_STEPS: usize = 50;
 
 /// Upper bound on a single step's `timeout_secs` in an agent-created workflow (1 hour).
@@ -54,9 +53,7 @@ pub(crate) const MAX_CREATED_WORKFLOW_NAME_LEN: usize = 64;
 
 /// Does this workflow advertise input parameters an agent can discover?
 ///
-/// True when an explicit `[[input_schema]]` block was authored **or** any step's `prompt_template` carries a
-/// `{{var}}` placeholder — the auto-detect fallback, which mirrors `Workflow::to_template()` so the discovery
-/// surface reads the same for both authoring styles (#4982 — gap 2).
+/// True when an explicit `[[input_schema]]` block was authored **or** any step's `prompt_template` carries a `{{var}}` placeholder — the auto-detect fallback, which mirrors `Workflow::to_template()` so the discovery surface reads the same for both authoring styles (#4982 — gap 2).
 fn has_discoverable_input_schema(workflow: &crate::workflow::Workflow) -> bool {
     let has_explicit = workflow
         .input_schema
@@ -83,11 +80,8 @@ fn summarize_workflow(workflow: &crate::workflow::Workflow) -> kernel_handle::Wo
 
 /// The agent-authored payload `workflow_create` accepts.
 ///
-/// Deliberately a `Deserialize` over the canonical [`crate::workflow::WorkflowStep`] /
-/// [`crate::workflow::WorkflowInputParam`] types rather than a hand-written `Value` walk: the tool's accepted shape
-/// is then the struct the engine executes, by construction, and cannot drift from it the way the `POST
-/// /api/workflows` parser has. It also means an input parameter's `param_type` is the key the struct actually reads
-/// — the same spelling `workflow_describe` reports back — so a described workflow round-trips.
+/// Deliberately a `Deserialize` over the canonical [`crate::workflow::WorkflowStep`] / [`crate::workflow::WorkflowInputParam`] types rather than a hand-written `Value` walk: the tool's accepted shape is then the struct the engine executes, by construction, and cannot drift from it the way the `POST /api/workflows` parser has.
+/// It also means an input parameter's `param_type` is the key the struct actually reads — the same spelling `workflow_describe` reports back — so a described workflow round-trips.
 #[derive(serde::Deserialize)]
 struct WorkflowCreateSpec {
     name: String,
@@ -102,10 +96,9 @@ struct WorkflowCreateSpec {
 
 /// Validate an agent-supplied workflow name.
 ///
-/// `[A-Za-z0-9_-]`, 1–[`MAX_CREATED_WORKFLOW_NAME_LEN`] chars. The name never reaches the filesystem — persistence
-/// is keyed by id (`<uuid>.workflow.json`) — so this is not a traversal guard. It exists because the name is how
-/// agents address the workflow afterwards and it lands verbatim in prompt text: control characters, newlines and
-/// leading/trailing whitespace all produce a workflow that is awkward or impossible to name back.
+/// `[A-Za-z0-9_-]`, 1–[`MAX_CREATED_WORKFLOW_NAME_LEN`] chars.
+/// The name never reaches the filesystem — persistence is keyed by id (`<uuid>.workflow.json`) — so this is not a traversal guard.
+/// It exists because the name is how agents address the workflow afterwards and it lands verbatim in prompt text: control characters, newlines and leading/trailing whitespace all produce a workflow that is awkward or impossible to name back.
 fn validate_created_workflow_name(name: &str) -> Result<(), String> {
     if name.is_empty() || name.chars().count() > MAX_CREATED_WORKFLOW_NAME_LEN {
         return Err(format!(
@@ -126,11 +119,9 @@ fn validate_created_workflow_name(name: &str) -> Result<(), String> {
 
 /// Turn an agent-authored spec into a registrable [`crate::workflow::Workflow`], or explain why it cannot be one.
 ///
-/// Pulled out of the trait method as a free function so every rejection branch is unit-testable without booting a
-/// kernel — the branches are the whole security surface of an always-available, LLM-driven creation tool.
+/// Pulled out of the trait method as a free function so every rejection branch is unit-testable without booting a kernel — the branches are the whole security surface of an always-available, LLM-driven creation tool.
 ///
-/// The returned `Err` is relayed to the model verbatim, so each one names the offending field and the limit it
-/// broke; a model that cannot see which ceiling it hit retries the same payload.
+/// The returned `Err` is relayed to the model verbatim, so each one names the offending field and the limit it broke; a model that cannot see which ceiling it hit retries the same payload.
 fn build_created_workflow(spec: &serde_json::Value) -> Result<crate::workflow::Workflow, String> {
     use crate::workflow::{Workflow, WorkflowId};
 
@@ -167,8 +158,7 @@ fn build_created_workflow(spec: &serde_json::Value) -> Result<crate::workflow::W
             ));
         }
     }
-    // Dependencies are checked in a second pass so a step may depend on one declared after it — DAG execution is
-    // topological, not positional, and rejecting a forward reference would forbid a legal workflow.
+    // Dependencies are checked in a second pass so a step may depend on one declared after it — DAG execution is topological, not positional, and rejecting a forward reference would forbid a legal workflow.
     for step in &spec.steps {
         for dep in &step.depends_on {
             if !seen.contains(dep.as_str()) {
@@ -199,8 +189,7 @@ fn build_created_workflow(spec: &serde_json::Value) -> Result<crate::workflow::W
         input_schema: spec.input_schema,
     };
 
-    // The same semantic pass `POST /api/workflows` and the canvas run: empty Transform code, unparseable Tera
-    // templates, zero / over-cap Wait durations, operator nodes wired into a DAG.
+    // The same semantic pass `POST /api/workflows` and the canvas run: empty Transform code, unparseable Tera templates, zero / over-cap Wait durations, operator nodes wired into a DAG.
     let errs = workflow.validate();
     if !errs.is_empty() {
         let detail = errs
@@ -652,9 +641,7 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
         let summary = summarize_workflow(&workflow);
         let name = workflow.name.clone();
 
-        // `register_unique_name`, not `list_workflows()`-then-`register()`: the name check and the insert have to be
-        // one operation or two agents creating the same name concurrently both win, and name-based lookup then
-        // resolves to whichever duplicate the registry iterator reaches first (#6934).
+        // `register_unique_name`, not `list_workflows()`-then-`register()`: the name check and the insert have to be one operation or two agents creating the same name concurrently both win, and name-based lookup then resolves to whichever duplicate the registry iterator reaches first (#6934).
         let id = self
             .workflows
             .engine
@@ -662,9 +649,8 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
             .await
             .map_err(|taken| KernelOpError::Conflict(taken.to_string()))?;
 
-        // Provenance trace, not an authorization gate: workflows have no ownership model, and an agent-authored one
-        // is executable by any agent the moment it is registered. Logging who asked for it is what makes that
-        // reviewable after the fact.
+        // Provenance trace, not an authorization gate: workflows have no ownership model, and an agent-authored one is executable by any agent the moment it is registered.
+        // Logging who asked for it is what makes that reviewable after the fact.
         tracing::info!(
             workflow_id = %id,
             workflow_name = %name,
@@ -702,14 +688,7 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
 mod tests {
     use super::*;
 
-    /// Pins the operator-facing timeout text format. Operators scrape
-    /// for `"workflow run timed out after"` and pull the seconds field;
-    /// any drift in this string is a breaking change to the contract
-    /// the PR explicitly locks in. If you need to change the format,
-    /// announce it in the changelog under a breaking-change bullet and
-    /// update this assertion.
-    /// A minimal spec that `build_created_workflow` accepts, as JSON, so each
-    /// test below can mutate exactly the field it is about.
+    /// A minimal spec that `build_created_workflow` accepts, as JSON, so each test below can mutate exactly the field it is about.
     fn spec(steps: serde_json::Value) -> serde_json::Value {
         serde_json::json!({
             "name": "nightly-report",
@@ -736,8 +715,7 @@ mod tests {
             &wf.steps[0].agent,
             crate::workflow::StepAgent::ByName { name } if name == "writer"
         ));
-        // Serde defaults fill the fields the model left out, rather than a
-        // hand-written parser inventing its own.
+        // Serde defaults fill the fields the model left out, rather than a hand-written parser inventing its own.
         assert_eq!(wf.steps[0].timeout_secs, 120);
         assert!(matches!(
             wf.steps[0].mode,
@@ -745,10 +723,7 @@ mod tests {
         ));
     }
 
-    /// The input-parameter key is `param_type` — the spelling
-    /// `WorkflowInputParam` deserializes and `workflow_describe` reports — so a
-    /// described workflow round-trips back through creation with its declared
-    /// types intact.
+    /// The input-parameter key is `param_type` — the spelling `WorkflowInputParam` deserializes and `workflow_describe` reports — so a described workflow round-trips back through creation with its declared types intact.
     #[test]
     fn build_created_workflow_preserves_declared_param_types() {
         let mut s = spec(one_step());
@@ -779,9 +754,8 @@ mod tests {
         assert!(err.contains("not a valid workflow definition"), "{err}");
     }
 
-    /// The ceiling is inclusive: exactly `MAX_CREATED_WORKFLOW_STEPS` steps is
-    /// a legal workflow, one more is not. Pinned in one test so a future edit
-    /// cannot quietly move the boundary by one.
+    /// The ceiling is inclusive: exactly `MAX_CREATED_WORKFLOW_STEPS` steps is a legal workflow, one more is not.
+    /// Pinned in one test so a future edit cannot quietly move the boundary by one.
     #[test]
     fn build_created_workflow_caps_the_step_count() {
         let steps = |n: usize| {
@@ -823,9 +797,7 @@ mod tests {
         assert!(err.contains("per-workflow ceiling"), "{err}");
     }
 
-    /// Step names address dependencies, so a duplicate makes `depends_on`
-    /// ambiguous and an unknown target makes it unsatisfiable — both produce a
-    /// workflow that cannot run, and both are cheap to catch at creation.
+    /// Step names address dependencies, so a duplicate makes `depends_on` ambiguous and an unknown target makes it unsatisfiable — both produce a workflow that cannot run, and both are cheap to catch at creation.
     #[test]
     fn build_created_workflow_rejects_broken_step_dependencies() {
         let dup = spec(serde_json::json!([
@@ -845,8 +817,7 @@ mod tests {
         assert!(err.contains("not a step in this workflow"), "{err}");
     }
 
-    /// A dependency on a step declared later is legal — DAG execution is
-    /// topological, not positional.
+    /// A dependency on a step declared later is legal — DAG execution is topological, not positional.
     #[test]
     fn build_created_workflow_allows_a_forward_dependency() {
         let s = spec(serde_json::json!([
@@ -870,9 +841,7 @@ mod tests {
         );
     }
 
-    /// The semantic pass `POST /api/workflows` runs must run here too — an
-    /// agent-authored operator node is exactly as unrunnable as a hand-written
-    /// one.
+    /// The semantic pass `POST /api/workflows` runs must run here too — an agent-authored operator node is exactly as unrunnable as a hand-written one.
     #[test]
     fn build_created_workflow_runs_the_shared_semantic_validation() {
         let s = spec(serde_json::json!([{
@@ -885,12 +854,9 @@ mod tests {
         assert!(err.contains("wait.duration_secs"), "{err}");
     }
 
-    /// The ceilings the tool schema advertises must be the ceilings this module
-    /// enforces.
+    /// The ceilings the tool schema advertises must be the ceilings this module enforces.
     ///
-    /// They live in two crates — the schema in `librefang-runtime`, the limits
-    /// here — so nothing but a test keeps them in step, and a model told one
-    /// number and rejected at another burns a turn discovering the difference.
+    /// They live in two crates — the schema in `librefang-runtime`, the limits here — so nothing but a test keeps them in step, and a model told one number and rejected at another burns a turn discovering the difference.
     /// The kernel is the only place both are visible.
     #[test]
     fn the_tool_schema_advertises_the_ceilings_this_module_enforces() {
@@ -926,6 +892,9 @@ mod tests {
         );
     }
 
+    /// Pins the operator-facing timeout text format.
+    /// Operators scrape for `"workflow run timed out after"` and pull the seconds field; any drift in this string is a breaking change to the contract the PR explicitly locks in.
+    /// If you need to change the format, announce it in the changelog under a breaking-change bullet and update this assertion.
     #[test]
     fn workflow_timeout_text_format_is_stable() {
         assert_eq!(

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -1208,6 +1208,31 @@ pub struct DryRunStep {
     pub skip_reason: Option<String>,
 }
 
+/// Rejection returned by [`WorkflowEngine::register_unique_name`] when another registered workflow already carries
+/// the proposed name.
+///
+/// Carries the id of the incumbent so callers can point the operator (or the agent that proposed the name) at the
+/// workflow they collided with instead of only telling them the name is taken.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowNameTaken {
+    /// The proposed name, as supplied — not lowercased.
+    pub name: String,
+    /// The workflow that already holds the name.
+    pub existing_id: WorkflowId,
+}
+
+impl std::fmt::Display for WorkflowNameTaken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "a workflow named '{}' already exists (id {})",
+            self.name, self.existing_id
+        )
+    }
+}
+
+impl std::error::Error for WorkflowNameTaken {}
+
 /// The workflow engine — manages definitions and executes pipeline runs.
 ///
 /// `runs` is a [`DashMap`] so concurrent step writes for *different* runs
@@ -1859,41 +1884,94 @@ impl WorkflowEngine {
         }
     }
 
-    /// Register a new workflow definition and persist it to disk.
+    /// Write one workflow definition to `workflows_dir`.
     ///
     /// Persistence is atomic: serialise → write `<id>.workflow.json.tmp` →
     /// rename to `<id>.workflow.json`. A crash mid-write leaves the `.tmp`
     /// side-file (ignored by `load_from_dir_sync`'s extension filter) but
     /// never a half-written `<id>.workflow.json` that would later refuse to
     /// parse and stall startup.
-    pub async fn register(&self, workflow: Workflow) -> WorkflowId {
+    ///
+    /// Every failure path is a `warn!` rather than an error return: refusing the registration because the disk write failed leaves the caller worse off than a workflow that is live now and does not survive a restart.
+    async fn persist_definition(&self, workflow: &Workflow) {
+        let Some(ref dir) = self.workflows_dir else {
+            return;
+        };
         let id = workflow.id;
-        if let Some(ref dir) = self.workflows_dir {
-            let path = dir.join(format!("{id}.workflow.json"));
-            let tmp_path = dir.join(format!("{id}.workflow.json.tmp"));
-            match serde_json::to_string_pretty(&workflow) {
-                Ok(json) => {
-                    if let Err(e) = tokio::fs::create_dir_all(dir).await {
-                        warn!(workflow_id = %id, error = %e, "Failed to create workflows dir");
-                    } else if let Err(e) = tokio::fs::write(&tmp_path, &json).await {
-                        warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition (tmp write)");
-                    } else if let Err(e) = tokio::fs::rename(&tmp_path, &path).await {
-                        warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition (atomic rename)");
-                        // Best-effort cleanup so the next register attempt isn't
-                        // blocked by a stale tmp file.
-                        let _ = tokio::fs::remove_file(&tmp_path).await;
-                    } else {
-                        debug!(workflow_id = %id, path = %path.display(), "Persisted workflow definition");
-                    }
-                }
-                Err(e) => {
-                    warn!(workflow_id = %id, error = %e, "Failed to serialize workflow definition");
+        let path = dir.join(format!("{id}.workflow.json"));
+        let tmp_path = dir.join(format!("{id}.workflow.json.tmp"));
+        match serde_json::to_string_pretty(workflow) {
+            Ok(json) => {
+                if let Err(e) = tokio::fs::create_dir_all(dir).await {
+                    warn!(workflow_id = %id, error = %e, "Failed to create workflows dir");
+                } else if let Err(e) = tokio::fs::write(&tmp_path, &json).await {
+                    warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition (tmp write)");
+                } else if let Err(e) = tokio::fs::rename(&tmp_path, &path).await {
+                    warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition (atomic rename)");
+                    // Best-effort cleanup so the next register attempt isn't
+                    // blocked by a stale tmp file.
+                    let _ = tokio::fs::remove_file(&tmp_path).await;
+                } else {
+                    debug!(workflow_id = %id, path = %path.display(), "Persisted workflow definition");
                 }
             }
+            Err(e) => {
+                warn!(workflow_id = %id, error = %e, "Failed to serialize workflow definition");
+            }
         }
+    }
+
+    /// Register a new workflow definition and persist it to disk.
+    ///
+    /// Last writer wins on the *name*: this overwrites nothing keyed by id, but two workflows may end up sharing a name.
+    /// Callers that need the name to be unique must use [`Self::register_unique_name`] instead — checking
+    /// [`Self::list_workflows`] first and calling this afterwards is a check-then-act race, because the read lock is
+    /// released before the insert takes the write lock.
+    pub async fn register(&self, workflow: Workflow) -> WorkflowId {
+        let id = workflow.id;
+        self.persist_definition(&workflow).await;
         self.workflows.write().await.insert(id, workflow);
         info!(workflow_id = %id, "Workflow registered");
         id
+    }
+
+    /// Register a workflow only if no registered workflow already carries its name, as one atomic operation.
+    ///
+    /// The name comparison and the insert happen under a single acquisition of the registry write lock, so two
+    /// concurrent callers proposing the same name cannot both observe it as free: whichever takes the lock second
+    /// sees the first one's entry and loses. This is the property `list_workflows()`-then-`register()` cannot
+    /// provide, and it matters because workflow lookup by name (`run_workflow`, `describe_workflow`) resolves to
+    /// whichever duplicate the `HashMap` iterator reaches first — a same-named second workflow silently shadows
+    /// the original for some fraction of calls.
+    ///
+    /// The comparison is case-insensitive to match that name-based lookup, which lowercases both sides; a
+    /// `Deploy` registered next to an existing `deploy` would be unreachable by name half the time.
+    ///
+    /// Persistence deliberately runs *after* the lock is released. Holding the registry write lock across a
+    /// `tokio::fs` round-trip would block every reader on disk IO, and the reservation is already in force the
+    /// moment the entry is in the map.
+    pub async fn register_unique_name(
+        &self,
+        workflow: Workflow,
+    ) -> Result<WorkflowId, WorkflowNameTaken> {
+        let id = workflow.id;
+        let name_lower = workflow.name.to_lowercase();
+        {
+            let mut registry = self.workflows.write().await;
+            if let Some(existing) = registry
+                .values()
+                .find(|w| w.name.to_lowercase() == name_lower)
+            {
+                return Err(WorkflowNameTaken {
+                    name: workflow.name.clone(),
+                    existing_id: existing.id,
+                });
+            }
+            registry.insert(id, workflow.clone());
+        }
+        self.persist_definition(&workflow).await;
+        info!(workflow_id = %id, name = %workflow.name, "Workflow registered with a reserved name");
+        Ok(id)
     }
 
     /// Load and register all workflow definitions from a directory (sync version for boot).
@@ -6869,6 +6947,187 @@ mod tests {
         let retrieved = engine.get_workflow(id).await;
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().name, "test-pipeline");
+    }
+
+    /// Build a `Workflow` whose only interesting property is its name.
+    fn named_workflow(name: &str) -> Workflow {
+        Workflow {
+            name: name.to_string(),
+            ..test_workflow()
+        }
+    }
+
+    /// Count registered workflows carrying `name`, compared the way name-based
+    /// lookup compares (`run_workflow` / `describe_workflow` both lowercase
+    /// each side before testing equality).
+    async fn count_named(engine: &WorkflowEngine, name: &str) -> usize {
+        let wanted = name.to_lowercase();
+        engine
+            .list_workflows()
+            .await
+            .iter()
+            .filter(|w| w.name.to_lowercase() == wanted)
+            .count()
+    }
+
+    /// Pins the bug [`WorkflowEngine::register_unique_name`] exists to close,
+    /// as the deterministic sequential replay of the interleaving two
+    /// concurrent callers can hit (#6934).
+    ///
+    /// `list_workflows()` takes the read lock and drops it before returning, so
+    /// a caller that decides a name is free on the strength of that snapshot is
+    /// deciding on stale information by the time it calls `register()`. Both
+    /// callers below see an empty registry, both conclude the name is theirs,
+    /// and the engine ends up holding two workflows named `deploy` — which
+    /// name-based lookup then resolves to whichever one the `HashMap` iterator
+    /// reaches first.
+    ///
+    /// Written out in one task rather than raced across two, so the failure is
+    /// reproducible on every run instead of on unlucky scheduling.
+    #[tokio::test]
+    async fn check_then_register_admits_a_duplicate_name() {
+        let engine = WorkflowEngine::new();
+
+        let free_for_a = count_named(&engine, "deploy").await == 0;
+        let free_for_b = count_named(&engine, "deploy").await == 0;
+        assert!(
+            free_for_a && free_for_b,
+            "both callers see the name as free"
+        );
+
+        engine.register(named_workflow("deploy")).await;
+        engine.register(named_workflow("deploy")).await;
+
+        assert_eq!(
+            count_named(&engine, "deploy").await,
+            2,
+            "check-then-register is expected to admit the duplicate — if this now fails, `register` itself grew a \
+             name check and `register_unique_name`'s reason for existing needs revisiting"
+        );
+    }
+
+    /// The regression for #6934: N callers racing on the same name must produce
+    /// exactly one registration.
+    ///
+    /// Multi-threaded runtime with more tasks than worker threads so the
+    /// reservations genuinely interleave. Against a check-then-act
+    /// implementation (read lock, drop, write lock) this fails — several tasks
+    /// observe the empty registry before any of them inserts. Against the
+    /// single-write-lock reservation it cannot: the losers are looking at a map
+    /// that already contains the winner's entry.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_register_unique_name_admits_exactly_one() {
+        const CALLERS: usize = 32;
+
+        let engine = WorkflowEngine::new();
+        let mut handles = Vec::with_capacity(CALLERS);
+        for _ in 0..CALLERS {
+            let engine = engine.clone();
+            handles.push(tokio::spawn(async move {
+                engine.register_unique_name(named_workflow("deploy")).await
+            }));
+        }
+
+        let mut winners = Vec::new();
+        let mut losers = 0usize;
+        for h in handles {
+            match h.await.expect("registration task must not panic") {
+                Ok(id) => winners.push(id),
+                Err(taken) => {
+                    assert_eq!(taken.name, "deploy");
+                    losers += 1;
+                }
+            }
+        }
+
+        assert_eq!(
+            winners.len(),
+            1,
+            "exactly one caller may win the name, got {winners:?}"
+        );
+        assert_eq!(losers, CALLERS - 1, "every other caller must be rejected");
+        assert_eq!(
+            count_named(&engine, "deploy").await,
+            1,
+            "the registry must hold one workflow named 'deploy'"
+        );
+        assert_eq!(
+            engine.get_workflow(winners[0]).await.map(|w| w.name),
+            Some("deploy".to_string()),
+            "the winner's id must be the one that resolves"
+        );
+    }
+
+    /// Every rejected caller must be told which workflow it collided with, so
+    /// the error can name the incumbent rather than only the taken name.
+    #[tokio::test]
+    async fn register_unique_name_reports_the_incumbent_id() {
+        let engine = WorkflowEngine::new();
+        let first = engine
+            .register_unique_name(named_workflow("deploy"))
+            .await
+            .expect("first registration wins");
+
+        let err = engine
+            .register_unique_name(named_workflow("deploy"))
+            .await
+            .expect_err("second registration must be rejected");
+        assert_eq!(err.existing_id, first);
+        assert!(
+            err.to_string().contains("already exists"),
+            "rendered error should read as a collision: {err}"
+        );
+    }
+
+    /// Name lookup lowercases both sides, so `Deploy` and `deploy` are the same
+    /// name as far as `run_workflow` is concerned. Reserving one must therefore
+    /// reserve the other, or the second registration is unreachable by name for
+    /// an arbitrary fraction of calls.
+    #[tokio::test]
+    async fn register_unique_name_is_case_insensitive() {
+        let engine = WorkflowEngine::new();
+        engine
+            .register_unique_name(named_workflow("deploy"))
+            .await
+            .expect("first registration wins");
+
+        let err = engine
+            .register_unique_name(named_workflow("Deploy"))
+            .await
+            .expect_err("a case variant is the same name to lookup, so it must collide");
+        assert_eq!(
+            err.name, "Deploy",
+            "the rejection echoes the proposed name as supplied"
+        );
+        assert_eq!(count_named(&engine, "deploy").await, 1);
+    }
+
+    /// A workflow reserved through `register_unique_name` must be persisted the
+    /// same way `register` persists one — the reservation is not allowed to
+    /// come at the cost of surviving a restart.
+    ///
+    /// Multi-thread flavor, and `load_from_dir_sync` behind `block_in_place`,
+    /// for the same reason as `register_writes_atomically_and_cleans_tmp`
+    /// above: the loader takes `blocking_write` on the registry.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_unique_name_persists_the_definition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let engine = WorkflowEngine::new_with_persistence(tmp.path());
+        let id = engine
+            .register_unique_name(named_workflow("deploy"))
+            .await
+            .expect("registration wins");
+
+        let reloaded = WorkflowEngine::new_with_persistence(tmp.path());
+        let loaded = tokio::task::block_in_place(|| {
+            reloaded.load_from_dir_sync(&tmp.path().join("workflows"))
+        });
+        assert_eq!(loaded, 1, "expected exactly one workflow loaded back");
+        assert_eq!(
+            reloaded.get_workflow(id).await.map(|w| w.name),
+            Some("deploy".to_string()),
+            "the reserved workflow must be on disk under its own id"
+        );
     }
 
     // Multi-thread flavor because `load_from_dir_sync` uses

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -1208,11 +1208,9 @@ pub struct DryRunStep {
     pub skip_reason: Option<String>,
 }
 
-/// Rejection returned by [`WorkflowEngine::register_unique_name`] when another registered workflow already carries
-/// the proposed name.
+/// Rejection returned by [`WorkflowEngine::register_unique_name`] when another registered workflow already carries the proposed name.
 ///
-/// Carries the id of the incumbent so callers can point the operator (or the agent that proposed the name) at the
-/// workflow they collided with instead of only telling them the name is taken.
+/// Carries the id of the incumbent so callers can point the operator (or the agent that proposed the name) at the workflow they collided with instead of only telling them the name is taken.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowNameTaken {
     /// The proposed name, as supplied — not lowercased.
@@ -1924,9 +1922,7 @@ impl WorkflowEngine {
     /// Register a new workflow definition and persist it to disk.
     ///
     /// Last writer wins on the *name*: this overwrites nothing keyed by id, but two workflows may end up sharing a name.
-    /// Callers that need the name to be unique must use [`Self::register_unique_name`] instead — checking
-    /// [`Self::list_workflows`] first and calling this afterwards is a check-then-act race, because the read lock is
-    /// released before the insert takes the write lock.
+    /// Callers that need the name to be unique must use [`Self::register_unique_name`] instead — checking [`Self::list_workflows`] first and calling this afterwards is a check-then-act race, because the read lock is released before the insert takes the write lock.
     pub async fn register(&self, workflow: Workflow) -> WorkflowId {
         let id = workflow.id;
         self.persist_definition(&workflow).await;
@@ -1937,19 +1933,12 @@ impl WorkflowEngine {
 
     /// Register a workflow only if no registered workflow already carries its name, as one atomic operation.
     ///
-    /// The name comparison and the insert happen under a single acquisition of the registry write lock, so two
-    /// concurrent callers proposing the same name cannot both observe it as free: whichever takes the lock second
-    /// sees the first one's entry and loses. This is the property `list_workflows()`-then-`register()` cannot
-    /// provide, and it matters because workflow lookup by name (`run_workflow`, `describe_workflow`) resolves to
-    /// whichever duplicate the `HashMap` iterator reaches first — a same-named second workflow silently shadows
-    /// the original for some fraction of calls.
+    /// The name comparison and the insert happen under a single acquisition of the registry write lock, so two concurrent callers proposing the same name cannot both observe it as free: whichever takes the lock second sees the first one's entry and loses.
+    /// This is the property `list_workflows()`-then-`register()` cannot provide, and it matters because workflow lookup by name (`run_workflow`, `describe_workflow`) resolves to whichever duplicate the `HashMap` iterator reaches first — a same-named second workflow silently shadows the original for some fraction of calls.
     ///
-    /// The comparison is case-insensitive to match that name-based lookup, which lowercases both sides; a
-    /// `Deploy` registered next to an existing `deploy` would be unreachable by name half the time.
+    /// The comparison is case-insensitive to match that name-based lookup, which lowercases both sides; a `Deploy` registered next to an existing `deploy` would be unreachable by name half the time.
     ///
-    /// Persistence deliberately runs *after* the lock is released. Holding the registry write lock across a
-    /// `tokio::fs` round-trip would block every reader on disk IO, and the reservation is already in force the
-    /// moment the entry is in the map.
+    /// Persistence deliberately runs *after* the lock is released. Holding the registry write lock across a `tokio::fs` round-trip would block every reader on disk IO, and the reservation is already in force the moment the entry is in the map.
     pub async fn register_unique_name(
         &self,
         workflow: Workflow,
@@ -6957,9 +6946,7 @@ mod tests {
         }
     }
 
-    /// Count registered workflows carrying `name`, compared the way name-based
-    /// lookup compares (`run_workflow` / `describe_workflow` both lowercase
-    /// each side before testing equality).
+    /// Count registered workflows carrying `name`, compared the way name-based lookup compares (`run_workflow` / `describe_workflow` both lowercase each side before testing equality).
     async fn count_named(engine: &WorkflowEngine, name: &str) -> usize {
         let wanted = name.to_lowercase();
         engine
@@ -6970,20 +6957,12 @@ mod tests {
             .count()
     }
 
-    /// Pins the bug [`WorkflowEngine::register_unique_name`] exists to close,
-    /// as the deterministic sequential replay of the interleaving two
-    /// concurrent callers can hit (#6934).
+    /// Pins the bug [`WorkflowEngine::register_unique_name`] exists to close, as the deterministic sequential replay of the interleaving two concurrent callers can hit (#6934).
     ///
-    /// `list_workflows()` takes the read lock and drops it before returning, so
-    /// a caller that decides a name is free on the strength of that snapshot is
-    /// deciding on stale information by the time it calls `register()`. Both
-    /// callers below see an empty registry, both conclude the name is theirs,
-    /// and the engine ends up holding two workflows named `deploy` — which
-    /// name-based lookup then resolves to whichever one the `HashMap` iterator
-    /// reaches first.
+    /// `list_workflows()` takes the read lock and drops it before returning, so a caller that decides a name is free on the strength of that snapshot is deciding on stale information by the time it calls `register()`.
+    /// Both callers below see an empty registry, both conclude the name is theirs, and the engine ends up holding two workflows named `deploy` — which name-based lookup then resolves to whichever one the `HashMap` iterator reaches first.
     ///
-    /// Written out in one task rather than raced across two, so the failure is
-    /// reproducible on every run instead of on unlucky scheduling.
+    /// Written out in one task rather than raced across two, so the failure is reproducible on every run instead of on unlucky scheduling.
     #[tokio::test]
     async fn check_then_register_admits_a_duplicate_name() {
         let engine = WorkflowEngine::new();
@@ -7006,15 +6985,11 @@ mod tests {
         );
     }
 
-    /// The regression for #6934: N callers racing on the same name must produce
-    /// exactly one registration.
+    /// The regression for #6934: N callers racing on the same name must produce exactly one registration.
     ///
-    /// Multi-threaded runtime with more tasks than worker threads so the
-    /// reservations genuinely interleave. Against a check-then-act
-    /// implementation (read lock, drop, write lock) this fails — several tasks
-    /// observe the empty registry before any of them inserts. Against the
-    /// single-write-lock reservation it cannot: the losers are looking at a map
-    /// that already contains the winner's entry.
+    /// Multi-threaded runtime with more tasks than worker threads so the reservations genuinely interleave.
+    /// Against a check-then-act implementation (read lock, drop, write lock) this fails — several tasks observe the empty registry before any of them inserts.
+    /// Against the single-write-lock reservation it cannot: the losers are looking at a map that already contains the winner's entry.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_register_unique_name_admits_exactly_one() {
         const CALLERS: usize = 32;
@@ -7058,8 +7033,7 @@ mod tests {
         );
     }
 
-    /// Every rejected caller must be told which workflow it collided with, so
-    /// the error can name the incumbent rather than only the taken name.
+    /// Every rejected caller must be told which workflow it collided with, so the error can name the incumbent rather than only the taken name.
     #[tokio::test]
     async fn register_unique_name_reports_the_incumbent_id() {
         let engine = WorkflowEngine::new();
@@ -7079,10 +7053,8 @@ mod tests {
         );
     }
 
-    /// Name lookup lowercases both sides, so `Deploy` and `deploy` are the same
-    /// name as far as `run_workflow` is concerned. Reserving one must therefore
-    /// reserve the other, or the second registration is unreachable by name for
-    /// an arbitrary fraction of calls.
+    /// Name lookup lowercases both sides, so `Deploy` and `deploy` are the same name as far as `run_workflow` is concerned.
+    /// Reserving one must therefore reserve the other, or the second registration is unreachable by name for an arbitrary fraction of calls.
     #[tokio::test]
     async fn register_unique_name_is_case_insensitive() {
         let engine = WorkflowEngine::new();
@@ -7102,13 +7074,9 @@ mod tests {
         assert_eq!(count_named(&engine, "deploy").await, 1);
     }
 
-    /// A workflow reserved through `register_unique_name` must be persisted the
-    /// same way `register` persists one — the reservation is not allowed to
-    /// come at the cost of surviving a restart.
+    /// A workflow reserved through `register_unique_name` must be persisted the same way `register` persists one — the reservation is not allowed to come at the cost of surviving a restart.
     ///
-    /// Multi-thread flavor, and `load_from_dir_sync` behind `block_in_place`,
-    /// for the same reason as `register_writes_atomically_and_cleans_tmp`
-    /// above: the loader takes `blocking_write` on the registry.
+    /// Multi-thread flavor, and `load_from_dir_sync` behind `block_in_place`, for the same reason as `register_writes_atomically_and_cleans_tmp` above: the loader takes `blocking_write` on the registry.
     #[tokio::test(flavor = "multi_thread")]
     async fn register_unique_name_persists_the_definition() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -100,6 +100,7 @@ pub(crate) mod tool_name {
     pub const WORKFLOW_STATUS: &str = "workflow_status";
     pub const WORKFLOW_START: &str = "workflow_start";
     pub const WORKFLOW_CANCEL: &str = "workflow_cancel";
+    pub const WORKFLOW_CREATE: &str = "workflow_create";
     pub const SYSTEM_TIME: &str = "system_time";
     pub const CANVAS_PRESENT: &str = "canvas_present";
     pub const READ_ARTIFACT: &str = "read_artifact";
@@ -1267,6 +1268,53 @@ use instead of web_fetch + file_write (which round-trips the entire body through
                         "run_id": { "type": "string", "description": "The workflow run UUID to cancel" }
                     },
                     "required": ["run_id"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::WORKFLOW_CREATE.to_string(),
+                description: "Define and register a new multi-step workflow so it can be run later with workflow_run / workflow_start. Use this when the same multi-agent sequence is worth repeating; for a one-off, send the agents messages directly instead. The workflow becomes available immediately and outlives the conversation. Names are unique across the daemon: a name already in use is rejected rather than overwritten, so call workflow_list first if you are unsure. Returns {id, name, description, step_count, has_input_schema}.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "description": "Unique name, 1-64 characters of letters, digits, '_' and '-'. This is how the workflow is addressed afterwards (e.g. 'nightly-report')." },
+                        "description": { "type": "string", "description": "What the workflow does, for whoever reads workflow_list later" },
+                        "steps": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 50,
+                            "description": "The steps, in execution order. Sequential by default; declare depends_on to run them as a DAG instead.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string", "description": "Step name, unique within the workflow. Other steps reference it in depends_on." },
+                                    "agent": { "type": "string", "description": "Name of the agent that runs this step (agent_list shows what exists). An object {\"id\": \"<uuid>\"} addresses one by UUID instead." },
+                                    "prompt_template": { "type": "string", "description": "Prompt for this step. {{input}} interpolates the previous step's output; {{var}} interpolates a workflow input parameter or an earlier step's output_var." },
+                                    "depends_on": { "type": "array", "items": { "type": "string" }, "description": "Names of steps that must finish first. Any step may be named, including one declared later. Omit for straight-line execution." },
+                                    "output_var": { "type": "string", "description": "Store this step's output under this name so later steps can reference it as {{name}}" },
+                                    "mode": { "description": "Sequencing for this step: the string \"sequential\" (default), \"fan_out\" to run in parallel with the following fan_out steps, or \"collect\" to gather them. Richer nodes take a tagged object, e.g. {\"conditional\": {\"condition\": \"APPROVED\"}}." },
+                                    "error_mode": { "description": "What to do when this step fails: \"fail\" (default, abort the run), \"skip\" (continue without it), or {\"retry\": {\"max_retries\": 3}}." },
+                                    "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 3600, "description": "Wall-clock limit for this step (default 120, ceiling 3600)" }
+                                },
+                                "required": ["name", "agent", "prompt_template"]
+                            }
+                        },
+                        "input_schema": {
+                            "type": "array",
+                            "description": "Parameters callers pass to workflow_run. Each becomes a {{name}} placeholder available to every step's prompt_template.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string", "description": "Parameter name, as referenced by {{name}} in a prompt_template" },
+                                    "param_type": { "type": "string", "enum": ["string", "number", "boolean", "file", "image", "agent_id"], "description": "Value type (default 'string'). Note the key is param_type, not type — this is the same spelling workflow_describe reports back." },
+                                    "required": { "type": "boolean", "description": "Whether callers must supply it (default true)" },
+                                    "description": { "type": "string", "description": "What the parameter means, shown by workflow_describe" }
+                                },
+                                "required": ["name"]
+                            }
+                        },
+                        "total_timeout_secs": { "type": "integer", "minimum": 1, "maximum": 86400, "description": "Wall-clock limit for the whole run (ceiling 86400 = 24h). Omit to use the daemon default." }
+                    },
+                    "required": ["name", "steps"]
                 }),
             },
             ToolDefinition {

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1207,6 +1207,7 @@ pub async fn execute_tool_raw(
             tool_workflow_start(input, *kernel, *caller_agent_id, *session_id).await
         }
         "workflow_cancel" => tool_workflow_cancel(input, *kernel).await,
+        "workflow_create" => tool_workflow_create(input, *kernel, *caller_agent_id).await,
 
         // Browser automation tools
         #[cfg(feature = "browser")]

--- a/crates/librefang-runtime/src/tool_runner/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/mod.rs
@@ -117,8 +117,8 @@ use self::workflow::{
     build_workflow_run_result, prepare_workflow_input, resolve_workflow_input_artifacts,
 };
 use self::workflow::{
-    tool_workflow_cancel, tool_workflow_describe, tool_workflow_list, tool_workflow_run,
-    tool_workflow_start, tool_workflow_status,
+    tool_workflow_cancel, tool_workflow_create, tool_workflow_describe, tool_workflow_list,
+    tool_workflow_run, tool_workflow_start, tool_workflow_status,
 };
 
 /// Maximum inter-agent call depth to prevent infinite recursion (A->B->C->...).

--- a/crates/librefang-runtime/src/tool_runner/workflow.rs
+++ b/crates/librefang-runtime/src/tool_runner/workflow.rs
@@ -329,14 +329,11 @@ pub(super) async fn tool_workflow_cancel(
 
 /// Register a new workflow from an agent-authored definition.
 ///
-/// This handler stays deliberately thin. It checks only the two things it can name a parameter for — a payload
-/// missing `name` or `steps` — and forwards the spec to the kernel, which owns every real check: name legality,
-/// the resource ceilings, `Workflow::validate()`, and the atomic name reservation. Splitting those across the two
-/// layers is how the tool schema and the enforced rule drift apart, and the kernel is the only side that can make
-/// the uniqueness check atomic with the insert.
+/// This handler stays deliberately thin.
+/// It checks only the two things it can name a parameter for — a payload missing `name` or `steps` — and forwards the spec to the kernel, which owns every real check: name legality, the resource ceilings, `Workflow::validate()`, and the atomic name reservation.
+/// Splitting those across the two layers is how the tool schema and the enforced rule drift apart, and the kernel is the only side that can make the uniqueness check atomic with the insert.
 ///
-/// The whole `input` object is forwarded rather than a rebuilt subset, so a field added to the kernel-side spec is
-/// reachable from the tool the moment it exists.
+/// The whole `input` object is forwarded rather than a rebuilt subset, so a field added to the kernel-side spec is reachable from the tool the moment it exists.
 pub(super) async fn tool_workflow_create(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
@@ -356,15 +353,12 @@ pub(super) async fn tool_workflow_create(
     }
 
     let kh = require_kernel_typed(kernel)?;
-    // `InvalidInput` (a spec that cannot become a workflow) and `Conflict` (the name is taken) both describe
-    // something the model can fix on its next turn, so the kernel's message is relayed as the reason rather than
-    // being flattened into an opaque upstream failure.
+    // `InvalidInput` (a spec that cannot become a workflow) and `Conflict` (the name is taken) both describe something the model can fix on its next turn, so the kernel's message is relayed as the reason rather than being flattened into an opaque upstream failure.
     let summary = kh
         .create_workflow(input, caller_agent_id)
         .await
         .map_err(|e| match e {
-            // The kernel's reason already names the offending field, so it is relayed whole rather than pinned to
-            // one schema parameter that may not be the one at fault.
+            // The kernel's reason already names the offending field, so it is relayed whole rather than pinned to one schema parameter that may not be the one at fault.
             librefang_types::error::LibreFangError::InvalidInput(reason) => {
                 ToolError::InvalidParameter {
                     name: "workflow",

--- a/crates/librefang-runtime/src/tool_runner/workflow.rs
+++ b/crates/librefang-runtime/src/tool_runner/workflow.rs
@@ -324,6 +324,73 @@ pub(super) async fn tool_workflow_cancel(
 }
 
 // ---------------------------------------------------------------------------
+// workflow_create — define a new workflow from a conversation (#6934)
+// ---------------------------------------------------------------------------
+
+/// Register a new workflow from an agent-authored definition.
+///
+/// This handler stays deliberately thin. It checks only the two things it can name a parameter for — a payload
+/// missing `name` or `steps` — and forwards the spec to the kernel, which owns every real check: name legality,
+/// the resource ceilings, `Workflow::validate()`, and the atomic name reservation. Splitting those across the two
+/// layers is how the tool schema and the enforced rule drift apart, and the kernel is the only side that can make
+/// the uniqueness check atomic with the insert.
+///
+/// The whole `input` object is forwarded rather than a rebuilt subset, so a field added to the kernel-side spec is
+/// reachable from the tool the moment it exists.
+pub(super) async fn tool_workflow_create(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+) -> ToolResult {
+    if !input["name"].is_string() {
+        return Err(ToolError::MissingParameter("name"));
+    }
+    let steps = input
+        .get("steps")
+        .ok_or(ToolError::MissingParameter("steps"))?;
+    if !steps.is_array() {
+        return Err(ToolError::InvalidParameter {
+            name: "steps",
+            reason: "must be an array of step objects".to_string(),
+        });
+    }
+
+    let kh = require_kernel_typed(kernel)?;
+    // `InvalidInput` (a spec that cannot become a workflow) and `Conflict` (the name is taken) both describe
+    // something the model can fix on its next turn, so the kernel's message is relayed as the reason rather than
+    // being flattened into an opaque upstream failure.
+    let summary = kh
+        .create_workflow(input, caller_agent_id)
+        .await
+        .map_err(|e| match e {
+            // The kernel's reason already names the offending field, so it is relayed whole rather than pinned to
+            // one schema parameter that may not be the one at fault.
+            librefang_types::error::LibreFangError::InvalidInput(reason) => {
+                ToolError::InvalidParameter {
+                    name: "workflow",
+                    reason,
+                }
+            }
+            librefang_types::error::LibreFangError::Conflict(reason) => {
+                ToolError::InvalidParameter {
+                    name: "name",
+                    reason,
+                }
+            }
+            other => ToolError::upstream(other),
+        })?;
+
+    Ok(serde_json::json!({
+        "id": summary.id,
+        "name": summary.name,
+        "description": summary.description,
+        "step_count": summary.step_count,
+        "has_input_schema": summary.has_input_schema,
+    })
+    .to_string())
+}
+
+// ---------------------------------------------------------------------------
 // workflow_describe — discover a workflow's input shape (#4982 — gap 2)
 // ---------------------------------------------------------------------------
 

--- a/crates/librefang-runtime/tests/tool_runner_workflow_write.rs
+++ b/crates/librefang-runtime/tests/tool_runner_workflow_write.rs
@@ -1,10 +1,7 @@
-// Integration tests for the workflow_start, workflow_cancel and workflow_create tools
-// (#4844 section E, #6934).
+// Integration tests for the workflow_start, workflow_cancel and workflow_create tools (#4844 section E, #6934).
 //
 // Uses the same hand-rolled stub kernel pattern as tool_runner_workflow_readonly.rs.
-// The write-side stub extends WorkflowRunner with start_workflow_async,
-// cancel_workflow_run and create_workflow implementations driven by per-test
-// configuration.
+// The write-side stub extends WorkflowRunner with start_workflow_async, cancel_workflow_run and create_workflow implementations driven by per-test configuration.
 
 use async_trait::async_trait;
 use librefang_kernel_handle::prelude::*;
@@ -45,9 +42,7 @@ struct WorkflowWriteStubKernel {
     start_run_id: Option<String>,
     cancel_result: StubCancelResult,
     create_result: StubCreateResult,
-    /// The `(spec, caller_agent_id)` pair the last create_workflow call received,
-    /// so the tests can assert what actually crossed the trait boundary rather
-    /// than only what came back.
+    /// The `(spec, caller_agent_id)` pair the last create_workflow call received, so the tests can assert what actually crossed the trait boundary rather than only what came back.
     create_seen: Mutex<Option<(serde_json::Value, Option<String>)>>,
 }
 
@@ -618,8 +613,8 @@ async fn workflow_cancel_missing_run_id_returns_error() {
 // workflow_create tests (#6934)
 // ---------------------------------------------------------------------------
 
-/// A well-formed creation payload. Individual tests mutate one field of it so
-/// the thing under test is the only difference from a known-good spec.
+/// A well-formed creation payload.
+/// Individual tests mutate one field of it so the thing under test is the only difference from a known-good spec.
 fn create_payload() -> serde_json::Value {
     json!({
         "name": "nightly-report",
@@ -651,9 +646,7 @@ fn workflow_create_appears_in_builtin_definitions() {
         vec!["name", "steps"],
         "name and steps are the only fields a workflow cannot be built without"
     );
-    // A step needs somewhere to run and something to say — the schema must say so,
-    // because the kernel rejects a step missing either and the model needs to know
-    // before it spends a turn on the call.
+    // A step needs somewhere to run and something to say — the schema must say so, because the kernel rejects a step missing either and the model needs to know before it spends a turn on the call.
     let step_required: Vec<&str> = def.input_schema["properties"]["steps"]["items"]["required"]
         .as_array()
         .expect("step required array")
@@ -733,9 +726,7 @@ async fn workflow_create_missing_or_malformed_steps_returns_error() {
         result.content
     );
 
-    // A single step object instead of an array is the shape a model most often
-    // gets wrong, and it must be named as such rather than reaching the kernel
-    // as an opaque deserialization failure.
+    // A single step object instead of an array is the shape a model most often gets wrong, and it must be named as such rather than reaching the kernel as an opaque deserialization failure.
     let mut payload = create_payload();
     payload["steps"] = json!({ "name": "write", "agent": "writer", "prompt_template": "go" });
     let result = execute_tool_raw("t1", "workflow_create", &payload, &ctx).await;
@@ -747,9 +738,7 @@ async fn workflow_create_missing_or_malformed_steps_returns_error() {
     );
 }
 
-/// A name collision is something the model can fix on its next turn — by
-/// picking another name — so the rejection has to arrive as a readable reason
-/// against the `name` field, not as an opaque upstream failure.
+/// A name collision is something the model can fix on its next turn — by picking another name — so the rejection has to arrive as a readable reason against the `name` field, not as an opaque upstream failure.
 #[tokio::test]
 async fn workflow_create_relays_a_name_collision() {
     let kernel: Arc<dyn KernelHandle> = Arc::new(WorkflowWriteStubKernel::with_create(
@@ -771,8 +760,7 @@ async fn workflow_create_relays_a_name_collision() {
     );
 }
 
-/// Same for a spec the kernel refused: the reason names the field and the limit,
-/// and a model that cannot see which one it broke retries the same payload.
+/// Same for a spec the kernel refused: the reason names the field and the limit, and a model that cannot see which one it broke retries the same payload.
 #[tokio::test]
 async fn workflow_create_relays_a_validation_failure() {
     let kernel: Arc<dyn KernelHandle> = Arc::new(WorkflowWriteStubKernel::with_create(

--- a/crates/librefang-runtime/tests/tool_runner_workflow_write.rs
+++ b/crates/librefang-runtime/tests/tool_runner_workflow_write.rs
@@ -1,14 +1,16 @@
-// Integration tests for the workflow_start and workflow_cancel tools (#4844 section E).
+// Integration tests for the workflow_start, workflow_cancel and workflow_create tools
+// (#4844 section E, #6934).
 //
 // Uses the same hand-rolled stub kernel pattern as tool_runner_workflow_readonly.rs.
-// The write-side stub extends WorkflowRunner with start_workflow_async and
-// cancel_workflow_run implementations driven by per-test configuration.
+// The write-side stub extends WorkflowRunner with start_workflow_async,
+// cancel_workflow_run and create_workflow implementations driven by per-test
+// configuration.
 
 use async_trait::async_trait;
 use librefang_kernel_handle::prelude::*;
 use librefang_runtime::tool_runner::{builtin_tool_definitions, execute_tool_raw, ToolExecContext};
 use serde_json::json;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 // ---------------------------------------------------------------------------
 // Error sentinel returned by stub cancel_workflow_run
@@ -22,6 +24,19 @@ enum StubCancelResult {
 }
 
 // ---------------------------------------------------------------------------
+// Outcome the stub create_workflow returns
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum StubCreateResult {
+    Ok,
+    /// The spec could not become a workflow — the kernel's `InvalidInput`.
+    Invalid(&'static str),
+    /// The name is already registered — the kernel's `Conflict`.
+    NameTaken(&'static str),
+}
+
+// ---------------------------------------------------------------------------
 // Stub kernel for write-tool tests
 // ---------------------------------------------------------------------------
 
@@ -29,27 +44,48 @@ struct WorkflowWriteStubKernel {
     /// run_id returned by start_workflow_async (None → simulate resolution error)
     start_run_id: Option<String>,
     cancel_result: StubCancelResult,
+    create_result: StubCreateResult,
+    /// The `(spec, caller_agent_id)` pair the last create_workflow call received,
+    /// so the tests can assert what actually crossed the trait boundary rather
+    /// than only what came back.
+    create_seen: Mutex<Option<(serde_json::Value, Option<String>)>>,
 }
 
 impl WorkflowWriteStubKernel {
+    fn base() -> Self {
+        Self {
+            start_run_id: Some("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".to_string()),
+            cancel_result: StubCancelResult::Ok,
+            create_result: StubCreateResult::Ok,
+            create_seen: Mutex::new(None),
+        }
+    }
+
     fn with_start(run_id: &str) -> Self {
         Self {
             start_run_id: Some(run_id.to_string()),
-            cancel_result: StubCancelResult::Ok,
+            ..Self::base()
         }
     }
 
     fn start_error() -> Self {
         Self {
             start_run_id: None,
-            cancel_result: StubCancelResult::Ok,
+            ..Self::base()
         }
     }
 
     fn with_cancel(cancel_result: StubCancelResult) -> Self {
         Self {
-            start_run_id: Some("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".to_string()),
             cancel_result,
+            ..Self::base()
+        }
+    }
+
+    fn with_create(create_result: StubCreateResult) -> Self {
+        Self {
+            create_result,
+            ..Self::base()
         }
     }
 }
@@ -256,6 +292,30 @@ impl WorkflowRunner for WorkflowWriteStubKernel {
             None => Err(librefang_kernel_handle::KernelOpError::Internal(
                 "workflow `unknown-workflow` not found".to_string(),
             )),
+        }
+    }
+
+    async fn create_workflow(
+        &self,
+        spec: &serde_json::Value,
+        caller_agent_id: Option<&str>,
+    ) -> Result<WorkflowSummary, librefang_kernel_handle::KernelOpError> {
+        *self.create_seen.lock().unwrap() =
+            Some((spec.clone(), caller_agent_id.map(str::to_string)));
+        match &self.create_result {
+            StubCreateResult::Ok => Ok(WorkflowSummary::new(
+                "11111111-1111-1111-1111-111111111111".to_string(),
+                spec["name"].as_str().unwrap_or_default().to_string(),
+                spec["description"].as_str().unwrap_or_default().to_string(),
+                spec["steps"].as_array().map(|a| a.len()).unwrap_or(0),
+                spec.get("input_schema").is_some(),
+            )),
+            StubCreateResult::Invalid(reason) => Err(
+                librefang_kernel_handle::KernelOpError::InvalidInput(reason.to_string()),
+            ),
+            StubCreateResult::NameTaken(reason) => Err(
+                librefang_kernel_handle::KernelOpError::Conflict(reason.to_string()),
+            ),
         }
     }
 
@@ -550,6 +610,183 @@ async fn workflow_cancel_missing_run_id_returns_error() {
     assert!(
         result.content.contains("run_id"),
         "error should mention run_id: {}",
+        result.content
+    );
+}
+
+// ---------------------------------------------------------------------------
+// workflow_create tests (#6934)
+// ---------------------------------------------------------------------------
+
+/// A well-formed creation payload. Individual tests mutate one field of it so
+/// the thing under test is the only difference from a known-good spec.
+fn create_payload() -> serde_json::Value {
+    json!({
+        "name": "nightly-report",
+        "description": "summarise the day",
+        "steps": [
+            { "name": "gather", "agent": "researcher", "prompt_template": "Collect today's {{topic}} news" },
+            { "name": "write", "agent": "writer", "prompt_template": "Summarise {{input}}", "depends_on": ["gather"] }
+        ],
+        "input_schema": [ { "name": "topic", "param_type": "string" } ]
+    })
+}
+
+#[test]
+fn workflow_create_appears_in_builtin_definitions() {
+    let defs = builtin_tool_definitions();
+    let def = defs
+        .iter()
+        .find(|d| d.name == "workflow_create")
+        .expect("workflow_create missing from builtin_tool_definitions");
+    assert_eq!(def.input_schema["type"], "object");
+    let required: Vec<&str> = def.input_schema["required"]
+        .as_array()
+        .expect("required array")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        required,
+        vec!["name", "steps"],
+        "name and steps are the only fields a workflow cannot be built without"
+    );
+    // A step needs somewhere to run and something to say — the schema must say so,
+    // because the kernel rejects a step missing either and the model needs to know
+    // before it spends a turn on the call.
+    let step_required: Vec<&str> = def.input_schema["properties"]["steps"]["items"]["required"]
+        .as_array()
+        .expect("step required array")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(step_required, vec!["name", "agent", "prompt_template"]);
+}
+
+#[tokio::test]
+async fn workflow_create_forwards_the_whole_spec_and_the_caller() {
+    let stub = Arc::new(WorkflowWriteStubKernel::with_create(StubCreateResult::Ok));
+    let kernel: Arc<dyn KernelHandle> = stub.clone();
+    let ctx = make_ctx(&kernel);
+
+    let payload = create_payload();
+    let result = execute_tool_raw("t1", "workflow_create", &payload, &ctx).await;
+    assert!(
+        !result.is_error,
+        "workflow_create failed: {}",
+        result.content
+    );
+
+    let v: serde_json::Value = serde_json::from_str(&result.content).expect("valid JSON");
+    assert_eq!(v["id"], "11111111-1111-1111-1111-111111111111");
+    assert_eq!(v["name"], "nightly-report");
+    assert_eq!(v["step_count"], 2);
+    assert_eq!(v["has_input_schema"], true);
+
+    let (seen_spec, seen_caller) = stub
+        .create_seen
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the kernel handle must have been called");
+    assert_eq!(
+        seen_spec, payload,
+        "the spec must reach the kernel unmodified — the handler is not allowed to rebuild a subset of it"
+    );
+    assert_eq!(
+        seen_caller.as_deref(),
+        Some("test-agent"),
+        "the caller must be forwarded so the registration can be traced back to a turn"
+    );
+}
+
+#[tokio::test]
+async fn workflow_create_missing_name_returns_error() {
+    let kernel: Arc<dyn KernelHandle> =
+        Arc::new(WorkflowWriteStubKernel::with_create(StubCreateResult::Ok));
+    let ctx = make_ctx(&kernel);
+
+    let mut payload = create_payload();
+    payload.as_object_mut().unwrap().remove("name");
+    let result = execute_tool_raw("t1", "workflow_create", &payload, &ctx).await;
+    assert!(result.is_error, "expected error for missing name");
+    assert!(
+        result.content.contains("name"),
+        "error should mention name: {}",
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn workflow_create_missing_or_malformed_steps_returns_error() {
+    let kernel: Arc<dyn KernelHandle> =
+        Arc::new(WorkflowWriteStubKernel::with_create(StubCreateResult::Ok));
+    let ctx = make_ctx(&kernel);
+
+    let mut payload = create_payload();
+    payload.as_object_mut().unwrap().remove("steps");
+    let result = execute_tool_raw("t1", "workflow_create", &payload, &ctx).await;
+    assert!(result.is_error, "expected error for missing steps");
+    assert!(
+        result.content.contains("steps"),
+        "error should mention steps: {}",
+        result.content
+    );
+
+    // A single step object instead of an array is the shape a model most often
+    // gets wrong, and it must be named as such rather than reaching the kernel
+    // as an opaque deserialization failure.
+    let mut payload = create_payload();
+    payload["steps"] = json!({ "name": "write", "agent": "writer", "prompt_template": "go" });
+    let result = execute_tool_raw("t1", "workflow_create", &payload, &ctx).await;
+    assert!(result.is_error, "expected error for a non-array steps");
+    assert!(
+        result.content.contains("array"),
+        "error should say steps must be an array: {}",
+        result.content
+    );
+}
+
+/// A name collision is something the model can fix on its next turn — by
+/// picking another name — so the rejection has to arrive as a readable reason
+/// against the `name` field, not as an opaque upstream failure.
+#[tokio::test]
+async fn workflow_create_relays_a_name_collision() {
+    let kernel: Arc<dyn KernelHandle> = Arc::new(WorkflowWriteStubKernel::with_create(
+        StubCreateResult::NameTaken("a workflow named 'nightly-report' already exists (id 42)"),
+    ));
+    let ctx = make_ctx(&kernel);
+
+    let result = execute_tool_raw("t1", "workflow_create", &create_payload(), &ctx).await;
+    assert!(result.is_error, "expected error for a taken name");
+    assert!(
+        result.content.contains("already exists"),
+        "the collision reason must survive to the model: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("name"),
+        "the collision must be attributed to the name field: {}",
+        result.content
+    );
+}
+
+/// Same for a spec the kernel refused: the reason names the field and the limit,
+/// and a model that cannot see which one it broke retries the same payload.
+#[tokio::test]
+async fn workflow_create_relays_a_validation_failure() {
+    let kernel: Arc<dyn KernelHandle> = Arc::new(WorkflowWriteStubKernel::with_create(
+        StubCreateResult::Invalid(
+            "step 'write' depends on 'research', which is not a step in this workflow",
+        ),
+    ));
+    let ctx = make_ctx(&kernel);
+
+    let result = execute_tool_raw("t1", "workflow_create", &create_payload(), &ctx).await;
+    assert!(result.is_error, "expected error for an invalid spec");
+    assert!(
+        result.content.contains("not a step in this workflow"),
+        "the validation reason must survive to the model: {}",
         result.content
     );
 }


### PR DESCRIPTION
Refs #6934.

## Credit, and why this PR exists

The issue analysis and the original approach are @DaBlitzStein's, in #6943 — the tool surface, the field set, the decision to make the engine's `register()` the single persistence surface, and the resource ceilings all come from that PR and its review rounds.
This is not a takeover.
#6943 has been blocked on a CHANGES_REQUESTED review since 2026-08-21, and every commit since has been a bare `Merge branch 'main'`, so the work stalled with the correctness item unaddressed.
Rather than let the issue sit, I wrote the smaller change directly against current `main`.
**I recommend #6943 be closed as superseded by this PR** — a recommendation only; I have not closed, labelled, or commented on it, and the call is @DaBlitzStein's and the maintainers'.

## Premise check

`workflow_create` and the kernel-side `create_workflow` are **absent from `main`** — I grepped before writing anything.
So this implements the issue rather than adjusting existing code, and the race described in the review comment on #6934 exists only in #6943's branch.
That changes what "fix the race" means here: instead of patching a check-then-act sequence, the atomic operation is the one that gets built, and the racy shape never lands.

CI on #6943 was red only from a stale-base `unused import` that #7791 already removed from `main`; nothing in this PR chases that.

## Substantive changes

- **`WorkflowEngine::register_unique_name`** (`crates/librefang-kernel/src/workflow.rs`) — compares the proposed name against the registry and inserts the entry under a **single acquisition of the write lock**.
  `list_workflows()`-then-`register()` cannot provide this: the read lock is released before the insert takes the write lock, so two concurrent creations both observe the name as free and both succeed.
  The consequence is not cosmetic — name-based lookup (`run_workflow`, `describe_workflow`) scans the map and takes the first match, so a duplicate silently shadows the original for an arbitrary fraction of calls.
  The comparison is case-insensitive because that lookup lowercases both sides.
  Rejection returns `WorkflowNameTaken { name, existing_id }` so the caller can name the workflow it collided with.
- **Persistence extracted to `persist_definition`**, shared by `register` and `register_unique_name`, and run *after* the lock is released — holding the registry write lock across a `tokio::fs` round-trip would block every reader on disk IO.
  `register()` itself is unchanged in behaviour and is now documented as last-writer-wins on the name.
- **`WorkflowRunner::create_workflow`** (`crates/librefang-kernel-handle`) — takes the tool payload as `serde_json::Value` plus the caller agent id, returns a `WorkflowSummary`.
  JSON rather than a typed struct because the workflow types live in `librefang-kernel`, which the runtime cannot depend on.
- **Kernel implementation** (`crates/librefang-kernel/src/kernel/handles/workflow_runner.rs`) — every check lives on this side of the boundary, because the caller is an LLM and a JSON-schema constraint is advice a model is free to ignore.
  Name legality (`[A-Za-z0-9_-]`, 1–64), 50 steps, 3600 s per step, 86400 s per workflow, unique step names, `depends_on` targets that exist (forward references allowed — DAG execution is topological, not positional), and the same `Workflow::validate()` pass the HTTP API runs.
  The spec is deserialized into the canonical `WorkflowStep` / `WorkflowInputParam` types rather than walked by hand, so the accepted shape is by construction the struct the engine executes.
  That is also why an input parameter's key is `param_type` — the spelling `workflow_describe` reports back, so a described workflow round-trips.
  The caller agent id is bound and logged with the registration as a provenance trace, stated in the code as a trace and not an authorization gate.
- **`workflow_create` tool** (`crates/librefang-runtime/src/tool_runner/`) — definition, dispatch arm, and a handler that names the two parameters it can (`name`, `steps`) and forwards the payload whole.
  `InvalidInput` and `Conflict` are relayed as readable parameter errors rather than flattened into an opaque upstream failure, because both describe something the model can fix on its next turn.
- **De-duplicated `has_input_schema`** — `list_workflows` and the new summary now share `has_discoverable_input_schema` instead of carrying two copies of the auto-detect rule.

## Verification

- `cargo test -p librefang-kernel --lib 'workflow::'` — 186 passed, including the five new registration tests.
- `cargo test -p librefang-kernel --lib workflow_runner::tests` — 12 passed (10 new: spec acceptance, `param_type` preservation, stepless spec, agent-less step, the step ceiling inclusive at 50 and rejecting 51, both timeout ceilings, duplicate and dangling step dependencies, forward dependency, name charset/length, the shared semantic validation, schema/constant agreement).
- `cargo test -p librefang-runtime --test tool_runner_workflow_write` — 18 passed (6 new: definition presence and required fields, whole-spec plus caller forwarding, missing `name`, missing and non-array `steps`, collision relay, validation relay).
- `cargo test -p librefang-runtime --lib tool_runner` — 442 passed.
- `cargo clippy -p librefang-kernel -p librefang-runtime -p librefang-kernel-handle --lib --tests -- -D warnings` — clean; `cargo fmt --check` clean.

**The regression fails before the fix.**
`concurrent_register_unique_name_admits_exactly_one` races 32 tasks on one name over a multi-threaded runtime.
I temporarily reverted `register_unique_name` to the check-then-act shape (`list_workflows()`, then insert) and ran it 10 times: 10 failures, typically 4 winners instead of 1.
Restored, it passes on every run.
`check_then_register_admits_a_duplicate_name` replays the same interleaving sequentially, so the bug itself is pinned deterministically rather than by timing.

## Deliberate deviations from #6943, and what is not here

- **Not added to `ALWAYS_NATIVE_TOOLS`.** The issue says "always-native: tool available to every agent without configuration", and it is — it is a builtin, available to every agent with no config, reachable via `tool_search` / `tool_load` in lazy mode.
  What `ALWAYS_NATIVE_TOOLS` actually buys is shipping the full schema in *every* LLM request, which #3044 reserves for the tools agents reach for constantly.
  No `workflow_*` tool is on that list today, and a rarely-used creation schema is the worst candidate for it.
- **No dashboard change.** The "Save as Workflow" chat button and the Workflows empty state are a separate surface from the tool, and the issue files the dashboard work under "Future".
- **No `workflow-creator` skill**, which is why this says `Refs #6934` and not `Closes`.
  The issue scopes it as PR 2, and the repo has no `skills/` tree the daemon loads — only `examples/custom-skill-*`.
  Where a first-party skill should live is a question worth answering on its own rather than inside this PR.
- **`validate_template_name` in `librefang-api` is untouched.** #6943 unified it with the new name rule via a shared `librefang-types` helper; that is a third crate and a third caller, so I left it alone rather than widen the blast radius.
  The rule here is local to the kernel handle and documented as such — it is not a path-traversal guard, because persistence is keyed by id (`<uuid>.workflow.json`) and the name never reaches the filesystem.
