### PR TITLE
fix(kernel): accept declared-but-not-installed names in agent skill and MCP allowlists

### DIFF
--- a/changelog.d/fixed/7772-agent-allowlist-inherited-declaration.md
+++ b/changelog.d/fixed/7772-agent-allowlist-inherited-declaration.md
@@ -1,0 +1,7 @@
+Editing an agent that inherited an MCP server this instance never installed no longer loses the edit.
+Saving the allowlist returned `[400] Internal error: Unknown MCP server: fetch`, naming a server the operator never asked for, because the check built its set of acceptable names from the MCP tools connected at that instant — a strict subset of what is configured, never mind what is installed — and the dashboard sends the whole array, so one inherited name took every unrelated change down with it.
+A declaration this instance has not installed is a legitimate state rather than a mistake: agent types are shared artefacts that say what the agent wants, `spawn` accepts such a manifest without any equivalent check, and the read side already surfaces the gap as pending, so the edit path was stricter than the path that created the agent.
+An MCP name is now accepted when it is configured in `config.toml`, connected or not, or present in the locally cached MCP catalog, and a skill when it is loaded or is the `[skill].name` of a directory sitting unloaded under the skills directory.
+Accepting one persists the name and nothing else — installing and connecting stay the operator's explicit action.
+Both rejections became `InvalidInput`, so a typo stops being reported as an internal fault; `mcp_servers = ["*"]` is storable again after the old check rejected the documented wildcard as an unknown server name; and a poisoned MCP tool lock no longer skips validation altogether.
+Reported and diagnosed by @DaBlitzStein. (#PR) (@houko)

--- a/changelog.d/fixed/7772-agent-allowlist-inherited-declaration.md
+++ b/changelog.d/fixed/7772-agent-allowlist-inherited-declaration.md
@@ -4,4 +4,4 @@ A declaration this instance has not installed is a legitimate state rather than 
 An MCP name is now accepted when it is configured in `config.toml`, connected or not, or present in the locally cached MCP catalog, and a skill when it is loaded or is the `[skill].name` of a directory sitting unloaded under the skills directory.
 Accepting one persists the name and nothing else — installing and connecting stay the operator's explicit action.
 Both rejections became `InvalidInput`, so a typo stops being reported as an internal fault; `mcp_servers = ["*"]` is storable again after the old check rejected the documented wildcard as an unknown server name; and a poisoned MCP tool lock no longer skips validation altogether.
-Reported and diagnosed by @DaBlitzStein. (#PR) (@houko)
+Reported and diagnosed by @DaBlitzStein. (#7898) (@houko)

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -20,6 +20,13 @@
 //!                                   the fields it omits, empty string clears,
 //!                                   and the result matches PATCH /config for
 //!                                   the same body — refs #6608)
+//!   PUT   /api/agents/{id}/mcp_servers (an inherited declaration this instance
+//!                                   has not installed saves rather than 400s,
+//!                                   a genuinely unknown name is still rejected
+//!                                   without "Internal error" wording — #7772)
+//!   PUT   /api/agents/{id}/skills  (an on-disk-but-unloaded skill saves under
+//!                                   its `[skill].name`, not its directory name
+//!                                   — #7772)
 //!
 //! Run: cargo test -p librefang-api --test agents_routes_integration
 
@@ -2544,5 +2551,217 @@ model = "test-model"
         body["available"],
         serde_json::json!(["ghost-mcp"]),
         "the connected server must now be in the available pool"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/agents/{id}/mcp_servers and PUT /api/agents/{id}/skills — an
+// inherited declaration this instance has not installed must not take the
+// whole save down with it (#7772).
+//
+// The dashboard PUTs the entire array, so an agent that inherited `fetch`
+// from a registry agent type could not be edited at all: the request failed
+// with `[400] Internal error: Unknown MCP server: fetch`, naming a server the
+// operator never asked for, and the servers they were actually adding were
+// never stored.
+// ---------------------------------------------------------------------------
+
+/// A helper to build a configured-but-transportless MCP server entry, the
+/// shape `config.toml`'s `[[mcp_servers]]` produces before anything dials.
+fn configured_mcp_entry(name: &str) -> librefang_types::config::McpServerConfigEntry {
+    librefang_types::config::McpServerConfigEntry {
+        name: name.to_string(),
+        template_id: None,
+        transport: None,
+        timeout_secs: 30,
+        env: Vec::new(),
+        headers: Vec::new(),
+        oauth: None,
+        taint_scanning: true,
+        taint_policy: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_mcp_servers_keeps_inherited_declaration_while_adding_configured_ones() {
+    // The reported failure, end to end. `fetch` ships in the pinned registry
+    // fixture's MCP catalog and is never configured here, so it is installed
+    // but not configured — exactly the state that used to 400.
+    let h = boot_with_mcp_servers(
+        TEST_TOKEN,
+        vec![
+            configured_mcp_entry("memory"),
+            configured_mcp_entry("camoufox"),
+            configured_mcp_entry("sequential-thinking"),
+        ],
+    )
+    .await;
+    let id = spawn_named(&h.state, "inherited-fetch-agent");
+
+    let saved = serde_json::json!(["memory", "fetch", "camoufox", "sequential-thinking"]);
+    let (status, body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/mcp_servers"),
+            serde_json::json!({ "mcp_servers": saved }),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "an inherited catalog-only declaration must not block a save that adds configured servers; body={body:?}"
+    );
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/mcp_servers"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["assigned"], saved,
+        "every name in the PUT must be persisted, the pending one included"
+    );
+    // `pending` here is a liveness answer (`unconnected_mcp_declarations`), and
+    // nothing dials in this harness, so every declared name is listed. What
+    // matters is that the un-installed one is reported rather than dropped.
+    let pending = body["pending"].as_array().expect("pending array");
+    assert!(
+        pending.iter().any(|v| v == "fetch"),
+        "the un-installed declaration stays visible as pending rather than being silently dropped, got: {pending:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_mcp_servers_rejects_unknown_name_without_internal_error_wording() {
+    // A name in neither config.toml nor the catalog is still rejected, but as
+    // a user-input problem: the old `Internal` variant is what made the
+    // dashboard say "Internal error" for a typo.
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "unknown-mcp-put-agent");
+
+    let (status, body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/mcp_servers"),
+            serde_json::json!({ "mcp_servers": ["totally-made-up-server"] }),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let msg = body["error"].as_str().expect("error message present");
+    assert!(
+        msg.contains("totally-made-up-server"),
+        "the message must name the rejected server, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Internal error"),
+        "a validation failure must not read as a server fault, got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_skills_accepts_pending_manifest_name_not_directory_name() {
+    // The skills half, with the directory name and `[skill].name` deliberately
+    // different. The running registry is keyed by the manifest name, so
+    // `actual-skill` is the only value that can ever match and `package-dir`
+    // is the value that never will — validating against directory names got
+    // this exactly backwards.
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "pending-skill-put-agent");
+
+    // Written after boot, so the directory is on disk but not in the loaded registry.
+    let skill_dir = h.state.kernel.home_dir().join("skills").join("package-dir");
+    std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+    std::fs::write(
+        skill_dir.join("skill.toml"),
+        r#"
+[skill]
+name = "actual-skill"
+version = "0.1.0"
+description = "directory name and manifest name deliberately differ"
+author = "test"
+
+[runtime]
+type = "promptonly"
+
+[source]
+type = "local"
+"#,
+    )
+    .expect("write skill.toml");
+
+    let (status, body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/skills"),
+            serde_json::json!({ "skills": ["actual-skill"] }),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the manifest name of an on-disk-but-unloaded skill must be accepted; body={body:?}"
+    );
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["assigned"], serde_json::json!(["actual-skill"]));
+
+    // The directory name must not be accepted in its place — a stored
+    // `package-dir` would match nothing once the skill loads.
+    let (status, body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/skills"),
+            serde_json::json!({ "skills": ["package-dir"] }),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "the directory name can never match after load and must be rejected; body={body:?}"
+    );
+    let msg = body["error"].as_str().expect("error message present");
+    assert!(
+        !msg.contains("Internal error"),
+        "a validation failure must not read as a server fault, got: {msg}"
+    );
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["assigned"],
+        serde_json::json!(["actual-skill"]),
+        "a rejected save must leave the stored allowlist untouched"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_put_skills_rejects_unknown_name_without_internal_error_wording() {
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "unknown-skill-put-agent");
+
+    let (status, body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/skills"),
+            serde_json::json!({ "skills": ["totally-made-up-skill"] }),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let msg = body["error"].as_str().expect("error message present");
+    assert!(
+        msg.contains("totally-made-up-skill"),
+        "the message must name the rejected skill, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Internal error"),
+        "a validation failure must not read as a server fault, got: {msg}"
     );
 }

--- a/crates/librefang-kernel/src/kernel/agent_state.rs
+++ b/crates/librefang-kernel/src/kernel/agent_state.rs
@@ -11,6 +11,7 @@
 //! `LibreFangKernel`'s private fields and inherent methods without any
 //! visibility surgery.
 
+use super::subsystems::McpSubsystemApi;
 use super::*;
 use serde::{Deserialize, Serialize};
 
@@ -548,6 +549,18 @@ impl LibreFangKernel {
     }
 
     /// Update an agent's skill allowlist. Empty = all skills (backward compat).
+    ///
+    /// A name is accepted when it is loaded in the skill registry, or when it is the `[skill].name` of a directory that exists under the skills directory but has not been loaded (#7772).
+    /// The second case is a *pending declaration*, which the read side already treats as a normal state rather than an error: `pending_skill_and_mcp_declarations` reports it, the dashboard badges it, and `spawn` accepts a manifest carrying it without any equivalent check.
+    /// Rejecting it only here made the edit path stricter than the path that created the agent, so an agent could exist in a state its own editor refused to save — and because the dashboard PUTs the whole array, one inherited name took every unrelated edit down with it.
+    /// Accepting it persists the allowlist entry and nothing else: no skill is loaded or activated as a side effect.
+    ///
+    /// The pending set comes from [`SkillRegistry::unloaded_on_disk_manifest_names`], not from `unloaded_on_disk_dirs`.
+    /// Those two return different kinds of identifier — the registry is keyed by `manifest.skill.name`, while the directory report is keyed by `path.file_name()` — so for `skills/package-dir/skill.toml` declaring `name = "actual-skill"`, validating against directory names would reject `actual-skill`, the only value that can ever match, and accept `package-dir`, which matches nothing once the skill loads.
+    ///
+    /// Unlike the MCP check below, skills have no locally cached catalog of everything installable: skill content is not part of `registry_sync`'s copy set, so on-disk-but-unloaded is the only additional source available, and the criterion is narrower on purpose.
+    /// `"*"` is likewise not special here, again unlike `mcp_servers`: the skill path has no wildcard, and `skills = ["*"]` grants no skill tools at all, so it is just a name that matches nothing.
+    /// A name that is neither loaded nor on disk is rejected as `InvalidInput` — it is a typo in user input, not an internal fault, and the old `Internal` variant is why the dashboard rendered "Internal error" for it.
     pub fn set_agent_skills(&self, agent_id: AgentId, skills: Vec<String>) -> KernelResult<()> {
         // Validate skill names if allowlist is non-empty
         if !skills.is_empty() {
@@ -556,13 +569,17 @@ impl LibreFangKernel {
                 .skill_registry
                 .read()
                 .unwrap_or_else(|e| e.into_inner());
-            let known = registry.skill_names();
+            let loaded = registry.skill_names();
+            let pending = registry.unloaded_on_disk_manifest_names();
             for name in &skills {
-                if !known.contains(name) {
-                    return Err(KernelError::LibreFang(LibreFangError::Internal(format!(
-                        "Unknown skill: {name}"
-                    ))));
+                if loaded.iter().any(|n| n == name) || pending.iter().any(|n| n == name) {
+                    continue;
                 }
+                return Err(KernelError::LibreFang(LibreFangError::InvalidInput(
+                    format!(
+                        "Unknown skill '{name}': not loaded, and no skill under the skills directory declares that name. Check the spelling, or install the skill first."
+                    ),
+                )));
             }
         }
 
@@ -614,6 +631,14 @@ impl LibreFangKernel {
 
     /// Update an agent's MCP server allowlist.
     /// Empty disables MCP servers; `["*"]` enables all connected servers.
+    ///
+    /// A name is accepted when it is configured in `config.toml` (`effective_mcp_servers`, which answers "did somebody write this down" — so a configured server that has not connected yet counts), or when it is present in the locally cached MCP catalog synced from the registry (`~/.librefang/mcp/catalog/`) (#7772).
+    /// The previous check built its accept-set by walking the MCP tools connected at that instant and resolving each back to a server, which is a strict subset of what is configured, never mind what is installed: it rejected a configured-but-not-yet-connected server and a catalog entry that is installed but not configured.
+    /// Since agent types are shared artefacts that declare what the agent *wants*, and `spawn` performs no equivalent check, a declaration this instance has not installed is a legitimate pending state — the same one `pending_skill_and_mcp_declarations` surfaces on the read side.
+    /// Accepting it persists the allowlist entry and nothing else: it does not install, connect, or touch `config.toml`.
+    ///
+    /// Only a name absent from both sources is rejected, as `InvalidInput` rather than `Internal`, so a typo stops being reported as a server fault.
+    /// Dropping the tool walk also removes the old lock guard: the whole check used to sit inside `if let Ok(mcp_tools) = self.mcp.mcp_tools.lock()`, so a poisoned lock skipped validation entirely instead of failing.
     pub fn set_agent_mcp_servers(
         &self,
         agent_id: AgentId,
@@ -632,31 +657,41 @@ impl LibreFangKernel {
 
         // Validate server names if allowlist is non-empty
         if !servers.is_empty() {
-            if let Ok(mcp_tools) = self.mcp.mcp_tools.lock() {
-                let mut known_servers: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                let configured_servers: Vec<String> = self
-                    .mcp
-                    .effective_mcp_servers
-                    .read()
-                    .map(|servers| servers.iter().map(|s| s.name.clone()).collect())
-                    .unwrap_or_default();
-                for tool in mcp_tools.iter() {
-                    if let Some(s) = librefang_runtime::mcp::resolve_mcp_server_from_known(
-                        &tool.name,
-                        configured_servers.iter().map(String::as_str),
-                    ) {
-                        known_servers.insert(librefang_runtime::mcp::normalize_name(s));
-                    }
+            let configured: std::collections::HashSet<String> = self
+                .mcp
+                .effective_mcp_servers
+                .read()
+                .map(|configured| {
+                    configured
+                        .iter()
+                        .map(|s| librefang_runtime::mcp::normalize_name(&s.name))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let catalog = self.mcp_catalog_load();
+            // Catalog entries carry an `id` from their manifest and are keyed by their file / directory name, and upstream does not guarantee the two agree. Accept either.
+            let catalog_ids: std::collections::HashSet<String> = catalog
+                .list()
+                .iter()
+                .map(|e| librefang_runtime::mcp::normalize_name(&e.id))
+                .collect();
+            for name in &servers {
+                // `["*"]` is a documented value meaning "all connected servers" (`AgentManifest::mcp_servers`, and `available_tools` step 3 honours it), but it is not the name of anything, so the old accept-set never contained it and saving a wildcard allowlist failed with `Unknown MCP server: *`.
+                if name == "*" {
+                    continue;
                 }
-                for name in &servers {
-                    let normalized = librefang_runtime::mcp::normalize_name(name);
-                    if !known_servers.contains(&normalized) {
-                        return Err(KernelError::LibreFang(LibreFangError::Internal(format!(
-                            "Unknown MCP server: {name}"
-                        ))));
-                    }
+                let normalized = librefang_runtime::mcp::normalize_name(name);
+                if configured.contains(&normalized)
+                    || catalog_ids.contains(&normalized)
+                    || catalog.get(name).is_some()
+                {
+                    continue;
                 }
+                return Err(KernelError::LibreFang(LibreFangError::InvalidInput(
+                    format!(
+                        "Unknown MCP server '{name}': not configured in config.toml and not present in the installed MCP catalog. Check the spelling, or add the server from the MCP settings surface first."
+                    ),
+                )));
             }
         }
 

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -3343,7 +3343,19 @@ fn sanitize_reviewer_line_strips_newlines_and_brackets() {
 /// registry's `load_skill` accepts it. Also drops a prompt_context.md
 /// to exercise the progressive-loading branch.
 fn install_test_skill(skills_parent: &std::path::Path, name: &str, tags: &[&str]) {
-    let dir = skills_parent.join(name);
+    install_test_skill_named(skills_parent, name, name, tags);
+}
+
+/// Install a skill whose directory name and `[skill].name` are given independently.
+///
+/// [`install_test_skill`] derives both from one argument, which makes it structurally unable to catch a caller that validates an allowlist against directory names instead of manifest names — the two values are always equal (#7772).
+fn install_test_skill_named(
+    skills_parent: &std::path::Path,
+    dir_name: &str,
+    manifest_name: &str,
+    tags: &[&str],
+) {
+    let dir = skills_parent.join(dir_name);
     std::fs::create_dir_all(&dir).unwrap();
     let tag_toml = tags
         .iter()
@@ -3352,7 +3364,7 @@ fn install_test_skill(skills_parent: &std::path::Path, name: &str, tags: &[&str]
         .join(", ");
     let toml = format!(
         "[skill]\n\
-         name = \"{name}\"\n\
+         name = \"{manifest_name}\"\n\
          version = \"0.1.0\"\n\
          description = \"test skill\"\n\
          author = \"test\"\n\
@@ -3564,6 +3576,348 @@ fn test_set_agent_mcp_servers_persists_allowlist_to_agent_toml() {
         written.contains("test-mcp-server"),
         "agent.toml must contain the assigned MCP server so it survives a restart, got:\n{written}"
     );
+
+    kernel.shutdown();
+}
+
+/// Boot a kernel over `home_dir` with a `data/` subdir, the shape every allowlist test below needs.
+fn boot_kernel_at(home_dir: &std::path::Path) -> LibreFangKernel {
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+    let config = KernelConfig {
+        home_dir: home_dir.to_path_buf(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    LibreFangKernel::boot_with_config(config).expect("boot")
+}
+
+/// Spawn a minimal agent for an allowlist test.
+fn spawn_allowlist_test_agent(kernel: &LibreFangKernel, name: &str) -> AgentId {
+    kernel
+        .spawn_agent_inner(
+            AgentManifest {
+                name: name.to_string(),
+                description: "allowlist validation regression".to_string(),
+                author: "test".to_string(),
+                module: "builtin:chat".to_string(),
+                ..Default::default()
+            },
+            None,
+            None,
+            None,
+        )
+        .expect("spawn")
+}
+
+/// Write a minimal MCP catalog entry at `<home_dir>/mcp/catalog/<id>.toml`, the layout `McpCatalog::load` reads at boot.
+fn write_test_mcp_catalog_entry(home_dir: &std::path::Path, id: &str) {
+    let dir = home_dir.join("mcp").join("catalog");
+    std::fs::create_dir_all(&dir).unwrap();
+    let toml = format!(
+        "id = \"{id}\"\n\
+         name = \"{id}\"\n\
+         description = \"test catalog entry\"\n\
+         category = \"devtools\"\n\
+         \n\
+         [transport]\n\
+         type = \"stdio\"\n\
+         command = \"true\"\n"
+    );
+    std::fs::write(dir.join(format!("{id}.toml")), toml).unwrap();
+}
+
+#[test]
+fn test_set_agent_skills_validates_against_manifest_name_not_directory_name() {
+    // #7772 review item: the pending-skill check must compare against `[skill].name`, which is what the loaded registry is keyed by, not against the directory name.
+    // The two identifiers are equal in every other skill test in this file, so only a deliberately mismatched fixture can tell the accessors apart.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("skills")).unwrap();
+    let kernel = boot_kernel_at(&home_dir);
+
+    // Installed after boot, so it is on disk but absent from the loaded registry.
+    install_test_skill_named(&home_dir.join("skills"), "package-dir", "actual-skill", &[]);
+
+    let agent_id = spawn_allowlist_test_agent(&kernel, "manifest-name-skill-agent");
+
+    kernel
+        .set_agent_skills(agent_id, vec!["actual-skill".to_string()])
+        .expect(
+            "the manifest name is the identifier the skill will load under, so it must be accepted",
+        );
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .skills,
+        vec!["actual-skill".to_string()]
+    );
+
+    // The directory name must not be silently accepted in its place: once the skill loads it lands in the registry under `actual-skill`, so a stored `package-dir` would match nothing and quietly strip the agent's skill at the next restart.
+    let err = kernel
+        .set_agent_skills(agent_id, vec!["package-dir".to_string()])
+        .expect_err("the directory name can never match after load and must be rejected");
+    match err {
+        KernelError::LibreFang(LibreFangError::InvalidInput(ref msg)) => {
+            assert!(
+                msg.contains("package-dir"),
+                "the error must name the rejected value, got: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got: {other:?}"),
+    }
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .skills,
+        vec!["actual-skill".to_string()],
+        "a rejected save must leave the previously stored allowlist untouched"
+    );
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_skills_accepts_on_disk_unloaded_pending_name() {
+    // A skill directory that exists on disk but is not in the running registry is a legitimate pending declaration — the same state `pending_skill_and_mcp_declarations` reports on the read side — and accepting it must not load or activate anything.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("skills")).unwrap();
+    let kernel = boot_kernel_at(&home_dir);
+
+    install_test_skill(&home_dir.join("skills"), "unloaded-pending-skill", &[]);
+
+    let agent_id = spawn_allowlist_test_agent(&kernel, "unloaded-skill-agent");
+
+    {
+        let registry = kernel.skills.skill_registry.read().unwrap();
+        assert!(
+            !registry
+                .skill_names()
+                .iter()
+                .any(|n| n == "unloaded-pending-skill"),
+            "precondition: the skill must not be loaded yet"
+        );
+    }
+
+    kernel
+        .set_agent_skills(agent_id, vec!["unloaded-pending-skill".to_string()])
+        .expect("an on-disk-but-unloaded skill name must be accepted as a pending declaration");
+
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .skills,
+        vec!["unloaded-pending-skill".to_string()]
+    );
+    {
+        let registry = kernel.skills.skill_registry.read().unwrap();
+        assert!(
+            !registry
+                .skill_names()
+                .iter()
+                .any(|n| n == "unloaded-pending-skill"),
+            "accepting a pending declaration must not load the skill as a side effect"
+        );
+    }
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_skills_rejects_name_unknown_everywhere_as_invalid_input() {
+    // A name that is neither loaded nor on disk is a typo, and must be rejected as `InvalidInput` — the old `Internal` variant is what rendered as "Internal error" at the API boundary for a user-input problem.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("skills")).unwrap();
+    let kernel = boot_kernel_at(&home_dir);
+    let agent_id = spawn_allowlist_test_agent(&kernel, "unknown-skill-agent");
+
+    let err = kernel
+        .set_agent_skills(agent_id, vec!["totally-made-up-skill".to_string()])
+        .expect_err("a name absent from both the registry and disk must be rejected");
+    match err {
+        KernelError::LibreFang(LibreFangError::InvalidInput(ref msg)) => {
+            assert!(
+                msg.contains("totally-made-up-skill"),
+                "the error must name the rejected skill, got: {msg}"
+            );
+            assert!(
+                !msg.contains("Internal"),
+                "a validation failure must not read as an internal fault, got: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got: {other:?}"),
+    }
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_mcp_servers_accepts_catalog_only_pending_name() {
+    // The reported bug: `fetch` is in the local MCP catalog but was never configured, so it never connected, so the old accept-set (built from connected tools) rejected it.
+    // Accepting it must persist the name and nothing else — no install, no connect, no `effective_mcp_servers` mutation.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    write_test_mcp_catalog_entry(&home_dir, "fetch");
+    let kernel = boot_kernel_at(&home_dir);
+
+    let before = kernel.mcp.effective_mcp_servers.read().unwrap().len();
+    let agent_id = spawn_allowlist_test_agent(&kernel, "catalog-only-agent");
+
+    kernel
+        .set_agent_mcp_servers(agent_id, vec!["fetch".to_string()])
+        .expect("a catalog-only server name is a legitimate pending declaration");
+
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .mcp_servers,
+        vec!["fetch".to_string()]
+    );
+    let after = kernel.mcp.effective_mcp_servers.read().unwrap();
+    assert_eq!(
+        before,
+        after.len(),
+        "accepting a pending declaration must not configure a server as a side effect"
+    );
+    assert!(
+        !after.iter().any(|s| s.name == "fetch"),
+        "fetch must not have been added to the effective server list"
+    );
+    drop(after);
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_mcp_servers_accepts_configured_but_unconnected_name() {
+    // The old check resolved connected *tools* back to servers, so a server configured in `config.toml` that had not dialed yet — or failed to dial — was rejected even though it is exactly what the operator wrote down.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    let kernel = boot_kernel_at(&home_dir);
+    register_mcp_server(&kernel, "configured-not-connected");
+    // Deliberately no tools pushed into `tools_ref` — nothing has connected.
+
+    let agent_id = spawn_allowlist_test_agent(&kernel, "unconnected-mcp-agent");
+    kernel
+        .set_agent_mcp_servers(agent_id, vec!["configured-not-connected".to_string()])
+        .expect("a configured server must be accepted whether or not it has connected");
+
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .mcp_servers,
+        vec!["configured-not-connected".to_string()]
+    );
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_mcp_servers_keeps_pending_name_when_adding_configured_ones() {
+    // The reported failure in full: the dashboard PUTs the whole array, so one inherited pending name (`fetch`) took down a save whose actual purpose was adding two configured servers.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    write_test_mcp_catalog_entry(&home_dir, "fetch");
+    let kernel = boot_kernel_at(&home_dir);
+    register_mcp_server(&kernel, "memory");
+    register_mcp_server(&kernel, "camoufox");
+    register_mcp_server(&kernel, "sequential-thinking");
+
+    let agent_id = spawn_allowlist_test_agent(&kernel, "inherited-fetch-agent");
+    let saved = vec![
+        "memory".to_string(),
+        "fetch".to_string(),
+        "camoufox".to_string(),
+        "sequential-thinking".to_string(),
+    ];
+    kernel
+        .set_agent_mcp_servers(agent_id, saved.clone())
+        .expect("adding configured servers alongside an inherited pending one must succeed");
+
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .mcp_servers,
+        saved
+    );
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_mcp_servers_accepts_wildcard_allowlist() {
+    // `["*"]` is a documented value meaning "all connected servers", but it is not the name of anything, so the connected-tool accept-set never contained it and saving it failed with `Unknown MCP server: *`.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    let kernel = boot_kernel_at(&home_dir);
+    let agent_id = spawn_allowlist_test_agent(&kernel, "wildcard-mcp-agent");
+
+    kernel
+        .set_agent_mcp_servers(agent_id, vec!["*".to_string()])
+        .expect("the documented wildcard must be storable");
+    assert_eq!(
+        kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .expect("agent exists")
+            .manifest
+            .mcp_servers,
+        vec!["*".to_string()]
+    );
+
+    kernel.shutdown();
+}
+
+#[test]
+fn test_set_agent_mcp_servers_rejects_name_unknown_everywhere_as_invalid_input() {
+    // A name absent from both `config.toml` and the catalog is genuinely unknown, and must still be rejected — as `InvalidInput`, not `Internal`.
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().to_path_buf();
+    let kernel = boot_kernel_at(&home_dir);
+    let agent_id = spawn_allowlist_test_agent(&kernel, "unknown-mcp-agent");
+
+    let err = kernel
+        .set_agent_mcp_servers(agent_id, vec!["totally-made-up-server".to_string()])
+        .expect_err("a name absent from config and catalog must be rejected");
+    match err {
+        KernelError::LibreFang(LibreFangError::InvalidInput(ref msg)) => {
+            assert!(
+                msg.contains("totally-made-up-server"),
+                "the error must name the rejected server, got: {msg}"
+            );
+            assert!(
+                !msg.contains("Internal"),
+                "a validation failure must not read as an internal fault, got: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got: {other:?}"),
+    }
 
     kernel.shutdown();
 }

--- a/crates/librefang-skills/src/registry.rs
+++ b/crates/librefang-skills/src/registry.rs
@@ -521,8 +521,46 @@ impl SkillRegistry {
     /// Names of on-disk skill directories under `skills_dir` that hold a `skill.toml` but are NOT currently loaded (compared by path, so a skill whose manifest name differs from its directory name is matched correctly).
     ///
     /// Used by the frozen (Stable-mode) reload path to report brand-new skill directories the registry deliberately will not pick up without a restart, instead of silently dropping them (#6540).
+    /// These are *directory* names, which is what an operator-facing "will not be picked up without a restart" report wants — see [`unloaded_on_disk_manifest_names`](Self::unloaded_on_disk_manifest_names) for the identifier an allowlist has to be validated against.
     /// Sorted for a deterministic report.
     pub fn unloaded_on_disk_dirs(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .unloaded_on_disk_entries()
+            .into_iter()
+            .map(|(dir_name, _)| dir_name)
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// `[skill].name` of every on-disk-but-unloaded skill directory, read from that directory's `skill.toml`.
+    ///
+    /// This is the identifier a skill allowlist must be validated against, and it is not interchangeable with [`unloaded_on_disk_dirs`](Self::unloaded_on_disk_dirs).
+    /// The loaded registry is keyed by the manifest name — `load_skill` inserts under `manifest.skill.name`, not under the directory name — so a directory `package-dir/` whose `skill.toml` declares `name = "actual-skill"` will appear as `actual-skill` the moment it loads.
+    /// Checking a pending declaration against directory names therefore rejects `actual-skill`, the only value that can ever match, and accepts `package-dir`, which matches nothing after the skill loads.
+    ///
+    /// A directory whose `skill.toml` cannot be read or parsed is skipped: an unparseable manifest never loads, so it contributes no identifier that could match later.
+    /// Sorted and de-duplicated for a deterministic result.
+    pub fn unloaded_on_disk_manifest_names(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .unloaded_on_disk_entries()
+            .into_iter()
+            .filter_map(|(_, path)| {
+                let toml_str = std::fs::read_to_string(path.join("skill.toml")).ok()?;
+                let manifest: SkillManifest = toml::from_str(&toml_str).ok()?;
+                Some(manifest.skill.name)
+            })
+            .collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// Every directory under `skills_dir` that holds a `skill.toml` and is not currently loaded, as `(directory name, directory path)`.
+    ///
+    /// Shared by [`unloaded_on_disk_dirs`](Self::unloaded_on_disk_dirs) and [`unloaded_on_disk_manifest_names`](Self::unloaded_on_disk_manifest_names) so the two answers can never disagree about *which* directories are unloaded, only about which identifier they report.
+    /// Unsorted — each caller sorts its own projection.
+    fn unloaded_on_disk_entries(&self) -> Vec<(String, PathBuf)> {
         let loaded: std::collections::HashSet<PathBuf> =
             self.skills.values().map(|s| s.path.clone()).collect();
         let mut out = Vec::new();
@@ -547,10 +585,9 @@ impl SkillRegistry {
             // `InstalledSkill.path` is canonicalized at load time (load_skill), so canonicalize here too — otherwise a symlinked skills_dir (e.g. macOS `/var` -> `/private/var`) would make every loaded skill compare as new.
             let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
             if !loaded.contains(&canonical) {
-                out.push(name.to_string());
+                out.push((name.to_string(), path));
             }
         }
-        out.sort();
         out
     }
 
@@ -958,6 +995,33 @@ entry = "main.py"
 
 [[tools.provided]]
 name = "{name}_tool"
+description = "A test tool"
+input_schema = {{ type = "object" }}
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Like [`create_test_skill`], but with the directory name and the manifest's `[skill].name` given independently, so a test can exercise the case where the two differ.
+    fn create_test_skill_named(dir: &Path, dir_name: &str, manifest_name: &str) {
+        let skill_dir = dir.join(dir_name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("skill.toml"),
+            format!(
+                r#"
+[skill]
+name = "{manifest_name}"
+version = "0.1.0"
+description = "Test skill"
+
+[runtime]
+type = "python"
+entry = "main.py"
+
+[[tools.provided]]
+name = "{manifest_name}_tool"
 description = "A test tool"
 input_schema = {{ type = "object" }}
 "#
@@ -1483,6 +1547,63 @@ input_schema = { type = "object" }
         );
         // Still frozen — count unchanged (the new dir was NOT loaded).
         assert_eq!(registry.count(), 2);
+    }
+
+    #[test]
+    fn unloaded_on_disk_manifest_names_reports_manifest_name_not_directory_name() {
+        // #7772: a skill allowlist is validated against the identifier the loaded registry is keyed by, which is `[skill].name` — not the directory name.
+        // A directory whose manifest declares a different name is the case where the two answers diverge, so it is the only case that can catch a caller reaching for the wrong accessor.
+        let dir = TempDir::new().unwrap();
+        create_test_skill_named(dir.path(), "package-dir", "actual-skill");
+
+        let mut registry = SkillRegistry::new(dir.path().to_path_buf());
+        registry.load_all().unwrap();
+        assert_eq!(
+            registry.skill_names(),
+            vec!["actual-skill".to_string()],
+            "the loaded registry keys on the manifest name, which is what makes the two accessors differ"
+        );
+
+        // Unload it by rebuilding an empty registry over the same directory: the skill is on disk, nothing is loaded.
+        let registry = SkillRegistry::new(dir.path().to_path_buf());
+        assert_eq!(
+            registry.unloaded_on_disk_dirs(),
+            vec!["package-dir".to_string()],
+            "unloaded_on_disk_dirs must keep reporting directory names for the operator-facing restart report"
+        );
+        assert_eq!(
+            registry.unloaded_on_disk_manifest_names(),
+            vec!["actual-skill".to_string()],
+            "unloaded_on_disk_manifest_names must report the manifest name, the value that will match once the skill loads"
+        );
+        assert!(
+            !registry
+                .unloaded_on_disk_manifest_names()
+                .iter()
+                .any(|n| n == "package-dir"),
+            "the directory name must not be reported as a manifest name — it can never match after load"
+        );
+    }
+
+    #[test]
+    fn unloaded_on_disk_manifest_names_skips_unparseable_manifests() {
+        // An unparseable skill.toml never loads, so it contributes no identifier that could ever match; reporting its directory name would let a value through that is guaranteed to break later.
+        let dir = TempDir::new().unwrap();
+        create_test_skill_named(dir.path(), "good-dir", "good-skill");
+        let broken = dir.path().join("broken-dir");
+        std::fs::create_dir_all(&broken).unwrap();
+        std::fs::write(broken.join("skill.toml"), "this is not valid toml [[[").unwrap();
+
+        let registry = SkillRegistry::new(dir.path().to_path_buf());
+        assert_eq!(
+            registry.unloaded_on_disk_manifest_names(),
+            vec!["good-skill".to_string()]
+        );
+        assert_eq!(
+            registry.unloaded_on_disk_dirs(),
+            vec!["broken-dir".to_string(), "good-dir".to_string()],
+            "the directory-name report is unchanged: an unparseable dir is still a dir the operator should see"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #7772.

## Credit

The report, the diagnosis and the fix design are @DaBlitzStein's, in #7772 and #7773.
Everything substantive here — that the accept-set is built from *connected* tools and is therefore a strict subset of what is configured; that a declaration this instance has not installed is a legitimate state rather than an error, because `spawn` performs no equivalent check and the edit path was stricter than the path that created the agent; that MCP should accept the local catalog while skills get the narrower on-disk-but-unloaded criterion, since skill content is not in `registry_sync`'s copy set; and that both errors should be `InvalidInput` — comes from that analysis, and I reused it directly.

This exists because #7773 stalled: it conflicts with `main` after #7807 refactored the same manifest-persistence helpers it relocated, and the one review item on it was never addressed.
Rather than ask for another rebase of a 617-line branch, I wrote the smaller change against current `main` and resolved toward `main`'s shape — the helper movement in that branch is no longer needed, so none of it is carried over.
**Recommendation only, for the maintainer to action:** close #7773 as superseded by this PR.
I have not touched it.

## The bug

`set_agent_mcp_servers` built its set of acceptable names by walking the MCP tools connected at that instant and resolving each back to a server.
That set is a strict subset of what is *configured*, never mind what is *installed*, so an agent that inherited `fetch` from a registry agent type could not be edited at all — the save failed with `[400] Internal error: Unknown MCP server: fetch`, naming a server the operator never asked for.
Because the dashboard PUTs the whole array, one inherited name took every unrelated edit down with it.

## Changes

- `crates/librefang-kernel/src/kernel/agent_state.rs` — `set_agent_mcp_servers` accepts a name that is configured in `config.toml` (connected or not) or present in the locally cached MCP catalog; `set_agent_skills` accepts a name that is loaded or is the `[skill].name` of an unloaded on-disk skill directory.
  Accepting a pending declaration persists the name and nothing else: no install, no connect, no `config.toml` write, no skill load.
- `crates/librefang-skills/src/registry.rs` — new `unloaded_on_disk_manifest_names()`, which parses each unloaded directory's `skill.toml` and yields `manifest.skill.name`.
  This is the review item on #7773: `unloaded_on_disk_dirs()` returns *directory* names, and the loaded registry is keyed by the *manifest* name (`load_skill` inserts under `manifest.skill.name`), so for `skills/package-dir/skill.toml` declaring `name = "actual-skill"` a directory-name check rejects `actual-skill` — the only value that can ever match — and accepts `package-dir`, which matches nothing once the skill loads.
  `unloaded_on_disk_dirs()` is unchanged and still returns directory names, because the frozen-reload report at `tools_and_skills.rs::reload_skills` genuinely wants them.
  Both now share one private directory walk, so they cannot disagree about *which* directories are unloaded, only about which identifier they report.

Three further defects in the same block, all fixed here rather than deferred:

- Both rejections were `LibreFangError::Internal`, which is why the dashboard rendered a user-input problem as an internal fault. Both are now `InvalidInput`, and the messages name the rejected value and say what to do.
- The whole MCP check sat inside `if let Ok(mcp_tools) = self.mcp.mcp_tools.lock()`, so a poisoned lock skipped validation entirely instead of failing. The tool walk is gone, and the guard with it.
- `mcp_servers = ["*"]` is a documented value meaning "all connected servers" (`AgentManifest::mcp_servers`, honoured by `available_tools` step 3), but it is not the name of anything, so the connected-tool accept-set never contained it and saving a wildcard allowlist failed with `Unknown MCP server: *`. It is now accepted.
  Deliberately not mirrored on the skills side: the skill path has no wildcard, `skills = ["*"]` grants no skill tools at all, and treating it as one there would be a lie.

## Verification

Route-level, against `TestServer` in `crates/librefang-api/tests/agents_routes_integration.rs`:

- `test_put_mcp_servers_keeps_inherited_declaration_while_adding_configured_ones` — the reported failure end to end. `fetch` ships in the pinned registry fixture's MCP catalog and is never configured, so it is installed but not configured; the PUT returns 200, the read-back shows all four names persisted, and `fetch` is still reported as pending.
- `test_put_skills_accepts_pending_manifest_name_not_directory_name` — directory `package-dir`, `[skill] name = "actual-skill"`. Asserts the manifest name saves and reads back, that the directory name is rejected with 400 rather than silently accepted in its place, and that the rejected save leaves the stored allowlist untouched.
- `test_put_mcp_servers_rejects_unknown_name_without_internal_error_wording`, `test_put_skills_rejects_unknown_name_without_internal_error_wording` — a genuinely unknown name is still 400, and the body no longer contains "Internal error".

Kernel-level, in `crates/librefang-kernel/src/kernel/tests.rs`:

- `test_set_agent_skills_validates_against_manifest_name_not_directory_name` — the review item. `install_test_skill` derived the directory and `[skill] name` from one argument, so it was structurally unable to catch this; it is now a thin wrapper over a new `install_test_skill_named(parent, dir_name, manifest_name, tags)`, and the fixture sets the two deliberately different.
- `test_set_agent_skills_accepts_on_disk_unloaded_pending_name` — asserts the skill is still not loaded afterwards, so acceptance has no side effect.
- `test_set_agent_mcp_servers_accepts_catalog_only_pending_name` — asserts `effective_mcp_servers` is unchanged and does not gain `fetch`.
- `test_set_agent_mcp_servers_accepts_configured_but_unconnected_name`, `test_set_agent_mcp_servers_keeps_pending_name_when_adding_configured_ones`, `test_set_agent_mcp_servers_accepts_wildcard_allowlist`, and `test_set_agent_{skills,mcp_servers}_rejects_name_unknown_everywhere_as_invalid_input`.

Registry-level, in `crates/librefang-skills/src/registry.rs`:

- `unloaded_on_disk_manifest_names_reports_manifest_name_not_directory_name` — pins that the two accessors return different identifiers for the same directory, so a future caller cannot swap one for the other unnoticed.
- `unloaded_on_disk_manifest_names_skips_unparseable_manifests` — an unparseable `skill.toml` never loads, so it contributes no identifier; the directory report still lists it, because an operator should see it.

Commands run:

- `cargo test -p librefang-api --test agents_routes_integration` — 63 passed, 0 failed.
- `cargo test -p librefang-kernel --lib set_agent_` — 13 passed; `--lib skill` — 123 passed.
- `cargo test -p librefang-skills --lib registry::` — 27 passed.
- `cargo clippy -p librefang-kernel --lib --tests -- -D warnings` and the same for `-p librefang-skills` — clean.
- `cargo fmt` clean; `scripts/check-changelog-attribution.py` clean.
- Branch merged with `origin/main` at `eac1a6bdf` before the final run; no newer commits on `main` at push time.

Nothing deferred.
