### PR TITLE
feat(skills): add the workflow-creator skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -558,7 +558,9 @@ def run(input: dict) -> str:
 librefang skill test ./my-skill --input '{"url": "https://example.com"}'
 ```
 
-5. Submit as a PR to `skills/community/` or publish to FangHub.
+5. Submit as a PR to [`librefang/librefang-registry`](https://github.com/librefang/librefang-registry) under `skills/<name>/`, or publish to FangHub.
+   Skills are registry content, not part of this repository — the daemon syncs the registry into `~/.librefang/registry/` and installs from there.
+   The `skills/community/` path this step used to name was removed in #1212 and is read by nothing.
 
 ### Steps (Prompt template)
 

--- a/changelog.d/added/6934-workflow-creator-skill.md
+++ b/changelog.d/added/6934-workflow-creator-skill.md
@@ -1,0 +1,4 @@
+Ship a `workflow-creator` skill so an agent reaching for `workflow_create` knows the shape of a good workflow rather than guessing at one.
+The tool has been available since #7857, but its JSON schema can only describe fields — not when a workflow beats a one-off `agent_send`, why `{"type": "researcher"}` binding makes a workflow portable to an instance where nothing is pre-registered, or which of the creation-time validations an author is most likely to trip.
+Installing it from the registry puts that in the system prompt.
+Two step fields the tool had always accepted are now advertised as well: `required_skills`, which fails a step before it bills an LLM call, and the per-step `session_mode` (#6934) (@houko)

--- a/changelog.d/added/6934-workflow-creator-skill.md
+++ b/changelog.d/added/6934-workflow-creator-skill.md
@@ -1,4 +1,4 @@
 Ship a `workflow-creator` skill so an agent reaching for `workflow_create` knows the shape of a good workflow rather than guessing at one.
 The tool has been available since #7857, but its JSON schema can only describe fields — not when a workflow beats a one-off `agent_send`, why `{"type": "researcher"}` binding makes a workflow portable to an instance where nothing is pre-registered, or which of the creation-time validations an author is most likely to trip.
 Installing it from the registry puts that in the system prompt.
-Two step fields the tool had always accepted are now advertised as well: `required_skills`, which fails a step before it bills an LLM call, and the per-step `session_mode` (#6934) (@houko)
+Two step fields the tool had always accepted are now advertised as well: `required_skills`, which fails a step before it bills an LLM call, and the per-step `session_mode` (#7873) (#6934) (@houko)

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -878,6 +878,60 @@ mod tests {
         );
     }
 
+    /// Every step field `WorkflowCreateSpec` accepts and acts on must be advertised in the tool schema.
+    ///
+    /// `WorkflowCreateSpec` deserialises the canonical [`crate::workflow::WorkflowStep`], so the tool silently accepts every field that struct grows — agent-type routing, `required_skills`, `session_mode` — whether or not the published schema mentions them.
+    /// A field accepted but unadvertised is a field no model will ever send, and the `workflow-creator` skill would be documenting keys the tool's own schema denies.
+    /// This asserts the acceptance and the advertisement together, so the two cannot drift apart in either direction.
+    #[test]
+    fn the_tool_schema_advertises_the_step_routing_fields_the_spec_accepts() {
+        use crate::workflow::StepAgent;
+        use librefang_types::agent::SessionMode;
+
+        let wf = build_created_workflow(&spec(serde_json::json!([{
+            "name": "review",
+            "agent": {"type": "code-reviewer"},
+            "prompt_template": "Review {{input}}",
+            "required_skills": ["git-expert"],
+            "session_mode": "new",
+            "inherit_context": false,
+        }])))
+        .expect("agent-type routing, required_skills and session_mode are accepted");
+
+        let step = &wf.steps[0];
+        assert!(
+            matches!(&step.agent, StepAgent::ByType { template } if template == "code-reviewer"),
+            "`{{\"type\": …}}` must bind find-or-spawn, got {:?}",
+            step.agent
+        );
+        assert_eq!(step.required_skills, vec!["git-expert".to_string()]);
+        assert!(matches!(step.session_mode, Some(SessionMode::New)));
+        assert_eq!(step.inherit_context, Some(false));
+
+        let defs = librefang_runtime::tool_runner::builtin_tool_definitions();
+        let step_props = &defs
+            .iter()
+            .find(|d| d.name == "workflow_create")
+            .expect("workflow_create must be a builtin tool")
+            .input_schema["properties"]["steps"]["items"]["properties"];
+
+        for field in ["required_skills", "session_mode", "inherit_context"] {
+            assert!(
+                step_props[field].is_object(),
+                "step field `{field}` is accepted by workflow_create but absent from its schema"
+            );
+        }
+        let agent_doc = step_props["agent"]["description"]
+            .as_str()
+            .expect("the agent property must be documented");
+        for routing_key in crate::workflow::STEP_AGENT_ROUTING_KEYS {
+            assert!(
+                agent_doc.contains(&format!("\"{routing_key}\"")),
+                "the agent binding doc must name the `{routing_key}` routing key, got: {agent_doc}"
+            );
+        }
+    }
+
     /// Pins the operator-facing timeout text format.
     /// Operators scrape for `"workflow run timed out after"` and pull the seconds field; any drift in this string is a breaking change to the contract the PR explicitly locks in.
     /// If you need to change the format, announce it in the changelog under a breaking-change bullet and update this assertion.

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -363,7 +363,7 @@ pub enum StepAgent {
 ///
 /// Ordered as they are reported in the "exactly one of" error so the
 /// message reads the same on every host.
-const STEP_AGENT_ROUTING_KEYS: [&str; 3] = ["id", "name", "type"];
+pub(crate) const STEP_AGENT_ROUTING_KEYS: [&str; 3] = ["id", "name", "type"];
 
 /// Select the [`StepAgent`] variant for one tagged-object payload.
 ///

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -1287,13 +1287,16 @@ use instead of web_fetch + file_write (which round-trips the entire body through
                                 "type": "object",
                                 "properties": {
                                     "name": { "type": "string", "description": "Step name, unique within the workflow. Other steps reference it in depends_on." },
-                                    "agent": { "type": "string", "description": "Name of the agent that runs this step (agent_list shows what exists). An object {\"id\": \"<uuid>\"} addresses one by UUID instead." },
+                                    "agent": { "description": "Which agent runs this step. A bare string is the agent's name (agent_list shows what exists). The object forms carry exactly one routing key: {\"name\": \"researcher\"} by name, {\"id\": \"<uuid>\"} by instance UUID, or {\"type\": \"researcher\"} by agent type — find-or-spawn, which reuses a registered agent of that name and otherwise spawns the template of that name, so the workflow stands on its own on an instance where nothing is pre-registered." },
                                     "prompt_template": { "type": "string", "description": "Prompt for this step. {{input}} interpolates the previous step's output; {{var}} interpolates a workflow input parameter or an earlier step's output_var." },
                                     "depends_on": { "type": "array", "items": { "type": "string" }, "description": "Names of steps that must finish first. Any step may be named, including one declared later. Omit for straight-line execution." },
                                     "output_var": { "type": "string", "description": "Store this step's output under this name so later steps can reference it as {{name}}" },
                                     "mode": { "description": "Sequencing for this step: the string \"sequential\" (default), \"fan_out\" to run in parallel with the following fan_out steps, or \"collect\" to gather them. Richer nodes take a tagged object, e.g. {\"conditional\": {\"condition\": \"APPROVED\"}}." },
                                     "error_mode": { "description": "What to do when this step fails: \"fail\" (default, abort the run), \"skip\" (continue without it), or {\"retry\": {\"max_retries\": 3}}." },
-                                    "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 3600, "description": "Wall-clock limit for this step (default 120, ceiling 3600)" }
+                                    "timeout_secs": { "type": "integer", "minimum": 1, "maximum": 3600, "description": "Wall-clock limit for this step (default 120, ceiling 3600)" },
+                                    "required_skills": { "type": "array", "items": { "type": "string" }, "description": "Skills the resolved agent must actually be able to use. Checked right after agent resolution and before the prompt is built, so an unmet requirement fails the run with an error naming the skill and the fix, and bills no LLM call. Omit unless the step cannot work without them." },
+                                    "session_mode": { "type": "string", "enum": ["persistent", "new"], "description": "Session this step's invocation uses: \"persistent\" reuses the target agent's long-running session, \"new\" mints a fresh one. Omit to defer to the agent's own setting." },
+                                    "inherit_context": { "type": "boolean", "description": "Set false to suppress parent-workflow context injection for this step regardless of the agent's setting. Omit to defer to the agent." }
                                 },
                                 "required": ["name", "agent", "prompt_template"]
                             }

--- a/crates/librefang-runtime/tests/fixtures/registry/README.md
+++ b/crates/librefang-runtime/tests/fixtures/registry/README.md
@@ -7,8 +7,9 @@ Pinned snapshot of [librefang/librefang-registry](https://github.com/librefang/l
 - `hands/` — all hands, `HAND.toml` + `SKILL*.md` only (READMEs pruned); `load_hands_from_disk` asserts ≥ 15 and `kernel-router` routes to 14 of them by id.
 - `agents/hello-world/agent.toml` — the template the default-agent dispatch path instantiates.
 - `aliases.toml` — `model_catalog` alias-resolution tests.
+- `skills/workflow-creator/SKILL.md` — the one skill this repo has a stake in, because it teaches the builtin `workflow_create` tool and would go silently wrong if that tool's ceilings moved; `tests/workflow_creator_skill.rs` loads it and checks its prose against the live tool schema. The other sixty registry skills teach domains outside this codebase and are deliberately absent.
 
-Anything the tests don't read (channels, workflow templates, schema.toml, other agent templates, hand READMEs) is deliberately absent — don't re-add content without a test that needs it.
+Anything the tests don't read (channels, workflow templates, schema.toml, other agent templates, hand READMEs, the rest of `skills/`) is deliberately absent — don't re-add content without a test that needs it.
 
 Consumed by `librefang_runtime::registry_sync::seed_registry_fixture_for_tests`, which copies it into a test home's `registry/` cache and fans content out exactly like a real sync — no network, deterministic under `LIBREFANG_REGISTRY_OFFLINE=1`.
 

--- a/crates/librefang-runtime/tests/fixtures/registry/skills/workflow-creator/SKILL.md
+++ b/crates/librefang-runtime/tests/fixtures/registry/skills/workflow-creator/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: workflow-creator
+description: Compose durable multi-step workflows with the workflow_create tool — step shape, agent binding, required skills, and the validation errors worth avoiding
+version: 0.1.0
+author: librefang
+tags: [productivity, automation, workflow]
+---
+# Composing Workflows with `workflow_create`
+
+A workflow is a named, persisted sequence of steps that dispatches each step to an agent and threads the outputs together.
+`workflow_create` registers one; `workflow_run` / `workflow_start` execute it afterwards, and it outlives the conversation that created it.
+
+## Decide whether a workflow is the right shape
+
+Reach for `workflow_create` when the same multi-agent sequence is worth repeating, when it needs to be startable later by a cron job or another agent, or when the steps should run as a DAG rather than one long turn.
+For something you will do once, message the agents directly with `agent_send` — a workflow you never run again is a name permanently taken on the daemon.
+
+Call `workflow_list` before creating.
+Names are unique across the daemon and the comparison is case-insensitive, so `Deploy` collides with an existing `deploy`.
+A collision is rejected outright and nothing is overwritten; the error names the workflow that already holds the name.
+
+## The step shape
+
+Every step requires `name`, `agent`, and `prompt_template`.
+
+- `name` is unique within the workflow and is how `depends_on` addresses the step.
+- `prompt_template` is the text sent to the agent. `{{input}}` interpolates the previous step's output; `{{whatever}}` interpolates a declared input parameter or an earlier step's `output_var`.
+- `output_var` stores this step's output under a name later steps reference as `{{that_name}}`. Without it, only the immediately following step can read the output, via `{{input}}`.
+- `depends_on` lists step names that must finish first. A step may name one declared later in the array — execution is topological, not positional.
+- `timeout_secs` is the wall-clock budget for the step: default 120, ceiling 3600.
+- `error_mode` is `"fail"` (default, abort the run), `"skip"` (continue without this step's output), or `{"retry": {"max_retries": 3}}`. The retry form also accepts `backoff_ms` and `jitter_pct`.
+- `mode` is `"sequential"` (default), `"fan_out"` to run alongside the following `fan_out` steps, or `"collect"` to gather them. Richer nodes take a tagged object, such as `{"conditional": {"condition": "APPROVED"}}`.
+
+A workflow holds at most 50 steps, and `total_timeout_secs` caps the whole run at 86400 seconds.
+The workflow `name` itself is 1–64 characters of letters, digits, `_` and `-`.
+
+## Agent binding
+
+The `agent` field accepts four shapes, and exactly one routing key in the object forms:
+
+| Written as | Meaning |
+|---|---|
+| `"researcher"` | By name — shorthand for the object below. The first registered agent answering to that name runs the step. |
+| `{"name": "researcher"}` | By name, spelled out. |
+| `{"id": "<uuid>"}` | By UUID — binds to one specific agent instance and survives a rename. |
+| `{"type": "researcher"}` | By agent *type* — find-or-spawn. A registered agent of that name is reused; otherwise the template of that name is loaded and spawned. |
+
+Supplying none of `id` / `name` / `type`, or more than one, is a deserialization error rather than a silently-preferred key.
+
+Prefer `{"type": ...}` when the workflow should stand on its own on a fresh install, because it does not require the operator to have pre-registered anything.
+Prefer `{"id": ...}` when the step must reach one particular long-running instance.
+Bare-string / `{"name": ...}` binding fails at run time if no agent answers to that name, so check `agent_list` first.
+
+Two optional per-step fields shape how the agent is invoked:
+
+- `session_mode` is `"persistent"` (reuse the target agent's long-running session, threading this step into its context) or `"new"` (a fresh session, isolated from prior state). Omit it to defer to the agent's own `session_mode`.
+- `inherit_context` set to `false` suppresses parent-workflow context injection for this step regardless of the agent's setting.
+
+## `required_skills`
+
+`required_skills` lists skills the step's agent must actually be able to use.
+The check runs right after agent resolution and before the prompt is built, so an unmet requirement fails with a named error and bills no LLM call.
+
+Each name is resolved against the loaded skill registry independently of the agent's allowlist, which means an unrestricted agent cannot mask a requirement for a skill that is not installed.
+The error distinguishes three cases, because each has a different fix: the skill is loaded but the agent's `skills` allowlist does not admit it; the agent declares it but nothing on the instance provides it; or nothing provides it and the agent never named it either, which is usually a typo.
+An agent with `skills_disabled = true` fails every requirement regardless of the registry.
+
+Use it for the one or two skills a step genuinely cannot work without.
+Listing every skill an agent happens to have turns a workflow into something that only runs on the machine it was written on.
+An empty or whitespace-only entry is rejected at creation.
+
+## Declaring inputs
+
+`input_schema` declares what callers pass to `workflow_run`, and each entry becomes a `{{name}}` placeholder available to every step's `prompt_template`.
+
+The type key is `param_type`, not `type` — this is the spelling `workflow_describe` reports back.
+Values are `string` (the default), `number`, `boolean`, `file`, `image`, or `agent_id`; `file` and `image` document that the caller may pass an artifact reference.
+`required` defaults to true.
+
+Declaring it is worth the few extra lines.
+When it is absent, `workflow_describe` falls back to scanning step prompts for `{{var}}` placeholders and reports every one it finds as a required string with no description — so the caller learns the parameter names but nothing about what they mean.
+
+## Worked example
+
+```json
+{
+  "name": "release-notes",
+  "description": "Draft release notes from a version tag, then fact-check them against the changelog",
+  "steps": [
+    {
+      "name": "collect",
+      "agent": {"type": "researcher"},
+      "prompt_template": "List every merged pull request in {{repo}} since tag {{since_tag}}. One line each: number, title, author.",
+      "output_var": "merged",
+      "timeout_secs": 600
+    },
+    {
+      "name": "draft",
+      "agent": {"type": "technical-writer"},
+      "prompt_template": "Write release notes for {{repo}} covering these changes. Group by theme and explain why each matters:\n{{merged}}",
+      "depends_on": ["collect"],
+      "output_var": "draft"
+    },
+    {
+      "name": "fact-check",
+      "agent": {"type": "code-reviewer"},
+      "prompt_template": "Check this draft against the merged list. Flag any claim the list does not support.\n\nDraft:\n{{draft}}\n\nMerged:\n{{merged}}",
+      "depends_on": ["collect", "draft"],
+      "required_skills": ["git-expert"],
+      "error_mode": "skip"
+    }
+  ],
+  "input_schema": [
+    {"name": "repo", "param_type": "string", "required": true, "description": "owner/name of the repository"},
+    {"name": "since_tag", "param_type": "string", "required": true, "description": "Tag to diff from, e.g. v0.4.0"}
+  ],
+  "total_timeout_secs": 3600
+}
+```
+
+`fact-check` reads both `{{draft}}` and `{{merged}}`, which is why `collect` sets an `output_var` even though `draft` could have read it as `{{input}}`.
+It is `error_mode: "skip"` because a missing fact-check is worse than no release notes at all, but not worth failing the run over.
+
+## Failure modes worth avoiding
+
+**Depending on a step that does not exist.** `depends_on` entries are checked against the step names in the same workflow and a miss is rejected at creation, with the offending pair named. A forward reference is fine; a typo is not.
+
+**Reusing a step name.** Step names address dependencies, so duplicates are rejected rather than disambiguated.
+
+**Operator nodes inside a DAG.** `wait`, `gate`, `approval`, `transform`, `branch` and `operator` steps execute only on the sequential path. Combining one with `depends_on` is rejected at creation, because the DAG executor would try to dispatch it to an agent instead.
+
+**A `prompt_template` on an operator node.** `wait`, `gate`, `approval`, `branch` and `operator` ignore the field at run time, so a non-empty template there is rejected rather than silently discarded. Leave it empty or use `{{input}}`.
+
+**Reaching for `{{input}}` across a fan-out.** `{{input}}` is the *previous* step's output. Once steps run in parallel, "previous" is not well defined — give each parallel step an `output_var` and read those by name.
+
+**Treating the workflow as private.** Workflows have no ownership model: the moment one is registered, any agent on the daemon can run it and any operator can read its step prompts. Keep credentials and personal data out of `prompt_template` and pass them as inputs at run time.
+
+**Assuming it disappeared with the conversation.** A created workflow is written to `~/.librefang/workflows/<id>.workflow.json` and reloaded at daemon start. It is durable and it holds its name until someone removes it.
+
+## After creating
+
+`workflow_create` returns `{id, name, description, step_count, has_input_schema}`.
+The workflow is runnable immediately: `workflow_run` executes it and waits, `workflow_start` returns a run id straight away, `workflow_status` polls that run, and `workflow_describe` reports the parameters back to whoever calls it next.

--- a/crates/librefang-runtime/tests/workflow_creator_skill.rs
+++ b/crates/librefang-runtime/tests/workflow_creator_skill.rs
@@ -1,0 +1,231 @@
+//! Contract tests for the bundled `workflow-creator` skill (#6934).
+//!
+//! The skill itself is registry content: it ships from `librefang/librefang-registry` under `skills/workflow-creator/` and is installed on demand like the other prompt-only skills the dashboard lists.
+//! What is testable here is the copy pinned in this repo's registry snapshot, and that copy is what the tests below load — so a change to the shipped skill that stops it loading, trips the load-boundary injection scan, or drifts away from the ceilings `workflow_create` actually enforces fails CI rather than reaching an agent's system prompt.
+//!
+//! Lives in `librefang-runtime` because that is the crate holding the registry snapshot (`registry_sync::REGISTRY_FIXTURE_DIR`) and it already depends on `librefang-skills`, so both halves of the contract are visible from one place.
+
+use librefang_skills::registry::SkillRegistry;
+use librefang_skills::SkillRuntime;
+use std::path::{Path, PathBuf};
+
+/// Name the skill registers under. Also its directory name in the snapshot.
+const SKILL_NAME: &str = "workflow-creator";
+
+/// The skill's directory inside the pinned registry snapshot.
+fn snapshot_skill_dir() -> PathBuf {
+    Path::new(librefang_runtime::registry_sync::REGISTRY_FIXTURE_DIR)
+        .join("skills")
+        .join(SKILL_NAME)
+}
+
+/// Copy the snapshot's `skills/` tree into a scratch directory.
+///
+/// `SkillRegistry::load_all` writes `skill.toml` and `prompt_context.md` beside a `SKILL.md` it auto-converts, so pointing it at the snapshot in-place would mutate a checked-in fixture.
+fn staged_skills_dir(tmp: &Path) -> PathBuf {
+    let dest = tmp.join("skills").join(SKILL_NAME);
+    std::fs::create_dir_all(&dest).expect("create staged skill dir");
+    for entry in std::fs::read_dir(snapshot_skill_dir()).expect("read snapshot skill dir") {
+        let entry = entry.expect("snapshot dir entry");
+        std::fs::copy(entry.path(), dest.join(entry.file_name())).expect("copy snapshot file");
+    }
+    tmp.join("skills")
+}
+
+/// Write a minimal prompt-only skill so the determinism test has neighbours to be ordered against.
+fn write_neighbour_skill(skills_dir: &Path, name: &str) {
+    let dir = skills_dir.join(name);
+    std::fs::create_dir_all(&dir).expect("create neighbour skill dir");
+    std::fs::write(
+        dir.join("skill.toml"),
+        format!(
+            "prompt_context = \"Body of {name}.\"\n\n[skill]\nname = \"{name}\"\nversion = \"0.1.0\"\ndescription = \"Neighbour skill for ordering\"\n\n[runtime]\ntype = \"promptonly\"\n"
+        ),
+    )
+    .expect("write neighbour manifest");
+}
+
+/// The registry ships this skill as `SKILL.md` and nothing else, and that is load-bearing rather than incidental.
+///
+/// `SkillRegistry::load_all` only auto-converts a `SKILL.md` when the directory has no `skill.toml`.
+/// Adding a `skill.toml` beside it without also writing `prompt_context.md` would load a manifest with no prompt context at all — the entire body of a prompt-only skill silently dropped, with no error anywhere.
+#[test]
+fn workflow_creator_ships_as_a_skill_md_with_no_competing_manifest() {
+    let dir = snapshot_skill_dir();
+    assert!(
+        dir.join("SKILL.md").is_file(),
+        "the snapshot must carry {SKILL_NAME}/SKILL.md at {}",
+        dir.display()
+    );
+    assert!(
+        !dir.join("skill.toml").exists(),
+        "a skill.toml beside SKILL.md suppresses the auto-convert and drops the prompt body; \
+         if structured metadata is genuinely needed, write prompt_context.md as well"
+    );
+}
+
+/// The shipped skill loads, registers under its own name, and arrives as prompt context rather than as a tool.
+///
+/// `load_all` returns `Err` from the load-boundary injection scan, so a body that trips a critical pattern fails here rather than at an operator's install.
+#[test]
+fn workflow_creator_loads_and_registers_as_a_prompt_only_skill() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let skills_dir = staged_skills_dir(tmp.path());
+
+    let mut registry = SkillRegistry::new(skills_dir);
+    let loaded = registry.load_all().expect("the shipped skill must load");
+    assert_eq!(loaded, 1, "exactly the staged skill should load");
+
+    let skill = registry
+        .get(SKILL_NAME)
+        .unwrap_or_else(|| panic!("{SKILL_NAME} must register under its frontmatter name"));
+    assert_eq!(
+        skill.manifest.runtime.runtime_type,
+        SkillRuntime::PromptOnly
+    );
+    assert!(
+        skill.manifest.tools.provided.is_empty(),
+        "a teaching skill must not declare tools of its own — it teaches the builtin workflow_create"
+    );
+
+    let body = skill
+        .manifest
+        .prompt_context
+        .as_deref()
+        .expect("the Markdown body must survive as prompt context");
+    assert!(
+        body.contains("workflow_create"),
+        "the skill exists to teach workflow_create and must name it"
+    );
+    assert!(
+        !skill.manifest.skill.description.is_empty(),
+        "the description lands in the <available_skills> prompt block and must not be empty"
+    );
+}
+
+/// The skill's prompt-facing surface must not depend on the order skills were loaded in (#3298).
+///
+/// Registry order reaches the LLM through `list()` and `all_tool_definitions()`; a reorder across processes invalidates provider prompt caches even when nothing changed.
+/// Both registries below hold identical content and differ only in insertion order.
+#[test]
+fn workflow_creator_prompt_surface_is_deterministic_across_insertion_orders() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let skills_dir = staged_skills_dir(tmp.path());
+    // Names chosen to straddle `workflow-creator` alphabetically, so a registry that
+    // emitted insertion order rather than sorted order would be caught either way.
+    write_neighbour_skill(&skills_dir, "alpha-helper");
+    write_neighbour_skill(&skills_dir, "zeta-helper");
+
+    // `load_all` converts SKILL.md in place, so this also leaves a skill.toml behind
+    // for the by-directory loads below.
+    let mut in_order = SkillRegistry::new(skills_dir.clone());
+    assert_eq!(in_order.load_all().expect("load_all"), 3);
+
+    let mut reversed = SkillRegistry::new(skills_dir.clone());
+    for name in ["zeta-helper", SKILL_NAME, "alpha-helper"] {
+        reversed
+            .load_skill(&skills_dir.join(name))
+            .unwrap_or_else(|e| panic!("load {name}: {e}"));
+    }
+
+    let render = |registry: &SkillRegistry| -> String {
+        registry
+            .list()
+            .iter()
+            .map(|s| {
+                format!(
+                    "{}\n{}\n{}",
+                    s.manifest.skill.name,
+                    s.manifest.skill.description,
+                    s.manifest.prompt_context.as_deref().unwrap_or_default()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n---\n")
+    };
+    assert_eq!(
+        render(&in_order),
+        render(&reversed),
+        "the rendered skill block must be byte-identical across insertion orders (#3298)"
+    );
+    assert_eq!(
+        in_order.list()[1].manifest.skill.name,
+        SKILL_NAME,
+        "sorted emission must place {SKILL_NAME} between its neighbours"
+    );
+    assert_eq!(
+        in_order.all_tool_definitions().len(),
+        reversed.all_tool_definitions().len()
+    );
+}
+
+/// The numbers in the skill's prose must be the numbers `workflow_create` advertises.
+///
+/// The skill teaches ceilings and key names, and prose drifts silently: a model told "at most 50 steps" by a skill and rejected at a different ceiling by the tool burns a turn discovering the difference.
+/// Reading them out of the live tool schema rather than hardcoding them here means a limit change fails this test instead of quietly making the skill wrong.
+#[test]
+fn workflow_creator_prose_matches_the_live_workflow_create_schema() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let skills_dir = staged_skills_dir(tmp.path());
+    let mut registry = SkillRegistry::new(skills_dir);
+    registry.load_all().expect("load_all");
+    let body = registry
+        .get(SKILL_NAME)
+        .expect("skill registered")
+        .manifest
+        .prompt_context
+        .clone()
+        .expect("prompt context");
+
+    let defs = librefang_runtime::tool_runner::builtin_tool_definitions();
+    let schema = defs
+        .iter()
+        .find(|d| d.name == "workflow_create")
+        .expect("workflow_create must be a builtin tool")
+        .input_schema
+        .clone();
+    let steps = &schema["properties"]["steps"];
+
+    for (label, value) in [
+        ("step ceiling", steps["maxItems"].as_u64()),
+        (
+            "per-step timeout ceiling",
+            steps["items"]["properties"]["timeout_secs"]["maximum"].as_u64(),
+        ),
+        (
+            "total timeout ceiling",
+            schema["properties"]["total_timeout_secs"]["maximum"].as_u64(),
+        ),
+    ] {
+        let value = value.unwrap_or_else(|| panic!("{label} must be advertised in the schema"));
+        assert!(
+            body.contains(&value.to_string()),
+            "the skill must quote the live {label} ({value}); it teaches a limit the tool enforces"
+        );
+    }
+
+    // Every step key the skill teaches has to be one the tool actually accepts.
+    let step_props = &steps["items"]["properties"];
+    for key in [
+        "depends_on",
+        "output_var",
+        "error_mode",
+        "required_skills",
+        "session_mode",
+        "inherit_context",
+    ] {
+        assert!(
+            step_props[key].is_object(),
+            "the skill documents step key `{key}`, which workflow_create does not advertise"
+        );
+        assert!(
+            body.contains(key),
+            "step key `{key}` is part of the contract and should be covered by the skill"
+        );
+    }
+
+    assert!(
+        body.contains("param_type"),
+        "input parameters use `param_type`, not `type` — the skill has to say so"
+    );
+}

--- a/docs/src/app/agent/skills/page.mdx
+++ b/docs/src/app/agent/skills/page.mdx
@@ -38,9 +38,9 @@ Skills are installed to `~/.librefang/skills/`. Official skills are available in
 | `prompt_only` | Markdown | N/A | Expert knowledge injected into system prompt. No code execution. |
 | `builtin` | Rust | N/A | Compiled into the binary. For core tools only. |
 
-### 60 Bundled Skills
+### 61 Bundled Skills
 
-LibreFang provides 60 expert knowledge skills available for installation from the dashboard:
+LibreFang provides 61 expert knowledge skills available for installation from the dashboard:
 
 | Category | Skills |
 |----------|--------|
@@ -58,6 +58,7 @@ LibreFang provides 60 expert knowledge skills available for installation from th
 | Collaboration | `slack-tools`, `notion`, `confluence`, `figma-expert` |
 | Career | `interview-prep`, `project-manager` |
 | Advanced | `wasm-expert`, `pdf-reader`, `web-search` |
+| Automation | `workflow-creator` |
 
 These are `prompt_only` skills using the SKILL.md format -- expert knowledge that gets injected into the agent's system prompt.
 

--- a/docs/src/app/zh/agent/skills/page.mdx
+++ b/docs/src/app/zh/agent/skills/page.mdx
@@ -38,9 +38,9 @@
 | `prompt_only` | Markdown | 不适用 | 专家知识注入系统提示词。无代码执行。 |
 | `builtin` | Rust | 不适用 | 编译到二进制文件中。仅用于核心工具。 |
 
-### 60 个内置技能
+### 61 个内置技能
 
-LibreFang 提供 60 个专家知识技能，可从仪表盘安装：
+LibreFang 提供 61 个专家知识技能，可从仪表盘安装：
 
 | 类别 | 技能 |
 |----------|--------|
@@ -58,6 +58,7 @@ LibreFang 提供 60 个专家知识技能，可从仪表盘安装：
 | 协作 | `slack-tools`, `notion`, `confluence`, `figma-expert` |
 | 职业 | `interview-prep`, `project-manager` |
 | 高级 | `wasm-expert`, `pdf-reader`, `web-search` |
+| 自动化 | `workflow-creator` |
 
 这些都是使用 SKILL.md 格式的 `prompt_only` 技能 -- 专家知识会被注入到 Agent 的系统提示词中。
 


### PR DESCRIPTION
Closes #6934

The remaining scope item of #6934 — "PR 2: `workflow-creator` skill". PR 1 merged as #7857; the issue's other two items are listed under **Future** and are untouched here.

## Premise correction: this repo has no bundled-skills directory

Skills are registry content. They ship from [librefang/librefang-registry](https://github.com/librefang/librefang-registry) under `skills/<name>/`, are synced into `~/.librefang/registry/`, and are installed on demand — `registry_sync::fanout_registry_content` says so in as many words ("Skills and plugins stay in registry — users install via dashboard"), and fans out providers, channels, MCP, agent templates and workflow templates but not skills.

The repo-root `skills/` directory that the unmerged #6943 puts its copy of this skill in was deleted in #1212 and is read by nothing on `main`; a `skills/workflow-creator/skill.toml` there would never load. `CONTRIBUTING.md` still pointed authors at that dead `skills/community/` path, which is fixed here.

So the skill itself goes to the registry: **librefang/librefang-registry#105**. What lands in this PR is the copy pinned in the registry snapshot plus the tests that keep it honest — `workflow-creator` is the one registry skill whose subject matter is this codebase, and its prose encodes limits this repo can move.

## Changes

- `crates/librefang-runtime/tests/fixtures/registry/skills/workflow-creator/SKILL.md` — the pinned copy of the shipped skill, and the fixture README's note on why this one entry is present when the other sixty are not.
- `crates/librefang-runtime/tests/workflow_creator_skill.rs` — four tests, below.
- `crates/librefang-runtime/src/tool_runner/definitions.rs` — `workflow_create`'s step schema now advertises `required_skills`, `session_mode` and `inherit_context`, and its `agent` description covers all four `StepAgent` shapes rather than only bare-string and `{"id": …}`.
- `crates/librefang-kernel/src/kernel/handles/workflow_runner.rs` — `the_tool_schema_advertises_the_step_routing_fields_the_spec_accepts`, a drift guard for the above. `STEP_AGENT_ROUTING_KEYS` becomes `pub(crate)` so the test reads the routing keys from their definition rather than restating them.
- `docs/src/app/agent/skills/page.mdx` and its `zh` twin — 60 → 61 bundled skills, new `Automation` row.
- `CONTRIBUTING.md`, changelog fragment.

## Why the schema change is in scope

`WorkflowCreateSpec` deserialises the canonical `WorkflowStep`, so `workflow_create` has always accepted `required_skills` (#7721), the per-step `session_mode`, `inherit_context`, and `{"type": …}` agent routing — none of which its published schema mentioned. A field accepted but unadvertised is a field no model sends, and shipping a skill that documents keys the tool's own schema denies would have been a contradiction inside one deliverable. The new test asserts acceptance and advertisement together, so the two cannot drift apart in either direction.

## Skill content

Written against the implementation, not the issue's sketch of it: the four agent-binding shapes and when each is right, `required_skills` with the three failure classes `RequiredSkillReport` distinguishes, the ceilings `build_created_workflow` enforces, `param_type` rather than `type` on input parameters, and six failure modes with the reason each is rejected — duplicate step names, a dependency on a step that does not exist, an operator node wired into a DAG, a `prompt_template` on a node that ignores the field, `{{input}}` across a fan-out, and treating a registered workflow as private when workflows have no ownership model.

## Verification

- `cargo test -p librefang-runtime --test workflow_creator_skill` — 4/4.
  - `workflow_creator_ships_as_a_skill_md_with_no_competing_manifest` pins the SKILL.md-only layout: `load_all` auto-converts a `SKILL.md` only when no `skill.toml` sits beside it, so adding one without also writing `prompt_context.md` drops the entire prompt body of a prompt-only skill with no error anywhere.
  - `workflow_creator_loads_and_registers_as_a_prompt_only_skill` loads it through `SkillRegistry::load_all` — the same path an operator's install takes, load-boundary prompt-injection scan included.
  - `workflow_creator_prompt_surface_is_deterministic_across_insertion_orders` renders the skill block from two registries holding identical content in opposite insertion orders and asserts byte equality (#3298).
  - `workflow_creator_prose_matches_the_live_workflow_create_schema` reads the step / per-step-timeout / total-timeout ceilings out of `builtin_tool_definitions()` instead of hardcoding them, so moving a limit fails CI rather than quietly making the skill wrong, and cross-checks every step key the skill teaches against the schema.
- `cargo test -p librefang-kernel --lib workflow_runner::tests` — 13/13, including the new drift guard.
- `cargo test -p librefang-api --test skills_routes_test` — 38/38 (the snapshot now seeds one `registry/skills/` entry where it seeded none).
- `cargo test -p librefang-skills --lib registry::tests` — 25/25, `all_tool_definitions_is_deterministic_across_insertion_orders` included.
- `cargo test -p librefang-runtime --lib tool_runner` (442), `--test tool_runner_workflow_write` (18), `--test tool_runner_workflow_readonly` (11).
- `cargo clippy -p librefang-runtime --tests` and `-p librefang-kernel --lib --tests`, both `-D warnings`, clean.

## Notes for review

- **Merge order.** librefang/librefang-registry#105 should land first — the snapshot entry here is a pin of it, and the fixture README's "pinned at commit …" line should be refreshed once it has a SHA.
- **Overlap with #6943.** That PR (@pnavarrete) carries an earlier version of this skill alongside its own `workflow_create`, whose tool half #7857 superseded. Not closing or relabelling it; flagging the overlap so its author can drop the skill commit or close it deliberately.
- No dashboard, route, or i18n changes.