### PR TITLE
feat(channels): add channel_members to read the group roster

### DIFF
--- a/changelog.d/fixed/7086-channel-members-roster-read.md
+++ b/changelog.d/fixed/7086-channel-members-roster-read.md
@@ -1,0 +1,7 @@
+An agent sitting in a shared Slack or Telegram group can now answer "who is in this channel?".
+The channel bridge has been persisting every group sender it observes into the `group_roster` table since that table landed, and `KernelHandle::roster_members` could always read it back — but nothing in the tree ever called it, so the roster was write-only in practice and the membership was invisible to agents and operators alike.
+The new read-only `channel_members` tool exposes it: `user_id`, `display_name` and `username` for everyone the daemon has seen speak in a conversation, defaulting to the conversation the current message arrived on.
+That `user_id` is what an agent needs to attribute a request to the person who made it when handing work to an external system.
+Reading a conversation other than the one the turn arrived on is refused on the same terms `channel_send` refuses a cross-chat dispatch, so one group cannot enumerate another's membership.
+Roster rows now also break a shared-display-name tie on the user id, because an unstable tail in a list that reaches the prompt invalidates provider prompt caches on unchanged content.
+(#7865) (@houko)

--- a/crates/librefang-memory/src/roster_store.rs
+++ b/crates/librefang-memory/src/roster_store.rs
@@ -64,13 +64,8 @@ impl RosterStore {
 
     /// List all members of a group chat, ordered by display name then user id.
     ///
-    /// The tiebreak is load-bearing, not cosmetic: this list reaches an LLM
-    /// prompt through the `channel_members` tool, and two members sharing a
-    /// display name would otherwise come back in whatever order SQLite
-    /// happened to produce, invalidating the provider prompt cache on
-    /// unchanged content (#3298).
-    /// The in-memory `GroupRosterStore::members` in `librefang-channels`
-    /// already breaks the same tie on the participant id.
+    /// The tiebreak is load-bearing, not cosmetic: this list reaches an LLM prompt through the `channel_members` tool, and two members sharing a display name would otherwise come back in whatever order SQLite happened to produce, invalidating the provider prompt cache on unchanged content (#3298).
+    /// The in-memory `GroupRosterStore::members` in `librefang-channels` already breaks the same tie on the participant id.
     pub fn members(
         &self,
         channel: &str,
@@ -197,10 +192,7 @@ mod tests {
         assert_eq!(members[0].1, "Alice Updated");
     }
 
-    // Two members with the same display name must come back in a fixed
-    // order regardless of insertion order: the list is rendered into an LLM
-    // prompt by the `channel_members` tool, so an unstable tail silently
-    // invalidates the provider prompt cache (#3298).
+    // Two members with the same display name must come back in a fixed order regardless of insertion order: the list is rendered into an LLM prompt by the `channel_members` tool, so an unstable tail silently invalidates the provider prompt cache (#3298).
     #[test]
     fn same_display_name_is_ordered_by_user_id_across_insertion_orders() {
         let forward = in_memory_store();

--- a/crates/librefang-memory/src/roster_store.rs
+++ b/crates/librefang-memory/src/roster_store.rs
@@ -62,7 +62,15 @@ impl RosterStore {
         Ok(())
     }
 
-    /// List all members of a group chat, ordered by display name.
+    /// List all members of a group chat, ordered by display name then user id.
+    ///
+    /// The tiebreak is load-bearing, not cosmetic: this list reaches an LLM
+    /// prompt through the `channel_members` tool, and two members sharing a
+    /// display name would otherwise come back in whatever order SQLite
+    /// happened to produce, invalidating the provider prompt cache on
+    /// unchanged content (#3298).
+    /// The in-memory `GroupRosterStore::members` in `librefang-channels`
+    /// already breaks the same tie on the participant id.
     pub fn members(
         &self,
         channel: &str,
@@ -81,7 +89,7 @@ impl RosterStore {
             .prepare(
                 "SELECT user_id, display_name, username FROM group_roster
                  WHERE channel_type = ?1 AND chat_id = ?2
-                 ORDER BY display_name",
+                 ORDER BY display_name, user_id",
             )
             .map_err(LibreFangError::memory)?;
         let rows = stmt
@@ -187,6 +195,28 @@ mod tests {
         let members = store.members("telegram", "-100").unwrap();
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].1, "Alice Updated");
+    }
+
+    // Two members with the same display name must come back in a fixed
+    // order regardless of insertion order: the list is rendered into an LLM
+    // prompt by the `channel_members` tool, so an unstable tail silently
+    // invalidates the provider prompt cache (#3298).
+    #[test]
+    fn same_display_name_is_ordered_by_user_id_across_insertion_orders() {
+        let forward = in_memory_store();
+        forward.upsert("slack", "C1", "U1", "Alex", None).unwrap();
+        forward.upsert("slack", "C1", "U2", "Alex", None).unwrap();
+
+        let reverse = in_memory_store();
+        reverse.upsert("slack", "C1", "U2", "Alex", None).unwrap();
+        reverse.upsert("slack", "C1", "U1", "Alex", None).unwrap();
+
+        let expected = vec![
+            ("U1".to_string(), "Alex".to_string(), None),
+            ("U2".to_string(), "Alex".to_string(), None),
+        ];
+        assert_eq!(forward.members("slack", "C1").unwrap(), expected);
+        assert_eq!(reverse.members("slack", "C1").unwrap(), expected);
     }
 
     #[test]

--- a/crates/librefang-runtime/src/tool_runner/channel.rs
+++ b/crates/librefang-runtime/src/tool_runner/channel.rs
@@ -161,23 +161,12 @@ fn resolve_send_target<'a>(
 
 /// Resolve the `(channel, chat_id)` pair a `channel_members` read targets.
 ///
-/// Both components default to the conversation the current turn arrived on, so
-/// the common "who is in this channel?" call needs no arguments at all.
+/// Both components default to the conversation the current turn arrived on, so the common "who is in this channel?" call needs no arguments at all.
 ///
-/// An explicit `chat_id` naming a *different* conversation on the channel the
-/// turn arrived on is refused. The roster carries the display name of every
-/// member the daemon has ever seen speak in a chat, so a free-form chat id
-/// would let one group enumerate the membership of every other chat the same
-/// bot sits in — the inbound twin of the #6117 cross-chat dispatch leak. The
-/// guard is deliberately the same shape as the one in `tool_channel_send`:
-/// only an explicit argument is scrutinised, only when the turn's channel is
-/// known, only within the same base channel type (so the WhatsApp gateway's
-/// `"whatsapp:<jid>"` stamp does not silently disable it), and the chat id is
-/// compared case-sensitively while the channel match is not. A cross-channel
-/// read stays allowed for the same reason a cross-channel send does — the
-/// agent is reaching into a surface the current conversation has no claim on
-/// either way, and out-of-band callers (cron, triggers) have no turn context
-/// to scope against.
+/// An explicit `chat_id` naming a *different* conversation on the channel the turn arrived on is refused.
+/// The roster carries the display name of every member the daemon has ever seen speak in a chat, so a free-form chat id would let one group enumerate the membership of every other chat the same bot sits in — the inbound twin of the #6117 cross-chat dispatch leak.
+/// The guard is deliberately the same shape as the one in `tool_channel_send`: only an explicit argument is scrutinised, only when the turn's channel is known, only within the same base channel type (so the WhatsApp gateway's `"whatsapp:<jid>"` stamp does not silently disable it), and the chat id is compared case-sensitively while the channel match is not.
+/// A cross-channel read stays allowed for the same reason a cross-channel send does — the agent is reaching into a surface the current conversation has no claim on either way, and out-of-band callers (cron, triggers) have no turn context to scope against.
 fn resolve_roster_target<'a>(
     explicit_channel: Option<&'a str>,
     explicit_chat_id: Option<&'a str>,
@@ -189,8 +178,7 @@ fn resolve_roster_target<'a>(
         .or_else(|| turn_channel.filter(|s| !s.is_empty()))
         .ok_or("Missing 'channel' parameter. It is auto-filled only while handling an inbound channel message — pass it explicitly from a cron job, trigger, or API-driven run.")?;
 
-    // The same canonical conversation id `channel_send` replies to: the chat /
-    // room, falling back to the peer for a DM.
+    // The same canonical conversation id `channel_send` replies to: the chat / room, falling back to the peer for a DM.
     let turn_conversation =
         resolve_send_target(None, turn_chat_id, turn_sender_id).filter(|s| !s.is_empty());
 
@@ -216,17 +204,10 @@ fn resolve_roster_target<'a>(
 
 /// `channel_members` — enumerate the persisted roster of a group conversation.
 ///
-/// This is the read half of the roster the channel bridge has been writing
-/// since the `group_roster` table landed: every group message the daemon
-/// observes upserts its sender through `ChannelBridgeHandle::roster_upsert`,
-/// and `KernelHandle::roster_members` has been able to read it back the whole
-/// time with no caller. Without this tool an agent sitting in a shared Slack
-/// or Telegram group cannot answer "who is in this channel?", and has no way
-/// to obtain the platform user id it needs to attribute a request to the
-/// person who made it (#7086).
+/// This is the read half of the roster the channel bridge has been writing since the `group_roster` table landed: every group message the daemon observes upserts its sender through `ChannelBridgeHandle::roster_upsert`, and `KernelHandle::roster_members` has been able to read it back the whole time with no caller.
+/// Without this tool an agent sitting in a shared Slack or Telegram group cannot answer "who is in this channel?", and has no way to obtain the platform user id it needs to attribute a request to the person who made it (#7086).
 ///
-/// Read-only and non-mutating: it neither sends anything nor teaches the
-/// roster about anyone new.
+/// Read-only and non-mutating: it neither sends anything nor teaches the roster about anyone new.
 pub(super) fn tool_channel_members(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
@@ -244,10 +225,7 @@ pub(super) fn tool_channel_members(
         sender_id,
     )?;
 
-    // The roster is keyed on the bare channel *type* (`channel_type_str` in
-    // the bridge), so strip the conversation suffix the WhatsApp gateway
-    // embeds in its channel string (#5227) before looking it up — otherwise
-    // every WhatsApp read misses.
+    // The roster is keyed on the bare channel *type* (`channel_type_str` in the bridge), so strip the conversation suffix the WhatsApp gateway embeds in its channel string (#5227) before looking it up — otherwise every WhatsApp read misses.
     let roster_channel = channel_base(channel);
 
     let members = kh
@@ -261,9 +239,8 @@ pub(super) fn tool_channel_members(
         "members": members,
     });
 
-    // An empty roster is the expected state for a DM, and for a group the
-    // daemon has never observed a message in. Say so, rather than letting the
-    // model read `[]` as "this channel has no members" or as a broken tool.
+    // An empty roster is the expected state for a DM, and for a group the daemon has never observed a message in.
+    // Say so, rather than letting the model read `[]` as "this channel has no members" or as a broken tool.
     if members.is_empty() {
         out["note"] = serde_json::Value::String(
             "No members recorded for this conversation. The roster is built from group messages the daemon has observed, so a member who has never spoken in it is absent, and a direct message has no roster at all.".to_string(),
@@ -723,8 +700,7 @@ mod tests {
         assert_eq!(resolved, ("slack", "C123"));
     }
 
-    // A DM stamps no chat id (or the peer's own id), so the peer is the
-    // conversation — the same fallback `channel_send` uses.
+    // A DM stamps no chat id (or the peer's own id), so the peer is the conversation — the same fallback `channel_send` uses.
     #[test]
     fn roster_target_falls_back_to_the_peer_in_a_dm() {
         let resolved =
@@ -735,8 +711,7 @@ mod tests {
         assert_eq!(empty_chat, ("telegram", "4242"));
     }
 
-    // Restating the current conversation is allowed — only a *different* one
-    // is a leak.
+    // Restating the current conversation is allowed — only a *different* one is a leak.
     #[test]
     fn roster_target_accepts_an_explicit_current_chat() {
         let resolved = resolve_roster_target(
@@ -750,8 +725,7 @@ mod tests {
         assert_eq!(resolved, ("slack", "C123"));
     }
 
-    // The inbound twin of the #6117 leak: one group must not enumerate
-    // another group's membership.
+    // The inbound twin of the #6117 leak: one group must not enumerate another group's membership.
     #[test]
     fn roster_target_rejects_another_chat_on_the_same_channel() {
         let err = resolve_roster_target(
@@ -766,8 +740,7 @@ mod tests {
         assert!(err.contains("C123"), "{err}");
     }
 
-    // The channel match is case-insensitive, so varying the casing cannot
-    // slip a foreign chat id past the guard.
+    // The channel match is case-insensitive, so varying the casing cannot slip a foreign chat id past the guard.
     #[test]
     fn roster_target_guard_survives_channel_case_variation() {
         assert!(resolve_roster_target(
@@ -781,9 +754,7 @@ mod tests {
     }
 
     // The WhatsApp gateway stamps `sender_channel = "whatsapp:<jid>"` (#5227).
-    // Comparing the raw strings would never match the bare `"whatsapp"` a tool
-    // call names, silently disabling the guard for exactly the multi-member
-    // groups it protects.
+    // Comparing the raw strings would never match the bare `"whatsapp"` a tool call names, silently disabling the guard for exactly the multi-member groups it protects.
     #[test]
     fn roster_target_guard_survives_the_whatsapp_channel_suffix() {
         assert!(resolve_roster_target(
@@ -805,9 +776,7 @@ mod tests {
         assert_eq!(ok, ("whatsapp", "123@g.us"));
     }
 
-    // A different channel than the turn arrived on stays readable, matching
-    // the `channel_send` scoping — the guard only covers intra-channel
-    // re-targeting.
+    // A different channel than the turn arrived on stays readable, matching the `channel_send` scoping — the guard only covers intra-channel re-targeting.
     #[test]
     fn roster_target_allows_a_different_channel() {
         let resolved = resolve_roster_target(
@@ -821,9 +790,7 @@ mod tests {
         assert_eq!(resolved, ("telegram", "-100"));
     }
 
-    // The tool has to be declared to be reachable: a dispatch arm with no
-    // matching `ToolDefinition` is invisible to the model and to
-    // `tool_load` / `tool_search`.
+    // The tool has to be declared to be reachable: a dispatch arm with no matching `ToolDefinition` is invisible to the model and to `tool_load` / `tool_search`.
     #[test]
     fn channel_members_is_registered_in_builtins() {
         let defs = crate::tool_runner::builtin_tool_definitions();
@@ -836,18 +803,14 @@ mod tests {
             .expect("properties object");
         assert!(props.contains_key("channel"));
         assert!(props.contains_key("chat_id"));
-        // Both arguments default to the current conversation, so a bare call
-        // during message handling must be valid.
+        // Both arguments default to the current conversation, so a bare call during message handling must be valid.
         assert!(
             def.input_schema.get("required").is_none(),
             "channel_members must have no required arguments"
         );
     }
 
-    // #3298: the schema is stringified into every request that declares this
-    // tool, so its key order has to be a canonical property of the literal
-    // rather than something a future edit can shuffle — a reordering
-    // invalidates provider prompt caches on byte-identical content.
+    // #3298: the schema is stringified into every request that declares this tool, so its key order has to be a canonical property of the literal rather than something a future edit can shuffle — a reordering invalidates provider prompt caches on byte-identical content.
     #[test]
     fn channel_members_schema_property_order_is_canonical() {
         let defs = crate::tool_runner::builtin_tool_definitions();
@@ -866,8 +829,7 @@ mod tests {
         assert_eq!(keys, sorted);
     }
 
-    // Out-of-band callers (cron, triggers) carry no turn context, so both
-    // arguments become required rather than resolving to something arbitrary.
+    // Out-of-band callers (cron, triggers) carry no turn context, so both arguments become required rather than resolving to something arbitrary.
     #[test]
     fn roster_target_requires_explicit_arguments_out_of_band() {
         let no_channel = resolve_roster_target(None, Some("C1"), None, None, None)

--- a/crates/librefang-runtime/src/tool_runner/channel.rs
+++ b/crates/librefang-runtime/src/tool_runner/channel.rs
@@ -159,6 +159,120 @@ fn resolve_send_target<'a>(
         .or(sender_id)
 }
 
+/// Resolve the `(channel, chat_id)` pair a `channel_members` read targets.
+///
+/// Both components default to the conversation the current turn arrived on, so
+/// the common "who is in this channel?" call needs no arguments at all.
+///
+/// An explicit `chat_id` naming a *different* conversation on the channel the
+/// turn arrived on is refused. The roster carries the display name of every
+/// member the daemon has ever seen speak in a chat, so a free-form chat id
+/// would let one group enumerate the membership of every other chat the same
+/// bot sits in — the inbound twin of the #6117 cross-chat dispatch leak. The
+/// guard is deliberately the same shape as the one in `tool_channel_send`:
+/// only an explicit argument is scrutinised, only when the turn's channel is
+/// known, only within the same base channel type (so the WhatsApp gateway's
+/// `"whatsapp:<jid>"` stamp does not silently disable it), and the chat id is
+/// compared case-sensitively while the channel match is not. A cross-channel
+/// read stays allowed for the same reason a cross-channel send does — the
+/// agent is reaching into a surface the current conversation has no claim on
+/// either way, and out-of-band callers (cron, triggers) have no turn context
+/// to scope against.
+fn resolve_roster_target<'a>(
+    explicit_channel: Option<&'a str>,
+    explicit_chat_id: Option<&'a str>,
+    turn_channel: Option<&'a str>,
+    turn_chat_id: Option<&'a str>,
+    turn_sender_id: Option<&'a str>,
+) -> Result<(&'a str, &'a str), String> {
+    let channel = explicit_channel
+        .or_else(|| turn_channel.filter(|s| !s.is_empty()))
+        .ok_or("Missing 'channel' parameter. It is auto-filled only while handling an inbound channel message — pass it explicitly from a cron job, trigger, or API-driven run.")?;
+
+    // The same canonical conversation id `channel_send` replies to: the chat /
+    // room, falling back to the peer for a DM.
+    let turn_conversation =
+        resolve_send_target(None, turn_chat_id, turn_sender_id).filter(|s| !s.is_empty());
+
+    if let (Some(explicit), Some(turn), Some(expected)) =
+        (explicit_chat_id, turn_channel, turn_conversation)
+    {
+        if !turn.is_empty()
+            && channel_base(turn).eq_ignore_ascii_case(channel_base(channel))
+            && explicit != expected
+        {
+            return Err(format!(
+                "channel_members chat_id '{explicit}' does not match the current chat '{expected}' on channel '{channel}'. Reading another chat's roster is forbidden — omit chat_id to list the members of the current conversation."
+            ));
+        }
+    }
+
+    let chat_id = explicit_chat_id
+        .or(turn_conversation)
+        .ok_or("Missing 'chat_id' parameter. It is auto-filled only while handling an inbound channel message — pass it explicitly from a cron job, trigger, or API-driven run.")?;
+
+    Ok((channel, chat_id))
+}
+
+/// `channel_members` — enumerate the persisted roster of a group conversation.
+///
+/// This is the read half of the roster the channel bridge has been writing
+/// since the `group_roster` table landed: every group message the daemon
+/// observes upserts its sender through `ChannelBridgeHandle::roster_upsert`,
+/// and `KernelHandle::roster_members` has been able to read it back the whole
+/// time with no caller. Without this tool an agent sitting in a shared Slack
+/// or Telegram group cannot answer "who is in this channel?", and has no way
+/// to obtain the platform user id it needs to attribute a request to the
+/// person who made it (#7086).
+///
+/// Read-only and non-mutating: it neither sends anything nor teaches the
+/// roster about anyone new.
+pub(super) fn tool_channel_members(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    sender_id: Option<&str>,
+    sender_channel: Option<&str>,
+    sender_chat_id: Option<&str>,
+) -> Result<String, String> {
+    let kh = require_kernel(kernel)?;
+
+    let (channel, chat_id) = resolve_roster_target(
+        trim_opt_string(input["channel"].as_str()),
+        trim_opt_string(input["chat_id"].as_str()),
+        sender_channel,
+        sender_chat_id,
+        sender_id,
+    )?;
+
+    // The roster is keyed on the bare channel *type* (`channel_type_str` in
+    // the bridge), so strip the conversation suffix the WhatsApp gateway
+    // embeds in its channel string (#5227) before looking it up — otherwise
+    // every WhatsApp read misses.
+    let roster_channel = channel_base(channel);
+
+    let members = kh
+        .roster_members(roster_channel, chat_id)
+        .map_err(|e| e.to_string())?;
+
+    let mut out = serde_json::json!({
+        "channel": roster_channel,
+        "chat_id": chat_id,
+        "count": members.len(),
+        "members": members,
+    });
+
+    // An empty roster is the expected state for a DM, and for a group the
+    // daemon has never observed a message in. Say so, rather than letting the
+    // model read `[]` as "this channel has no members" or as a broken tool.
+    if members.is_empty() {
+        out["note"] = serde_json::Value::String(
+            "No members recorded for this conversation. The roster is built from group messages the daemon has observed, so a member who has never spoken in it is absent, and a direct message has no roster at all.".to_string(),
+        );
+    }
+
+    Ok(out.to_string())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn tool_channel_send(
     input: &serde_json::Value,
@@ -548,7 +662,7 @@ pub(super) async fn tool_channel_send(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_send_target;
+    use super::{resolve_roster_target, resolve_send_target};
 
     // A group turn: the speaker (`sender_id`) and the room (`sender_chat_id`)
     // differ. A no-recipient send must reply to the room, not the speaker —
@@ -599,5 +713,170 @@ mod tests {
     #[test]
     fn no_identity_resolves_none() {
         assert_eq!(resolve_send_target(None, None, None), None);
+    }
+
+    // A bare `channel_members` call during a group turn reads that group.
+    #[test]
+    fn roster_target_defaults_to_the_current_group() {
+        let resolved =
+            resolve_roster_target(None, None, Some("slack"), Some("C123"), Some("U9")).unwrap();
+        assert_eq!(resolved, ("slack", "C123"));
+    }
+
+    // A DM stamps no chat id (or the peer's own id), so the peer is the
+    // conversation — the same fallback `channel_send` uses.
+    #[test]
+    fn roster_target_falls_back_to_the_peer_in_a_dm() {
+        let resolved =
+            resolve_roster_target(None, None, Some("telegram"), None, Some("4242")).unwrap();
+        assert_eq!(resolved, ("telegram", "4242"));
+        let empty_chat =
+            resolve_roster_target(None, None, Some("telegram"), Some(""), Some("4242")).unwrap();
+        assert_eq!(empty_chat, ("telegram", "4242"));
+    }
+
+    // Restating the current conversation is allowed — only a *different* one
+    // is a leak.
+    #[test]
+    fn roster_target_accepts_an_explicit_current_chat() {
+        let resolved = resolve_roster_target(
+            Some("slack"),
+            Some("C123"),
+            Some("slack"),
+            Some("C123"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved, ("slack", "C123"));
+    }
+
+    // The inbound twin of the #6117 leak: one group must not enumerate
+    // another group's membership.
+    #[test]
+    fn roster_target_rejects_another_chat_on_the_same_channel() {
+        let err = resolve_roster_target(
+            Some("slack"),
+            Some("C999"),
+            Some("slack"),
+            Some("C123"),
+            Some("U9"),
+        )
+        .expect_err("cross-chat roster read must be refused");
+        assert!(err.contains("C999"), "{err}");
+        assert!(err.contains("C123"), "{err}");
+    }
+
+    // The channel match is case-insensitive, so varying the casing cannot
+    // slip a foreign chat id past the guard.
+    #[test]
+    fn roster_target_guard_survives_channel_case_variation() {
+        assert!(resolve_roster_target(
+            Some("Slack"),
+            Some("C999"),
+            Some("slack"),
+            Some("C123"),
+            None
+        )
+        .is_err());
+    }
+
+    // The WhatsApp gateway stamps `sender_channel = "whatsapp:<jid>"` (#5227).
+    // Comparing the raw strings would never match the bare `"whatsapp"` a tool
+    // call names, silently disabling the guard for exactly the multi-member
+    // groups it protects.
+    #[test]
+    fn roster_target_guard_survives_the_whatsapp_channel_suffix() {
+        assert!(resolve_roster_target(
+            Some("whatsapp"),
+            Some("other@g.us"),
+            Some("whatsapp:123@g.us"),
+            Some("123@g.us"),
+            None
+        )
+        .is_err());
+        let ok = resolve_roster_target(
+            Some("whatsapp"),
+            Some("123@g.us"),
+            Some("whatsapp:123@g.us"),
+            Some("123@g.us"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(ok, ("whatsapp", "123@g.us"));
+    }
+
+    // A different channel than the turn arrived on stays readable, matching
+    // the `channel_send` scoping — the guard only covers intra-channel
+    // re-targeting.
+    #[test]
+    fn roster_target_allows_a_different_channel() {
+        let resolved = resolve_roster_target(
+            Some("telegram"),
+            Some("-100"),
+            Some("slack"),
+            Some("C123"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved, ("telegram", "-100"));
+    }
+
+    // The tool has to be declared to be reachable: a dispatch arm with no
+    // matching `ToolDefinition` is invisible to the model and to
+    // `tool_load` / `tool_search`.
+    #[test]
+    fn channel_members_is_registered_in_builtins() {
+        let defs = crate::tool_runner::builtin_tool_definitions();
+        let def = defs
+            .iter()
+            .find(|d| d.name == "channel_members")
+            .expect("channel_members must appear in builtin_tool_definitions");
+        let props = def.input_schema["properties"]
+            .as_object()
+            .expect("properties object");
+        assert!(props.contains_key("channel"));
+        assert!(props.contains_key("chat_id"));
+        // Both arguments default to the current conversation, so a bare call
+        // during message handling must be valid.
+        assert!(
+            def.input_schema.get("required").is_none(),
+            "channel_members must have no required arguments"
+        );
+    }
+
+    // #3298: the schema is stringified into every request that declares this
+    // tool, so its key order has to be a canonical property of the literal
+    // rather than something a future edit can shuffle — a reordering
+    // invalidates provider prompt caches on byte-identical content.
+    #[test]
+    fn channel_members_schema_property_order_is_canonical() {
+        let defs = crate::tool_runner::builtin_tool_definitions();
+        let def = defs
+            .iter()
+            .find(|d| d.name == "channel_members")
+            .expect("channel_members must appear in builtin_tool_definitions");
+        let keys: Vec<&str> = def.input_schema["properties"]
+            .as_object()
+            .expect("properties object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        assert_eq!(keys, sorted);
+    }
+
+    // Out-of-band callers (cron, triggers) carry no turn context, so both
+    // arguments become required rather than resolving to something arbitrary.
+    #[test]
+    fn roster_target_requires_explicit_arguments_out_of_band() {
+        let no_channel = resolve_roster_target(None, Some("C1"), None, None, None)
+            .expect_err("channel must be required without a turn");
+        assert!(no_channel.contains("channel"), "{no_channel}");
+        let no_chat = resolve_roster_target(Some("slack"), None, None, None, None)
+            .expect_err("chat_id must be required without a turn");
+        assert!(no_chat.contains("chat_id"), "{no_chat}");
+        let both = resolve_roster_target(Some("slack"), Some("C1"), None, None, None).unwrap();
+        assert_eq!(both, ("slack", "C1"));
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -79,6 +79,7 @@ pub(crate) mod tool_name {
     pub const CRON_CANCEL: &str = "cron_cancel";
     pub const CRON_ENABLE: &str = "cron_enable";
     pub const CHANNEL_SEND: &str = "channel_send";
+    pub const CHANNEL_MEMBERS: &str = "channel_members";
     pub const HAND_LIST: &str = "hand_list";
     pub const HAND_ACTIVATE: &str = "hand_activate";
     pub const HAND_STATUS: &str = "hand_status";
@@ -1007,6 +1008,17 @@ use instead of web_fetch + file_write (which round-trips the entire body through
                         "poll_explanation": { "type": "string", "description": "Explanation shown after answering (quiz mode)" }
                     },
                     "required": ["channel", "message"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::CHANNEL_MEMBERS.to_string(),
+                description: "List the known members of a group conversation on a channel: the platform user_id, display_name, and username of everyone the daemon has seen speak there. Use it to answer \"who is in this channel?\", to attribute a request to the person who made it when handing work to an external system, and to obtain the platform user id needed to address one member individually. Both arguments default to the conversation the current message arrived on, so during message handling this can be called with no arguments; a direct message has no roster. Read-only.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "channel": { "type": "string", "description": "Channel type to read the roster of (e.g. 'slack', 'telegram', 'discord', 'whatsapp'). Omit while handling an inbound message to use the channel it arrived on." },
+                        "chat_id": { "type": "string", "description": "Platform conversation id (Slack channel id, Telegram chat_id, WhatsApp group JID). Omit while handling an inbound message to use the current conversation — naming a different conversation on that same channel is refused." }
+                    }
                 }),
             },
             ToolDefinition {

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1165,6 +1165,12 @@ pub async fn execute_tool_raw(
             .map_err(ToolError::upstream_msg)
         }
 
+        // Roster read — the companion of `channel_send` (#7086). The bridge has
+        // been persisting group senders through `roster_upsert` all along;
+        // this is the first caller of the matching read.
+        "channel_members" => tool_channel_members(input, *kernel, *sender_id, *channel, *chat_id)
+            .map_err(ToolError::upstream_msg),
+
         // Persistent process tools.
         "process_start" => {
             tool_process_start(

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1165,9 +1165,8 @@ pub async fn execute_tool_raw(
             .map_err(ToolError::upstream_msg)
         }
 
-        // Roster read — the companion of `channel_send` (#7086). The bridge has
-        // been persisting group senders through `roster_upsert` all along;
-        // this is the first caller of the matching read.
+        // Roster read — the companion of `channel_send` (#7086).
+        // The bridge has been persisting group senders through `roster_upsert` all along; this is the first caller of the matching read.
         "channel_members" => tool_channel_members(input, *kernel, *sender_id, *channel, *chat_id)
             .map_err(ToolError::upstream_msg),
 

--- a/crates/librefang-runtime/src/tool_runner/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/mod.rs
@@ -50,7 +50,7 @@ use self::agent::{
 use self::artifact::tool_read_artifact;
 pub use self::canvas::sanitize_canvas_html;
 use self::canvas::tool_canvas_present;
-use self::channel::tool_channel_send;
+use self::channel::{tool_channel_members, tool_channel_send};
 use self::cron::{tool_cron_cancel, tool_cron_create, tool_cron_enable, tool_cron_list};
 pub(crate) use self::definitions::tool_name;
 pub use self::definitions::{builtin_tool_definitions, select_native_tools, ALWAYS_NATIVE_TOOLS};

--- a/crates/librefang-runtime/tests/tool_runner_channel_members.rs
+++ b/crates/librefang-runtime/tests/tool_runner_channel_members.rs
@@ -1,0 +1,394 @@
+//! End-to-end wiring for the `channel_members` roster read (#7086).
+//!
+//! The channel bridge has persisted every group sender it sees through
+//! `ChannelBridgeHandle::roster_upsert` since the `group_roster` table landed,
+//! and `KernelHandle::roster_members` could always read it back — with no
+//! caller anywhere in the tree. These tests cover the boundary that closes
+//! that gap: the dispatch arm resolves the conversation from the turn context,
+//! calls `roster_members` with the bare channel type, and refuses to read a
+//! conversation other than the one the turn arrived on.
+
+use async_trait::async_trait;
+use librefang_kernel_handle::prelude::*;
+use librefang_runtime::tool_runner::{execute_tool_raw, ToolExecContext};
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+
+/// Every `(channel, chat_id)` pair the tool asked the kernel about.
+type RosterCallLog = Arc<Mutex<Vec<(String, String)>>>;
+
+struct RosterKernel {
+    calls: RosterCallLog,
+}
+
+impl RosterKernel {
+    fn new() -> (Self, RosterCallLog) {
+        let calls: RosterCallLog = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                calls: Arc::clone(&calls),
+            },
+            calls,
+        )
+    }
+}
+
+#[async_trait]
+impl AgentControl for RosterKernel {
+    async fn spawn_agent(
+        &self,
+        _: &str,
+        _: Option<&str>,
+    ) -> Result<(String, String), librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn send_to_agent(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<String, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    fn list_agents(&self) -> Vec<AgentInfo> {
+        vec![]
+    }
+    fn kill_agent(&self, _: &str) -> Result<(), librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    fn find_agents(&self, _: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for RosterKernel {
+    fn memory_store(
+        &self,
+        _key: &str,
+        _value: serde_json::Value,
+        _agent_id: Option<&str>,
+        _peer_id: Option<&str>,
+    ) -> Result<(), librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    fn memory_recall(
+        &self,
+        _key: &str,
+        _agent_id: Option<&str>,
+        _peer_id: Option<&str>,
+    ) -> Result<Option<serde_json::Value>, librefang_kernel_handle::KernelOpError> {
+        Ok(None)
+    }
+    fn memory_list(
+        &self,
+        _agent_id: Option<&str>,
+        _peer_id: Option<&str>,
+    ) -> Result<Vec<String>, librefang_kernel_handle::KernelOpError> {
+        Ok(vec![])
+    }
+}
+
+impl WikiAccess for RosterKernel {}
+
+#[async_trait]
+impl TaskQueue for RosterKernel {
+    async fn task_post(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> Result<String, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_claim(
+        &self,
+        _: &str,
+    ) -> Result<Option<serde_json::Value>, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_complete(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(), librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_list(
+        &self,
+        _: Option<&str>,
+    ) -> Result<Vec<serde_json::Value>, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_delete(&self, _: &str) -> Result<bool, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_retry(&self, _: &str) -> Result<bool, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_get(
+        &self,
+        _: &str,
+    ) -> Result<Option<serde_json::Value>, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn task_update_status(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<bool, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+}
+
+#[async_trait]
+impl EventBus for RosterKernel {
+    async fn publish_event(
+        &self,
+        _: &str,
+        _: serde_json::Value,
+    ) -> Result<(), librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+}
+
+#[async_trait]
+impl KnowledgeGraph for RosterKernel {
+    async fn knowledge_add_entity(
+        &self,
+        _: &librefang_types::memory::Entity,
+        _agent_id: &str,
+        _: Option<&str>,
+    ) -> Result<String, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn knowledge_add_relation(
+        &self,
+        _: &librefang_types::memory::Relation,
+        _agent_id: &str,
+        _: Option<&str>,
+    ) -> Result<String, librefang_kernel_handle::KernelOpError> {
+        Err("not implemented".into())
+    }
+    async fn knowledge_query(
+        &self,
+        _: librefang_types::memory::GraphPattern,
+        _: Option<&str>,
+    ) -> Result<Vec<librefang_types::memory::GraphMatch>, librefang_kernel_handle::KernelOpError>
+    {
+        Err("not implemented".into())
+    }
+}
+
+impl CronControl for RosterKernel {}
+impl ApprovalGate for RosterKernel {}
+impl HandsControl for RosterKernel {}
+impl A2ARegistry for RosterKernel {}
+impl PromptStore for RosterKernel {}
+impl WorkflowRunner for RosterKernel {}
+impl GoalControl for RosterKernel {}
+impl ToolPolicy for RosterKernel {}
+impl librefang_kernel_handle::CatalogQuery for RosterKernel {}
+impl librefang_kernel_handle::ApiAuth for RosterKernel {
+    fn auth_snapshot(&self) -> librefang_kernel_handle::ApiAuthSnapshot {
+        librefang_kernel_handle::ApiAuthSnapshot::default()
+    }
+}
+impl librefang_kernel_handle::SessionWriter for RosterKernel {
+    fn inject_attachment_blocks(
+        &self,
+        _agent_id: librefang_types::agent::AgentId,
+        _session_id: librefang_types::agent::SessionId,
+        _blocks: Vec<librefang_types::message::ContentBlock>,
+    ) {
+    }
+}
+impl librefang_kernel_handle::AcpFsBridge for RosterKernel {}
+impl librefang_kernel_handle::AcpTerminalBridge for RosterKernel {}
+
+/// The rows the real `ChannelSenderHandle` builds out of
+/// `RosterStore::members`, in the order that store returns them (display name,
+/// then user id).
+impl ChannelSender for RosterKernel {
+    fn roster_members(
+        &self,
+        channel: &str,
+        chat_id: &str,
+    ) -> Result<Vec<serde_json::Value>, librefang_kernel_handle::KernelOpError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((channel.to_string(), chat_id.to_string()));
+        if (channel, chat_id) != ("slack", "C0DESIGN") {
+            return Ok(vec![]);
+        }
+        Ok(vec![
+            json!({"user_id": "U001", "display_name": "Ana", "username": "ana"}),
+            json!({"user_id": "U002", "display_name": "Bo", "username": null}),
+        ])
+    }
+}
+
+fn make_ctx<'a>(
+    kernel: &'a Arc<dyn KernelHandle>,
+    channel: Option<&'a str>,
+    chat_id: Option<&'a str>,
+    sender_id: Option<&'a str>,
+) -> ToolExecContext<'a> {
+    ToolExecContext {
+        kernel: Some(kernel),
+        allowed_tools: None,
+        available_tools: None,
+        caller_agent_id: Some("test-agent"),
+        skill_registry: None,
+        allowed_skills: None,
+        mcp_connections: None,
+        web_ctx: None,
+        browser_ctx: None,
+        allowed_env_vars: None,
+        workspace_root: None,
+        media_engine: None,
+        media_drivers: None,
+        exec_policy: None,
+        tts_engine: None,
+        docker_config: None,
+        process_manager: None,
+        process_registry: None,
+        sender_id,
+        channel,
+        chat_id,
+        sender_account_id: None,
+        session_id: None,
+        spill_threshold_bytes: 0,
+        max_artifact_bytes: 0,
+        checkpoint_manager: None,
+        interrupt: None,
+        dangerous_command_checker: None,
+    }
+}
+
+/// The use case from #7086: an agent in a shared Slack channel answers "who is
+/// in here?" with no arguments, and gets back the platform user id it needs to
+/// attribute the request to a person.
+#[tokio::test]
+async fn channel_members_reads_the_current_conversation_with_no_arguments() {
+    let (kernel, calls) = RosterKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, Some("slack"), Some("C0DESIGN"), Some("U002"));
+    let result = execute_tool_raw("t1", "channel_members", &json!({}), &ctx).await;
+
+    assert!(
+        !result.is_error,
+        "channel_members should succeed: {}",
+        result.content
+    );
+    let body: serde_json::Value = serde_json::from_str(&result.content).expect("json body");
+    assert_eq!(body["channel"], "slack");
+    assert_eq!(body["chat_id"], "C0DESIGN");
+    assert_eq!(body["count"], 2);
+    assert_eq!(body["members"][0]["user_id"], "U001");
+    assert_eq!(body["members"][0]["display_name"], "Ana");
+    assert_eq!(body["members"][1]["user_id"], "U002");
+    assert!(
+        body.get("note").is_none(),
+        "a populated roster carries no empty-roster note: {}",
+        result.content
+    );
+
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![("slack".to_string(), "C0DESIGN".to_string())]
+    );
+}
+
+/// An empty roster is the normal state for a DM and for a group nobody has
+/// spoken in yet, so it must not read as a broken tool.
+#[tokio::test]
+async fn channel_members_explains_an_empty_roster() {
+    let (kernel, _calls) = RosterKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, Some("slack"), None, Some("U777"));
+    let result = execute_tool_raw("t2", "channel_members", &json!({}), &ctx).await;
+
+    assert!(!result.is_error, "{}", result.content);
+    let body: serde_json::Value = serde_json::from_str(&result.content).expect("json body");
+    // No chat id stamped: the DM peer is the conversation, as for channel_send.
+    assert_eq!(body["chat_id"], "U777");
+    assert_eq!(body["count"], 0);
+    assert!(body["members"].as_array().expect("array").is_empty());
+    assert!(body["note"].as_str().expect("note").contains("roster"));
+}
+
+/// The inbound twin of the #6117 cross-chat dispatch leak: a member of one
+/// group must not be able to enumerate another group's membership, and the
+/// refusal has to happen before the kernel is asked.
+#[tokio::test]
+async fn channel_members_refuses_another_chat_on_the_same_channel() {
+    let (kernel, calls) = RosterKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, Some("slack"), Some("C0DESIGN"), Some("U002"));
+    let input = json!({"channel": "slack", "chat_id": "C0SECRET"});
+    let result = execute_tool_raw("t3", "channel_members", &input, &ctx).await;
+
+    assert!(
+        result.is_error,
+        "cross-chat roster read must be refused: {}",
+        result.content
+    );
+    assert!(result.content.contains("C0SECRET"), "{}", result.content);
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "the kernel must not be queried for a refused read"
+    );
+}
+
+/// The WhatsApp gateway stamps `sender_channel = "whatsapp:<jid>"` (#5227)
+/// while the roster is keyed on the bare channel type, so the lookup key has
+/// to be the base type or every WhatsApp read misses.
+#[tokio::test]
+async fn channel_members_strips_the_channel_suffix_before_the_lookup() {
+    let (kernel, calls) = RosterKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(
+        &kernel,
+        Some("whatsapp:123@g.us"),
+        Some("123@g.us"),
+        Some("44700@s.whatsapp.net"),
+    );
+    let result = execute_tool_raw("t4", "channel_members", &json!({}), &ctx).await;
+
+    assert!(!result.is_error, "{}", result.content);
+    let body: serde_json::Value = serde_json::from_str(&result.content).expect("json body");
+    assert_eq!(body["channel"], "whatsapp");
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![("whatsapp".to_string(), "123@g.us".to_string())]
+    );
+}
+
+/// Out-of-band callers (cron, triggers) have no conversation to default to, so
+/// the arguments become required instead of resolving to something arbitrary.
+#[tokio::test]
+async fn channel_members_requires_arguments_without_a_turn() {
+    let (kernel, calls) = RosterKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, None, None);
+    let missing = execute_tool_raw("t5", "channel_members", &json!({}), &ctx).await;
+    assert!(missing.is_error, "{}", missing.content);
+    assert!(missing.content.contains("channel"), "{}", missing.content);
+
+    let explicit = json!({"channel": "slack", "chat_id": "C0DESIGN"});
+    let ok = execute_tool_raw("t6", "channel_members", &explicit, &ctx).await;
+    assert!(!ok.is_error, "{}", ok.content);
+    let body: serde_json::Value = serde_json::from_str(&ok.content).expect("json body");
+    assert_eq!(body["count"], 2);
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![("slack".to_string(), "C0DESIGN".to_string())]
+    );
+}

--- a/crates/librefang-runtime/tests/tool_runner_channel_members.rs
+++ b/crates/librefang-runtime/tests/tool_runner_channel_members.rs
@@ -1,12 +1,7 @@
 //! End-to-end wiring for the `channel_members` roster read (#7086).
 //!
-//! The channel bridge has persisted every group sender it sees through
-//! `ChannelBridgeHandle::roster_upsert` since the `group_roster` table landed,
-//! and `KernelHandle::roster_members` could always read it back — with no
-//! caller anywhere in the tree. These tests cover the boundary that closes
-//! that gap: the dispatch arm resolves the conversation from the turn context,
-//! calls `roster_members` with the bare channel type, and refuses to read a
-//! conversation other than the one the turn arrived on.
+//! The channel bridge has persisted every group sender it sees through `ChannelBridgeHandle::roster_upsert` since the `group_roster` table landed, and `KernelHandle::roster_members` could always read it back — with no caller anywhere in the tree.
+//! These tests cover the boundary that closes that gap: the dispatch arm resolves the conversation from the turn context, calls `roster_members` with the bare channel type, and refuses to read a conversation other than the one the turn arrived on.
 
 use async_trait::async_trait;
 use librefang_kernel_handle::prelude::*;
@@ -206,9 +201,7 @@ impl librefang_kernel_handle::SessionWriter for RosterKernel {
 impl librefang_kernel_handle::AcpFsBridge for RosterKernel {}
 impl librefang_kernel_handle::AcpTerminalBridge for RosterKernel {}
 
-/// The rows the real `ChannelSenderHandle` builds out of
-/// `RosterStore::members`, in the order that store returns them (display name,
-/// then user id).
+/// The rows the real `ChannelSenderHandle` builds out of `RosterStore::members`, in the order that store returns them (display name, then user id).
 impl ChannelSender for RosterKernel {
     fn roster_members(
         &self,
@@ -267,9 +260,7 @@ fn make_ctx<'a>(
     }
 }
 
-/// The use case from #7086: an agent in a shared Slack channel answers "who is
-/// in here?" with no arguments, and gets back the platform user id it needs to
-/// attribute the request to a person.
+/// The use case from #7086: an agent in a shared Slack channel answers "who is in here?" with no arguments, and gets back the platform user id it needs to attribute the request to a person.
 #[tokio::test]
 async fn channel_members_reads_the_current_conversation_with_no_arguments() {
     let (kernel, calls) = RosterKernel::new();
@@ -302,8 +293,7 @@ async fn channel_members_reads_the_current_conversation_with_no_arguments() {
     );
 }
 
-/// An empty roster is the normal state for a DM and for a group nobody has
-/// spoken in yet, so it must not read as a broken tool.
+/// An empty roster is the normal state for a DM and for a group nobody has spoken in yet, so it must not read as a broken tool.
 #[tokio::test]
 async fn channel_members_explains_an_empty_roster() {
     let (kernel, _calls) = RosterKernel::new();
@@ -321,9 +311,7 @@ async fn channel_members_explains_an_empty_roster() {
     assert!(body["note"].as_str().expect("note").contains("roster"));
 }
 
-/// The inbound twin of the #6117 cross-chat dispatch leak: a member of one
-/// group must not be able to enumerate another group's membership, and the
-/// refusal has to happen before the kernel is asked.
+/// The inbound twin of the #6117 cross-chat dispatch leak: a member of one group must not be able to enumerate another group's membership, and the refusal has to happen before the kernel is asked.
 #[tokio::test]
 async fn channel_members_refuses_another_chat_on_the_same_channel() {
     let (kernel, calls) = RosterKernel::new();
@@ -345,9 +333,7 @@ async fn channel_members_refuses_another_chat_on_the_same_channel() {
     );
 }
 
-/// The WhatsApp gateway stamps `sender_channel = "whatsapp:<jid>"` (#5227)
-/// while the roster is keyed on the bare channel type, so the lookup key has
-/// to be the base type or every WhatsApp read misses.
+/// The WhatsApp gateway stamps `sender_channel = "whatsapp:<jid>"` (#5227) while the roster is keyed on the bare channel type, so the lookup key has to be the base type or every WhatsApp read misses.
 #[tokio::test]
 async fn channel_members_strips_the_channel_suffix_before_the_lookup() {
     let (kernel, calls) = RosterKernel::new();
@@ -370,8 +356,7 @@ async fn channel_members_strips_the_channel_suffix_before_the_lookup() {
     );
 }
 
-/// Out-of-band callers (cron, triggers) have no conversation to default to, so
-/// the arguments become required instead of resolving to something arbitrary.
+/// Out-of-band callers (cron, triggers) have no conversation to default to, so the arguments become required instead of resolving to something arbitrary.
 #[tokio::test]
 async fn channel_members_requires_arguments_without_a_turn() {
     let (kernel, calls) = RosterKernel::new();

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -821,10 +821,7 @@ impl ToolProfile {
                 "agent_send",
                 "agent_list",
                 "channel_send",
-                // The read half of the channel surface (#7086): an agent that
-                // may reply into a shared group but cannot enumerate its
-                // members has no way to attribute a request to the person who
-                // made it.
+                // The read half of the channel surface (#7086): an agent that may reply into a shared group but cannot enumerate its members has no way to attribute a request to the person who made it.
                 "channel_members",
                 "memory_store",
                 "memory_list",

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -821,6 +821,11 @@ impl ToolProfile {
                 "agent_send",
                 "agent_list",
                 "channel_send",
+                // The read half of the channel surface (#7086): an agent that
+                // may reply into a shared group but cannot enumerate its
+                // members has no way to attribute a request to the person who
+                // made it.
+                "channel_members",
                 "memory_store",
                 "memory_list",
                 "memory_recall",
@@ -835,6 +840,7 @@ impl ToolProfile {
                 "agent_send",
                 "agent_list",
                 "channel_send",
+                "channel_members",
                 "memory_store",
                 "memory_list",
                 "memory_recall",
@@ -2474,14 +2480,17 @@ mod tests {
         assert!(tools.contains(&"agent_send".to_string()));
         assert!(tools.contains(&"channel_send".to_string()));
         assert!(tools.contains(&"memory_recall".to_string()));
-        assert_eq!(tools.len(), 6);
+        // The roster read ships with the send (#7086).
+        assert!(tools.contains(&"channel_members".to_string()));
+        assert_eq!(tools.len(), 7);
     }
 
     #[test]
     fn test_tool_profile_automation() {
         let tools = ToolProfile::Automation.tools();
         assert!(tools.contains(&"channel_send".to_string()));
-        assert_eq!(tools.len(), 12);
+        assert!(tools.contains(&"channel_members".to_string()));
+        assert_eq!(tools.len(), 13);
     }
 
     #[test]

--- a/docs/src/app/agent/tools/page.mdx
+++ b/docs/src/app/agent/tools/page.mdx
@@ -98,8 +98,14 @@ The claim TTL exists to recover from worker crashes — if the claimer doesn't `
 | Tool | Arguments | Purpose |
 |---|---|---|
 | `channel_send` | `channel`, `target`, `content` (text / image / file / poll) | Send a message, image, file, or poll to a channel user — **without going through the agent loop**. Useful for pushing alerts, async results, or out-of-band notifications. |
+| `channel_members` | optional `channel`, `chat_id` | List the known members of a group conversation — `user_id`, `display_name`, `username` for everyone the daemon has seen speak there. Read-only. |
 
 `channel_send` is what `[deliver_only]` webhook mode uses internally; agents can also call it directly. Capability: `channel.*`.
+
+`channel_members` reads the roster the channel bridge builds as it observes group messages, so it lists the people who have spoken in a conversation rather than the platform's full membership list.
+Both arguments default to the conversation the current message arrived on, so during message handling it can be called with no arguments at all; a direct message has no roster.
+Naming a different conversation on the channel the turn arrived on is refused, for the same reason `channel_send` refuses a cross-chat dispatch — one group must not be able to enumerate another's membership.
+Use it to attribute a request to the person who made it, and to obtain the platform `user_id` an external system needs in order to notify them.
 
 ---
 

--- a/docs/src/app/zh/agent/tools/page.mdx
+++ b/docs/src/app/zh/agent/tools/page.mdx
@@ -98,8 +98,14 @@ claim TTL 用来从 worker 崩溃中恢复 —— 认领者没在 TTL 内 `task_
 | 工具 | 参数 | 用途 |
 |---|---|---|
 | `channel_send` | `channel`、`target`、`content`(文本 / 图 / 文件 / poll) | 给某 channel 用户发消息、图片、文件或 poll —— **不走 agent 循环**。适合推告警、异步结果、带外通知。 |
+| `channel_members` | 可选 `channel`、`chat_id` | 列出群会话中已知的成员 —— 守护进程见过发言的每个人的 `user_id`、`display_name`、`username`。只读。 |
 
 `channel_send` 是 `[deliver_only]` webhook 模式内部用的工具;agent 也能直接调。Capability:`channel.*`。
+
+`channel_members` 读取 channel bridge 在观察群消息时建立的花名册,因此它列出的是在该会话中发过言的人,而不是平台的完整成员列表。
+两个参数都默认取当前消息所在的会话,所以在处理消息时可以完全不带参数调用;私聊没有花名册。
+指定当前轮次所在 channel 上的另一个会话会被拒绝,理由与 `channel_send` 拒绝跨会话投递相同 —— 一个群不能枚举另一个群的成员。
+用它把请求归属到提出请求的人,并拿到外部系统通知此人所需的平台 `user_id`。
 
 ---
 


### PR DESCRIPTION
Refs #7086

## Premise check first — the issue's framing does not hold on `origin/main`

Issue #7086 says the `group_members` tool "has no data on Slack".
There is no `group_members` tool.
`grep -rn "group_members"` over `origin/main` finds it only as a sidecar wire field (`sdk/python/librefang/sidecar/protocol.py`, `crates/librefang-channels/src/{types,sidecar,bridge}.rs`) and as a column-less mention in `docs/architecture/sidecar-protocol.md`.

What actually exists, and what does not:

- `crates/librefang-memory/src/roster_store.rs` — a full store: `upsert`, `members`, `remove_member`, `member_count`, backed by the `group_roster` table from `migration::migrate_v28`.
- `KernelHandle::roster_members` / `roster_upsert` / `roster_remove_member` — declared in `crates/librefang-kernel-handle/src/channel_sender.rs`, implemented in `crates/librefang-kernel/src/kernel/handles/channel_sender.rs`.
- The write path is live: `upsert_sender_into_roster` in `crates/librefang-channels/src/bridge.rs` persists every group sender on every inbound group message.
- **The read had no caller.** The only references to `roster_members` anywhere in the tree were `crates/librefang-kernel/tests/kernel_handle_contract_broader.rs`.

So the read path exists as far as the kernel handle and stops dead there: no tool, no API route, no CLI, no dashboard.
The roster is write-only in practice, which is why an agent in a shared group cannot answer "who is in this channel?" even though the daemon has been recording the answer all along.
That is the defect this PR fixes.

## Changes

- **`channel_members` builtin tool** (`crates/librefang-runtime/src/tool_runner/channel.rs`).
  Read-only. Returns `{channel, chat_id, count, members: [{user_id, display_name, username}]}`.
  Both arguments default to the conversation the current turn arrived on, so during message handling it is a zero-argument call; out-of-band callers (cron, triggers, API-driven runs) have no turn context and must pass both.
  The `user_id` it returns is what the issue's first use case needs — attributing a request to the person who made it when handing work to an external system.
- **Lookup key is the base channel type.** The WhatsApp gateway stamps `sender_channel = "whatsapp:<jid>"` (#5227) while the roster is keyed on `channel_type_str` (the bare type), so the suffix is stripped before the lookup or every WhatsApp read misses.
- **Cross-chat read guard.** An explicit `chat_id` naming a different conversation on the channel the turn arrived on is refused, before the kernel is queried.
  This is the inbound twin of the #6117 cross-chat dispatch leak — the roster holds the display names of everyone the bot has seen in a chat, so a free-form chat id would let one group enumerate every other group the same bot sits in.
  Deliberately the same shape as the `tool_channel_send` guard: only an explicit argument is scrutinised, only within the same base channel type, chat id compared case-sensitively and channel case-insensitively, cross-channel reads still allowed.
- **Empty roster carries a note** rather than a bare `[]`, so a model does not read "no members recorded" as "this channel has no members" or as a broken tool. Same reasoning as the #7808 note on `memory_recall`.
- **`RosterStore::members` ordering is now total** — `ORDER BY display_name, user_id` instead of `ORDER BY display_name`.
  This list reaches an LLM prompt through the new tool, and two members sharing a display name would otherwise come back in whatever order SQLite produced, invalidating provider prompt caches on unchanged content (#3298).
  The in-memory `GroupRosterStore::members` in `librefang-channels` already broke the same tie on the participant id; the SQLite store had not.
- **Tool profiles.** `channel_members` added to `messaging` and `automation`, which already grant `channel_send`. An agent allowed to reply into a shared group but not to enumerate it cannot do the attribution the issue asks for. `full` (the default) grants `*` and was already covered.
- Docs: a row and four sentences in `docs/src/app/agent/tools/page.mdx` and the `zh` mirror.
- Changelog fragment: `changelog.d/fixed/7086-channel-members-roster-read.md`.

Left lazy-loaded rather than added to `ALWAYS_NATIVE_TOOLS`: a roster read is rare enough that a schema on every turn is not worth the tokens, and `tool_search` / `tool_load` find it.

## Verification

`cargo test -p librefang-runtime --test tool_runner_channel_members` — 5 passed. New file, dispatching through the real `execute_tool_raw` against a `KernelHandle` whose `ChannelSender::roster_members` records every `(channel, chat_id)` it is asked for:

- `channel_members_reads_the_current_conversation_with_no_arguments` — the #7086 use case: no arguments during a Slack group turn returns both members with their user ids, and the kernel was asked for exactly `("slack", "C0DESIGN")`.
- `channel_members_explains_an_empty_roster` — DM (no chat id stamped) falls back to the peer, `count` is 0, the note is present.
- `channel_members_refuses_another_chat_on_the_same_channel` — the cross-chat read is an error and the kernel is never queried.
- `channel_members_strips_the_channel_suffix_before_the_lookup` — a `whatsapp:123@g.us` turn queries the roster as `("whatsapp", "123@g.us")`.
- `channel_members_requires_arguments_without_a_turn` — no turn context makes both arguments required, and supplying them works.

`cargo test -p librefang-runtime --lib tool_runner::channel` — 15 passed (8 new `resolve_roster_target` cases covering the guard, the DM fallback, case variation, the WhatsApp suffix and cross-channel; plus `channel_members_is_registered_in_builtins` and `channel_members_schema_property_order_is_canonical`).

`cargo test -p librefang-memory --lib roster_store` — 9 passed, including the new `same_display_name_is_ordered_by_user_id_across_insertion_orders`, which inserts two same-named members in both orders and asserts one fixed result.

`cargo test -p librefang-types --lib tool_profile` — 10 passed (the two count assertions updated).

`cargo check -p librefang-runtime --lib`, `cargo clippy -p librefang-runtime -p librefang-memory -p librefang-types --lib --tests -- -D warnings` — clean.
`cargo fmt --all -- --check` — clean.
`python3 scripts/check-changelog-attribution.py` — OK.

No API route was added, so there is no `TestServer` test here; the boundary this PR adds is a runtime tool.
Full-workspace build and the `librefang-api` suite are left to CI — the host disk went under the safe threshold partway through, so builds were kept scoped to the three crates touched.

## Deliberately not in scope

This PR is the read surface only. It does not settle the architecture the rest of #7086 needs:

- **Targeted delivery to one user** (the issue's gap 2) — whether `channel_send` gains a per-user DM path, or `owner_notice` gets routed by the sidecar adapters, is the open design question. `channel_members` supplies the `user_id` that either answer will consume; it does not pick one.
- **Slack `conversations.members` + `users.info`** (gaps 1 and 3) — populating the roster from Slack's own membership list, and resolving `user_name` beyond the raw `U09…` id, are changes to `sdk/python/librefang/sidecar/adapters/slack.py`. Today the roster is observational: it lists who has spoken, not who is a member. The tool's description and the docs say so explicitly rather than implying full membership.
- **An operator-facing view.** There is still no HTTP route or dashboard panel for the roster. That belongs with the sidecar-config write surface discussion from #7842 rather than with this fix.
