### PR TITLE
feat(tui): name every step agent binding in the workflow creator

### DIFF
--- a/changelog.d/fixed/7724-tui-step-agent-type-hint.md
+++ b/changelog.d/fixed/7724-tui-step-agent-type-hint.md
@@ -1,0 +1,3 @@
+The TUI's workflow creator now names the three agent bindings a step may carry.
+It authors steps as one raw JSON blob, so nothing on the screen told an operator that `agent_type` — bind the step to a template and let the daemon spawn one when nothing of that type is running — is accepted at all; the placeholder can only show one binding at a time, and it shows `agent_name`.
+A hint under the steps field now names all three as mutually exclusive and mentions the per-step `session_mode`, so the binding the Canvas editor exposes as a selector is at least discoverable where the TUI authors the same steps (#7869) (@houko)

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -2088,6 +2088,7 @@ tui-workflows-label-name = Workflow name:
 tui-workflows-placeholder-name = my-workflow
 tui-workflows-label-desc = Description:
 tui-workflows-placeholder-desc = What this workflow does
+tui-workflows-hint-steps = Each step sets exactly one of agent_id, agent_name or agent_type; agent_type names a template and is spawned when nothing of that type is running. Add session_mode = "new" for a fresh session per run.
 tui-workflows-label-steps = Steps (JSON array):
 tui-workflows-placeholder-steps = {"[{\"name\":\"draft\",\"agent_name\":\"writer\",\"prompt\":\"{{input}}\",\"session_mode\":\"new\"}]"}
 tui-workflows-label-review = Review — press Enter to create

--- a/crates/librefang-cli/locales/ko/main.ftl
+++ b/crates/librefang-cli/locales/ko/main.ftl
@@ -2088,6 +2088,7 @@ tui-workflows-label-name = 워크플로 이름:
 tui-workflows-placeholder-name = my-workflow
 tui-workflows-label-desc = 설명:
 tui-workflows-placeholder-desc = 이 워크플로가 하는 일
+tui-workflows-hint-steps = 각 단계는 agent_id, agent_name, agent_type 중 정확히 하나만 지정합니다. agent_type은 템플릿 이름이며 해당 타입이 실행 중이 아니면 새로 생성됩니다. 실행마다 새 세션을 쓰려면 session_mode = "new"를 추가하세요.
 tui-workflows-label-steps = 단계 (JSON 배열):
 tui-workflows-placeholder-steps = {"[{\"name\":\"draft\",\"agent_name\":\"writer\",\"prompt\":\"{{input}}\",\"session_mode\":\"new\"}]"}
 tui-workflows-label-review = 검토 — Enter를 눌러 생성

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -2107,6 +2107,7 @@ tui-workflows-label-name = Назва воркфлоу:
 tui-workflows-placeholder-name = мій-воркфлоу
 tui-workflows-label-desc = Опис:
 tui-workflows-placeholder-desc = Що робить цей воркфлоу
+tui-workflows-hint-steps = Кожен крок задає рівно один із agent_id, agent_name або agent_type; agent_type називає шаблон і запускається, коли жодного агента цього типу не працює. Додайте session_mode = "new" для нової сесії на кожен запуск.
 tui-workflows-label-steps = Кроки (JSON-масив):
 tui-workflows-placeholder-steps = {"[{\"name\":\"draft\",\"agent_name\":\"writer\",\"prompt\":\"{{input}}\",\"session_mode\":\"new\"}]"}
 tui-workflows-label-review = Огляд — натисніть Enter, щоб створити

--- a/crates/librefang-cli/locales/zh-CN/main.ftl
+++ b/crates/librefang-cli/locales/zh-CN/main.ftl
@@ -1154,6 +1154,7 @@ tui-workflows-label-name = 工作流名称:
 tui-workflows-placeholder-name = my-workflow
 tui-workflows-label-desc = 描述:
 tui-workflows-placeholder-desc = 此工作流的作用
+tui-workflows-hint-steps = 每个步骤只能设置 agent_id、agent_name 或 agent_type 之一；agent_type 指定模板名称，当该类型没有运行中的智能体时会自动创建。添加 session_mode = "new" 可让每次运行使用全新会话。
 tui-workflows-label-steps = 步骤 (JSON 数组):
 tui-workflows-placeholder-steps = {"[{\"name\":\"draft\",\"agent_name\":\"writer\",\"prompt\":\"{{input}}\",\"session_mode\":\"new\"}]"}
 tui-workflows-label-review = 确认 — 按 Enter 创建

--- a/crates/librefang-cli/src/tui/screens/workflows.rs
+++ b/crates/librefang-cli/src/tui/screens/workflows.rs
@@ -6,7 +6,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{ListItem, ListState, Paragraph};
+use ratatui::widgets::{ListItem, ListState, Paragraph, Wrap};
 use ratatui::Frame;
 
 // ── Data types ──────────────────────────────────────────────────────────────
@@ -592,6 +592,25 @@ fn draw_create(f: &mut Frame, area: Rect, state: &WorkflowState) {
                 ]),
             ]),
             chunks[6],
+        );
+    }
+
+    // The steps field is authored as one raw JSON blob, so the routing keys a
+    // step may carry are not discoverable from any control (#7724).
+    // `agent_type` in particular has no other mention on this screen: the
+    // placeholder can only show one binding at a time, and it shows
+    // `agent_name`.
+    if state.create_step == 2 {
+        f.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    crate::i18n::t("tui-workflows-hint-steps"),
+                    Style::default().fg(theme::TEXT_TERTIARY),
+                ),
+            ]))
+            .wrap(Wrap { trim: true }),
+            chunks[7],
         );
     }
 


### PR DESCRIPTION
## What

The TUI's workflow creator authors steps as one raw JSON blob, so the routing keys a step may carry are not discoverable from any control.
Nothing on that screen mentioned `agent_type` at all: the placeholder can only show one binding at a time, and #7862 left it showing `agent_name` — exactly the binding #7724 is not about.

- `crates/librefang-cli/src/tui/screens/workflows.rs` — render a hint on the steps stage of the creator, into the `Constraint::Min(0)` chunk that already sits between the input and the hint bar, so no other stage of the wizard moves.
  Guarded on `create_step == 2`; the review stage already occupies `chunks[6]` and is untouched.
- `crates/librefang-cli/locales/{en,ko,uk,zh-CN}/main.ftl` — the new `tui-workflows-hint-steps` string in every CLI locale.
  It names `agent_id` / `agent_name` / `agent_type` as mutually exclusive, says `agent_type` resolves to a template spawned when nothing of that type is running, and mentions the per-step `session_mode`.
- `changelog.d/fixed/7724-tui-step-agent-type-hint.md`.

The TUI already posts to `POST /api/workflows`, which accepts all three keys (`parse_step_agent`, `crates/librefang-api/src/routes/workflows/mod.rs:236`), so this closes a discoverability gap rather than adding a capability.

## Verification

- `cargo check -p librefang-cli --bins` — clean.
- `cargo clippy -p librefang-cli --bins -- -D warnings` — clean.
- `cargo test -p librefang-cli --test i18n_checks` — 3 passed.
  This is the guard that matters here: `test_no_dead_locale_keys` fails on a key no Rust code references, and `test_locales_cover_used_i18n_keys` fails on a locale missing a key the code uses.
- No route change, so no `TestServer` test applies.

## What this does not do

#7724 also asks for a per-step *fresh instance* control on both surfaces.
That has no backend to bind to on `main`: #7717 is still open, and neither `StepAgent` (`crates/librefang-kernel/src/workflow.rs:344`) nor the HTTP step parser carries a `fresh` field.
The issue should stay open for it — hence `Refs`, not `Closes`.

Refs #7724