### PR TITLE
fix(memory): charge confidence decay per elapsed interval, not per tick

### DIFF
--- a/changelog.d/fixed/7756-confidence-decay-double-charging.md
+++ b/changelog.d/fixed/7756-confidence-decay-double-charging.md
@@ -1,0 +1,6 @@
+Confidence decay now charges each interval of idle time exactly once, instead of re-applying a memory's entire idle span on every hourly tick.
+The `UPDATE` wrote `confidence` and nothing else, so each run recomputed the exponent from an `accessed_at` that never moved and applied it to an already-decayed value: a row idle for `D` days accrued `24 x rate x D` of decay per day rather than `rate`, growing quadratically in idle time.
+On the instance that reported this, configured for a roughly 70-day half-life, that drove the median raw-dialogue memory to 0.001 across a corpus whose oldest row is 102 days old — where the configured rate can produce no less than 0.36.
+A new `memories.last_decayed_at` column (schema v48) records when a row was last charged, and the pass measures from the later of that stamp and `accessed_at` so an actively recalled memory is not handed one large retroactive decay the first hour it goes idle.
+Rows written before the migration read back NULL and fall back to `accessed_at`, taking exactly the one-time decay the documented formula always intended rather than jumping at the migration boundary.
+(#7864) (@houko)

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 47;
+const SCHEMA_VERSION: u32 = 48;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -225,6 +225,11 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     // which is backward compatible with every existing row and a no-op for
     // single-user agents.
     run_step!(47, migrate_v47);
+    // v48 (#7756): add `memories.last_decayed_at` so confidence decay charges
+    // each interval of idle time exactly once instead of re-applying the whole
+    // elapsed idle span on every hourly tick. NULL on pre-migration rows, which
+    // the read path treats as "clock starts at accessed_at".
+    run_step!(48, migrate_v48);
 
     // Audit-trail consistency (#3538): user_version must match the count
     // of distinct rows in `migrations`. Drift means an earlier migration
@@ -884,6 +889,36 @@ fn migrate_v47(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) VALUES (47, datetime('now'), 'Add peer_id to entities and relations for per-user isolation (#6494)')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// v48 (#7756): Record when confidence decay last ran for each memory.
+///
+/// `decay_confidence` derived its exponent from `accessed_at` and wrote back
+/// only `confidence`, so nothing advanced between ticks.
+/// Every hourly run therefore re-applied the *entire* elapsed idle span to an
+/// already-decayed value, and the accumulated exponent grew quadratically in
+/// idle time rather than linearly — a row idle for `D` days accrued
+/// `24 * rate * D` per day instead of `rate`.
+/// A corpus configured for a ~70-day half-life collapsed to ~1e-3 in weeks.
+///
+/// `NULL` means "no decay tick has stamped this row yet", which is every row
+/// written before this migration.
+/// The read path falls back to `accessed_at` for those, so a pre-migration
+/// memory takes exactly the one-time decay its doc-commented formula always
+/// intended and no row jumps at the migration boundary.
+fn migrate_v48(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !try_column_exists(conn, "memories", "last_decayed_at")? {
+        conn.execute(
+            "ALTER TABLE memories ADD COLUMN last_decayed_at TEXT DEFAULT NULL",
+            [],
+        )?;
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (48, datetime('now'), 'Add memories.last_decayed_at so confidence decay charges each idle interval once (#7756)')",
         [],
     )?;
     Ok(())
@@ -2466,6 +2501,52 @@ mod tests {
         assert_eq!(name, "Acme");
         assert_eq!(props, "{\"k\":1}");
         assert_eq!(peer, "", "a pre-v47 row migrates to the '' shared sentinel");
+    }
+
+    #[test]
+    fn test_migrate_v48_adds_last_decayed_at_column() {
+        // #7756: confidence decay needs to know when it last ran for a row.
+        // The column is nullable with no default so every pre-migration memory
+        // reads back NULL, which the decay pass treats as "charge from
+        // accessed_at" — no row jumps at the migration boundary.
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        assert!(column_exists(&conn, "memories", "last_decayed_at"));
+
+        // A legacy-shaped INSERT that omits last_decayed_at leaves it NULL.
+        conn.execute(
+            "INSERT INTO memories (id, agent_id, content, source, scope, confidence, metadata, created_at, accessed_at, access_count, deleted) \
+             VALUES ('legacy-mem', 'agent-1', 'c', 'conversation', 'agent_memory', 1.0, '{}', '2026-07-19T00:00:00+00:00', '2026-07-19T00:00:00+00:00', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let stamp: Option<String> = conn
+            .query_row(
+                "SELECT last_decayed_at FROM memories WHERE id = 'legacy-mem'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stamp, None,
+            "a pre-v48 memory row must read back NULL, not a synthetic timestamp"
+        );
+
+        // A second call is a no-op (column already present) and must not
+        // disturb the seeded row.
+        migrate_v48(&conn).unwrap();
+        let confidence: f64 = conn
+            .query_row(
+                "SELECT confidence FROM memories WHERE id = 'legacy-mem'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            confidence, 1.0,
+            "re-running migrate_v48 must not touch data"
+        );
     }
 
     #[test]

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -262,7 +262,28 @@ impl ProactiveMemoryStore {
     /// For each memory not accessed in the last day, applies:
     ///   `effective_rate = decay_rate / boost`, where
     ///   `boost = min(1 + log2(access_count), MAX_BOOST)`.
-    ///   `new_confidence = current_confidence * e^(-effective_rate * days_since_access)`
+    ///   `new_confidence = current_confidence * e^(-effective_rate * days_since_last_charge)`
+    ///
+    /// `days_since_last_charge` is measured from the later of `last_decayed_at`
+    /// and `accessed_at` — **not** from `accessed_at` alone (#7756).
+    /// Each tick writes `last_decayed_at = now` alongside the new confidence, so
+    /// every interval of idle time is charged exactly once and the total decay
+    /// over a span depends on the span, not on how many times the scheduler
+    /// happened to fire inside it.
+    /// Before this bookkeeping existed the `UPDATE` wrote `confidence` only,
+    /// nothing advanced, and each hourly tick re-applied the *whole* elapsed
+    /// idle span to an already-decayed value: the accumulated exponent grew
+    /// quadratically in idle time instead of linearly, driving a corpus
+    /// configured for a ~70-day half-life to ~1e-3 within weeks.
+    ///
+    /// Taking the *later* of the two timestamps is what keeps an actively
+    /// recalled memory safe. Such a row never matches the `accessed_at <
+    /// one_day_ago` gate, so its `last_decayed_at` stays stale for the whole
+    /// active period; charging from that stale stamp would hand the row one
+    /// large retroactive decay the first hour it finally goes idle.
+    /// `last_decayed_at IS NULL` — every row written before the v48 migration —
+    /// falls back to `accessed_at`, so a pre-migration memory takes exactly the
+    /// one-time decay this formula always intended rather than collapsing.
     ///
     /// Popular memories decay *slower* (rate divided by boost) instead of being
     /// multiplied back up. The previous formula multiplied by `boost` and
@@ -293,19 +314,20 @@ impl ProactiveMemoryStore {
 
         let mut stmt = conn
             .prepare(
-                "SELECT id, confidence, accessed_at, access_count
+                "SELECT id, confidence, accessed_at, access_count, last_decayed_at
                  FROM memories
                  WHERE deleted = 0 AND accessed_at < ?1",
             )
             .map_err(LibreFangError::memory)?;
 
-        let rows: Vec<(String, f64, String, i64)> = stmt
+        let rows: Vec<(String, f64, String, i64, Option<String>)> = stmt
             .query_map(rusqlite::params![one_day_ago.to_rfc3339()], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, f64>(1)?,
                     row.get::<_, String>(2)?,
                     row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
                 ))
             })
             .map_err(LibreFangError::memory)?
@@ -318,7 +340,9 @@ impl ProactiveMemoryStore {
             })
             .collect();
 
-        for (id, current_confidence, accessed_str, access_count) in &rows {
+        let now_rfc3339 = now.to_rfc3339();
+
+        for (id, current_confidence, accessed_str, access_count, last_decayed_str) in &rows {
             let accessed_at = match chrono::DateTime::parse_from_rfc3339(accessed_str) {
                 Ok(dt) => dt.with_timezone(&Utc),
                 Err(e) => {
@@ -332,8 +356,43 @@ impl ProactiveMemoryStore {
                 }
             };
 
-            let days_since_access = (now - accessed_at).num_seconds() as f64 / 86400.0;
-            if days_since_access <= 0.0 {
+            // An unparseable `last_decayed_at` is treated as absent rather than
+            // fatal: falling back to `accessed_at` charges this row from its
+            // access clock, which is the same conservative path a pre-migration
+            // row takes. Failing the whole pass instead would let one corrupt
+            // stamp stop decay for every other memory.
+            let last_decayed_at = last_decayed_str.as_deref().and_then(|raw| {
+                match chrono::DateTime::parse_from_rfc3339(raw) {
+                    Ok(dt) => Some(dt.with_timezone(&Utc)),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to parse last_decayed_at '{}' for memory {}, \
+                             falling back to accessed_at: {}",
+                            raw,
+                            id,
+                            e
+                        );
+                        None
+                    }
+                }
+            });
+
+            // Charge from the later of the two clocks — see the method doc for
+            // why `last_decayed_at` alone is not safe for a row that was
+            // actively recalled while it never qualified for a tick.
+            let charged_through = match last_decayed_at {
+                Some(dt) if dt > accessed_at => dt,
+                _ => accessed_at,
+            };
+
+            // Milliseconds, not seconds: at the hourly scheduler cadence the two
+            // agree, but truncating to whole seconds would silently drop the
+            // remainder of every interval and let a fast caller (a manual
+            // `/decay` request, a test) advance `last_decayed_at` without ever
+            // charging the sub-second span it skipped.
+            let days_since_last_charge =
+                (now - charged_through).num_milliseconds() as f64 / 86_400_000.0;
+            if days_since_last_charge <= 0.0 {
                 continue;
             }
 
@@ -346,12 +405,16 @@ impl ProactiveMemoryStore {
             let count = (*access_count).max(1) as f64;
             let boost = (1.0 + count.log2()).min(MAX_BOOST);
             let effective_rate = decay_rate / boost;
-            let new_confidence =
-                (current_confidence * (-effective_rate * days_since_access).exp()).clamp(0.0, 1.0);
+            let new_confidence = (current_confidence
+                * (-effective_rate * days_since_last_charge).exp())
+            .clamp(0.0, 1.0);
 
+            // `last_decayed_at` moves in the same statement as `confidence`.
+            // Writing one without the other is the bug this replaces: the next
+            // tick would charge the same span again.
             conn.execute(
-                "UPDATE memories SET confidence = ?1 WHERE id = ?2",
-                rusqlite::params![new_confidence, id],
+                "UPDATE memories SET confidence = ?1, last_decayed_at = ?2 WHERE id = ?3",
+                rusqlite::params![new_confidence, now_rfc3339, id],
             )
             .map_err(LibreFangError::memory)?;
         }
@@ -4643,6 +4706,219 @@ mod tests {
             "popular memory must decay below 1.0; got {after} (boost-immortality regression)"
         );
         assert!(after > 0.0, "confidence must remain positive; got {after}");
+    }
+
+    /// Seed one stale, non-popular memory: 10 days idle, `confidence = 1.0`,
+    /// `access_count = 1` (so `boost = 1 + log2(1) = 1` and the effective rate is
+    /// exactly the configured `confidence_decay_rate`), and `last_decayed_at`
+    /// left NULL as if the row predates the v48 migration.
+    fn seed_stale_memory(store: &ProactiveMemoryStore, idle_days: i64) -> String {
+        let agent = AgentId::new();
+        let mid = store
+            .semantic
+            .remember(
+                agent,
+                "the deploy key lives in the vault",
+                MemorySource::Conversation,
+                "agent_memory",
+                HashMap::new(),
+            )
+            .unwrap();
+        let id = mid.0.to_string();
+        let stale = (Utc::now() - chrono::Duration::days(idle_days)).to_rfc3339();
+        let db = store.semantic.pool().get().unwrap();
+        db.execute(
+            "UPDATE memories \
+             SET confidence = 1.0, access_count = 1, accessed_at = ?1, last_decayed_at = NULL \
+             WHERE id = ?2",
+            rusqlite::params![stale, id],
+        )
+        .unwrap();
+        id
+    }
+
+    fn read_confidence(store: &ProactiveMemoryStore, id: &str) -> f64 {
+        store
+            .semantic
+            .pool()
+            .get()
+            .unwrap()
+            .query_row(
+                "SELECT confidence FROM memories WHERE id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    fn read_last_decayed_at(store: &ProactiveMemoryStore, id: &str) -> Option<String> {
+        store
+            .semantic
+            .pool()
+            .get()
+            .unwrap()
+            .query_row(
+                "SELECT last_decayed_at FROM memories WHERE id = ?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    /// Rewind a row's decay clock, simulating wall-clock time passing between
+    /// two scheduler ticks without making the test sleep.
+    fn rewind_decay_clock(store: &ProactiveMemoryStore, id: &str, days: i64) {
+        let then = (Utc::now() - chrono::Duration::days(days)).to_rfc3339();
+        store
+            .semantic
+            .pool()
+            .get()
+            .unwrap()
+            .execute(
+                "UPDATE memories SET last_decayed_at = ?1 WHERE id = ?2",
+                rusqlite::params![then, id],
+            )
+            .unwrap();
+    }
+
+    /// The #7756 regression: total decay must be a function of elapsed time, not
+    /// of how many times the scheduler fired.
+    ///
+    /// Before the fix the `UPDATE` wrote `confidence` only, so `days_since_access`
+    /// was recomputed from an `accessed_at` that never moved and each tick
+    /// re-applied the *entire* 10-day span to an already-decayed value. Five
+    /// back-to-back ticks produced `exp(-0.01 * 10)^5 = 0.607` instead of
+    /// `exp(-0.01 * 10) = 0.905` — and the real scheduler fires hourly, which is
+    /// how a corpus configured for a ~70-day half-life reached ~1e-3 in weeks.
+    #[test]
+    fn decay_total_depends_on_elapsed_time_not_tick_count() {
+        let substrate = Arc::new(MemorySubstrate::open_in_memory(0.05).unwrap());
+        let store = ProactiveMemoryStore::with_default_config(substrate);
+        let rate = store.config().confidence_decay_rate;
+        let id = seed_stale_memory(&store, 10);
+
+        store.decay_confidence().unwrap();
+        let after_one_tick = read_confidence(&store, &id);
+
+        // Four more ticks with no wall-clock time to charge for.
+        for _ in 0..4 {
+            store.decay_confidence().unwrap();
+        }
+        let after_five_ticks = read_confidence(&store, &id);
+
+        let expected = (-rate * 10.0f64).exp();
+        assert!(
+            (after_one_tick - expected).abs() < 1e-6,
+            "one tick over a 10-day idle span must apply exp(-rate*10) = {expected}; got {after_one_tick}"
+        );
+        assert!(
+            (after_five_ticks - after_one_tick).abs() < 1e-6,
+            "five ticks in the same instant must equal one tick: \
+             got {after_five_ticks} after five vs {after_one_tick} after one \
+             (pre-fix this compounded to {})",
+            after_one_tick.powi(5)
+        );
+    }
+
+    /// The other half of the same property: when time *does* pass between ticks,
+    /// decay must accumulate for exactly that extra span.
+    #[test]
+    fn decay_accumulates_over_time_between_ticks() {
+        let substrate = Arc::new(MemorySubstrate::open_in_memory(0.05).unwrap());
+        let store = ProactiveMemoryStore::with_default_config(substrate);
+        let rate = store.config().confidence_decay_rate;
+        let id = seed_stale_memory(&store, 10);
+
+        store.decay_confidence().unwrap();
+        let after_first = read_confidence(&store, &id);
+
+        // Five more days of idleness elapse, then the scheduler fires again.
+        rewind_decay_clock(&store, &id, 5);
+        store.decay_confidence().unwrap();
+        let after_second = read_confidence(&store, &id);
+
+        assert!(
+            after_second < after_first,
+            "a tick after five more idle days must decay further: {after_second} !< {after_first}"
+        );
+        let expected = (-rate * 15.0f64).exp();
+        assert!(
+            (after_second - expected).abs() < 1e-6,
+            "10 idle days then 5 more must total exp(-rate*15) = {expected}; got {after_second}"
+        );
+    }
+
+    /// A row written before the v48 migration has `last_decayed_at IS NULL`. It
+    /// must fall back to `accessed_at` and take the single one-time decay the
+    /// formula always intended — not collapse to zero, and not be skipped.
+    #[test]
+    fn pre_migration_row_decays_once_without_collapsing() {
+        let substrate = Arc::new(MemorySubstrate::open_in_memory(0.05).unwrap());
+        let store = ProactiveMemoryStore::with_default_config(substrate);
+        let rate = store.config().confidence_decay_rate;
+        let id = seed_stale_memory(&store, 60);
+
+        assert_eq!(
+            read_last_decayed_at(&store, &id),
+            None,
+            "seed must reproduce a pre-migration row"
+        );
+
+        store.decay_confidence().unwrap();
+
+        let after = read_confidence(&store, &id);
+        let expected = (-rate * 60.0f64).exp();
+        assert!(
+            (after - expected).abs() < 1e-6,
+            "a 60-day-idle pre-migration row must decay to exp(-rate*60) = {expected}; got {after}"
+        );
+        assert!(
+            after > 0.5,
+            "60 days at the default rate must not collapse the row; got {after}"
+        );
+        assert!(
+            read_last_decayed_at(&store, &id).is_some(),
+            "the tick must stamp last_decayed_at so the next one charges only the new span"
+        );
+    }
+
+    /// Decay is monotonic and stays inside `[0, 1]` no matter how far it runs,
+    /// including once the exponential has underflowed to zero.
+    #[test]
+    fn decay_is_monotonic_and_clamped_to_unit_range() {
+        let substrate = Arc::new(MemorySubstrate::open_in_memory(0.05).unwrap());
+        let store = ProactiveMemoryStore::with_default_config(substrate);
+        let mut config = store.config();
+        // An aggressive rate so 20 charged intervals drive the value through the
+        // floor within the test rather than hovering near 1.0.
+        config.confidence_decay_rate = 2.0;
+        store.update_config(config);
+
+        let id = seed_stale_memory(&store, 10);
+
+        let mut previous = read_confidence(&store, &id);
+        for tick in 0..20 {
+            rewind_decay_clock(&store, &id, 10);
+            store.decay_confidence().unwrap();
+            let current = read_confidence(&store, &id);
+            assert!(
+                (0.0..=1.0).contains(&current),
+                "confidence must stay in [0,1]; tick {tick} gave {current}"
+            );
+            assert!(
+                current <= previous,
+                "confidence must never increase; tick {tick} went {previous} -> {current}"
+            );
+            previous = current;
+        }
+        assert!(
+            previous < 1e-100,
+            "200 idle days at rate 2.0 must drive confidence to the floor; got {previous}"
+        );
+        assert!(
+            previous >= 0.0,
+            "confidence must never go negative or NaN; got {previous}"
+        );
     }
 
     /// `metadata["confidence"]` written by the LLM extractor must be honored


### PR DESCRIPTION
Fixes defect 1.1 of #7756 only — the confidence-decay bug. The RFC's architectural half (shrinking core, making the `MemoryProvider` seam capable enough to attach mem0 / Zep / Letta) is untouched and still needs a decision, so this is `Refs`, not `Closes`.

## The defect

`decay_confidence` computed its exponent from `accessed_at` and wrote back `confidence` alone:

```rust
let days_since_access = (now - accessed_at).num_seconds() as f64 / 86400.0;
let new_confidence = (current_confidence * (-effective_rate * days_since_access).exp()).clamp(0.0, 1.0);
conn.execute("UPDATE memories SET confidence = ?1 WHERE id = ?2", ...)
```

Nothing recorded that a tick had run — `grep -c last_decayed_at` over `crates/librefang-memory/` returned 0 and the `memories` table had no such column.
`accessed_at` never moved, so every hourly pass re-applied the **whole** elapsed idle span to an already-decayed value.
A row idle for `D` days accrued `24 x rate x D` of decay per day rather than `rate`: the accumulated exponent is quadratic in idle time, not linear.
This matches @nevgenov's reading in the issue exactly, and the doc comment one screen above already stated the intended semantics — the formula evaluated once over the span, not once per tick.

## Changes

- **Schema v48** (`migrate_v48`): `ALTER TABLE memories ADD COLUMN last_decayed_at TEXT DEFAULT NULL`, additive and nullable, guarded by `try_column_exists` with an `INSERT OR IGNORE` audit row, following the v46 single-column convention. `SCHEMA_VERSION` bumped 47 -> 48.
- **`decay_confidence`** selects `last_decayed_at`, measures the span from the **later** of that stamp and `accessed_at`, and writes the new stamp in the same `UPDATE` as the new confidence.
- **Why the later of the two**, not `last_decayed_at` alone: an actively recalled row never matches the `accessed_at < one_day_ago` gate, so its stamp stays stale for the entire active period. Charging from that stale stamp would hand the row one large retroactive decay the first hour it finally goes idle — reintroducing the jump in a different place.
- **Pre-migration rows** (`last_decayed_at IS NULL` — every row written before v48) fall back to `accessed_at` and take exactly the one-time decay the documented formula always intended. No row jumps at the migration boundary.
- An unparseable `last_decayed_at` is treated as absent rather than fatal, so one corrupt stamp cannot stop the decay pass for every other memory.
- Elapsed time is measured in milliseconds rather than truncated to whole seconds. At the hourly cadence the two agree; truncation would let a caller faster than the scheduler (a manual `POST /api/memory/decay`, a test) advance the stamp past a span it never charged for.
- Changelog fragment under `changelog.d/fixed/`.

## A correction to how this was described

The bug is not that decay fails to compound — it is that decay compounds *wrongly*.
Because the formula multiplies the **current** stored confidence, N back-to-back ticks produce `c0 * exp(-rate * D)^N`, not `c0 * exp(-rate * D)`.
So "run it N times, assert the result differs from one run" passes on the broken code too; the assertion that actually discriminates is that N ticks with no wall-clock time between them must **equal** one tick, and that decay grows only when real time passes.
Both directions are asserted below.

## Verification

`cargo test -p librefang-memory --lib` — 376 passed, 0 failed. New tests:

- `proactive::tests::decay_total_depends_on_elapsed_time_not_tick_count` — 10-day-idle row, `access_count = 1` so `boost = 1` and the effective rate is the configured rate. One tick must give `exp(-0.01 * 10) = 0.905`; five back-to-back ticks must give the same within 1e-6. Pre-fix the five ticks produced `0.905^5 = 0.607`.
- `proactive::tests::decay_accumulates_over_time_between_ticks` — after the first tick, five more idle days elapse; the next tick must total `exp(-rate * 15)` and be strictly below the first result.
- `proactive::tests::pre_migration_row_decays_once_without_collapsing` — a 60-day-idle row with `last_decayed_at IS NULL` decays to `exp(-rate * 60)`, stays above 0.5, and comes back with the stamp set.
- `proactive::tests::decay_is_monotonic_and_clamped_to_unit_range` — 20 charged intervals at rate 2.0; confidence stays in `[0, 1]`, never increases, and reaches the floor without going negative or NaN.
- `migration::tests::test_migrate_v48_adds_last_decayed_at_column` — column present after `run_migrations`, a legacy-shaped INSERT reads back NULL, and a second `migrate_v48` call is a no-op that does not disturb data.

The pre-existing `proactive::tests::popular_memory_decay_is_monotonic_not_frozen` still passes unchanged — it seeds exactly the pre-migration shape.

Also run: `cargo clippy -p librefang-memory --lib --tests` (clean), `cargo check -p librefang-api --lib` (the largest downstream consumer; no public signature changed, the column is additive).

No route or wiring change, so no `TestServer` test — `POST /api/memory/decay` still calls `decay_confidence_with_guard` with the same signature. The behaviour that changed is SQL-level and is asserted at that layer.

## Deliberately not changed

`MemoryExport` does not carry `last_decayed_at`. An imported row lands with NULL and therefore takes the same one-time decay from its `accessed_at` that any pre-migration row takes, which is the correct outcome; adding the field would change the import/export wire format for no behavioural gain.

## For @nevgenov

Your offer to test against the live ~1000-row instance stands and would be valuable — this is the one part CI cannot reproduce. What would be most useful:

1. Before upgrading, snapshot `SELECT id, confidence, accessed_at, access_count FROM memories` so there is a baseline to diff against.
2. After the first boot on this build, confirm `PRAGMA user_version` reads 48 and that `SELECT COUNT(*) FROM memories WHERE last_decayed_at IS NOT NULL` climbs from 0 as ticks run.
3. The important check: after the **first** decay tick post-migration, confirm no row's confidence dropped by more than `exp(-rate * days_idle)` relative to the snapshot — that is the one-time catch-up charge, and it should be the only large movement any row ever sees.
4. Then let it run 24h and confirm the daily drop is now on the order of `rate` per day rather than `24 x rate x days_idle`. Your log line `Confidence decay applied to N memories` should keep reporting a similar N — the gate is unchanged, only the amount charged is.

Note this does **not** restore confidence to rows that already collapsed to ~0.001; that is lost state and would need a separate backfill decision. Worth saying explicitly since your issue raises it: recall still does not restore confidence, which remains open under the RFC.
