### PR TITLE
feat(workflow): record run owner and roll spawned-worker spend up

### DIFF
--- a/changelog.d/added/7878-workflow-run-owner-attribution.md
+++ b/changelog.d/added/7878-workflow-run-owner-attribution.md
@@ -1,0 +1,8 @@
+Workflow runs now record which agent asked for them, and a spawned worker's spend rolls up to the agent that spawned it.
+  Before this, a workflow started by an agent was indistinguishable from one an operator started by hand, and a step agent resolved from a `type` reference billed every owner's work to itself — so two teams sharing one `researcher` type had no way to tell their spend apart.
+  Ownership is recorded on the *run* rather than on the executing agent, because find-or-spawn deliberately resolves a type to one shared canonical instance; attaching ownership to that instance would have made the second owner's runs report the first owner's.
+  The owner is stamped once at creation and carried forward by resume and re-run, so re-running someone else's workflow does not silently transfer it to you.
+  Billing is a second column rather than a rewrite of the existing one, which keeps quota enforcement pointed at the agent that actually made the call — attribution and enforcement stay independent, and per-agent limits behave exactly as before.
+  The proposed `fresh = true` step flag is deliberately not part of this: per-step `session_mode = "new"` already isolates a step from a shared agent's history, and owner attribution already separates spend, so an extra agent instance per run would have bought only registry growth.
+  See `docs/architecture/workflow-run-attribution.md`.
+  (#7878) (@houko)

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1295,7 +1295,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         msg
     }
 
-    async fn run_workflow_text(&self, name: &str, input: &str) -> String {
+    async fn run_workflow_text(&self, name: &str, input: &str, owner: Option<AgentId>) -> String {
         let workflows = self.kernel.workflow_engine().list_workflows().await;
         let wf = match workflows.iter().find(|w| w.name.eq_ignore_ascii_case(name)) {
             Some(w) => w.clone(),
@@ -1305,7 +1305,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         let run_id = match self
             .kernel
             .workflow_engine()
-            .create_run(wf.id, input.to_string())
+            .create_run_owned(wf.id, input.to_string(), owner)
             .await
         {
             Some(id) => id,

--- a/crates/librefang-api/src/routes/workflows/workflow.rs
+++ b/crates/librefang-api/src/routes/workflows/workflow.rs
@@ -768,6 +768,11 @@ pub async fn get_workflow_run(
                 "error": run.error,
                 "started_at": run.started_at.to_rfc3339(),
                 "completed_at": run.completed_at.map(|t| t.to_rfc3339()),
+                // #7714: the agent that asked for this run, `null` when an
+                // operator started it. Recording ownership is only useful if
+                // something can read it back, and this is the one endpoint
+                // that renders a single run in full.
+                "owner_agent_id": run.owner_agent_id.map(|a| a.to_string()),
                 "step_results": run.step_results.iter().map(|s| serde_json::json!({
                     "step_name": s.step_name,
                     "agent_id": s.agent_id,
@@ -814,8 +819,11 @@ pub async fn rerun_workflow_run(
 
     let engine = state.kernel.workflow_engine();
     // Read the workflow + input off the stored run rather than trusting the caller, so a re-run is always a faithful repeat of what executed.
-    let (workflow_id, input) = match engine.get_run(run_id).await {
-        Some(run) => (run.workflow_id, run.input),
+    // #7714: the owner is copied off the original run rather than re-derived.
+    // A re-run is a repeat of the same work on the same owner's behalf, and
+    // the operator who pressed re-run is not that owner.
+    let (workflow_id, input, owner) = match engine.get_run(run_id).await {
+        Some(run) => (run.workflow_id, run.input, run.owner_agent_id),
         None => {
             return ApiErrorResponse::not_found(format!("Run '{run_id}' not found"))
                 .into_json_tuple();
@@ -823,7 +831,7 @@ pub async fn rerun_workflow_run(
     };
 
     // `create_run` returns None when the workflow definition is gone (e.g. it was deleted after the original run); surface that as a 404.
-    let new_run_id = match engine.create_run(workflow_id, input).await {
+    let new_run_id = match engine.create_run_owned(workflow_id, input, owner).await {
         Some(rid) => rid,
         None => {
             return ApiErrorResponse::not_found(format!(

--- a/crates/librefang-api/tests/workflow_lifecycle_test.rs
+++ b/crates/librefang-api/tests/workflow_lifecycle_test.rs
@@ -701,6 +701,89 @@ async fn rerun_workflow_run_starts_new_run_with_same_input() {
     assert_eq!(detail["workflow_id"].as_str(), Some(wf_id_str.as_str()));
 }
 
+/// #7714: a re-run repeats the same work on the same owner's behalf, so it
+/// inherits the original run's owner rather than becoming ownerless (or
+/// picking up the operator who pressed the button, who is not the owner).
+#[tokio::test(flavor = "multi_thread")]
+async fn rerun_workflow_run_inherits_the_original_runs_owner() {
+    use librefang_kernel::workflow::WorkflowId;
+    use librefang_types::agent::AgentId;
+
+    let h = boot().await;
+    let wf_id_str = create_workflow(&h).await;
+    let wf_id = WorkflowId(wf_id_str.parse().unwrap());
+    let engine = h.state.kernel.workflow_engine();
+
+    let owner = AgentId::new();
+    let original = engine
+        .create_run_owned(wf_id, "owned params".to_string(), Some(owner))
+        .await
+        .expect("create owned run");
+
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/workflows/runs/{original}/rerun"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{body:?}");
+    let new_id = body["run_id"].as_str().expect("run_id in body").to_string();
+
+    // Asserted over HTTP, because the owner is only useful if a client can
+    // read it back off the run.
+    let (status, detail) = get(&h, &format!("/api/workflows/runs/{new_id}")).await;
+    assert_eq!(status, StatusCode::OK, "{detail:?}");
+    assert_eq!(
+        detail["owner_agent_id"].as_str(),
+        Some(owner.to_string().as_str()),
+        "the re-run must carry the original owner forward: {detail:?}"
+    );
+    assert_eq!(detail["input"].as_str(), Some("owned params"));
+
+    // The original is untouched and still reports the same owner.
+    let (status, original_detail) = get(&h, &format!("/api/workflows/runs/{original}")).await;
+    assert_eq!(status, StatusCode::OK, "{original_detail:?}");
+    assert_eq!(
+        original_detail["owner_agent_id"].as_str(),
+        Some(owner.to_string().as_str())
+    );
+}
+
+/// #7714: an ownerless run re-runs as ownerless. The re-run path must not
+/// invent an owner for a run that never had one.
+#[tokio::test(flavor = "multi_thread")]
+async fn rerun_of_an_ownerless_run_stays_ownerless() {
+    use librefang_kernel::workflow::WorkflowId;
+
+    let h = boot().await;
+    let wf_id_str = create_workflow(&h).await;
+    let wf_id = WorkflowId(wf_id_str.parse().unwrap());
+    let engine = h.state.kernel.workflow_engine();
+
+    let original = engine
+        .create_run(wf_id, "operator params".to_string())
+        .await
+        .expect("create ownerless run");
+
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/workflows/runs/{original}/rerun"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{body:?}");
+    let new_id = body["run_id"].as_str().expect("run_id in body").to_string();
+
+    let (status, detail) = get(&h, &format!("/api/workflows/runs/{new_id}")).await;
+    assert_eq!(status, StatusCode::OK, "{detail:?}");
+    assert!(
+        detail["owner_agent_id"].is_null(),
+        "an operator re-run of an ownerless run must stay ownerless: {detail:?}"
+    );
+}
+
 /// Re-running a run id that does not exist is a 404.
 #[tokio::test(flavor = "multi_thread")]
 async fn rerun_unknown_run_returns_404() {

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -407,7 +407,18 @@ pub trait ChannelBridgeHandle: Send + Sync {
     }
 
     /// Run a workflow by name with the given input text.
-    async fn run_workflow_text(&self, _name: &str, _input: &str) -> String {
+    ///
+    /// `owner` is the agent currently bound to the channel and chat the
+    /// command arrived on, when one is bound. The kernel records it as the
+    /// run's owner (#7714), which is what keeps two channels driving the same
+    /// workflow — and therefore the same shared step-agent type — attributable
+    /// to different agents. `None` when no agent is selected for the channel.
+    async fn run_workflow_text(
+        &self,
+        _name: &str,
+        _input: &str,
+        _owner: Option<AgentId>,
+    ) -> String {
         "Workflows not available.".to_string()
     }
 
@@ -7113,7 +7124,12 @@ async fn handle_command(
                 } else {
                     String::new()
                 };
-                handle.run_workflow_text(wf_name, &input).await
+                // #7714: a channel `/workflow run` is owned by the agent bound
+                // to that channel, the same binding every other command in
+                // this dispatcher resolves through.
+                handle
+                    .run_workflow_text(wf_name, &input, resolve_for_command())
+                    .await
             } else {
                 "Usage: /workflow run <name> [input]".to_string()
             }

--- a/crates/librefang-kernel-handle/src/workflow_runner.rs
+++ b/crates/librefang-kernel-handle/src/workflow_runner.rs
@@ -228,6 +228,30 @@ pub trait WorkflowRunner: Send + Sync {
         Err(KernelOpError::unavailable("Workflow engine"))
     }
 
+    /// Owner-aware variant of [`Self::run_workflow`] (#7714).
+    ///
+    /// `caller_agent_id` is the agent that invoked the `workflow_run` tool.
+    /// The kernel records it on the run as the run's owner, which is what lets
+    /// two owners drive the same shared step-agent type and still keep their
+    /// attribution apart.
+    ///
+    /// `&str` rather than `AgentId` for trait-object compatibility, matching
+    /// [`Self::start_workflow_async_tracked`]; the kernel parses it and treats
+    /// an unparseable or absent value as an ownerless run.
+    ///
+    /// The default impl forwards to [`Self::run_workflow`] and drops the
+    /// owner, so an implementor that has not adopted ownership keeps its
+    /// current behaviour.
+    async fn run_workflow_owned(
+        &self,
+        workflow_id: &str,
+        input: &str,
+        caller_agent_id: Option<&str>,
+    ) -> Result<(String, String), KernelOpError> {
+        let _ = caller_agent_id;
+        self.run_workflow(workflow_id, input).await
+    }
+
     /// List all registered workflow definitions, sorted by name for determinism.
     async fn list_workflows(&self) -> Vec<WorkflowSummary> {
         Vec::new()

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -15,6 +15,27 @@ use super::*;
 use crate::kernel::llm_drivers::resolve_effective_fallbacks;
 use crate::MeteringSubsystemApi;
 
+/// The agent a call's cost rolls up to (#7714).
+///
+/// A worker spawned by another agent spends on its spawner's behalf, so the
+/// spawner needs that cost on its own budget line rather than scattered
+/// across throwaway children it cannot enumerate. A top-level agent has no
+/// parent and bills to itself, which is the pre-#7714 behaviour for every
+/// agent.
+///
+/// This deliberately does **not** touch the quota subject. `UsageRecord::agent_id`
+/// stays the executing agent at every write site, so the pre-call
+/// `check_quota(agent_id, &entry.manifest.resources)` and the post-call
+/// `check_all_and_record(&record, &manifest.resources, ..)` keep asking about
+/// the same agent against that same agent's ceiling. Re-pointing `agent_id`
+/// at the parent instead would have made the pre-call check read the child's
+/// spend and the post-call check read the parent's, both compared against the
+/// child's limits — attribution and enforcement have to stay independent
+/// dimensions.
+pub(crate) fn billed_agent_for(entry: &AgentEntry) -> AgentId {
+    entry.parent.unwrap_or(entry.id)
+}
+
 /// Detect + strip the cron `[SILENT]` marker at the start of a message.
 ///
 /// Returns `(message_for_llm, is_silent)`.
@@ -1468,6 +1489,11 @@ impl LibreFangKernel {
             user_id: billed_user_id,
             channel: attribution_channel.clone(),
             session_id: Some(effective_session_id),
+            // #7714: a step agent (or any spawned worker) bills its spend to
+            // the agent that spawned it, so the spawner keeps budget
+            // visibility over work done on its behalf. `agent_id` above is
+            // untouched and remains the quota subject — see `billed_agent_for`.
+            billed_agent_id: Some(billed_agent_for(entry)),
         };
         if let Err(e) = self.metering.engine.check_all_and_record(
             &usage_record,
@@ -1610,5 +1636,42 @@ mod silent_marker_tests {
             strip_silent_cron_marker("[SILENT] note: keep this [SILENT] tag literal", true);
         assert_eq!(out, "note: keep this [SILENT] tag literal");
         assert!(silent);
+    }
+}
+
+#[cfg(test)]
+mod billing_attribution_tests {
+    use super::billed_agent_for;
+    use librefang_types::agent::{AgentEntry, AgentId};
+
+    fn entry_with_parent(parent: Option<AgentId>) -> AgentEntry {
+        AgentEntry {
+            id: AgentId::new(),
+            name: "worker".to_string(),
+            parent,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_top_level_agent_bills_to_itself() {
+        // #7714: no parent means no rollup — this is the pre-#7714 behaviour
+        // for every agent, and must stay untouched.
+        let entry = entry_with_parent(None);
+        assert_eq!(billed_agent_for(&entry), entry.id);
+    }
+
+    #[test]
+    fn a_spawned_worker_bills_to_its_spawner() {
+        // The whole point of the column: a worker spends on its spawner's
+        // behalf, so the cost belongs on the spawner's budget line.
+        let parent = AgentId::new();
+        let entry = entry_with_parent(Some(parent));
+        assert_eq!(billed_agent_for(&entry), parent);
+        assert_ne!(
+            billed_agent_for(&entry),
+            entry.id,
+            "a parented worker must not also bill to itself"
+        );
     }
 }

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -210,8 +210,21 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
         workflow_id: &str,
         input: &str,
     ) -> Result<(String, String), kernel_handle::KernelOpError> {
+        // Fully qualified: `LibreFangKernel` also has an inherent
+        // `run_workflow_owned` taking a typed `WorkflowId`, which would
+        // otherwise win method resolution here.
+        kernel_handle::WorkflowRunner::run_workflow_owned(self, workflow_id, input, None).await
+    }
+
+    async fn run_workflow_owned(
+        &self,
+        workflow_id: &str,
+        input: &str,
+        caller_agent_id: Option<&str>,
+    ) -> Result<(String, String), kernel_handle::KernelOpError> {
         use crate::workflow::WorkflowId;
         use kernel_handle::KernelOpError;
+        use librefang_types::agent::AgentId;
 
         // Try parsing as UUID first, then fall back to name lookup.
         let wf_id = if let Ok(uuid) = uuid::Uuid::parse_str(workflow_id) {
@@ -233,14 +246,19 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
         // The nesting cap in `LibreFangKernel::run_workflow` raises `CapabilityDenied`, and folding it into `Internal` here would deliver it to `tool_workflow_run` as an opaque upstream failure — a 5xx-class shape that reads as a downstream crash and invites retry, which is exactly the confusion the comment in `tool_agent_send` argues against.
         // `KernelOpError` *is* `LibreFangError`, so the variant survives verbatim.
         // Everything else keeps the historical stringified `Internal` shape, including its prefix.
-        let (run_id, output) = LibreFangKernel::run_workflow(self, wf_id, input.to_string())
-            .await
-            .map_err(|e| match e {
-                crate::error::KernelError::LibreFang(
-                    librefang_types::error::LibreFangError::CapabilityDenied(msg),
-                ) => KernelOpError::CapabilityDenied(msg),
-                other => KernelOpError::Internal(format!("Workflow execution failed: {other}")),
-            })?;
+        // #7714: an unparseable caller id degrades to an ownerless run rather
+        // than failing the call — the run is still worth executing, it just
+        // carries no attribution.
+        let owner = caller_agent_id.and_then(|raw| raw.parse::<AgentId>().ok());
+        let (run_id, output) =
+            LibreFangKernel::run_workflow_owned(self, wf_id, input.to_string(), owner)
+                .await
+                .map_err(|e| match e {
+                    crate::error::KernelError::LibreFang(
+                        librefang_types::error::LibreFangError::CapabilityDenied(msg),
+                    ) => KernelOpError::CapabilityDenied(msg),
+                    other => KernelOpError::Internal(format!("Workflow execution failed: {other}")),
+                })?;
 
         Ok((run_id.to_string(), output))
     }
@@ -431,10 +449,16 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
                 })?
         };
 
+        // #7714: the tracker already parses `caller_agent_id` below for its
+        // own registration, but it does so only when BOTH ids are present.
+        // Ownership must not inherit that condition: a `workflow_start` with a
+        // caller agent and no session is still owned by that agent, so parse it
+        // independently here.
+        let owner = caller_agent_id.and_then(|raw| raw.parse::<AgentId>().ok());
         let run_id = self
             .workflows
             .engine
-            .create_run(wf_id, input.to_string())
+            .create_run_owned(wf_id, input.to_string(), owner)
             .await
             .ok_or_else(|| KernelOpError::Internal("Workflow not found".to_string()))?;
 

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -811,6 +811,9 @@ impl LibreFangKernel {
             user_id: billed_user_id,
             channel: None,
             session_id: None,
+            // #7714: an ephemeral turn on a spawned worker still spends on
+            // its spawner's behalf, so it rolls up the same way as a full turn.
+            billed_agent_id: Some(crate::kernel::agent_execution::billed_agent_for(&entry)),
         };
         if let Err(e) = self.metering.engine.check_all_and_record(
             &usage_record,
@@ -2801,6 +2804,10 @@ impl LibreFangKernel {
         // Use `effective_owner` (already null for forks, computed above) NOT the raw owner, so a sub-agent's spend is not mis-attributed to the parent turn's user.
         // Snapshot into a Copy local before the spawn moves it into the task.
         let billed_user_id: Option<UserId> = effective_owner.or(attribution_user_id);
+        // #7714: resolved here, before the spawn, so the async block moves a
+        // plain `AgentId` instead of borrowing the registry entry across the
+        // task boundary. Mirrors how `billed_user_id` is captured above.
+        let billed_agent_id = crate::kernel::agent_execution::billed_agent_for(&entry);
 
         // `loop_opts` is already a local — the spawned async move will
         // capture it. Agent loop reads these at each turn-end / save /
@@ -3205,6 +3212,8 @@ impl LibreFangKernel {
                         user_id: billed_user_id,
                         channel: attribution_channel.clone(),
                         session_id: Some(effective_session_id),
+                        // #7714: same rollup as the non-streaming path.
+                        billed_agent_id: Some(billed_agent_id),
                     };
                     if let Err(e) = kernel_clone.metering.engine.check_all_and_record(
                         &usage_record,

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -1259,6 +1259,19 @@ impl LibreFangKernel {
                 user_id: None,
                 channel: Some("system".to_string()),
                 session_id: None,
+                // #7714: the review is charged to the triggering agent, so it
+                // rolls up to that agent's spawner for the same reason its own
+                // turns do. Resolved through the registry because this site
+                // holds an id rather than the entry; an agent that has since
+                // been killed bills to itself.
+                billed_agent_id: Some(
+                    kernel
+                        .agents
+                        .registry
+                        .get(triggering_agent_id)
+                        .and_then(|e| e.parent)
+                        .unwrap_or(triggering_agent_id),
+                ),
             };
             if let Err(e) = kernel.metering.engine.record(&usage_record) {
                 tracing::debug!(error = %e, "Failed to record background review usage");

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -1236,6 +1236,22 @@ impl LibreFangKernel {
         workflow_id: WorkflowId,
         input: String,
     ) -> KernelResult<(WorkflowRunId, String)> {
+        self.run_workflow_owned(workflow_id, input, None).await
+    }
+
+    /// [`Self::run_workflow`], recording `owner` as the run's owning agent (#7714).
+    ///
+    /// `owner` is the agent that invoked the `workflow_run` tool. It is
+    /// stamped on the run at creation and never reassigned, so the resume and
+    /// operator-action paths carry it forward rather than re-deriving it from
+    /// whoever resumed. `None` produces an ownerless run, which is what an
+    /// operator-initiated run is.
+    pub async fn run_workflow_owned(
+        &self,
+        workflow_id: WorkflowId,
+        input: String,
+        owner: Option<AgentId>,
+    ) -> KernelResult<(WorkflowRunId, String)> {
         let cfg = self.config.load_full();
 
         // Bound nested workflow runs (refs #6659).
@@ -1264,7 +1280,7 @@ impl LibreFangKernel {
         let run_id = self
             .workflows
             .engine
-            .create_run(workflow_id, input)
+            .create_run_owned(workflow_id, input, owner)
             .await
             .ok_or_else(|| {
                 KernelError::LibreFang(LibreFangError::Internal("Workflow not found".to_string()))

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -353,6 +353,16 @@ pub enum StepAgent {
     /// agent-template directories and spawned top-level under the canonical
     /// name-derived UUID (#4614), so a workflow can express "use the
     /// researcher agent type" without the operator pre-registering one.
+    ///
+    /// **There is deliberately no `fresh` variant** that would spawn a
+    /// throwaway instance per run (#7714).
+    /// To isolate a step from the type's prior context, set
+    /// [`WorkflowStep::session_mode`] to `New` — that mints a fresh session
+    /// for the invocation without minting a second agent, workspace and
+    /// registry entry per run.
+    /// To keep two owners' spend apart on a shared type, that is what
+    /// `WorkflowRun::owner_agent_id` and `UsageRecord::billed_agent_id` are
+    /// for. See `docs/architecture/workflow-run-attribution.md`.
     ByType {
         #[serde(rename = "type")]
         template: String,
@@ -1300,6 +1310,18 @@ pub struct WorkflowRun {
     /// same `{{input}}` it would have seen.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub paused_current_input: Option<String>,
+    /// The agent that asked for this run (#7714).
+    ///
+    /// Set from the caller of the `workflow_run` / `workflow_start` tools, from the agent bound to the channel that issued a `/workflow` command, or from an API caller that named one.
+    /// `None` for an operator-initiated run with no calling agent.
+    ///
+    /// This is a property of the *run*, deliberately not of the agent that executes a step.
+    /// A `ByType` step resolves find-or-spawn to one shared canonical instance (`kernel::step_agent::find_or_spawn_agent_type`), so that agent is the same object for every owner that references the type; hanging ownership off it would make the second owner's runs report the first owner's.
+    /// Keeping the owner on the run is what lets two owners drive the same agent type and still keep their attribution apart.
+    ///
+    /// Set once at creation and never reassigned: resume and operator-action paths carry the original run's owner forward rather than re-deriving it from whoever resumed the run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_agent_id: Option<AgentId>,
 }
 
 impl WorkflowRun {
@@ -2402,6 +2424,26 @@ impl WorkflowEngine {
         workflow_id: WorkflowId,
         input: String,
     ) -> Option<WorkflowRunId> {
+        self.create_run_owned(workflow_id, input, None).await
+    }
+
+    /// Start a workflow run owned by a specific agent (#7714).
+    ///
+    /// `owner` is the agent that asked for the run — the caller of the
+    /// `workflow_run` / `workflow_start` tools, the agent bound to the channel
+    /// that issued the command, or an agent an API caller named. It is
+    /// recorded on the run and never reassigned, so the resume and
+    /// operator-action paths carry it forward instead of re-deriving it from
+    /// whoever happened to resume.
+    ///
+    /// [`Self::create_run`] is the ownerless form and is what an
+    /// operator-initiated run uses.
+    pub async fn create_run_owned(
+        &self,
+        workflow_id: WorkflowId,
+        input: String,
+        owner: Option<AgentId>,
+    ) -> Option<WorkflowRunId> {
         let workflow = self.workflows.read().await.get(&workflow_id)?.clone();
         let run_id = WorkflowRunId::new();
 
@@ -2420,6 +2462,7 @@ impl WorkflowEngine {
             paused_step_index: None,
             paused_variables: BTreeMap::new(),
             paused_current_input: None,
+            owner_agent_id: owner,
         };
 
         // Persist the freshly-created Pending row before it goes into
@@ -7002,6 +7045,7 @@ fn workflow_run_to_row(run: &WorkflowRun) -> WorkflowRunRow {
         started_at: run.started_at.to_rfc3339(),
         completed_at: run.completed_at.map(|dt| dt.to_rfc3339()),
         created_at: run.started_at.to_rfc3339(),
+        owner_agent_id: run.owner_agent_id.map(|a| a.to_string()),
     }
 }
 
@@ -7122,6 +7166,24 @@ fn row_to_workflow_run(row: &WorkflowRunRow) -> Result<WorkflowRun, String> {
         paused_step_index: row.paused_step_index.map(|i| i as usize),
         paused_variables,
         paused_current_input: row.paused_current_input.clone(),
+        // #7714: a malformed owner is dropped rather than failing the whole
+        // reload. Recovering a run without its attribution is a strictly
+        // better outcome than refusing to recover it at all, and the run is
+        // then indistinguishable from a legitimately ownerless one.
+        owner_agent_id: row.owner_agent_id.as_deref().and_then(|raw| {
+            match raw.parse::<AgentId>() {
+                Ok(id) => Some(id),
+                Err(e) => {
+                    warn!(
+                        run_id = %row.id,
+                        owner = %raw,
+                        error = %e,
+                        "row_to_workflow_run: owner_agent_id failed to parse; reloading run as ownerless"
+                    );
+                    None
+                }
+            }
+        }),
     })
 }
 
@@ -10382,6 +10444,7 @@ prompt_template = "do {{x}}"
             paused_step_index: None,
             paused_variables: BTreeMap::new(),
             paused_current_input: None,
+            owner_agent_id: None,
         }
     }
 
@@ -10448,6 +10511,7 @@ prompt_template = "do {{x}}"
             paused_step_index: None,
             paused_variables: BTreeMap::new(),
             paused_current_input: None,
+            owner_agent_id: None,
         };
         let running_id = running.id;
 
@@ -11020,6 +11084,181 @@ prompt_template = "do {{x}}"
             other => panic!("expected Paused after reload, got {:?}", other),
         }
         assert_eq!(run.paused_step_index, Some(0));
+    }
+
+    /// #7714: the mechanism the "no `fresh` variant" decision leans on.
+    ///
+    /// `fresh = true` was proposed to isolate a `ByType` step from the
+    /// canonical instance's cross-run history. Per-step `session_mode`
+    /// (#7862) already does that, so the flag was declined — see
+    /// `docs/architecture/workflow-run-attribution.md`. That makes the
+    /// forwarding of `session_mode` to the step executor load-bearing for a
+    /// decision, not merely a feature: if it silently stopped reaching the
+    /// executor, the declined alternative would become necessary again.
+    #[tokio::test]
+    async fn per_step_session_mode_reaches_the_executor_for_a_shared_type() {
+        use std::sync::Mutex;
+
+        let engine = WorkflowEngine::new();
+        let mut wf = test_workflow();
+        wf.steps.truncate(1);
+        wf.steps[0].agent = StepAgent::ByType {
+            template: "researcher".to_string(),
+        };
+        // Isolate this step from whatever the shared canonical instance has
+        // been doing for every other run.
+        wf.steps[0].session_mode = Some(SessionMode::New);
+        let wf_id = engine.register(wf).await;
+
+        let run_id = engine
+            .create_run(wf_id, "input".to_string())
+            .await
+            .expect("create_run must succeed");
+
+        let seen: Arc<Mutex<Vec<Option<SessionMode>>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_for_closure = seen.clone();
+        let sender = move |_id: AgentId, msg: String, sm: Option<SessionMode>| {
+            let seen = seen_for_closure.clone();
+            async move {
+                seen.lock().unwrap().push(sm);
+                Ok((format!("ok: {msg}"), 1u64, 1u64))
+            }
+        };
+
+        engine
+            .execute_run(run_id, mock_resolver, sender)
+            .await
+            .expect("run must complete");
+
+        let observed = seen.lock().unwrap().clone();
+        assert_eq!(
+            observed.len(),
+            1,
+            "the single step must have dispatched once"
+        );
+        assert_eq!(
+            observed[0],
+            Some(SessionMode::New),
+            "the per-step session_mode must reach the executor; without it a \
+             `ByType` step cannot be isolated from the shared instance's history \
+             and the declined `fresh = true` flag would be needed after all"
+        );
+    }
+
+    /// #7714: an operator-initiated run has no calling agent, so `create_run`
+    /// must leave the run ownerless rather than inventing an owner.
+    #[tokio::test]
+    async fn create_run_leaves_the_run_ownerless() {
+        let engine = WorkflowEngine::new();
+        let wf_id = engine.register(test_workflow()).await;
+        let run_id = engine
+            .create_run(wf_id, "data".to_string())
+            .await
+            .expect("create_run must succeed");
+
+        let run = engine.get_run(run_id).await.unwrap();
+        assert_eq!(
+            run.owner_agent_id, None,
+            "the ownerless entry point must not synthesize an owner"
+        );
+    }
+
+    /// #7714: the owner recorded at creation must survive the round trip
+    /// through SQLite, because the paths that read it back (resume, re-run,
+    /// billing rollup) run against a reloaded run after a daemon restart.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn owner_round_trips_through_the_store() {
+        use r2d2::Pool;
+        use r2d2_sqlite::SqliteConnectionManager;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("workflows.db");
+        let make_store = || {
+            let pool = Pool::builder()
+                .max_size(2)
+                .build(SqliteConnectionManager::file(&db_path))
+                .unwrap();
+            librefang_memory::migration::run_migrations(&pool.get().unwrap())
+                .expect("migrations must apply");
+            librefang_memory::WorkflowStore::new(pool)
+        };
+
+        let owner = AgentId::new();
+        let run_id: WorkflowRunId;
+        {
+            let engine = WorkflowEngine::new_with_store(make_store(), tmp.path());
+            let wf_id = engine.register(test_workflow()).await;
+            run_id = engine
+                .create_run_owned(wf_id, "data".to_string(), Some(owner))
+                .await
+                .expect("create_run_owned must succeed");
+            assert_eq!(
+                engine.get_run(run_id).await.unwrap().owner_agent_id,
+                Some(owner),
+                "the owner must be visible on the in-memory run immediately"
+            );
+        }
+
+        let engine = WorkflowEngine::new_with_store(make_store(), tmp.path());
+        tokio::task::block_in_place(|| engine.load_runs()).expect("load_runs must succeed");
+        let reloaded = engine
+            .get_run(run_id)
+            .await
+            .expect("the run must be reloadable");
+        assert_eq!(
+            reloaded.owner_agent_id,
+            Some(owner),
+            "the owner must survive the SQLite round trip"
+        );
+    }
+
+    /// #7714: the core attribution guarantee.
+    ///
+    /// A `ByType` step resolves find-or-spawn to a single canonical instance
+    /// shared by every owner that references the type, so the executing agent
+    /// cannot carry ownership. Two owners running that same type must still
+    /// come back attributed to themselves — which is exactly what keeping the
+    /// owner on the *run* rather than on the agent buys.
+    #[tokio::test]
+    async fn two_owners_running_the_same_agent_type_keep_separate_attribution() {
+        let engine = WorkflowEngine::new();
+        let mut wf = test_workflow();
+        // A shared step-agent type, the case the guarantee is about.
+        wf.steps[0].agent = StepAgent::ByType {
+            template: "researcher".to_string(),
+        };
+        let wf_id = engine.register(wf).await;
+
+        let alice = AgentId::new();
+        let bob = AgentId::new();
+        let alice_run = engine
+            .create_run_owned(wf_id, "alice input".to_string(), Some(alice))
+            .await
+            .expect("alice run must be created");
+        let bob_run = engine
+            .create_run_owned(wf_id, "bob input".to_string(), Some(bob))
+            .await
+            .expect("bob run must be created");
+
+        assert_ne!(alice_run, bob_run, "each owner gets a distinct run");
+        assert_eq!(
+            engine.get_run(alice_run).await.unwrap().owner_agent_id,
+            Some(alice)
+        );
+        assert_eq!(
+            engine.get_run(bob_run).await.unwrap().owner_agent_id,
+            Some(bob),
+            "the second owner's run must report the second owner, not the first"
+        );
+
+        // The step agent itself is deliberately shared: a canonical instance
+        // per type. If this ever stops holding, ownership-on-the-run is no
+        // longer load-bearing and this test should be revisited alongside it.
+        let step = &engine.get_workflow(wf_id).await.unwrap().steps[0];
+        assert!(
+            matches!(step.agent, StepAgent::ByType { ref template } if template == "researcher"),
+            "the shared-type premise of this test must hold"
+        );
     }
 
     /// A Pending run created on engine #1 must survive a crash that

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 48;
+const SCHEMA_VERSION: u32 = 49;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -230,6 +230,13 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     // elapsed idle span on every hourly tick. NULL on pre-migration rows, which
     // the read path treats as "clock starts at accessed_at".
     run_step!(48, migrate_v48);
+
+    // v49 (#7714): add `workflow_runs.owner_agent_id` so a run records which
+    // agent asked for it, and `usage_events.billed_agent_id` so a spawned
+    // worker's spend rolls up to the agent that spawned it. Both are NULL on
+    // every pre-migration row: an ownerless run stays ownerless, and a usage
+    // row with no `billed_agent_id` bills to `agent_id` exactly as before.
+    run_step!(49, migrate_v49);
 
     // Audit-trail consistency (#3538): user_version must match the count
     // of distinct rows in `migrations`. Drift means an earlier migration
@@ -919,6 +926,37 @@ fn migrate_v48(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (48, datetime('now'), 'Add memories.last_decayed_at so confidence decay charges each idle interval once (#7756)')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// v49 (#7714): Record who owns a workflow run, and who a call's spend bills to.
+///
+/// `workflow_runs.owner_agent_id` is the agent that asked for the run — the caller of `workflow_run` / `workflow_start`, the agent bound to the channel that issued the command, or the agent an API caller named.
+/// It is a property of the *run*, not of the agent that executes a step, which is what lets two owners drive the same shared step-agent type and still keep their attribution apart.
+///
+/// `usage_events.billed_agent_id` is the agent a call's cost rolls up to: a spawned worker's spend belongs on its spawner's budget line, not on the throwaway child's.
+/// It is deliberately a second column rather than a rewrite of `agent_id`: `agent_id` remains the quota subject that both the pre-call `check_quota` and the post-call `check_all_and_record` evaluate, so those two continue to ask about the same agent against that same agent's limits.
+/// Folding attribution into `agent_id` would have made the pre-call check read the child's history while the post-call check read the parent's, both against the child's ceiling.
+///
+/// `NULL` in either column means "no attribution recorded", which is every row written before this migration and every call with no owner or parent.
+fn migrate_v49(conn: &Connection) -> Result<(), rusqlite::Error> {
+    if !try_column_exists(conn, "workflow_runs", "owner_agent_id")? {
+        conn.execute(
+            "ALTER TABLE workflow_runs ADD COLUMN owner_agent_id TEXT DEFAULT NULL",
+            [],
+        )?;
+    }
+    if !try_column_exists(conn, "usage_events", "billed_agent_id")? {
+        conn.execute(
+            "ALTER TABLE usage_events ADD COLUMN billed_agent_id TEXT DEFAULT NULL",
+            [],
+        )?;
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (49, datetime('now'), 'Add workflow_runs.owner_agent_id and usage_events.billed_agent_id for run ownership and spend rollup (#7714)')",
         [],
     )?;
     Ok(())
@@ -2547,6 +2585,80 @@ mod tests {
             confidence, 1.0,
             "re-running migrate_v48 must not touch data"
         );
+    }
+
+    #[test]
+    fn test_migrate_v49_adds_owner_and_billed_agent_columns() {
+        // #7714: a run records who asked for it, and a usage row records whose
+        // budget line its cost belongs on. Both columns are nullable with no
+        // default, so every pre-migration row reads back NULL — an ownerless
+        // run stays ownerless and an unbilled usage row still bills to
+        // `agent_id`, which is exactly the pre-migration behaviour.
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        assert!(column_exists(&conn, "workflow_runs", "owner_agent_id"));
+        assert!(column_exists(&conn, "usage_events", "billed_agent_id"));
+
+        // Legacy-shaped INSERTs that omit the new columns leave them NULL.
+        conn.execute(
+            "INSERT INTO workflow_runs (id, workflow_id, workflow_name, state, input, step_results, started_at) \
+             VALUES ('legacy-run', 'wf-1', 'wf', 'completed', 'in', '[]', '2026-07-19T00:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+        let owner: Option<String> = conn
+            .query_row(
+                "SELECT owner_agent_id FROM workflow_runs WHERE id = 'legacy-run'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            owner, None,
+            "a pre-v49 workflow run must read back an absent owner, not a synthetic one"
+        );
+
+        conn.execute(
+            "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms) \
+             VALUES ('legacy-usage', 'agent-1', '2026-07-19T00:00:00+00:00', 'm', 'p', 1, 2, 0.5, 0, 10)",
+            [],
+        )
+        .unwrap();
+        let billed: Option<String> = conn
+            .query_row(
+                "SELECT billed_agent_id FROM usage_events WHERE id = 'legacy-usage'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            billed, None,
+            "a pre-v49 usage row must read back NULL so it still bills to agent_id"
+        );
+
+        // A second call is a no-op (both columns already present) and must not
+        // disturb either seeded row.
+        migrate_v49(&conn).unwrap();
+        let (state, cost): (String, f64) = (
+            conn.query_row(
+                "SELECT state FROM workflow_runs WHERE id = 'legacy-run'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap(),
+            conn.query_row(
+                "SELECT cost_usd FROM usage_events WHERE id = 'legacy-usage'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            state, "completed",
+            "re-running migrate_v49 must not touch data"
+        );
+        assert_eq!(cost, 0.5, "re-running migrate_v49 must not touch data");
     }
 
     #[test]

--- a/crates/librefang-memory/src/usage.rs
+++ b/crates/librefang-memory/src/usage.rs
@@ -45,6 +45,29 @@ pub struct UsageRecord {
     /// and for pre-v30 records that pre-date this column.
     #[serde(default)]
     pub session_id: Option<SessionId>,
+    /// #7714: the agent this call's cost rolls up to, when it differs from
+    /// the agent that made it.
+    ///
+    /// A worker spawned by another agent spends on its spawner's behalf, so
+    /// the spawner needs that cost on its own budget line rather than
+    /// scattered across throwaway children it cannot enumerate.
+    /// Call sites set it to `entry.parent.unwrap_or(agent_id)`, so a
+    /// top-level agent bills to itself.
+    ///
+    /// This is deliberately a *separate* column from [`Self::agent_id`]
+    /// rather than a rewrite of it. `agent_id` stays the quota subject: the
+    /// pre-call `check_quota` and the post-call `check_all_and_record` both
+    /// evaluate the executing agent against that agent's own
+    /// `manifest.resources`, so the two checks keep asking the same question
+    /// about the same agent. Re-pointing `agent_id` at the parent would have
+    /// made the pre-call check read the child's spend and the post-call check
+    /// read the parent's, both against the child's ceiling — the attribution
+    /// dimension and the enforcement dimension have to stay independent.
+    ///
+    /// `None` on pre-v49 records, which the read path treats as "bills to
+    /// `agent_id`".
+    #[serde(default)]
+    pub billed_agent_id: Option<AgentId>,
 }
 
 impl UsageRecord {
@@ -80,6 +103,7 @@ impl UsageRecord {
             user_id: None,
             channel: None,
             session_id: None,
+            billed_agent_id: None,
         }
     }
 }
@@ -238,8 +262,8 @@ impl UsageStore {
         // v30 added session_id — all are NULL-able so missing attribution
         // round-trips as NULL.
         conn.execute(
-            "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, user_id, channel, session_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            "INSERT INTO usage_events (id, agent_id, timestamp, model, provider, input_tokens, output_tokens, cost_usd, tool_calls, latency_ms, user_id, channel, session_id, billed_agent_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             rusqlite::params![
                 id,
                 record.agent_id.0.to_string(),
@@ -254,6 +278,7 @@ impl UsageStore {
                 record.user_id.map(|u| u.to_string()),
                 record.channel.as_deref(),
                 record.session_id.map(|s| s.0.to_string()),
+                record.billed_agent_id.map(|a| a.0.to_string()),
             ],
         )
         .map_err(LibreFangError::memory)?;
@@ -1075,6 +1100,34 @@ impl UsageStore {
         Ok(summary)
     }
 
+    /// Query the usage that rolls up to one agent's budget line (#7714).
+    ///
+    /// "Bills to `agent_id`" means `COALESCE(billed_agent_id, agent_id) = agent_id`: a call the agent made for itself (no `billed_agent_id`, or one pointing at itself) plus every call a worker it spawned made on its behalf.
+    /// This is the query that gives a spawner the budget visibility it loses when its children each spend under their own id.
+    ///
+    /// Distinct from [`Self::query_summary`], which answers "what did this agent execute" and stays the right question for quota enforcement.
+    pub fn query_billed_summary(&self, agent_id: AgentId) -> LibreFangResult<UsageSummary> {
+        let conn = self.pool.get().map_err(LibreFangError::memory)?;
+        let summary = conn
+            .query_row(
+                "SELECT COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+                        COALESCE(SUM(cost_usd), 0.0), COUNT(*), COALESCE(SUM(tool_calls), 0)
+                 FROM usage_events WHERE COALESCE(billed_agent_id, agent_id) = ?1",
+                rusqlite::params![agent_id.0.to_string()],
+                |row| {
+                    Ok(UsageSummary {
+                        total_input_tokens: row.get::<_, i64>(0)? as u64,
+                        total_output_tokens: row.get::<_, i64>(1)? as u64,
+                        total_cost_usd: row.get(2)?,
+                        call_count: row.get::<_, i64>(3)? as u64,
+                        total_tool_calls: row.get::<_, i64>(4)? as u64,
+                    })
+                },
+            )
+            .map_err(LibreFangError::memory)?;
+        Ok(summary)
+    }
+
     /// Query usage grouped by model.
     pub fn query_by_model(&self) -> LibreFangResult<Vec<ModelUsage>> {
         let conn = self.pool.get().map_err(LibreFangError::memory)?;
@@ -1399,6 +1452,90 @@ mod tests {
         assert_eq!(summary.total_output_tokens, 250);
         assert!((summary.total_cost_usd - 0.011).abs() < 0.0001);
         assert_eq!(summary.total_tool_calls, 3);
+    }
+
+    #[test]
+    fn spawned_worker_spend_rolls_up_to_the_parent_budget_line() {
+        // #7714: a worker spawned by another agent spends on its spawner's
+        // behalf. The spawner must be able to see that cost on its own budget
+        // line, which is what `query_billed_summary` answers.
+        let store = setup();
+        let parent = AgentId::new();
+        let worker = AgentId::new();
+
+        // The parent's own turn: no `billed_agent_id`, so it bills to itself.
+        store
+            .record(&UsageRecord {
+                agent_id: parent,
+                cost_usd: 1.0,
+                input_tokens: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        // The worker's turn, billed to the parent.
+        store
+            .record(&UsageRecord {
+                agent_id: worker,
+                billed_agent_id: Some(parent),
+                cost_usd: 0.25,
+                input_tokens: 5,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let billed = store.query_billed_summary(parent).unwrap();
+        assert_eq!(
+            billed.call_count, 2,
+            "the parent's budget line must include the worker's call"
+        );
+        assert!(
+            (billed.total_cost_usd - 1.25).abs() < 1e-9,
+            "expected 1.25 rolled up, got {}",
+            billed.total_cost_usd
+        );
+        assert_eq!(billed.total_input_tokens, 15);
+
+        // The worker bills nothing to itself — its spend belongs to the parent.
+        let worker_billed = store.query_billed_summary(worker).unwrap();
+        assert_eq!(
+            worker_billed.call_count, 0,
+            "a worker whose spend rolls up must not also carry it itself"
+        );
+
+        // Enforcement is a separate dimension: `agent_id` is untouched, so the
+        // quota subject each call is checked against is still the agent that
+        // actually made it. This is what keeps the pre-call and post-call
+        // quota checks asking about the same agent.
+        assert_eq!(
+            store.query_summary(Some(worker)).unwrap().call_count,
+            1,
+            "the executing agent must remain the quota subject for its own call"
+        );
+        assert_eq!(
+            store.query_summary(Some(parent)).unwrap().call_count,
+            1,
+            "attribution must not retroactively move the child's call onto the parent's quota"
+        );
+    }
+
+    #[test]
+    fn usage_record_without_billed_agent_bills_to_itself() {
+        // Every pre-#7714 call site leaves `billed_agent_id` unset. Those rows
+        // must keep rolling up to `agent_id`, or the migration would silently
+        // drop historical spend out of every budget view.
+        let store = setup();
+        let agent_id = AgentId::new();
+        store
+            .record(&UsageRecord {
+                agent_id,
+                cost_usd: 0.5,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let billed = store.query_billed_summary(agent_id).unwrap();
+        assert_eq!(billed.call_count, 1);
+        assert!((billed.total_cost_usd - 0.5).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/librefang-memory/src/workflow_store.rs
+++ b/crates/librefang-memory/src/workflow_store.rs
@@ -36,6 +36,13 @@ pub struct WorkflowRunRow {
     pub started_at: String,
     pub completed_at: Option<String>,
     pub created_at: String,
+    /// #7714: the agent that asked for this run, when there was one.
+    ///
+    /// A property of the run rather than of whichever agent executes a step,
+    /// so two owners driving the same shared step-agent type keep their
+    /// attribution apart. `None` for operator-initiated runs with no calling
+    /// agent, and for every row written before schema v49.
+    pub owner_agent_id: Option<String>,
 }
 
 /// Persistent workflow run store backed by SQLite.
@@ -81,12 +88,12 @@ impl WorkflowStore {
                 id, workflow_id, workflow_name, state, input, output, error,
                 resume_token, pause_reason, paused_at, paused_step_index,
                 paused_variables, paused_current_input,
-                step_results, started_at, completed_at
+                step_results, started_at, completed_at, owner_agent_id
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7,
                 ?8, ?9, ?10, ?11,
                 ?12, ?13,
-                ?14, ?15, ?16
+                ?14, ?15, ?16, ?17
             ) ON CONFLICT(id) DO UPDATE SET
                 state = excluded.state,
                 input = excluded.input,
@@ -117,6 +124,7 @@ impl WorkflowStore {
                 row.step_results,
                 row.started_at,
                 row.completed_at,
+                row.owner_agent_id,
             ],
         )
         .map_err(|e| LibreFangError::memory_msg(format!("workflow upsert failed: {e}")))?;
@@ -131,7 +139,8 @@ impl WorkflowStore {
                 "SELECT id, workflow_id, workflow_name, state, input, output, error,
                         resume_token, pause_reason, paused_at, paused_step_index,
                         paused_variables, paused_current_input,
-                        step_results, started_at, completed_at, created_at
+                        step_results, started_at, completed_at, created_at,
+                        owner_agent_id
                  FROM workflow_runs WHERE id = ?1",
             )
             .map_err(|e| {
@@ -159,7 +168,8 @@ impl WorkflowStore {
                 "SELECT id, workflow_id, workflow_name, state, input, output, error,
                         resume_token, pause_reason, paused_at, paused_step_index,
                         paused_variables, paused_current_input,
-                        step_results, started_at, completed_at, created_at
+                        step_results, started_at, completed_at, created_at,
+                        owner_agent_id
                  FROM workflow_runs WHERE state = ?1 ORDER BY started_at DESC"
                     .to_string(),
                 vec![Box::new(state.to_string()) as Box<dyn rusqlite::types::ToSql>],
@@ -168,7 +178,8 @@ impl WorkflowStore {
                 "SELECT id, workflow_id, workflow_name, state, input, output, error,
                         resume_token, pause_reason, paused_at, paused_step_index,
                         paused_variables, paused_current_input,
-                        step_results, started_at, completed_at, created_at
+                        step_results, started_at, completed_at, created_at,
+                        owner_agent_id
                  FROM workflow_runs ORDER BY started_at DESC"
                     .to_string(),
                 vec![],
@@ -235,12 +246,13 @@ impl WorkflowStore {
                     id, workflow_id, workflow_name, state, input, output, error,
                     resume_token, pause_reason, paused_at, paused_step_index,
                     paused_variables, paused_current_input,
-                    step_results, started_at, completed_at, created_at
+                    step_results, started_at, completed_at, created_at,
+                    owner_agent_id
                 ) VALUES (
                     ?1, ?2, ?3, ?4, ?5, ?6, ?7,
                     ?8, ?9, ?10, ?11,
                     ?12, ?13,
-                    ?14, ?15, ?16, ?17
+                    ?14, ?15, ?16, ?17, ?18
                 ) ON CONFLICT(id) DO UPDATE SET
                     state = excluded.state,
                     output = excluded.output,
@@ -265,6 +277,7 @@ impl WorkflowStore {
                     row.started_at,
                     row.completed_at,
                     row.created_at,
+                    row.owner_agent_id,
                 ],
             )
             .map_err(|e| {
@@ -314,6 +327,7 @@ fn row_from_sqlite(row: &rusqlite::Row<'_>) -> Result<WorkflowRunRow, rusqlite::
         started_at: row.get(14)?,
         completed_at: row.get(15)?,
         created_at: row.get(16)?,
+        owner_agent_id: row.get(17)?,
     })
 }
 
@@ -349,7 +363,58 @@ mod tests {
             started_at: "2026-05-06T00:00:00Z".to_string(),
             completed_at: None,
             created_at: "2026-05-06T00:00:00Z".to_string(),
+            owner_agent_id: None,
         }
+    }
+
+    #[test]
+    fn owner_agent_id_round_trips_and_survives_updates() {
+        // #7714: the owner is stamped once when the run is created and must
+        // still be there after the state transitions that follow, because
+        // every later write goes through the same `upsert_run` ON CONFLICT
+        // path and that clause deliberately does not reassign the owner.
+        let store = in_memory_store();
+        let mut row = sample_row("run-owned", "pending");
+        row.owner_agent_id = Some("11111111-1111-4111-8111-111111111111".to_string());
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("run-owned").unwrap().expect("row must exist");
+        assert_eq!(
+            loaded.owner_agent_id.as_deref(),
+            Some("11111111-1111-4111-8111-111111111111"),
+            "the owner must round-trip through the store"
+        );
+
+        // A later state transition writes the row again. Real callers rebuild
+        // the row from the live run, but a caller that lost the owner must not
+        // be able to blank it out.
+        let mut finished = sample_row("run-owned", "completed");
+        finished.owner_agent_id = None;
+        store.upsert_run(&finished).unwrap();
+
+        let reloaded = store.get_run("run-owned").unwrap().expect("row must exist");
+        assert_eq!(
+            reloaded.state, "completed",
+            "the state transition must land"
+        );
+        assert_eq!(
+            reloaded.owner_agent_id.as_deref(),
+            Some("11111111-1111-4111-8111-111111111111"),
+            "an update must not clear the owner recorded at creation"
+        );
+    }
+
+    #[test]
+    fn ownerless_run_round_trips_as_none() {
+        // An operator-initiated run has no calling agent. That must read back
+        // as "no owner" rather than as a synthetic or empty-string owner,
+        // because downstream billing distinguishes the two.
+        let store = in_memory_store();
+        store
+            .upsert_run(&sample_row("run-plain", "running"))
+            .unwrap();
+        let loaded = store.get_run("run-plain").unwrap().expect("row must exist");
+        assert_eq!(loaded.owner_agent_id, None);
     }
 
     #[test]

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1204,7 +1204,9 @@ pub async fn execute_tool_raw(
         "goal_update" => tool_goal_update(input, *kernel),
 
         // Workflow tools.
-        "workflow_run" => tool_workflow_run(input, *kernel).await,
+        // #7714: forward the caller so the kernel can stamp it on the run as
+        // the run's owner, exactly as `workflow_start` already forwards it.
+        "workflow_run" => tool_workflow_run(input, *kernel, *caller_agent_id).await,
         "workflow_list" => tool_workflow_list(*kernel).await,
         "workflow_describe" => tool_workflow_describe(input, *kernel).await,
         "workflow_status" => tool_workflow_status(input, *kernel).await,

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -1577,7 +1577,7 @@ async fn workflow_run_depth_refusal_is_permission_denied_not_upstream() {
     let kernel: Arc<dyn KernelHandle> = denying;
     let input = serde_json::json!({ "workflow_id": "some-workflow" });
 
-    let err = super::workflow::tool_workflow_run(&input, Some(&kernel))
+    let err = super::workflow::tool_workflow_run(&input, Some(&kernel), None)
         .await
         .expect_err("a CapabilityDenied from the kernel must surface as an error");
     match &err {
@@ -1599,7 +1599,7 @@ async fn workflow_run_depth_refusal_is_permission_denied_not_upstream() {
     // Any other kernel failure still goes through `upstream` — the mapping is a narrow special case, not a blanket reclassification.
     let plain = Arc::new(DispatchCapture::default());
     let kernel: Arc<dyn KernelHandle> = plain;
-    let err = super::workflow::tool_workflow_run(&input, Some(&kernel))
+    let err = super::workflow::tool_workflow_run(&input, Some(&kernel), None)
         .await
         .expect_err("the default stub reports the engine unavailable");
     assert!(

--- a/crates/librefang-runtime/src/tool_runner/workflow.rs
+++ b/crates/librefang-runtime/src/tool_runner/workflow.rs
@@ -127,6 +127,7 @@ pub(super) fn build_workflow_run_result(
 pub(super) async fn tool_workflow_run(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
 ) -> ToolResult {
     let workflow_id = input["workflow_id"]
         .as_str()
@@ -146,8 +147,11 @@ pub(super) async fn tool_workflow_run(
     // A nesting-depth refusal arrives as `CapabilityDenied` (refs #6659) and must stay a policy error rather than becoming `Upstream`.
     // Two reasons, the same ones spelled out in `tool_agent_send`: `Upstream` lifts to a 5xx-class `ToolExecution` that reads as a downstream crash to retry logic, and `PermissionDenied` classifies as `ToolExecutionStatus::Denied` — a soft failure — so a capped agent that keeps trying does not burn through `MAX_CONSECUTIVE_ALL_FAILED` and lose the turn to an abort.
     // Every other kernel failure stays `Upstream`.
+    // #7714: `run_workflow_owned` records the caller as the run's owner so
+    // the run carries attribution even though the step agent it resolves may
+    // be a canonical instance shared with every other owner of that type.
     let (run_id, output) = kh
-        .run_workflow(workflow_id, &input_str)
+        .run_workflow_owned(workflow_id, &input_str, caller_agent_id)
         .await
         .map_err(|e| match e {
             librefang_types::error::LibreFangError::CapabilityDenied(msg) => {

--- a/docs/architecture/workflow-run-attribution.md
+++ b/docs/architecture/workflow-run-attribution.md
@@ -1,0 +1,73 @@
+# Workflow run attribution: who owns a run, and whose budget a step spends
+
+Two questions a workflow run has to be able to answer, and they have different answers:
+
+- **Who asked for this run?** — recorded on the run as `owner_agent_id`.
+- **Whose budget line does this LLM call land on?** — recorded on the usage event as `billed_agent_id`.
+
+Both columns arrive in schema **v49** (`crates/librefang-memory/src/migration.rs: migrate_v49`), and both are nullable, because both questions legitimately have no answer for an operator-initiated run made by no agent at all.
+
+## Ownership lives on the run, not on the agent
+
+A step written as `{ type = "researcher" }` resolves through find-or-spawn (`crates/librefang-kernel/src/kernel/step_agent.rs: find_or_spawn_agent_type`) to the *canonical* name-derived instance for that type (#4614).
+That is deliberate: a step agent outlives the run that first needed it and is shared by every later run of every workflow that references the type, which is also why it is spawned top-level with `parent = None` rather than being parented to whichever run happened to be first.
+
+The consequence is that the executing agent cannot carry ownership.
+If two agents each start a workflow whose first step is `{ type = "researcher" }`, both runs execute on the same `researcher` instance, with the same agent id.
+Hanging ownership off that instance would make the second owner's runs report the first owner's, and the report would look perfectly consistent while being wrong.
+
+So the owner is a property of the run.
+`WorkflowRun::owner_agent_id` is stamped once at creation by `WorkflowEngine::create_run_owned` and never reassigned.
+`WorkflowEngine::create_run` is the ownerless entry point and is what an operator-initiated run uses.
+
+Where the owner comes from, per entry point:
+
+| Entry point | Owner |
+| --- | --- |
+| `workflow_run` tool | the calling agent, forwarded as `caller_agent_id` through `WorkflowRunner::run_workflow_owned` |
+| `workflow_start` tool | the calling agent, via the `caller_agent_id` `start_workflow_async_tracked` already receives |
+| Channel `/workflow run` | the agent bound to that channel and chat, resolved by the same binding every other channel command uses |
+| `POST /api/workflows/{id}/run` | none — an operator action |
+| `POST /api/workflows/runs/{id}/rerun` | copied off the original run |
+
+The re-run row deserves its own sentence, because it is the case that is easy to get wrong.
+A re-run is a repeat of the same work on the same owner's behalf, and the operator who pressed the button is not that owner — so the owner is read off the stored run rather than re-derived from the caller.
+The resume path inherits the owner for free: it mutates the existing run rather than creating a new one.
+
+`workflow_start` parses `caller_agent_id` for ownership *independently* of the async-task tracker, which registers only when both a caller agent and a caller session are present.
+A `workflow_start` with an agent and no session is still owned by that agent.
+
+## Billing rolls up to the spawner, and does not disturb quotas
+
+`UsageRecord::billed_agent_id` is set at every LLM write site to `entry.parent.unwrap_or(agent_id)` (`crates/librefang-kernel/src/kernel/agent_execution.rs: billed_agent_for`).
+A worker spawned by another agent spends on its spawner's behalf, so the spawner needs that cost on its own budget line rather than scattered across throwaway children it cannot enumerate.
+A top-level agent has no parent and bills to itself, which is the behaviour every agent had before this existed.
+
+`billed_agent_id` is a **separate column from `agent_id`, not a rewrite of it**, and that is the whole design.
+
+`agent_id` remains the quota subject. The pre-call check is `check_quota(agent_id, &entry.manifest.resources)`; the post-call check is `check_all_and_record(&record, &manifest.resources, ..)` keyed on `record.agent_id`.
+Both therefore ask about the same agent, against that same agent's ceiling.
+
+Re-pointing `agent_id` at the parent would have broken that pairing in two ways at once: the pre-call check would read the child's accumulated spend while the post-call check read the parent's, and both would compare against the *child's* limits.
+Attribution and enforcement are independent dimensions and have to stay independent.
+
+Read the rollup with `UsageStore::query_billed_summary(agent_id)`, which sums `COALESCE(billed_agent_id, agent_id) = agent_id` — the agent's own calls plus every call a worker made on its behalf.
+`query_summary` still answers "what did this agent execute", which stays the right question for quota work.
+
+## Why there is no `fresh = true` on a step agent
+
+The original proposal for #7714 included a third form, `{ type = "x", fresh = true }`, spawning a new random-id instance with a per-run name tag.
+It is not implemented, and the reason is that both things it was for now have answers.
+
+Its stated motivation was that find-or-spawn "always reuses the canonical instance, which carries cross-run history".
+That is a statement about **history**, and per-step `session_mode` (#7862) answers it directly: `session_mode = "new"` on a step mints a fresh `SessionId` for that step's invocation regardless of what the target agent's manifest defaults to, so the step sees none of the agent's prior state.
+That is a fresh session per run without a second agent per run.
+
+The other thing an instance-level flag would have bought is a distinct budget line per owner, and that is what `owner_agent_id` and `billed_agent_id` above provide — without registry churn, and correctly for the case that actually motivates it, which is two *different* owners sharing one agent type.
+
+What `fresh = true` would still add is a distinct agent *identity* per run, and the cost of that is concrete: one registry entry, one workspace, one scheduler bootstrap and one set of channel/cron registrations per run, accumulating forever, with no reaper.
+Bounded registry growth is the reason find-or-spawn resolves to a canonical id in the first place.
+Paying that to isolate history that `session_mode` already isolates, and to separate budgets that ownership already separates, is not a trade worth making.
+
+**If you want a workflow step isolated from an agent's prior context, set `session_mode = "new"` on the step.**
+If a future case genuinely needs a distinct workspace or a distinct capability ceiling per run — the two things a session cannot give you — that is a different feature from the one this note declines, and it should be specified against those requirements rather than resurrected from this one.


### PR DESCRIPTION
Closes #7714.

## What the issue asked for, and what happened to each ask

**1. Persist `owner_agent_id` on workflow runs, thread the caller agent in, copy it on resume / operator-action paths.** Implemented.

**2. Spawned step agents bill to the owner (`billed_agent = parent.unwrap_or(agent_id)` in the usage record).** Implemented, as a new column on the usage record rather than a rewrite of `agent_id` — see "The review item that stalled #7717" below.

**3. `{ type = "x", fresh = true }`.** Deliberately **not** implemented, with reasoning below and in `docs/architecture/workflow-run-attribution.md`. This is the decision the issue was reopened to get, not a silent scope cut.

### The migration number moved

The issue's acceptance text says "migration v48 idempotence". v48 is taken on `main` by #7756 (`memories.last_decayed_at`, `crates/librefang-memory/src/migration.rs`). **This lands as v49**, and the acceptance line needs renumbering for anyone reading the issue later.

## Ownership lives on the run, not on the agent

`crates/librefang-kernel/src/kernel/step_agent.rs: find_or_spawn_agent_type` resolves a `type` reference to the *canonical* name-derived instance (#4614) and spawns it top-level with `parent = None`, on the stated grounds that a step agent outlives the run that first needed it and is shared by every later run referencing that type.

That makes the executing agent unable to carry ownership: two agents starting workflows whose first step is `{ type = "researcher" }` execute on the same instance with the same id, so ownership hung off that instance would report the first owner for both — consistently, and wrongly.

So `owner_agent_id` is a property of the run. `WorkflowEngine::create_run_owned` stamps it once at creation and nothing reassigns it; `create_run` remains the ownerless entry point an operator-initiated run uses, which is why the ~80 existing `create_run` test call sites are untouched.

Where it comes from:

| Entry point | Owner |
| --- | --- |
| `workflow_run` tool | calling agent, via a new `WorkflowRunner::run_workflow_owned` (default impl forwards to `run_workflow`, so no other implementor breaks) |
| `workflow_start` tool | calling agent, via the `caller_agent_id` `start_workflow_async_tracked` already receives |
| Channel `/workflow run` | the agent bound to that channel and chat, from the same `resolve_for_command()` binding every other channel command uses |
| `POST /api/workflows/{id}/run` | none — an operator action |
| `POST /api/workflows/runs/{id}/rerun` | copied off the original run |

Two details worth flagging for review:

- **Re-run copies rather than re-derives.** A re-run repeats the same work on the same owner's behalf, and the operator who pressed the button is not that owner.
- **`workflow_start` parses the caller for ownership independently of the async-task tracker**, which registers only when *both* a caller agent and a caller session are present. A `workflow_start` with an agent and no session is still owned by that agent, and inheriting the tracker's two-id condition would have silently dropped those.

`GET /api/workflows/runs/{id}` now renders `owner_agent_id`. That handler builds an untyped `json!` map with a `crate::types::JsonObject` body, so this is not an OpenAPI schema change and no golden moves.

## The review item that stalled #7717: pre-call and post-call quota subjects

This is why `billed_agent_id` is a **new column and not a rewrite of `agent_id`**.

Today the two checks are:

- pre-call — `check_quota(agent_id, &entry.manifest.resources)` (`agent_execution.rs`)
- post-call — `check_all_and_record(&record, &manifest.resources, ..)`, keyed on `record.agent_id`

Both ask about the same agent against that same agent's ceiling. Setting `record.agent_id = parent` breaks that pairing twice over: the pre-call check would read the *child's* accumulated spend while the post-call check read the *parent's*, and both would compare against the *child's* limits.

So attribution and enforcement are kept as independent dimensions. `agent_id` is untouched and remains the quota subject; `billed_agent_id = entry.parent.unwrap_or(agent_id)` is set alongside it at all four usage write sites (`execute_llm_agent`, the streaming task, the ephemeral `/btw` path, and background skill review). Read the rollup with `UsageStore::query_billed_summary`, which sums `COALESCE(billed_agent_id, agent_id) = ?1` — so every pre-v49 row still bills to `agent_id` and no historical spend drops out of a budget view.

## Why there is no `fresh = true`

The issue's own motivation for the flag was that find-or-spawn "always reuses the canonical instance, **which carries cross-run history**". That is a statement about history, and per-step `session_mode` (#7862, shipped after this issue was written) answers it directly: `session_mode = "new"` mints a fresh `SessionId` for the step's invocation regardless of the target agent's manifest default.

The other thing an instance-level flag would have bought is a separate budget line per owner — which is exactly what asks 1 and 2 in this PR provide, and they provide it for the case that actually motivates it, two *different* owners sharing one type.

What is left is a distinct agent *identity* per run, and its cost is concrete: one registry entry, one workspace, one scheduler bootstrap and one set of channel/cron registrations per run, accumulating with no reaper. Bounded registry growth is why find-or-spawn resolves to a canonical id at all.

I picked option (b) from the reopened issue's three, and the doc states the condition for revisiting: a case that genuinely needs a distinct *workspace* or *capability ceiling* per run is a different feature and should be specified against those requirements rather than resurrected from this one.

`per_step_session_mode_reaches_the_executor_for_a_shared_type` guards the mechanism the decision leans on — if per-step `session_mode` silently stopped reaching the executor, the declined alternative would become necessary again.

## Changes

- `migration.rs` — `SCHEMA_VERSION` 48 → 49; `migrate_v49` adds `workflow_runs.owner_agent_id` and `usage_events.billed_agent_id`, both nullable, both idempotent via `try_column_exists`.
- `workflow_store.rs` — `owner_agent_id` on `WorkflowRunRow`, in the insert/select/bulk-upsert column lists and `row_from_sqlite`. Deliberately **not** in the `ON CONFLICT DO UPDATE SET` clause, so a later state transition cannot blank an owner recorded at creation.
- `usage.rs` — `billed_agent_id` on `UsageRecord`, written by `insert_record`; new `query_billed_summary`.
- `workflow.rs` — `WorkflowRun::owner_agent_id`; `create_run_owned`; both row conversions. A malformed stored owner logs a `WARN` and reloads the run as ownerless rather than failing the whole boot recovery.
- `triggers_and_workflow.rs`, `handles/workflow_runner.rs`, `kernel-handle/workflow_runner.rs`, `tool_runner/{workflow,dispatch}.rs`, `channels/bridge.rs`, `api/channel_bridge.rs`, `routes/workflows/workflow.rs` — owner threading.
- `agent_execution.rs` — `billed_agent_for` helper; wired at all four usage write sites.
- `docs/architecture/workflow-run-attribution.md` — the model and the `fresh` decision.

## Verification

Run with `CARGO_TARGET_DIR` pointed at a scratch dir.

- `cargo test -p librefang-memory --lib` — **385 passed, 0 failed**. Includes the new `migration::tests::test_migrate_v49_adds_owner_and_billed_agent_columns` (column presence, pre-migration rows read back NULL, re-running touches no data), `workflow_store::tests::owner_agent_id_round_trips_and_survives_updates`, `workflow_store::tests::ownerless_run_round_trips_as_none`, `usage::tests::spawned_worker_spend_rolls_up_to_the_parent_budget_line` (also asserts the quota subject did *not* move), `usage::tests::usage_record_without_billed_agent_bills_to_itself`.
- `cargo test -p librefang-kernel --lib workflow::` — **204 passed, 0 failed**. Includes `create_run_leaves_the_run_ownerless`, `owner_round_trips_through_the_store` (create → drop engine → reload from SQLite), `two_owners_running_the_same_agent_type_keep_separate_attribution`, `per_step_session_mode_reaches_the_executor_for_a_shared_type`.
- `cargo test -p librefang-kernel --lib billing_attribution` — **2 passed** (`a_top_level_agent_bills_to_itself`, `a_spawned_worker_bills_to_its_spawner`).
- `cargo check --lib` clean on `librefang-memory`, `librefang-kernel`, `librefang-kernel-handle`, `librefang-runtime`, `librefang-channels`, `librefang-api`.

**Not run locally, please watch CI for these:** `crates/librefang-api/tests/workflow_lifecycle_test.rs::rerun_workflow_run_inherits_the_original_runs_owner` and `::rerun_of_an_ownerless_run_stays_ownerless`. Both assert over HTTP against `TestServer`. The shared `target/` on this machine is contended by several concurrent worktrees, which kept swapping `librefang-memory` / `librefang-kernel-handle` rlibs mid-build; the `librefang-api` *lib* compiled clean, but I could not get the integration-test target and its whole dependency chain fresh in the same window, and free disk was falling. Not blocked on anything in the diff.

## Deferred

Nothing. No follow-up work is intended from this PR.
