### PR TITLE
feat(dashboard): author a workflow step's required skills on the canvas

### DIFF
--- a/changelog.d/added/7721-canvas-required-skills-editor.md
+++ b/changelog.d/added/7721-canvas-required-skills-editor.md
@@ -1,0 +1,4 @@
+The workflow canvas step editor can now set a step's `required_skills`, and the dry-run panel shows the mismatch when an agent cannot satisfy them.
+The gate itself shipped one release earlier with no editor surface at all, so the only way to require a skill was to hand-edit the workflow TOML or post the JSON yourself — and because a skill mismatch leaves `agent_found` true, the dry-run panel marked every step green while reporting the workflow as invalid, which is the least useful pair of signals it could have given.
+Installed skills autocomplete the box without restricting it: requiring a skill that is declared but not yet installed is a real workflow, and naming that gap is the dry run's job rather than the editor's.
+(#7871) (@houko)

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -600,6 +600,9 @@ export interface WorkflowStep {
   /** Per-step `SessionMode` override. `null` / absent defers to the target
    *  agent's manifest, which is how the API serializes an unset value. */
   session_mode?: "persistent" | "new" | null;
+  /** Skill names the step's resolved agent must be able to use (#7721).
+   *  Empty when the step requires nothing; the API sorts and de-duplicates the list on persist. */
+  required_skills?: string[];
 }
 
 export interface WorkflowLastRunSummary {
@@ -2624,6 +2627,9 @@ export interface DryRunStepPreview {
   resolved_prompt: string;
   skipped: boolean;
   skip_reason?: string;
+  /** Why the resolved agent cannot satisfy the step's `required_skills` (#7721).
+   *  Present only for a mismatch, and it is a step-level failure: the run stops here, so the dry run reports `valid: false` even though `agent_found` is true. */
+  skill_error?: string | null;
 }
 
 /** Response from the dry-run endpoint. */

--- a/crates/librefang-api/dashboard/src/components/StepAgentBinding.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/StepAgentBinding.test.tsx
@@ -16,8 +16,10 @@ import {
   StepAgentBinding,
   bindingFromNodeData,
   bindingToNodeData,
+  formatRequiredSkills,
   isStepBound,
   normalizeSessionMode,
+  parseRequiredSkills,
   stepAgentFields,
   switchAgentSource,
   type StepAgentBindingValue,
@@ -43,6 +45,7 @@ function Harness({
     <StepAgentBinding
       value={value}
       agents={AGENTS}
+      skills={SKILLS}
       onChange={next => {
         setValue(next);
         onValue(next);
@@ -57,12 +60,15 @@ function last(values: StepAgentBindingValue[]): StepAgentBindingValue {
   return values[values.length - 1];
 }
 
+const SKILLS = ["browser-automation", "pdf-extract"];
+
 const EMPTY: StepAgentBindingValue = {
   source: "instance",
   agentId: "",
   agentName: "",
   agentType: "",
   sessionMode: "",
+  requiredSkills: "",
 };
 
 describe("bindingFromNodeData", () => {
@@ -73,6 +79,7 @@ describe("bindingFromNodeData", () => {
       agentName: "researcher",
       agentType: "",
       sessionMode: "",
+      requiredSkills: "",
     });
   });
 
@@ -89,6 +96,7 @@ describe("bindingFromNodeData", () => {
       agentName: "",
       agentType: "researcher",
       sessionMode: "",
+      requiredSkills: "",
     });
   });
 
@@ -116,6 +124,18 @@ describe("bindingFromNodeData", () => {
     expect(bindingFromNodeData({ sessionMode: "bogus" } as unknown as CanvasNodeData).sessionMode).toBe("");
     expect(normalizeSessionMode(42)).toBe("");
     expect(normalizeSessionMode("new")).toBe("new");
+  });
+});
+
+describe("bindingFromNodeData required skills", () => {
+  it("seeds the box from a stored list and drops a malformed one", () => {
+    expect(
+      bindingFromNodeData({ requiredSkills: ["b", "a"] } as CanvasNodeData).requiredSkills,
+    ).toBe("b, a");
+    expect(
+      bindingFromNodeData({ requiredSkills: "b,a" } as unknown as CanvasNodeData)
+        .requiredSkills,
+    ).toBe("");
   });
 });
 
@@ -202,6 +222,28 @@ describe("stepAgentFields", () => {
   });
 });
 
+describe("parseRequiredSkills", () => {
+  it("trims, drops blanks and de-duplicates", () => {
+    expect(parseRequiredSkills("  a , ,a,  b ")).toEqual(["a", "b"]);
+  });
+
+  it("reads an all-whitespace box as no requirement", () => {
+    expect(parseRequiredSkills("  ,  , ")).toEqual([]);
+  });
+});
+
+describe("formatRequiredSkills", () => {
+  it("renders a stored list back into the editable box", () => {
+    expect(formatRequiredSkills(["a", "b"])).toBe("a, b");
+  });
+
+  it("reads anything that is not a string array as no requirement", () => {
+    expect(formatRequiredSkills(undefined)).toBe("");
+    expect(formatRequiredSkills("a,b")).toBe("");
+    expect(formatRequiredSkills([1, "", "  ", "a"])).toBe("a");
+  });
+});
+
 describe("isStepBound", () => {
   it("counts a name-only binding as bound", () => {
     expect(isStepBound({ agentName: "researcher" })).toBe(true);
@@ -231,6 +273,7 @@ describe("switchAgentSource", () => {
       agentName: "not-spawned-yet",
       agentType: "",
       sessionMode: "",
+      requiredSkills: "",
     });
   });
 
@@ -364,6 +407,71 @@ describe("StepAgentBinding", () => {
     // an empty string the API would log and discard.
     await user.selectOptions(sessionSelect, "");
     expect(bindingToNodeData(last(seen), AGENTS).sessionMode).toBeUndefined();
+  });
+
+  // #7721 shipped `required_skills` on the kernel and the API with no editor surface, so a workflow author could only set it by hand-editing TOML or posting JSON.
+  // These pin the whole path: typed text becomes the API array, a stored array comes back into the box, and the box survives an agent rebinding.
+  it("sends the typed required skills as the API array", async () => {
+    const user = userEvent.setup();
+    const seen: StepAgentBindingValue[] = [];
+    render(<Harness initial={{ ...EMPTY, agentId: "id-research" }} onValue={v => seen.push(v)} />);
+
+    const input = screen.getByLabelText("canvas.required_skills_label");
+    expect(input).toHaveValue("");
+
+    await user.type(input, "browser-automation, pdf-extract");
+    const data = bindingToNodeData(last(seen), AGENTS);
+    expect(data.requiredSkills).toEqual(["browser-automation", "pdf-extract"]);
+    expect(stepAgentFields(data).required_skills).toEqual([
+      "browser-automation",
+      "pdf-extract",
+    ]);
+  });
+
+  it("omits the field entirely when the box is blank", async () => {
+    const user = userEvent.setup();
+    const seen: StepAgentBindingValue[] = [];
+    render(
+      <Harness
+        initial={{ ...EMPTY, agentId: "id-research", requiredSkills: "pdf-extract" }}
+        onValue={v => seen.push(v)}
+      />,
+    );
+
+    // A stray comma must not become a blank requirement: the API rejects one with a 400 naming the step, so the workflow would stop saving at all.
+    await user.clear(screen.getByLabelText("canvas.required_skills_label"));
+    await user.type(screen.getByLabelText("canvas.required_skills_label"), " , ");
+    const data = bindingToNodeData(last(seen), AGENTS);
+    expect(data.requiredSkills).toBeUndefined();
+    expect(stepAgentFields(data).required_skills).toBeUndefined();
+  });
+
+  it("keeps the required skills when the agent binding is switched", async () => {
+    const user = userEvent.setup();
+    const seen: StepAgentBindingValue[] = [];
+    render(
+      <Harness
+        initial={{ ...EMPTY, agentId: "id-research", requiredSkills: "browser-automation" }}
+        onValue={v => seen.push(v)}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText("canvas.agent_source_label"), "type");
+    expect(screen.getByLabelText("canvas.required_skills_label")).toHaveValue(
+      "browser-automation",
+    );
+    expect(bindingToNodeData(last(seen), AGENTS).requiredSkills).toEqual([
+      "browser-automation",
+    ]);
+  });
+
+  it("offers the loaded skills as datalist suggestions", () => {
+    render(<Harness initial={EMPTY} onValue={vi.fn()} />);
+    const input = screen.getByLabelText("canvas.required_skills_label");
+    const list = document.getElementById(input.getAttribute("list")!);
+    expect([...list!.querySelectorAll("option")].map(o => o.getAttribute("value"))).toEqual(
+      SKILLS,
+    );
   });
 
   it("offers every known agent name as a datalist suggestion", () => {

--- a/crates/librefang-api/dashboard/src/components/StepAgentBinding.tsx
+++ b/crates/librefang-api/dashboard/src/components/StepAgentBinding.tsx
@@ -55,7 +55,35 @@ export type StepAgentBindingValue = {
   /** Agent template name — the payload when `source === "type"`. */
   agentType: string;
   sessionMode: StepSessionMode;
+  /** Raw, comma-separated `required_skills` text exactly as typed (#7721).
+   *  Kept as text rather than a parsed array so a half-typed name — the moment after a comma, a trailing space — survives a re-render instead of being normalised out from under the cursor.
+   *  Parsed on projection. */
+  requiredSkills: string;
 };
+
+/**
+ * Parse the comma-separated `required_skills` box into the array the API takes.
+ *
+ * Trims, drops empties and de-duplicates, so `"a, , a"` is `["a"]` and an all-whitespace box is an empty list rather than one blank requirement — the API rejects a blank entry with a 400 rather than ignoring it, which would turn a stray comma into an unsaveable workflow.
+ * Order is the operator's; the API sorts on persist.
+ */
+export function parseRequiredSkills(raw: string): string[] {
+  const seen = new Set<string>();
+  for (const part of raw.split(",")) {
+    const name = part.trim();
+    if (name) seen.add(name);
+  }
+  return [...seen];
+}
+
+/** Render a stored `required_skills` list back into the editable box.
+ *  Anything that is not an array of strings reads as "none required", which is what an older canvas draft and a step with no requirement both look like. */
+export function formatRequiredSkills(raw: unknown): string {
+  if (!Array.isArray(raw)) return "";
+  return raw.filter((name): name is string => typeof name === "string" && name.trim() !== "")
+    .map(name => name.trim())
+    .join(", ");
+}
 
 /** Narrow an untrusted `session_mode` to the two values the API parses.
  *  Anything else (absent, null, a typo, a number) means "defer to the
@@ -86,6 +114,7 @@ export function bindingFromNodeData(data: CanvasNodeData): StepAgentBindingValue
     agentName,
     agentType,
     sessionMode: normalizeSessionMode(data.sessionMode),
+    requiredSkills: formatRequiredSkills(data.requiredSkills),
   };
 }
 
@@ -100,8 +129,14 @@ export function bindingFromNodeData(data: CanvasNodeData): StepAgentBindingValue
 export function bindingToNodeData(
   value: StepAgentBindingValue,
   agents: AgentItem[],
-): Pick<CanvasNodeData, "agentSource" | "agentId" | "agentName" | "agentType" | "sessionMode"> {
+): Pick<
+  CanvasNodeData,
+  "agentSource" | "agentId" | "agentName" | "agentType" | "sessionMode" | "requiredSkills"
+> {
   const sessionMode = value.sessionMode === "" ? undefined : value.sessionMode;
+  // An empty requirement list is stored as absent rather than `[]`: the two mean the same thing to the API, and absent is what every step authored before this control existed already looks like.
+  const parsedSkills = parseRequiredSkills(value.requiredSkills);
+  const requiredSkills = parsedSkills.length > 0 ? parsedSkills : undefined;
   if (value.source === "name") {
     const name = value.agentName.trim();
     return {
@@ -110,6 +145,7 @@ export function bindingToNodeData(
       agentName: name || undefined,
       agentType: undefined,
       sessionMode,
+      requiredSkills,
     };
   }
   if (value.source === "type") {
@@ -120,6 +156,7 @@ export function bindingToNodeData(
       agentName: undefined,
       agentType: type || undefined,
       sessionMode,
+      requiredSkills,
     };
   }
   const agent = agents.find(a => a.id === value.agentId);
@@ -129,11 +166,12 @@ export function bindingToNodeData(
     agentName: agent?.name || undefined,
     agentType: undefined,
     sessionMode,
+    requiredSkills,
   };
 }
 
 /**
- * The `agent_*` / `session_mode` fields of the API step payload for a node.
+ * The `agent_*` / `session_mode` / `required_skills` fields of the API step payload for a node.
  *
  * The routing key comes from `stepAgentPayload`, which sends exactly one of
  * `agent_id` / `agent_name` / `agent_type`: a payload carrying several is
@@ -141,17 +179,23 @@ export function bindingToNodeData(
  * is the only one emitted. `session_mode` is omitted rather than sent empty
  * — the parser logs and discards a value it cannot read, and an unset
  * override is how a step defers to the target agent's manifest.
+ *
+ * `required_skills` is omitted when empty for the same reason, and because the API's parser for it is strict rather than lenient (#7721): a blank entry is a 400 naming the step, not a silently dropped requirement.
  */
 export function stepAgentFields(data: CanvasNodeData): {
   agent_id?: string;
   agent_name?: string;
   agent_type?: string;
   session_mode?: "persistent" | "new";
+  required_skills?: string[];
 } {
   const sessionMode = normalizeSessionMode(data.sessionMode);
+  const requiredSkills = formatRequiredSkills(data.requiredSkills);
+  const parsedSkills = parseRequiredSkills(requiredSkills);
   return {
     ...(stepAgentPayload(data) ?? {}),
     session_mode: sessionMode === "" ? undefined : sessionMode,
+    required_skills: parsedSkills.length > 0 ? parsedSkills : undefined,
   };
 }
 
@@ -196,11 +240,15 @@ export function switchAgentSource(
 export function StepAgentBinding({
   value,
   agents,
+  skills = [],
   onChange,
   t,
 }: {
   value: StepAgentBindingValue;
   agents: AgentItem[];
+  /** Names of the skills loaded on this instance, offered as suggestions.
+   *  Suggestions only — a workflow may legitimately require a skill that is declared but not yet installed, and the dry run is what reports that. */
+  skills?: string[];
   onChange: (next: StepAgentBindingValue) => void;
   t: (key: string) => string;
 }) {
@@ -312,6 +360,27 @@ export function StepAgentBinding({
       </select>
       <p className="mt-1 text-[10px] leading-snug text-text-dim/70">
         {t("canvas.session_mode_hint")}
+      </p>
+
+      <label className={CANVAS_LABEL_CLASS} htmlFor="step-required-skills">
+        {t("canvas.required_skills_label")}
+      </label>
+      <input
+        id="step-required-skills"
+        type="text"
+        list="step-required-skills-options"
+        value={value.requiredSkills}
+        placeholder={t("canvas.required_skills_placeholder")}
+        onChange={e => onChange({ ...value, requiredSkills: e.target.value })}
+        className={CANVAS_INPUT_CLASS}
+      />
+      <datalist id="step-required-skills-options">
+        {skills.map(name => (
+          <option key={name} value={name} />
+        ))}
+      </datalist>
+      <p className="mt-1 text-[10px] leading-snug text-text-dim/70">
+        {t("canvas.required_skills_hint")}
       </p>
     </div>
   );

--- a/crates/librefang-api/dashboard/src/lib/canvas.ts
+++ b/crates/librefang-api/dashboard/src/lib/canvas.ts
@@ -27,6 +27,9 @@ export type CanvasNodeData = {
   /** Per-step `session_mode` override sent to the API: `"persistent"`,
    *  `"new"`, or absent to defer to the target agent's manifest. */
   sessionMode?: "persistent" | "new";
+  /** Skill names this step's agent must be able to use (#7721).
+   *  Absent — not `[]` — when the step requires nothing, which is what every step authored before this field existed looks like. */
+  requiredSkills?: string[];
   prompt?: string;
   timeoutSecs?: number;
   maxRetries?: number;
@@ -86,7 +89,7 @@ function isCanvasNodeData(value: unknown, depth: number): value is CanvasNodeDat
   const booleanFields = ["_expanded"];
   if (booleanFields.some((field) => value[field] !== undefined && typeof value[field] !== "boolean")) return false;
 
-  for (const field of ["dependsOn", "_childIds"]) {
+  for (const field of ["dependsOn", "_childIds", "requiredSkills"]) {
     const fieldValue = value[field];
     if (fieldValue !== undefined
       && (!Array.isArray(fieldValue) || fieldValue.some((item) => typeof item !== "string"))) return false;

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1647,7 +1647,10 @@
     "session_mode_default": "Agent default",
     "session_mode_persistent": "Reuse the agent's session",
     "session_mode_new": "Fresh session each run",
-    "session_mode_hint": "A fresh session isolates this step from anything the agent said before."
+    "session_mode_hint": "A fresh session isolates this step from anything the agent said before.",
+    "required_skills_label": "Required skills",
+    "required_skills_placeholder": "browser-automation, pdf-extract",
+    "required_skills_hint": "Comma-separated. The step fails before it runs if the agent cannot use one of them."
   },
   "workflows": {
     "title": "Workflows",

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -1647,7 +1647,10 @@
     "session_mode_default": "에이전트 기본값",
     "session_mode_persistent": "에이전트의 세션 재사용",
     "session_mode_new": "실행마다 새 세션",
-    "session_mode_hint": "새 세션은 이 단계를 에이전트의 이전 대화와 분리합니다."
+    "session_mode_hint": "새 세션은 이 단계를 에이전트의 이전 대화와 분리합니다.",
+    "required_skills_label": "필요한 스킬",
+    "required_skills_placeholder": "browser-automation, pdf-extract",
+    "required_skills_hint": "쉼표로 구분합니다. 에이전트가 그중 하나라도 사용할 수 없으면 단계는 실행 전에 실패합니다."
   },
   "workflows": {
     "title": "워크플로",

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -1647,7 +1647,10 @@
     "session_mode_default": "Domyślnie jak agent",
     "session_mode_persistent": "Użyj ponownie sesji agenta",
     "session_mode_new": "Nowa sesja przy każdym uruchomieniu",
-    "session_mode_hint": "Nowa sesja izoluje ten krok od wszystkiego, co agent powiedział wcześniej."
+    "session_mode_hint": "Nowa sesja izoluje ten krok od wszystkiego, co agent powiedział wcześniej.",
+    "required_skills_label": "Wymagane umiejętności",
+    "required_skills_placeholder": "browser-automation, pdf-extract",
+    "required_skills_hint": "Rozdzielone przecinkami. Krok kończy się błędem przed uruchomieniem, jeśli agent nie może użyć którejś z nich."
   },
   "workflows": {
     "title": "Przepływy pracy",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -1647,7 +1647,10 @@
     "session_mode_default": "Як в агента",
     "session_mode_persistent": "Використати сесію агента повторно",
     "session_mode_new": "Нова сесія на кожен запуск",
-    "session_mode_hint": "Нова сесія ізолює цей крок від усього, що агент казав раніше."
+    "session_mode_hint": "Нова сесія ізолює цей крок від усього, що агент казав раніше.",
+    "required_skills_label": "Потрібні навички",
+    "required_skills_placeholder": "browser-automation, pdf-extract",
+    "required_skills_hint": "Через кому. Крок завершиться помилкою ще до запуску, якщо агент не може скористатися однією з них."
   },
   "workflows": {
     "title": "Воркфлоу",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1647,7 +1647,10 @@
     "session_mode_default": "跟随智能体默认值",
     "session_mode_persistent": "复用智能体的会话",
     "session_mode_new": "每次运行使用新会话",
-    "session_mode_hint": "新会话会将该步骤与智能体之前说过的内容隔离。"
+    "session_mode_hint": "新会话会将该步骤与智能体之前说过的内容隔离。",
+    "required_skills_label": "所需技能",
+    "required_skills_placeholder": "browser-automation, pdf-extract",
+    "required_skills_hint": "以逗号分隔。若智能体无法使用其中任意一项，该步骤会在运行前失败。"
   },
   "workflows": {
     "title": "工作流",

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -70,6 +70,7 @@ import {
 import { useCreateSchedule } from "../lib/mutations/schedules";
 import { useWorkflows, useWorkflowTemplates, workflowQueries } from "../lib/queries/workflows";
 import { useAgents } from "../lib/queries/agents";
+import { useSkills } from "../lib/queries/skills";
 import {
   StepAgentBinding,
   bindingFromNodeData,
@@ -114,6 +115,8 @@ type WorkflowStepBuild = {
   agent_type?: string;
   /** Per-step session override; omitted to defer to the agent manifest. */
   session_mode?: "persistent" | "new";
+  /** Skills the step's agent must be able to use; omitted when none (#7721). */
+  required_skills?: string[];
   prompt: string;
   timeout_secs: number;
   mode?:
@@ -658,9 +661,10 @@ function useAgentPanelWidth(): [number, (next: number) => void] {
 }
 
 function NodeConfigPanel({
-  node, agents, onUpdate, onClose, onDelete, siblingNodes, width, onResize, t
+  node, agents, skills, onUpdate, onClose, onDelete, siblingNodes, width, onResize, t
 }: {
-  node: CanvasNode; agents: AgentItem[]; onUpdate: (id: string, data: CanvasNodeData) => void;
+  node: CanvasNode; agents: AgentItem[]; skills: string[];
+  onUpdate: (id: string, data: CanvasNodeData) => void;
   /** Avoids stuffing arbitrary fields onto ReactFlow's Node type. */
   siblingNodes?: Array<{ id: string; label: string }>;
   width: number; onResize: (next: number) => void;
@@ -787,7 +791,13 @@ function NodeConfigPanel({
         </div>
 
         {/* Agent binding */}
-        <StepAgentBinding value={binding} agents={agents} onChange={setBinding} t={t} />
+        <StepAgentBinding
+          value={binding}
+          agents={agents}
+          skills={skills}
+          onChange={setBinding}
+          t={t}
+        />
 
         {/* Prompt */}
         {hasAgent && (
@@ -932,6 +942,13 @@ function CanvasPageInner() {
   const queryClient = useQueryClient();
   const agentsQuery = useAgents();
   const agents = useMemo(() => agentsQuery.data ?? [], [agentsQuery.data]);
+  // Suggestions for a step's `required_skills` box.
+  // A workflow may require a skill this instance has not installed — that is a case the dry run is meant to report — so this list only autocompletes, it never restricts.
+  const skillsQuery = useSkills();
+  const skillNames = useMemo(
+    () => (skillsQuery.data ?? []).map(s => s.name).sort((a, b) => a.localeCompare(b)),
+    [skillsQuery.data],
+  );
   const workflowsQuery = useWorkflows();
   const workflows = useMemo(() => workflowsQuery.data ?? [], [workflowsQuery.data]);
   const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowItem | null>(null);
@@ -1573,6 +1590,10 @@ function CanvasPageInner() {
                 ? "name"
                 : undefined,
           sessionMode: normalizeSessionMode(s.session_mode) || undefined,
+          requiredSkills:
+            Array.isArray(s.required_skills) && s.required_skills.length > 0
+              ? s.required_skills
+              : undefined,
         },
       }));
       const hasDag = steps.some((step) => Array.isArray(step.depends_on) && step.depends_on.length > 0);
@@ -2577,7 +2598,7 @@ function CanvasPageInner() {
                       onClick={() => setExpandedDryStep(expandedDryStep === i ? null : i)}>
                       {step.skipped
                         ? <SkipForward className="w-3 h-3 text-text-dim/40 shrink-0" />
-                        : step.agent_found
+                        : step.agent_found && !step.skill_error
                           ? <CheckCircle2 className="w-3 h-3 text-success shrink-0" />
                           : <AlertCircle className="w-3 h-3 text-warning shrink-0" />}
                       <span className="text-[10px] font-bold truncate flex-1">{step.step_name}</span>
@@ -2590,6 +2611,8 @@ function CanvasPageInner() {
                     {expandedDryStep === i && (
                       <div className="px-3 pb-3 space-y-1.5 border-t border-border-subtle">
                         {!step.agent_found && <p className="text-[10px] text-warning mt-2">{t("canvas.agent_not_found")}</p>}
+                        {/* The kernel's own mismatch text names the step, the agent, the missing skill and the fix (#7721), so it is shown verbatim rather than flattened into a generic "invalid step" line. */}
+                        {step.skill_error && <p className="text-[10px] text-warning mt-2">{step.skill_error}</p>}
                         {step.skip_reason && <p className="text-[10px] text-text-dim mt-2">{step.skip_reason}</p>}
                         <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("canvas.resolved_prompt")}</p>
                         <pre className="text-[10px] text-text whitespace-pre-wrap max-h-20 overflow-y-auto bg-surface rounded-lg p-2">
@@ -2670,6 +2693,7 @@ function CanvasPageInner() {
                 .filter(n => n.id !== editingNode.id && AGENT_NODE_TYPES_SET.has(n.data.nodeType ?? ""))
                 .map(n => ({ id: n.id, label: n.data.label || n.id }))}
               agents={agents}
+              skills={skillNames}
               width={agentPanelWidth}
               onResize={setAgentPanelWidth}
               onUpdate={handleNodeUpdate} onClose={() => setEditingNode(null)}


### PR DESCRIPTION
Closes #7721.

## The gap

#7863 shipped `required_skills` on `WorkflowStep`, the kernel gate, the dry run and the API step parser.
`grep -c required_skills crates/librefang-api/dashboard/src/` on `main` returns 0, so the only ways to require a skill were hand-editing the workflow TOML or posting the JSON directly — while the issue lists the dashboard step editor as one of the four surfaces.

A second, smaller defect fell out of reading that code.
A skill mismatch is reported with `agent_found: true` and a `skill_error`, and the panel keyed its per-step icon on `agent_found` alone.
So a dry run over a workflow with a bad requirement showed the header badge "Issues found" above a list where every step carried a green check — the failing step was the one thing the operator could not see.
It is four lines in the file this PR already changes, so it is fixed here rather than deferred.

## Changes

- **Step config panel**: a comma-separated Required skills box, rendered by `StepAgentBinding` beside the agent binding and the session override.
  That is where the gate itself lives conceptually — it runs immediately after agent resolution — and it means the field switches losslessly along with the rest of the binding.
- **Parsing**: the box holds raw text and is parsed on projection, so a half-typed name (the moment after a comma, a trailing space) is not normalised out from under the cursor.
  Entries are trimmed and de-duplicated; an empty result omits the field rather than sending `[]` or a blank entry, because the API's parser for this key is deliberately strict and answers a blank with a 400 naming the step.
- **Suggestions**: `useSkills()` feeds a datalist of the skills loaded on this instance.
  Suggestions only — requiring a skill that is declared but not installed is a real workflow, and distinguishing that case is exactly what the kernel's three-class error does, so the editor must not pre-empt it.
- **Hydration**: a saved workflow's `required_skills` seeds the box (`workflow_to_json` already emits it), and `CanvasNodeData.requiredSkills` is validated as a string array by the canvas-draft guard so an imported draft cannot smuggle another shape in.
- **Dry-run panel**: `skill_error` is rendered verbatim, and a step carrying one shows the warning icon rather than the green check.
  Verbatim because the kernel's text already names the step, the agent, the skill and the fix; flattening it into a generic localized line would throw that away.

## Verification

- `src/components/StepAgentBinding.test.tsx`, new cases: typed text becomes the API array; a box holding only commas emits no field at all; the value survives switching the step between the instance / name / type bindings; the datalist offers the loaded skills.
  Plus unit coverage for `parseRequiredSkills` / `formatRequiredSkills` and for `bindingFromNodeData` seeding from a malformed stored value.
- `pnpm exec vitest run` — 1253 tests across 126 files, all passing.
- `pnpm run typecheck`, `pnpm run build`, `pnpm run lint` — clean.
- No route change, so no new `TestServer` test.
  The parser this UI feeds is already pinned by `workflow_create_round_trips_step_required_skills` and `workflow_create_rejects_malformed_required_skills` in `crates/librefang-api/tests/workflows_routes_integration.rs`.

## Why this closes the issue

Walking the acceptance list:

- `required_skills = [...]` on a step — `crates/librefang-kernel/src/workflow.rs:300`, `#[serde(default)]`, so the workflow TOML/JSON schema carries it without a separate loader change.
- Checked at resolution time against the loaded registry, naming the step, the skill and the agent — `enforce_required_skills` / `classify_required_skills`, `crates/librefang-kernel/src/workflow.rs:1839-1879`.
- Three failure classes distinguished, including declared-but-unavailable — `RequiredSkillReport`, kernel tests at `crates/librefang-kernel/src/kernel/tools_and_skills.rs:2435-2600`.
- Surfaces: workflow TOML/JSON schema (serde), API step parser (`parse_required_skills`, `crates/librefang-api/src/routes/workflows/mod.rs:575`), dashboard step editor (this PR).
  TUI step authoring is a raw `steps_json` text field (`crates/librefang-cli/src/tui/screens/workflows.rs:53`) with no per-field step form, so it accepts the key already and there is nothing there to extend.
- API integration test for the parser — `workflows_routes_integration.rs:571` and `:644`.

## Deferred

Nothing.

## Why this is not one PR with the #7605 memory-config work

Different issue, different subsystem, different reviewers (`area/skills` versus `area/memory`), and the two diffs share no file.
