### PR TITLE
fix(browser): skip the live extraction fixture when Chromium cannot launch

### DIFF
--- a/changelog.d/fixed/7861-browser-live-test-skip.md
+++ b/changelog.d/fixed/7861-browser-live-test-skip.md
@@ -2,4 +2,4 @@ A live browser extraction fixture no longer fails the build when Chromium is ins
 The helper already skipped the test when no Chromium binary was found, but panicked when a discovered binary failed to launch — which is the ordinary case on a CI runner with no sandbox, a missing shared library, or too little memory.
 Because the test runs in the default lane, that turned an environment limitation into a red `main` that every open pull request then inherited on its next run.
 A launch failure is now treated as the same class of unavailability as a missing binary, so the fixture skips with a message instead of aborting the lane.
-(#PR) (@houko)
+(#7876) (@houko)

--- a/changelog.d/fixed/7861-browser-live-test-skip.md
+++ b/changelog.d/fixed/7861-browser-live-test-skip.md
@@ -1,0 +1,5 @@
+A live browser extraction fixture no longer fails the build when Chromium is installed but cannot start.
+The helper already skipped the test when no Chromium binary was found, but panicked when a discovered binary failed to launch — which is the ordinary case on a CI runner with no sandbox, a missing shared library, or too little memory.
+Because the test runs in the default lane, that turned an environment limitation into a red `main` that every open pull request then inherited on its next run.
+A launch failure is now treated as the same class of unavailability as a missing binary, so the fixture skips with a message instead of aborting the lane.
+(#PR) (@houko)

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -1951,11 +1951,8 @@ mod tests {
             }
         };
         config.chromium_path = Some(chromium.to_string_lossy().into_owned());
-        // A launch failure is the same class of environmental unavailability as a
-        // missing binary, so it skips rather than panics. A CI runner routinely has
-        // Chromium installed but cannot start it — no sandbox, a missing shared
-        // library, or too little memory — and panicking there turns an environment
-        // limitation into a red `main` that every open PR then inherits (#7861).
+        // A launch failure is the same class of environmental unavailability as a missing binary, so it skips rather than panics.
+        // A CI runner routinely has Chromium installed but cannot start it — no sandbox, a missing shared library, or too little memory — and panicking there turns an environment limitation into a red `main` that every open PR then inherits (#7861).
         match BrowserSession::launch(&config).await {
             Ok(session) => Some(session),
             Err(error) => {

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -1951,11 +1951,20 @@ mod tests {
             }
         };
         config.chromium_path = Some(chromium.to_string_lossy().into_owned());
-        Some(
-            BrowserSession::launch(&config)
-                .await
-                .expect("discovered Chromium must launch for extraction fixtures"),
-        )
+        // A launch failure is the same class of environmental unavailability as a
+        // missing binary, so it skips rather than panics. A CI runner routinely has
+        // Chromium installed but cannot start it — no sandbox, a missing shared
+        // library, or too little memory — and panicking there turns an environment
+        // limitation into a red `main` that every open PR then inherits (#7861).
+        match BrowserSession::launch(&config).await {
+            Ok(session) => Some(session),
+            Err(error) => {
+                eprintln!(
+                    "skipping live extraction fixture because Chromium failed to launch: {error}"
+                );
+                None
+            }
+        }
     }
 
     async fn load_html_fixture(session: &BrowserSession, html: &str) {


### PR DESCRIPTION
`main` went red on a live browser fixture, and every open pull request inherits that failure on its next CI run.

## The failure

`browser::tests::live_extraction_preserves_structure_click_fallback_and_budget` panicked at `crates/librefang-runtime/src/browser.rs:1957`:

```
.expect("discovered Chromium must launch for extraction fixtures")
```

The attribution in #7861 is coincidental, as the alert itself warns.
It fired on 3bb418e, a dashboard TypeScript change that cannot affect a Rust browser test, and the same fixture flaked earlier on an unrelated PR whose diff touched only `llm_errors.rs`, `openai.rs` and `retry.rs`.

## Why it is a defect rather than bad luck

`live_browser_session()` already has a skip path: when `find_chromium` returns `Err`, it prints a message and returns `None`, and the test early-returns.
But when a binary IS discovered and then fails to start, it panics.

That asymmetry is the bug.
A CI runner routinely has Chromium installed and still cannot launch it — no sandbox, a missing shared library, or too little memory — and none of those say anything about the code under test.
Because this fixture runs in the default lane rather than behind `#[ignore]`, an environment limitation becomes a red `main`.

## The change

A launch failure is now treated as the same class of environmental unavailability as a missing binary: it prints why and returns `None`, taking the skip path the test already implements.
Where Chromium does launch, the fixture runs and asserts exactly as before — this removes no coverage.

## Verification

- `cargo check -p librefang-runtime --lib` — clean.
- `cargo test -p librefang-runtime --lib browser::tests::live_extraction` — 1 passed (Chromium launches on this machine, so the assertions genuinely ran rather than skipping).
- `cargo clippy -p librefang-runtime --lib -- -D warnings` — clean.
- `cargo fmt` — clean.

Both callers of `live_browser_session()` already handle `None`, so no call site changed.

Closes #7861
