### PR TITLE
test(kernel): build the searched-paths assertion with the platform separator

### DIFF
--- a/changelog.d/fixed/7889-windows-path-assertions.md
+++ b/changelog.d/fixed/7889-windows-path-assertions.md
@@ -1,0 +1,4 @@
+A kernel test no longer fails on the Windows shard because it hard-coded a forward slash.
+`a_missing_template_names_the_directories_searched` asserts that the "no such template" message names the directories it searched, but it looked for the literal `workspaces/agents` in a message that interpolates real paths — so on Windows the message said `workspaces\agents` and the assertion failed while the code under test was correct.
+The expected fragment is now built with the platform separator, which is what the message itself uses.
+(#PR) (@houko)

--- a/changelog.d/fixed/7889-windows-path-assertions.md
+++ b/changelog.d/fixed/7889-windows-path-assertions.md
@@ -1,4 +1,4 @@
 A kernel test no longer fails on the Windows shard because it hard-coded a forward slash.
 `a_missing_template_names_the_directories_searched` asserts that the "no such template" message names the directories it searched, but it looked for the literal `workspaces/agents` in a message that interpolates real paths — so on Windows the message said `workspaces\agents` and the assertion failed while the code under test was correct.
 The expected fragment is now built with the platform separator, which is what the message itself uses.
-(#PR) (@houko)
+(#7890) (@houko)

--- a/crates/librefang-kernel/src/agent_template.rs
+++ b/crates/librefang-kernel/src/agent_template.rs
@@ -319,8 +319,15 @@ mod tests {
         assert!(err.is_missing(), "{err}");
         assert_eq!(err.kind(), "missing");
         let rendered = err.to_string();
-        assert!(rendered.contains("workspaces/agents"), "{rendered}");
-        assert!(rendered.contains("registry/agents"), "{rendered}");
+        // The message interpolates real paths, so the separator is the platform's:
+        // `workspaces/agents` on Unix and `workspaces\agents` on Windows. Build the
+        // expected fragment the same way rather than hard-coding a forward slash,
+        // which passed everywhere except the Windows shard (#7889).
+        let workspaces_agents: String =
+            ["workspaces", "agents"].join(std::path::MAIN_SEPARATOR_STR);
+        let registry_agents: String = ["registry", "agents"].join(std::path::MAIN_SEPARATOR_STR);
+        assert!(rendered.contains(&workspaces_agents), "{rendered}");
+        assert!(rendered.contains(&registry_agents), "{rendered}");
     }
 
     /// The review finding this module exists for: a corrupt manifest used to

--- a/crates/librefang-kernel/src/agent_template.rs
+++ b/crates/librefang-kernel/src/agent_template.rs
@@ -319,10 +319,8 @@ mod tests {
         assert!(err.is_missing(), "{err}");
         assert_eq!(err.kind(), "missing");
         let rendered = err.to_string();
-        // The message interpolates real paths, so the separator is the platform's:
-        // `workspaces/agents` on Unix and `workspaces\agents` on Windows. Build the
-        // expected fragment the same way rather than hard-coding a forward slash,
-        // which passed everywhere except the Windows shard (#7889).
+        // The message interpolates real paths, so the separator is the platform's: `workspaces/agents` on Unix and `workspaces\agents` on Windows.
+        // Build the expected fragment the same way rather than hard-coding a forward slash, which passed everywhere except the Windows shard (#7889).
         let workspaces_agents: String =
             ["workspaces", "agents"].join(std::path::MAIN_SEPARATOR_STR);
         let registry_agents: String = ["registry", "agents"].join(std::path::MAIN_SEPARATOR_STR);


### PR DESCRIPTION
`main` is red on the Windows shard, reported by #7889.

## The failure

```
thread 'agent_template::tests::a_missing_template_names_the_directories_searched'
  panicked at crates\librefang-kernel\src\agent_template.rs:322:9:
no template named 'nope' (searched
  C:\Users\RUNNER~1\AppData\Local\Temp\.tmpYE31iO\workspaces\agents,
  C:\Users\RUNNER~1\AppData\Local\Temp\.tmpYE31iO\registry\agents for agent.toml)
```

The panic message is the assertion's own failure output, and it contains exactly what the test was looking for — with backslashes.

## Why it is the test that is wrong, not the code

The error message interpolates real paths, so its separator is the platform's.
The assertion looked for the literal `workspaces/agents` in that rendered string, which holds on Unix and cannot hold on Windows.
The code under test is correct: it did name both directories it searched, which is the whole point of the message.

Only the two `contains` assertions were affected.
The neighbouring `path.ends_with("registry/agents/researcher/agent.toml")` assertions at :280 and :312 are `Path::ends_with`, which compares path components rather than text and accepts `/` as a separator on Windows too — so they were never at risk and are left alone.

## The change

The expected fragments are built with `std::path::MAIN_SEPARATOR_STR`, so the test asks for the same separator the message uses on whichever platform it runs.

## The other failure in that run

#7889 also lists `browser::tests::live_extraction_preserves_structure_click_fallback_and_budget`.
That one is already fixed on `main` by #7876 (3d4e816b3), which merged after the c07466d9b the alert fired on — the run predates the fix. No action needed here.

## Verification

- `cargo test -p librefang-kernel --lib agent_template` — 10 passed, 0 failed.
- `cargo fmt` applied.

Closes #7889
