### PR TITLE
fix(memory): give the prompt memory section an owned budget

### DIFF
--- a/changelog.d/fixed/7867-memory-section-budget.md
+++ b/changelog.d/fixed/7867-memory-section-budget.md
@@ -1,0 +1,4 @@
+The prompt's memory section now enforces an explicit character budget instead of relying on the product of two independent caps that nothing stated or checked.
+A shortened memory is cut at a sentence boundary where one fits and at a word boundary where that keeps most of the text, so a bullet ends mid-token only when neither is available.
+Memories dropped for space are reported with their count.
+(#7867) (@nevgenov)

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -615,6 +615,172 @@ pub fn build_memory_section(memories: &[(String, String)]) -> String {
     out
 }
 
+/// Maximum number of memory bullets rendered into the section.
+pub const MEMORY_SECTION_MAX_ITEMS: usize = 10;
+
+/// Character budget for the memory bullets, excluding the framing header.
+///
+/// The section has three independent producers — substrate recall capped at `MEMORY_RECALL_LIMIT`, proactive items appended after it, and the `MEMORY_SECTION_MAX_ITEMS` cut here — and before this budget existed none of them owned the total.
+/// Each item was independently capped, so the section's real ceiling was the product of the two caps and nothing stated it.
+///
+/// The value is the former implicit ceiling (10 items × 500 chars), but it is a ceiling on the section rather than on content alone, so the reachable maximum is lower.
+/// The `- ` and newline framing each bullet is charged against its allowance, and a notice reserve is held back whenever memories were dropped.
+/// Measured worst case is 5000 characters of body — the budget exactly — against the 5060 the unbudgeted version produced, about 1 % less content in exchange for a limit that is stated and enforced.
+/// At roughly four characters per token the budget is about 1250 tokens.
+pub const MEMORY_SECTION_BUDGET_CHARS: usize = 5000;
+
+/// Below this an item is not worth rendering — a fragment this short carries no usable context and only spends budget.
+///
+/// The equal share never decreases — a bullet can never cost more than the share it was granted — and its floor is about 490.
+/// The guard compares the share minus this item's framing, whose worst case is `MAX_BULLET_FRAMING_CHARS` — 73 with the key capped at 64, since `cap_str` adds three characters of its own — so it cannot fire as the constants stand.
+/// It is kept as a tripwire: raising the item count, lowering the budget or widening the key cap should drop a memory rather than emit an unusable fragment, and skipping one item leaves the rest of the section intact.
+pub const MEMORY_SECTION_MIN_ITEM_CHARS: usize = 120;
+
+/// Characters held back for the omission notice.
+///
+/// The notice is `- [+N further memories not shown]\n`: 33 characters of fixed text plus the count.
+/// The count is bounded only by the caller's input, so the widest form is a twenty-digit `usize`, giving 53.
+/// The reserve keeps headroom above that so a future rewording does not silently overrun.
+/// Held back before any bullet is emitted, because discovering afterwards that the notice does not fit leaves no way to honour the budget without dropping a bullet that was already rendered.
+const OMISSION_NOTICE_RESERVE: usize = 96;
+
+/// Worst-case framing charged to one bullet: `- `, the newline, the `[key] ` wrapper, the capped key, and the `...` that `cap_str` appends when it truncates.
+///
+/// The ellipsis is counted here for the same reason `SKILL_BOILERPLATE_OVERHEAD` counts it — `cap_str` returns up to `max_chars + 3`, so a cap of 64 renders up to 67.
+const MAX_BULLET_FRAMING_CHARS: usize = MEMORY_SECTION_MAX_KEY_CHARS + 9;
+
+/// Whether an item can be skipped for its own framing cost.
+///
+/// Derived from the constants rather than asserted, so that widening the key cap, raising the item count or lowering the budget flips it automatically.
+/// When it is true a notice can appear with fewer memories than the item cut allows, and the reserve has to be held for that case too — otherwise the notice is written past the budget.
+const SKIP_POSSIBLE: bool = skip_possible(
+    MEMORY_SECTION_BUDGET_CHARS,
+    MEMORY_SECTION_MAX_ITEMS,
+    MEMORY_SECTION_MIN_ITEM_CHARS,
+    MAX_BULLET_FRAMING_CHARS,
+);
+
+/// Whether the smallest equal share can fall under the floor once an item's
+/// worst-case framing is taken out of it.
+///
+/// A free function rather than an inline expression so the rule can be exercised at inputs the shipped constants do not reach.
+/// Comparing `SKIP_POSSIBLE` against a re-derivation beside it proves nothing: a definition that drops a term still evaluates to the same value at the shipped constants, and the disagreement only appears once one of them moves.
+const fn skip_possible(budget: usize, items: usize, floor: usize, framing: usize) -> bool {
+    budget / items < floor + framing
+}
+
+/// Ceiling for the rendered key label.
+///
+/// Keys reach this function through a `pub` entry point and a `pub` field, and nothing upstream bounds their length.
+/// An unbounded key is charged against its own item's allowance, so without this cap a long enough label pushes the allowance below `MEMORY_SECTION_MIN_ITEM_CHARS` and the memory cannot render at all.
+/// A label longer than this carries no additional meaning to the model.
+/// `cap_str` appends `...` when it truncates, so the rendered label reaches 67; `MAX_BULLET_FRAMING_CHARS` accounts for that.
+pub const MEMORY_SECTION_MAX_KEY_CHARS: usize = 64;
+
+/// Ceiling for a single bullet, independent of how much budget is free.
+///
+/// The section budget alone is not sufficient protection: with few memories the per-item share grows to the whole section, and a single pathological row — an attachment stored verbatim, for instance — would then fill it.
+/// Keeping the historical per-item cap means this change makes the total explicit without altering how much any one memory may contribute.
+pub const MEMORY_SECTION_MAX_ITEM_CHARS: usize = 500;
+
+/// Marker appended whenever content was dropped, so the model can tell a shortened memory from a complete one.
+const TRUNCATION_MARKER: &str = "...";
+
+/// Truncate at the last sentence boundary that fits, falling back to a word boundary and then to a hard cut.
+///
+/// Cutting mid-sentence is what the previous fixed per-item cap did, and on a corpus where raw conversational excerpts dominate it left the majority of bullets ending mid-clause.
+/// A truncated sentence reads as a claim the speaker did not finish, which is worse than a shorter but complete one.
+///
+/// Every truncating branch appends [`TRUNCATION_MARKER`], including the sentence-boundary one.
+/// A cut that ends on a full stop is indistinguishable from a memory that simply ended there, and silent shortening is worse than visible shortening: the model has no way to know context is missing.
+///
+/// The returned string never exceeds `max_chars` including the marker, so callers can budget against the limit they passed rather than against the limit plus an unstated overhead.
+fn truncate_at_sentence_boundary(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    // The marker is part of the budget, so the content window shrinks to make
+    // room for it.
+    let marker_chars = TRUNCATION_MARKER.chars().count();
+    let content_chars = max_chars.saturating_sub(marker_chars + 1);
+    if content_chars == 0 {
+        // Unreachable from the section, whose allowance floor is
+        // `MEMORY_SECTION_MIN_ITEM_CHARS`, but the helper is `max_chars`-generic
+        // and must not hand back more than it was given.
+        // Counted in chars, not bytes: `safe_truncate_str` takes a byte count,
+        // and passing a char count to it only happens to work while the marker
+        // is ASCII.
+        return TRUNCATION_MARKER.chars().take(max_chars).collect();
+    }
+    let cut = s
+        .char_indices()
+        .nth(content_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    let window = safe_truncate_str(s, cut);
+
+    // Terminal punctuation followed by whitespace, or at the very end of the
+    // window. Bare `.` is not enough — abbreviations and version numbers.
+    let sentence_end = window
+        .char_indices()
+        .filter(|&(i, c)| {
+            if !matches!(c, '.' | '!' | '?' | '…') {
+                return false;
+            }
+            let after = &window[i + c.len_utf8()..];
+            after.is_empty() || after.starts_with(char::is_whitespace)
+        })
+        .map(|(i, c)| i + c.len_utf8())
+        .next_back();
+
+    // A boundary before the halfway mark discards more than it keeps, so it is
+    // rejected in favour of the next strategy down.
+    // Both boundary searches need this guard, not just the sentence one: the
+    // word fallback runs precisely when the sentence guard rejected a break,
+    // and `rfind` is just as capable of landing at position 1 when the window
+    // ends in an unbroken token such as a URL, a path or a hash.
+    let halfway_ok = |end: usize| end * 2 >= window.len();
+
+    if let Some(end) = sentence_end.filter(|&e| halfway_ok(e)) {
+        return clamp_to(
+            format!("{} {TRUNCATION_MARKER}", window[..end].trim_end()),
+            max_chars,
+        );
+    }
+
+    let out = match window.rfind(char::is_whitespace) {
+        Some(sp) if sp > 0 && halfway_ok(sp) => {
+            format!("{}{TRUNCATION_MARKER}", window[..sp].trim_end())
+        }
+        _ => format!("{}{TRUNCATION_MARKER}", window.trim_end()),
+    };
+
+    clamp_to(out, max_chars)
+}
+
+/// Last line of defence for the `max_chars` contract.
+///
+/// The reserve is sized for the separator the sentence branch inserts, and an arithmetic slip there would be invisible in release, where `debug_assert` is compiled out.
+/// `format_memories_with_budget` clamps for the same reason.
+/// Applied on every return path, including the sentence branch — that branch is the one which spends the reserved character, so guarding only the paths that keep a spare would leave the case this exists for uncovered.
+fn clamp_to(s: String, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s;
+    }
+    // Trim content, never the marker. A plain `take(max_chars)` eats the
+    // marker's tail instead, leaving a bullet that ends in `..` — the signal
+    // that context was cut, silently degraded into something that reads like
+    // punctuation. That failure is invisible to a length assertion, which is
+    // the only thing a clamp can otherwise be tested by.
+    let marker_chars = TRUNCATION_MARKER.chars().count();
+    if max_chars <= marker_chars {
+        return TRUNCATION_MARKER.chars().take(max_chars).collect();
+    }
+    let keep = max_chars - marker_chars;
+    let body: String = s.chars().take(keep).collect();
+    format!("{}{TRUNCATION_MARKER}", body.trim_end())
+}
+
 /// Format recalled memories as a natural personal-context block.
 ///
 /// Used by both the system prompt (appended to the Memory section) and
@@ -647,14 +813,91 @@ pub fn format_memory_items_as_personal_context(memories: &[(String, String)]) ->
          - If a memory is clearly outdated or the user contradicts it, trust the current \
          conversation over stored context.\n\n",
     );
-    for (key, content) in memories.iter().take(10) {
-        let capped = cap_str(content, 500);
-        if key.is_empty() {
-            out.push_str(&format!("- {capped}\n"));
+    let header_chars = out.chars().count();
+    let selected: Vec<&(String, String)> = memories.iter().take(MEMORY_SECTION_MAX_ITEMS).collect();
+
+    // The omission notice is itself part of the section, so its worst case is
+    // reserved up front rather than appended past the limit. Same discipline as
+    // `librefang_types::memory::format_memories_with_budget`, which reserves
+    // before emitting bullets for exactly this reason.
+    // Reserved only when a notice is actually possible. Holding it back
+    // unconditionally spent 96 characters on every prompt that had nothing to
+    // omit, which is the common case.
+    //
+    // Two limits can drop a memory, and both have to be modelled here. The
+    // item cut is the reachable one today; the framing skip is not, but a
+    // skip emits a notice while leaving the budget fully spendable by the
+    // remaining items, so failing to reserve for it writes the notice past the
+    // limit. `SKIP_POSSIBLE` is derived from the constants so that the three
+    // changes which make the skip reachable also turn the reserve back on.
+    let notice_possible = memories.len() > MEMORY_SECTION_MAX_ITEMS || SKIP_POSSIBLE;
+    let mut remaining_budget = if notice_possible {
+        MEMORY_SECTION_BUDGET_CHARS.saturating_sub(OMISSION_NOTICE_RESERVE)
+    } else {
+        MEMORY_SECTION_BUDGET_CHARS
+    };
+    let mut rendered = 0usize;
+
+    for (idx, (key, content)) in selected.iter().enumerate() {
+        let items_left = selected.len() - idx;
+        // `- ` plus the trailing newline, and the `[key] ` prefix when present.
+        // Charged against the allowance rather than discovered afterwards —
+        // deducting it only after the bullet was built is what let the section
+        // run past its own limit.
+        //
+        // The key is capped before it is charged. Nothing validates key length
+        // upstream, and an unbounded key spends the item's whole allowance on
+        // its own label: at 375 characters the remaining allowance drops under
+        // `MEMORY_SECTION_MIN_ITEM_CHARS` and the item cannot render at all.
+        let key = cap_str(key, MEMORY_SECTION_MAX_KEY_CHARS);
+        let overhead = 3 + if key.is_empty() {
+            0
         } else {
-            out.push_str(&format!("- [{key}] {capped}\n"));
+            key.chars().count() + 3
+        };
+        // Equal share of what is left, so one long fragment cannot consume the
+        // section. Recomputing each step lets an item shorter than its share
+        // hand the surplus to later items — which is the common case, since
+        // extracted facts run an order of magnitude shorter than raw excerpts.
+        let allowance = (remaining_budget / items_left)
+            .saturating_sub(overhead)
+            .min(MEMORY_SECTION_MAX_ITEM_CHARS);
+        if allowance < MEMORY_SECTION_MIN_ITEM_CHARS {
+            // Skip this item rather than ending the section. The share is
+            // non-decreasing, so a later item with a shorter key can still fit,
+            // and `break` here would discard every remaining memory because one
+            // of them carried an expensive label.
+            continue;
         }
+        let capped = truncate_at_sentence_boundary(content, allowance);
+        let bullet = if key.is_empty() {
+            format!("- {capped}\n")
+        } else {
+            format!("- [{key}] {capped}\n")
+        };
+        remaining_budget = remaining_budget.saturating_sub(bullet.chars().count());
+        out.push_str(&bullet);
+        rendered += 1;
     }
+
+    if rendered < memories.len() {
+        let dropped = memories.len() - rendered;
+        // Deliberately does not name a cause. Two limits can drop a memory —
+        // `MEMORY_SECTION_MAX_ITEMS` and, for an item whose framing eats its
+        // share, `MEMORY_SECTION_MIN_ITEM_CHARS` — and naming one of them would
+        // be wrong for the other. The count is what the reader can act on.
+        out.push_str(&format!(
+            "- [+{dropped} further memor{plural} not shown]\n",
+            plural = if dropped == 1 { "y" } else { "ies" }
+        ));
+    }
+
+    debug_assert!(
+        out.chars().count() - header_chars <= MEMORY_SECTION_BUDGET_CHARS,
+        "memory section body exceeded its budget: {} > {}",
+        out.chars().count() - header_chars,
+        MEMORY_SECTION_BUDGET_CHARS
+    );
     out
 }
 

--- a/crates/librefang-runtime/src/prompt_builder/tests.rs
+++ b/crates/librefang-runtime/src/prompt_builder/tests.rs
@@ -159,26 +159,537 @@ fn test_format_memory_items_empty() {
     assert!(ctx.is_empty());
 }
 
+/// The section total is now owned. Previously each item was capped
+/// independently and nothing bounded their sum.
+///
+/// The fixture deliberately contains no whitespace: content with an early space
+/// collapses through the word-boundary path and never approaches the ceiling,
+/// which is how the first version of this test passed against a section that
+/// actually overran by 74 characters.
 #[test]
-fn test_memory_cap_at_10() {
-    let memories: Vec<(String, String)> = (0..15)
-        .map(|i| (format!("k{i}"), format!("value {i}")))
-        .collect();
-    let section = build_memory_section(&memories);
-    assert!(section.contains("[k0]"));
-    assert!(section.contains("[k9]"));
-    assert!(!section.contains("[k10]"));
+fn memory_section_total_stays_within_budget() {
+    for filler in ["a", "\u{5b57}"] {
+        let memories: Vec<(String, String)> = (0..20)
+            .map(|_| (String::new(), filler.repeat(4000)))
+            .collect();
+
+        let ctx = format_memory_items_as_personal_context(&memories);
+        let body = memory_body_chars(&ctx);
+        assert!(
+            body <= MEMORY_SECTION_BUDGET_CHARS,
+            "filler {filler:?}: body consumed {body} chars, budget is {MEMORY_SECTION_BUDGET_CHARS}"
+        );
+    }
 }
 
+/// The budget must hold for keyed memories too.
+///
+/// The other budget test uses empty keys, so the framing charged per item is a constant 3 and the skip path is structurally unreachable from it.
+/// That is the path a breach travels: a key eats its item's share, the item is skipped, its share is spent by the others, and the notice it triggers is written past the limit.
+///
+/// Both dimensions are swept as ranges rather than from literals.
+/// A breach on this path needs an item count high enough for the share to run out but below `MEMORY_SECTION_MAX_ITEMS`, so that the item cut does not reserve for the notice by itself, and a key length inside a window that moves with the constants.
+/// A literal sweep only lands in those windows for whatever the constants happened to be when it was written: `[1, 9, 10, 11, 40]` covered the count at 10 and missed a live 5031-against-5000 overrun at 27 items once the constant reached 30, and `[1, 30, 64, 500]` covers the key length until `MEMORY_SECTION_MIN_ITEM_CHARS` climbs toward the per-item ceiling, where the window narrows to lengths near 48 and every literal misses it.
 #[test]
-fn test_memory_content_capped() {
-    let long_content = "x".repeat(1000);
-    let memories = vec![("k".to_string(), long_content)];
-    let section = build_memory_section(&memories);
-    // Content should be capped at 500 chars + "..."
-    assert!(section.contains("..."));
-    // The section includes the natural-use preamble + capped content
-    assert!(section.len() < 2000);
+fn memory_section_budget_holds_with_keys() {
+    let key_lengths = (0..=MEMORY_SECTION_MAX_KEY_CHARS * 2)
+        .step_by(8)
+        .chain([MEMORY_SECTION_MAX_KEY_CHARS, 500]);
+    for key_len in key_lengths {
+        for n in (1..=MEMORY_SECTION_MAX_ITEMS + 1).chain([MEMORY_SECTION_MAX_ITEMS * 4]) {
+            let memories: Vec<(String, String)> = (0..n)
+                .map(|_| ("k".repeat(key_len), "x".repeat(4000)))
+                .collect();
+            let ctx = format_memory_items_as_personal_context(&memories);
+            let body = memory_body_chars(&ctx);
+            assert!(
+                body <= MEMORY_SECTION_BUDGET_CHARS,
+                "key {key_len}, n {n}: body {body} exceeds {MEMORY_SECTION_BUDGET_CHARS}"
+            );
+        }
+    }
+}
+
+/// Everything after the framing header, counted whole.
+///
+/// Counting only lines that start with `- ` misses the continuations of
+/// multi-line memories, which are the dominant shape in a real corpus, so the
+/// budget check has to measure the body rather than sample it.
+fn memory_body_chars(ctx: &str) -> usize {
+    let header_end = ctx
+        .find("conversation over stored context.\n\n")
+        .map(|i| i + "conversation over stored context.\n\n".len())
+        .expect("framing header must be present");
+    ctx[header_end..].chars().count()
+}
+
+/// The per-item share must do the limiting early, not the per-item ceiling.
+///
+/// Comparing the first bullet with the last is what separates the two
+/// mechanisms. Early items are bound by the equal share; by the last item the
+/// share has absorbed every predecessor's surplus and grown past the ceiling,
+/// so the ceiling binds instead. Remove the share recomputation and every
+/// bullet becomes the same size.
+///
+/// Measuring only the longest bullet cannot see this — the longest is the last
+/// one, and it is ceiling-bound either way.
+#[test]
+fn per_item_share_binds_before_the_ceiling_does() {
+    let memories: Vec<(String, String)> = (0..MEMORY_SECTION_MAX_ITEMS)
+        .map(|_| (String::new(), "word ".repeat(400)))
+        .collect();
+    let ctx = format_memory_items_as_personal_context(&memories);
+
+    let sizes: Vec<usize> = ctx
+        .lines()
+        .filter(|l| l.starts_with("- word"))
+        .map(|l| l.chars().count())
+        .collect();
+    assert_eq!(
+        sizes.len(),
+        MEMORY_SECTION_MAX_ITEMS,
+        "every memory should have rendered"
+    );
+
+    let first = sizes[0];
+    let last = *sizes.last().unwrap();
+    assert!(
+        first < last,
+        "share never bound anything: first bullet {first}, last {last} — \
+         identical sizes mean the ceiling did all the limiting"
+    );
+    assert!(
+        first < MEMORY_SECTION_MAX_ITEM_CHARS,
+        "first bullet {first} reached the ceiling {MEMORY_SECTION_MAX_ITEM_CHARS}"
+    );
+}
+
+/// The ceiling must bind when the share cannot.
+///
+/// With few memories the equal share grows to most of the section, so only the
+/// per-item ceiling stands between one pathological row — an attachment stored
+/// verbatim — and the whole budget.
+#[test]
+fn per_item_ceiling_binds_when_the_share_is_large() {
+    let memories = vec![
+        (String::new(), "x".repeat(200_000)),
+        (String::new(), "Prefers brief answers.".to_string()),
+    ];
+    let ctx = format_memory_items_as_personal_context(&memories);
+
+    let biggest = ctx
+        .lines()
+        .filter(|l| l.starts_with("- x"))
+        .map(|l| l.chars().count())
+        .max()
+        .expect("the long memory must render");
+    // Deliberately a literal rather than `MEMORY_SECTION_MAX_ITEM_CHARS + n`.
+    // A bound derived from the constant moves with it, so raising the ceiling
+    // would keep this test green — which is exactly the regression it exists to
+    // catch. Update the literal knowingly if the ceiling ever changes.
+    const CEILING_PLUS_BULLET_OVERHEAD: usize = 510;
+    assert!(
+        biggest <= CEILING_PLUS_BULLET_OVERHEAD,
+        "one row took {biggest} chars; the per-item ceiling should have held it near 500"
+    );
+    let share = MEMORY_SECTION_BUDGET_CHARS / 2;
+    assert!(
+        biggest < share,
+        "the share of {share} was the only thing limiting it, so the ceiling is untested"
+    );
+}
+
+/// One oversized fragment must not starve the rest.
+#[test]
+fn one_long_memory_does_not_starve_the_others() {
+    let memories = vec![
+        (String::new(), "x".repeat(9000)),
+        (String::new(), "Prefers brief answers.".to_string()),
+        (String::new(), "Works in Rust.".to_string()),
+    ];
+    let ctx = format_memory_items_as_personal_context(&memories);
+    assert!(ctx.contains("Prefers brief answers."));
+    assert!(ctx.contains("Works in Rust."));
+}
+
+/// Short items are returned whole — the budget must not clip an extracted fact
+/// that already fits, which is the common case.
+#[test]
+fn short_memories_are_not_truncated() {
+    let memories = vec![
+        (String::new(), "Communicates in Russian.".to_string()),
+        (
+            "pref".to_string(),
+            "Prefers very brief writing.".to_string(),
+        ),
+    ];
+    let ctx = format_memory_items_as_personal_context(&memories);
+    assert!(ctx.contains("- Communicates in Russian.\n"));
+    assert!(ctx.contains("- [pref] Prefers very brief writing.\n"));
+}
+
+/// The boundary chosen must be the last one that fits, not the first.
+#[test]
+fn truncation_prefers_a_sentence_boundary() {
+    let text = "First sentence here. Second sentence follows. Third one trails off with a lot of extra words that will not fit";
+    let cut = truncate_at_sentence_boundary(text, 60);
+    assert_eq!(
+        cut, "First sentence here. Second sentence follows. ...",
+        "expected the last fitting sentence break, kept whole, with the marker"
+    );
+}
+
+/// With no sentence break in range, fall back to a word boundary rather than
+/// splitting a word.
+#[test]
+fn truncation_falls_back_to_word_boundary() {
+    let text = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
+    let cut = truncate_at_sentence_boundary(text, 24);
+    assert_eq!(
+        cut, "alpha beta gamma...",
+        "expected a word-boundary cut carrying the marker"
+    );
+}
+
+/// A sentence break very early in the window discards too much; the word-level
+/// fallback carries more of the memory.
+#[test]
+fn truncation_ignores_a_too_early_sentence_break() {
+    let text = "Ok. Then a much longer continuation follows that carries the actual content of this memory";
+    let cut = truncate_at_sentence_boundary(text, 60);
+    assert!(cut.len() > "Ok. ...".len(), "kept only {cut:?}");
+    assert!(cut.starts_with("Ok. Then a much longer"));
+}
+
+/// The word fallback needs the same halfway guard as the sentence branch.
+///
+/// A window whose tail is one unbroken token — a URL, a path, a hash — puts the
+/// last whitespace near the start, and an unguarded `rfind` throws the rest of
+/// the allowance away.
+#[test]
+fn truncation_does_not_collapse_on_an_unbroken_tail() {
+    let text = format!("Reference for the current task: {}", "x".repeat(3000));
+    let cut = truncate_at_sentence_boundary(&text, 500);
+    let kept = cut.chars().count();
+    assert!(
+        kept > 400,
+        "collapsed to {kept} chars: {:?}",
+        &cut[..cut.len().min(80)]
+    );
+}
+
+/// Truncation must stay inside the limit it was given, marker included, so the
+/// section can budget against that limit rather than against an unstated
+/// overhead.
+#[test]
+fn truncation_never_exceeds_its_limit() {
+    let samples = [
+        "word ".repeat(200),
+        "x".repeat(1000),
+        "\u{5b57}".repeat(1000),
+        "Sentence one. Sentence two. ".repeat(40),
+    ];
+    for s in &samples {
+        for limit in [5usize, 17, 120, 499, 500] {
+            let cut = truncate_at_sentence_boundary(s, limit);
+            assert!(
+                cut.chars().count() <= limit,
+                "limit {limit} produced {} chars for {:?}",
+                cut.chars().count(),
+                &s[..s.len().min(20)]
+            );
+        }
+    }
+}
+
+/// Multi-byte input must never be split inside a character, and the kept prefix
+/// must actually come from the input.
+#[test]
+fn truncation_is_utf8_safe_and_faithful() {
+    let text = "\u{41f}\u{43e}\u{43b}\u{44c}\u{437}\u{43e}\u{432}\u{430}\u{442}\u{435}\u{43b}\u{44c} \u{43f}\u{440}\u{435}\u{434}\u{43f}\u{43e}\u{447}\u{438}\u{442}\u{430}\u{435}\u{442} \u{43a}\u{440}\u{430}\u{442}\u{43a}\u{438}\u{435} \u{43e}\u{442}\u{432}\u{435}\u{442}\u{44b} \u{431}\u{435}\u{437} \u{43e}\u{433}\u{43e}\u{432}\u{43e}\u{440}\u{43e}\u{43a} ".repeat(4);
+    for limit in [7usize, 33, 120, 501] {
+        let cut = truncate_at_sentence_boundary(&text, limit);
+        let body = cut.trim_end_matches('.').trim_end();
+        assert!(
+            text.starts_with(body),
+            "limit {limit}: kept text is not a prefix of the input: {body:?}"
+        );
+    }
+}
+
+/// Dropped items are reported.
+#[test]
+fn omitted_memories_are_reported() {
+    let many_short: Vec<(String, String)> = (0..40)
+        .map(|i| {
+            (
+                String::new(),
+                format!("memory number {i} with some padding text"),
+            )
+        })
+        .collect();
+    let ctx = format_memory_items_as_personal_context(&many_short);
+    assert!(
+        ctx.contains("- [+30 further memories not shown]"),
+        "expected an omission notice naming the count: {ctx}"
+    );
+}
+
+/// The notice reserve is held back only when something can actually be
+/// omitted.
+///
+/// Reserving unconditionally cost every prompt 96 characters of content for a
+/// line it would never print.
+#[test]
+fn notice_reserve_is_not_charged_when_nothing_is_dropped() {
+    let exactly_full: Vec<(String, String)> = (0..MEMORY_SECTION_MAX_ITEMS)
+        .map(|_| (String::new(), "x".repeat(4000)))
+        .collect();
+    // Everything below assumes a skip cannot fire.
+    // Once `SKIP_POSSIBLE` is true the reserve is held unconditionally and must be: a skipped item leaves its share spendable, so the notice it triggers has to be paid for in advance.
+    // Which assertion reports it depends on how far the share has shrunk, and only ever one of them does, since the first aborts the test before the second runs.
+    // Up to about four times the shipped item count the share still covers every memory, so the skip drops nothing and only the budget assertion fires.
+    // Past that the skip starts dropping memories the fixture assumes are present, and the first assertion fires instead.
+    // Either way the smallest edit satisfying the message is removing `|| SKIP_POSSIBLE`, which reopens the overrun `memory_section_budget_holds_with_keys` covers.
+    //
+    // The guard sits above both for that reason.
+    // Placed between them it still let the lower-budget tripwire trip the first assertion and lead a reader to the same wrong edit.
+    if SKIP_POSSIBLE {
+        return;
+    }
+
+    let ctx = format_memory_items_as_personal_context(&exactly_full);
+    assert!(
+        !ctx.contains("not shown"),
+        "nothing should have been dropped"
+    );
+
+    let body = memory_body_chars(&ctx);
+    // Deliberately a literal. Deriving this from `OMISSION_NOTICE_RESERVE`
+    // would move with it and stop detecting the regression; shrinking the
+    // reserve must not quietly re-hide an unconditional charge. Update it
+    // knowingly if the framing overhead changes.
+    const MAX_UNSPENT_FRAMING: usize = 60;
+    assert!(
+        body > MEMORY_SECTION_BUDGET_CHARS - MAX_UNSPENT_FRAMING,
+        "body of {body} leaves more than {MAX_UNSPENT_FRAMING} unspent; the \
+         reserve was charged even though no notice was possible"
+    );
+    assert!(body <= MEMORY_SECTION_BUDGET_CHARS);
+}
+
+/// Multi-byte content must keep as much of its allowance as ASCII does.
+///
+/// `safe_truncate_str` takes a *byte* count, so a window computed in bytes is
+/// still memory-safe but silently holds a third of the characters for
+/// three-byte scripts. Asserting only that the kept text is a valid prefix
+/// cannot see that: a naive byte cut passes it.
+#[test]
+fn truncation_keeps_multibyte_content_to_its_allowance() {
+    for filler in ["\u{43f}", "\u{5b57}", "\u{1f600}"] {
+        let text = filler.repeat(3000);
+        let cut = truncate_at_sentence_boundary(&text, 500);
+        let kept = cut.chars().count();
+        assert!(
+            kept >= 490,
+            "{filler:?}: kept only {kept} of a 500-char allowance — \
+             the window was measured in bytes, not characters"
+        );
+    }
+}
+
+/// Terminal punctuation at the very end of the window is the case the marker
+/// reserve is sized for.
+///
+/// The sentence branch inserts a separator before the marker, so the reserve
+/// carries an extra character beyond the marker itself. Every earlier sample
+/// happened to avoid landing a full stop on the last position of the window,
+/// which left that extra character unpinned.
+#[test]
+fn truncation_respects_its_limit_with_punctuation_at_the_window_edge() {
+    // The head length is swept rather than fixed. The window edge sits at
+    // `limit - 5` for the reserve as written, but a test pinned to that one
+    // offset only exercises the edge while the reserve is correct — change the
+    // reserve and the full stop moves off the edge, which is how an earlier
+    // version of this test passed against an arithmetic it was written to
+    // guard. Sweeping guarantees some sample lands on the edge whatever the
+    // reserve is.
+    for limit in [40usize, 120, 200, 500] {
+        for back in 3..=8usize {
+            let head = "a".repeat(limit.saturating_sub(back));
+            let text = format!("{head}. and then a continuation that will not fit at all");
+            let cut = truncate_at_sentence_boundary(&text, limit);
+            assert!(
+                cut.chars().count() <= limit,
+                "limit {limit}, head {}: produced {} chars: {cut:?}",
+                limit - back,
+                cut.chars().count()
+            );
+        }
+    }
+}
+
+/// A long key must not take the section down with it.
+///
+/// Key length is charged against the item's own allowance, and nothing
+/// upstream bounds it. Before the label was capped, ten memories with a
+/// 375-character key rendered zero bullets: the guard tripped on the first
+/// item and `break` discarded the rest.
+#[test]
+fn a_long_key_does_not_empty_the_section() {
+    let memories: Vec<(String, String)> = (0..MEMORY_SECTION_MAX_ITEMS)
+        .map(|_| {
+            (
+                "k".repeat(375),
+                "Prefers brief answers about Rust.".to_string(),
+            )
+        })
+        .collect();
+    let ctx = format_memory_items_as_personal_context(&memories);
+
+    let rendered = ctx.lines().filter(|l| l.starts_with("- [k")).count();
+    assert_eq!(
+        rendered, MEMORY_SECTION_MAX_ITEMS,
+        "expected every memory to render; got {rendered}"
+    );
+    assert!(
+        memory_body_chars(&ctx) <= MEMORY_SECTION_BUDGET_CHARS,
+        "capping the key must not push the section past its budget"
+    );
+}
+
+/// The rendered label is capped, and the cap is what bounds the framing cost.
+#[test]
+fn key_label_is_capped() {
+    let memories = vec![("k".repeat(500), "Some content.".to_string())];
+    let ctx = format_memory_items_as_personal_context(&memories);
+    let label = ctx
+        .lines()
+        .find(|l| l.starts_with("- [k"))
+        .expect("the bullet must render");
+    let key_chars = label.chars().skip(3).take_while(|&c| c != ']').count();
+    // Literal rather than derived: a bound taken from the constant it guards
+    // moves with it and stops detecting a change.
+    assert!(key_chars <= 67, "key rendered {key_chars} chars");
+}
+
+/// The truncation marker must survive clamping intact.
+///
+/// A clamp that trims from the end eats the marker's own tail, leaving a
+/// bullet that ends in `..` — the "context was cut" signal degraded into what
+/// reads as punctuation. No length assertion can see that, which is why it
+/// needs its own test.
+#[test]
+fn clamping_never_eats_the_marker() {
+    for max in [8usize, 17, 40, 120] {
+        for over in [1usize, 2, 3, 7] {
+            let s = format!("{}{TRUNCATION_MARKER}", "a".repeat(max + over));
+            let out = clamp_to(s, max);
+            assert!(out.chars().count() <= max, "clamp exceeded {max}: {out:?}");
+            assert!(
+                out.ends_with(TRUNCATION_MARKER),
+                "marker degraded at max {max}, over {over}: {out:?}"
+            );
+        }
+    }
+}
+
+/// Every path that shortens content ends with the whole marker.
+#[test]
+fn truncation_always_ends_with_the_whole_marker() {
+    let samples = [
+        "word ".repeat(200),
+        "x".repeat(1000),
+        "\u{5b57}".repeat(1000),
+        "Sentence one. Sentence two. ".repeat(40),
+        format!("{}. tail continues", "a".repeat(300)),
+    ];
+    for s in &samples {
+        for limit in [17usize, 40, 120, 499] {
+            let cut = truncate_at_sentence_boundary(s, limit);
+            if cut.chars().count() < s.chars().count() {
+                assert!(
+                    cut.ends_with(TRUNCATION_MARKER),
+                    "limit {limit}: shortened without a full marker: {:?}",
+                    cut.chars().rev().take(8).collect::<String>()
+                );
+            }
+        }
+    }
+}
+
+/// The skip rule is exercised at inputs the shipped constants do not reach.
+///
+/// The rule cannot be pinned by comparing `SKIP_POSSIBLE` against a
+/// re-derivation: dropping `MAX_BULLET_FRAMING_CHARS` from the definition
+/// leaves the value unchanged at the shipped constants, so both sides stay
+/// `false` and the mistake — the same wrong-quantity error this branch already
+/// made once in the guard — survives every test while re-opening the
+/// 5031-against-5000 overrun a widened key cap produces.
+#[test]
+fn skip_rule_reacts_to_each_input() {
+    // Shipped shape: a 500-character share against a 193-character demand.
+    assert!(!skip_possible(5000, 10, 120, 73));
+
+    // Each of the three documented tripwires, one at a time.
+    assert!(
+        skip_possible(5000, 10, 120, 409),
+        "a 400-char key cap must flip it"
+    );
+    assert!(skip_possible(5000, 40, 120, 73), "40 items must flip it");
+    assert!(
+        skip_possible(1250, 10, 120, 73),
+        "a 1250 budget must flip it"
+    );
+
+    // The framing term has to participate: without it the first tripwire is
+    // invisible, which is exactly the mutation that survived.
+    assert_ne!(
+        skip_possible(5000, 10, 120, 409),
+        skip_possible(5000, 10, 120, 0),
+        "framing must affect the result"
+    );
+
+    // Boundary: equality is not a skip.
+    assert!(!skip_possible(1930, 10, 120, 73));
+    assert!(skip_possible(1929, 10, 120, 73));
+}
+
+/// The shipped constants sit on the safe side of that rule.
+#[test]
+#[allow(
+    clippy::assertions_on_constants,
+    reason = "the subject is a constant: this pins that the shipped values \
+              stay on the safe side of the skip rule"
+)]
+fn shipped_constants_do_not_allow_a_skip() {
+    assert!(!SKIP_POSSIBLE);
+    assert_eq!(
+        SKIP_POSSIBLE,
+        skip_possible(
+            MEMORY_SECTION_BUDGET_CHARS,
+            MEMORY_SECTION_MAX_ITEMS,
+            MEMORY_SECTION_MIN_ITEM_CHARS,
+            MAX_BULLET_FRAMING_CHARS
+        )
+    );
+}
+
+/// Worst-case framing counts the ellipsis `cap_str` appends.
+#[test]
+fn framing_accounts_for_the_cap_str_ellipsis() {
+    let memories = vec![("k".repeat(500), "Some content.".to_string())];
+    let ctx = format_memory_items_as_personal_context(&memories);
+    let label = ctx
+        .lines()
+        .find(|l| l.starts_with("- [k"))
+        .expect("the bullet must render");
+    let key_chars = label.chars().skip(3).take_while(|&c| c != ']').count();
+    assert_eq!(
+        MAX_BULLET_FRAMING_CHARS,
+        key_chars + 6,
+        "framing constant must match the rendered label plus `- `, `[] ` and the newline"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Lands the half of #7756 §1.3 that stands on its own, as suggested in that thread: give the memory section an owned budget and stop cutting bullets mid-sentence. No plugin, no seam, independent of the RFC outcome.

## Problem

Three producers feed the memory section and none of them owns its total.

- Substrate recall is capped at `MEMORY_RECALL_LIMIT = 5` (`agent_loop/prompt.rs:309`), fetched wider and truncated back.
- Proactive items are appended after that cap.
- The formatter then took the first ten and capped each at 500 characters.

So the section's real ceiling was the product of two independent caps — nothing stated it, and `cap_str` sits downstream of all three producers knowing nothing about how many contributed.

The per-item cut was also unconditional, landing mid-clause whenever content exceeded it. Measured on one production corpus: 57% of raw memory rows exceed 500 characters, median length 599, while no extracted fact does — median 105. So the truncation this fixes is almost entirely a property of one class of memory.

## Change

**An explicit section budget** at the value the ceiling already implicitly had, so the limit becomes stated and enforceable without changing how much context an agent receives.

**Per-item share recomputed as the section is built.** An item shorter than its share hands the surplus to later items, which is the common case given the length asymmetry above. A per-item ceiling keeps a single oversized row — an attachment stored verbatim, for instance — from filling the section when few memories are present, and the key label is capped so an unbounded one cannot spend its item's whole share.

**Framing charged up front.** The `- `, the newline and the `[key] ` wrapper come out of the allowance rather than being discovered afterwards, and the omission notice is reserved for before any bullet is written — the discipline `librefang_types::memory::format_memories_with_budget` already uses. A final clamp holds the contract in release, where `debug_assert` is compiled out.

**Sentence-boundary truncation**, falling back to a word boundary and then a hard cut. Both boundary searches reject a break before the halfway mark of the window, since an early one discards more than it keeps: an unbroken tail such as a URL otherwise collapses a bullet to whatever preceded its first space. Every shortened bullet carries the marker, so a memory cut at a full stop is not mistaken for one that ended there.

**Dropped items are reported** with their count.

## Tests

Every property is pinned by a test verified to fail under a mutation that reintroduces the defect: the budget total, the per-item share, the per-item and key ceilings, each truncation branch, the marker surviving the clamp, and the notice reserve.

Two things learned the hard way and applied throughout:

- Sweeps are derived from the constants they depend on. A literal sweep only covers the window its constants happened to produce when it was written, and stops covering as soon as one moves.
- Bounds that guard a constant are literals, for the mirror-image reason: derived from the constant they guard, they move with it and stop detecting the change.

The three constant changes documented as tripwires each fail a test rather than silently altering behaviour.

## Verification

- `cargo test -p librefang-runtime --lib prompt_builder` — 105 passed, 0 failed.
- `cargo test -p librefang-runtime --lib` — 2346 passed, 2 failed; the same two as on the untouched base (`browser::tests::live_extraction_…` needs a Chromium binary that is absent here, and `agent_context::tests::poisoned_cache_lock_recovers_cached_context` flakes under the parallel run on the base too). Verified by stashing this change and re-running there.
- `cargo check --workspace --lib`, `cargo clippy -p librefang-runtime --lib --tests -- -D warnings`, `cargo fmt --all -- --check` — clean.

The branch went through nine adversarial self-review passes before this was opened for review, each in a separate session against the previous round's diff. They found, among other things, that the budget was not actually enforced (5074 against a stated 5000), that a long key could render the section empty, and several tests that did not fail under mutation of the behaviour they were named for. All of it is folded into the single commit here; I have not kept the intermediate history, since it is my process rather than part of the change.

## Not included

The other half of §1.3 — who owns the budget across the three producers rather than only within the formatter — needs the producers to agree on a contract and belongs with the seam discussion. This bounds the section where it is assembled, which holds regardless of how that resolves.

Refs #7756
