### PR TITLE
test(channels): lock the group roster write path, and correct its docs

### DIFF
--- a/changelog.d/documentation/7086-roster-write-path.md
+++ b/changelog.d/documentation/7086-roster-write-path.md
@@ -1,0 +1,6 @@
+Corrected three comments that described the group roster inaccurately, and locked the roster write path with tests.
+  `extract_group_members` in the channel bridge claimed to persist bulk membership metadata to the roster store; it never did, and the only roster writer is the per-sender `upsert_sender_into_roster`, which records one row per person actually observed speaking.
+  That distinction decides who `channel_dm` is allowed to reach, so a comment implying the wider set is worth more than a typo.
+  The memory crate still pointed readers at a `group_members` tool that was renamed `channel_members` before it shipped, and the Slack sidecar still said display names are never resolved, which stopped being true when `SLACK_RESOLVE_DISPLAY_NAMES` landed.
+  The new tests pin the junction the whole feature rests on: a resolved display name has to survive the bridge to reach the roster column `channel_members` reads back, and direct messages, senderless group messages and blank ids must not be recorded at all.
+  (#7901) (@houko)

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2801,8 +2801,12 @@ fn should_process_group_message(
 }
 
 /// Extract structured `GroupMember` entries from the inbound message metadata.
-/// Channels that supply `group_members` (a JSON array of `{user_id, display_name, username?}`)
-/// populate this; the bridge persists them to the roster store for later queries.
+///
+/// Channels that supply `group_members` (a JSON array of `{user_id, display_name, username?}`) populate `SenderContext.group_members` through this, and that is where it stops: nothing outside this crate reads that field, and no channel adapter on `main` emits the key.
+///
+/// This is NOT the roster write path, despite what this comment claimed until #7086 was audited.
+/// The persistent `group_roster` table is written from exactly one place, `upsert_sender_into_roster`, one row per person actually observed speaking — bulk membership metadata is parsed here and dropped.
+/// The distinction is load-bearing rather than pedantic: `channel_dm` authorizes a private message against the roster, so widening it from "people this daemon has heard from" to "everyone a platform reports as a member" would let an agent DM someone who has never interacted with it.
 fn extract_group_members(message: &ChannelMessage) -> Vec<GroupMember> {
     message
         .metadata
@@ -12402,6 +12406,182 @@ mod tests {
                 lifecycle_reaction_emoji(&AgentPhase::Error, true),
                 default_phase_emoji(&AgentPhase::Error)
             );
+        }
+    }
+
+    /// The roster write path, which is what makes `channel_members` (#7865) and Slack display-name resolution (#7874) visible to an agent.
+    ///
+    /// `upsert_sender_into_roster` is the only `roster_upsert` call site in the tree, and until now nothing exercised it.
+    /// Every way it can go wrong looks like a working feature from the outside: drop the display name and `channel_members` goes back to listing opaque `U09…` ids, roster the conversation's own `platform_id` instead of the speaker and `channel_dm` will accept the group id as a "member", skip a message that should have been recorded and the person who spoke is simply never addressable.
+    mod roster_write_path {
+        use super::*;
+
+        /// One recorded `roster_upsert`, in the argument order the trait declares.
+        type RosterCall = (String, String, String, String, Option<String>);
+
+        /// Records every `roster_upsert` with the exact arguments it arrived with.
+        #[derive(Default)]
+        struct RosterRecorder {
+            calls: Mutex<Vec<RosterCall>>,
+        }
+
+        #[async_trait]
+        impl ChannelBridgeHandle for RosterRecorder {
+            async fn send_message(
+                &self,
+                _agent_id: AgentId,
+                _message: &str,
+            ) -> Result<String, String> {
+                Ok(String::new())
+            }
+            async fn find_agent_by_name(&self, _name: &str) -> Result<Option<AgentId>, String> {
+                Ok(None)
+            }
+            async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+                Ok(Vec::new())
+            }
+            async fn spawn_agent_by_name(&self, _manifest_name: &str) -> Result<AgentId, String> {
+                Err("spawn not implemented in mock".to_string())
+            }
+            async fn roster_upsert(
+                &self,
+                channel: &str,
+                chat_id: &str,
+                user_id: &str,
+                display_name: &str,
+                username: Option<&str>,
+            ) -> Result<(), String> {
+                self.calls.lock().unwrap().push((
+                    channel.to_string(),
+                    chat_id.to_string(),
+                    user_id.to_string(),
+                    display_name.to_string(),
+                    username.map(str::to_string),
+                ));
+                Ok(())
+            }
+            fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {
+                // Test mock: no event bus to forward to.
+            }
+        }
+
+        /// A Slack message shaped the way the sidecar emits one: `platform_id` is the conversation, the individual speaker lives under `SENDER_USER_ID_KEY`, and `display_name` carries whatever the adapter resolved for them.
+        fn slack_message(
+            is_group: bool,
+            sender_user_id: Option<&str>,
+            display_name: &str,
+            username: Option<&str>,
+        ) -> ChannelMessage {
+            let mut metadata = std::collections::HashMap::new();
+            if let Some(uid) = sender_user_id {
+                metadata.insert(SENDER_USER_ID_KEY.to_string(), serde_json::json!(uid));
+            }
+            if let Some(handle) = username {
+                metadata.insert("sender_username".to_string(), serde_json::json!(handle));
+            }
+            ChannelMessage {
+                channel: ChannelType::Slack,
+                platform_message_id: "1700000000.000100".to_string(),
+                sender: ChannelUser {
+                    platform_id: "C0DESIGN".to_string(),
+                    display_name: display_name.to_string(),
+                    librefang_user: None,
+                },
+                content: ChannelContent::Text("ship it".to_string()),
+                target_agent: None,
+                timestamp: chrono::Utc::now(),
+                is_group,
+                thread_id: None,
+                metadata,
+            }
+        }
+
+        async fn record(message: &ChannelMessage) -> Vec<RosterCall> {
+            let recorder = Arc::new(RosterRecorder::default());
+            let handle: Arc<dyn ChannelBridgeHandle> = recorder.clone();
+            upsert_sender_into_roster(&handle, message).await;
+            let calls = recorder.calls.lock().unwrap().clone();
+            calls
+        }
+
+        /// The #7086 payoff: a name the Slack adapter resolved through `users.info` has to survive the bridge to reach `group_roster.display_name`, because that column is verbatim what `channel_members` hands the model.
+        #[tokio::test]
+        async fn a_resolved_display_name_and_handle_reach_the_roster() {
+            let calls = record(&slack_message(
+                true,
+                Some("U09ABC"),
+                "Ada Lovelace",
+                Some("ada"),
+            ))
+            .await;
+
+            assert_eq!(
+                calls,
+                vec![(
+                    "slack".to_string(),
+                    "C0DESIGN".to_string(),
+                    "U09ABC".to_string(),
+                    "Ada Lovelace".to_string(),
+                    Some("ada".to_string()),
+                )],
+                "the roster is keyed on (bare channel type, conversation id, speaker id) and stores the resolved name and handle"
+            );
+        }
+
+        /// `SLACK_RESOLVE_DISPLAY_NAMES` defaults to off, and every failure path in the adapter falls back to the raw id.
+        /// Turning resolution off must degrade the *label*, never the membership record — otherwise `channel_dm` would refuse to reach anyone on a default install.
+        #[tokio::test]
+        async fn an_unresolved_raw_id_is_still_rostered() {
+            let calls = record(&slack_message(true, Some("U09ABC"), "U09ABC", None)).await;
+
+            assert_eq!(calls.len(), 1, "membership does not depend on resolution");
+            assert_eq!(calls[0].2, "U09ABC");
+            assert_eq!(calls[0].3, "U09ABC");
+            assert_eq!(calls[0].4, None, "no handle resolved, no handle stored");
+        }
+
+        /// A DM has no roster: `platform_id` is the peer rather than a conversation with members, and recording it would invent a one-person group.
+        #[tokio::test]
+        async fn a_direct_message_is_not_rostered() {
+            let calls = record(&slack_message(false, Some("U09ABC"), "Ada Lovelace", None)).await;
+            assert!(calls.is_empty(), "DMs must not write roster rows");
+        }
+
+        /// Without `SENDER_USER_ID_KEY` the only id available is the conversation's own `platform_id`.
+        /// Storing that would make the group a member of itself, and `channel_dm`'s membership check would then authorize the group id as a private recipient — the broadcast the tool exists to avoid.
+        #[tokio::test]
+        async fn a_group_message_with_no_sender_user_id_is_not_rostered() {
+            let calls = record(&slack_message(true, None, "Ada Lovelace", None)).await;
+            assert!(
+                calls.is_empty(),
+                "a message with no individual speaker id must not fall back to the conversation id"
+            );
+        }
+
+        /// An empty id is the same hazard as a missing one, and an empty conversation id would key a row nothing can ever read back.
+        #[tokio::test]
+        async fn empty_ids_are_not_rostered() {
+            assert!(record(&slack_message(true, Some(""), "Ada Lovelace", None))
+                .await
+                .is_empty());
+
+            let mut blank_conversation = slack_message(true, Some("U09ABC"), "Ada Lovelace", None);
+            blank_conversation.sender.platform_id = String::new();
+            assert!(record(&blank_conversation).await.is_empty());
+        }
+
+        /// The WhatsApp gateway stamps its channel as `whatsapp:<jid>` (#5227), but the roster is keyed on the bare channel *type* that `channel_type_str` produces.
+        /// `channel_members` and `channel_dm` both strip the suffix before reading, so the write side has to agree or every WhatsApp lookup misses.
+        #[tokio::test]
+        async fn the_roster_key_is_the_bare_channel_type() {
+            let mut msg = slack_message(true, Some("44@s.whatsapp.net"), "Ada", None);
+            msg.channel = ChannelType::WhatsApp;
+            msg.sender.platform_id = "123@g.us".to_string();
+
+            let calls = record(&msg).await;
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].0, "whatsapp");
+            assert_eq!(calls[0].1, "123@g.us");
         }
     }
 }

--- a/crates/librefang-memory/src/roster_store.rs
+++ b/crates/librefang-memory/src/roster_store.rs
@@ -1,8 +1,10 @@
 //! SQLite-backed group roster store.
 //!
-//! Tracks which users have been seen in each group chat, persisting across
-//! daemon restarts. Agents query this via the `group_members` tool instead
-//! of having the roster injected into the system prompt (saving tokens).
+//! Tracks which users have been seen in each group chat, persisting across daemon restarts.
+//! Agents query this on demand through the `channel_members` tool (#7865) rather than having the roster injected into every system prompt, which keeps the token cost proportional to the questions asked instead of to the number of turns.
+//!
+//! Membership here is observational: a row exists for someone because they spoke in that chat, not because a platform listed them.
+//! `channel_dm` (#7086) uses the same rows as its authorization set, so that narrower definition is deliberate.
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -844,10 +844,8 @@ def parse_slack_event(
         # G… for private groups). The kernel uses this as the reply
         # target — matching Rust's `sender.platform_id = channel`.
         user_id=channel,
-        # Display name is the Slack user id verbatim — the Rust
-        # adapter doesn't try to resolve display names (it would
-        # need an extra `users.info` call per message). Operators
-        # who want human-readable names set them in `[users]`.
+        # Placeholder only. This is a pure function with no workspace access, so it stamps the raw Slack user id and `SlackAdapter._apply_identity` overwrites it with a resolved display name when `SLACK_RESOLVE_DISPLAY_NAMES` is on (#7086).
+        # With resolution off — the default — the raw id is what the agent sees, and operators who want names without the `users:read` scope set them in `[users]`.
         user_name=user_id,
         content=content,
         message_id=ts,


### PR DESCRIPTION
Refs #7086. **Does not close it** — see "What is still open" below.

## The briefing's premise did not hold

I was sent to implement gap 3 of #7086 — cached `users.info` display-name resolution for Slack — on the understanding that it was the remaining ask.
It shipped in #7874 (merged `cb6449e0dd3930899580f32d7aa4f44b62093192`, 2026-08-24) and is complete end to end on `origin/main` @ `eac1a6bdf`.
Evidence, since the whole point of checking is to be checkable:

- `sdk/python/librefang/sidecar/adapters/slack.py:450` `parse_users_identity` — the `profile.display_name` → `profile.real_name` → `user.real_name` → `user.name` ladder, returning `(None, None)` for a definitive absence and `(None, err)` for a transient one.
- `slack.py:485` `_IdentityCache` — bounded, TTL'd, oldest-first eviction; `slack.py:1277` `_lookup_identity` writes the cache on **every** exit path including the failures, with `NEGATIVE_TTL_SECS` for transient errors and the full TTL for definitive ones.
- `slack.py:1318` `_apply_identity` is wired into both inbound paths: `slack.py:1729` (`events_api`) and `slack.py:1747` (`interactive`).
- Operator controls are in `describe()`: `SLACK_RESOLVE_DISPLAY_NAMES` at `slack.py:1035` (default `false`) and `SLACK_DISPLAY_NAME_TTL` at `slack.py:1041` (default 21600 s), parsed and validated at `slack.py:1102`–`:1117`.
- 17 tests cover it in `sdk/python/tests/test_slack_adapter.py`, including `test_repeated_ids_cost_exactly_one_users_info_call` and `test_transient_failure_uses_the_short_cooldown_not_the_full_ttl`. `python3 -m pytest tests/test_slack_adapter.py` — 200 passed.

The other two landings verify too: `channel_members` at `crates/librefang-runtime/src/tool_runner/channel.rs:319` (#7865), `channel_dm` at `channel.rs:202` with the roster-authorization rule at `channel.rs:233`–`:242` and the out-of-band refusal at `channel.rs:169`–`:185` (#7874), both present in the `messaging` and `automation` tool profiles (`crates/librefang-types/src/agent.rs:823`, `:841`). Slack inbound files (#7812) at `slack.py:662` `parse_slack_files`.

So there was nothing to implement or wire. What the audit turned up instead is below.

## What this PR does

**Tests the roster write path, which nothing tested.**
`upsert_sender_into_roster` (`crates/librefang-channels/src/bridge.rs:2983`) is the only `roster_upsert` call site in the tree, and it is the junction the whole of #7086 rests on: it is what carries a name resolved by #7874 into the column #7865 reads back.
Every way it can fail looks like a working feature from the outside — a dropped display name puts opaque `U09…` ids back in `channel_members`, a rostered `platform_id` makes a group a member of itself and hands `channel_dm` the group id as a valid private recipient, a skipped message makes that person permanently unaddressable.
Six tests in a new `bridge::tests::roster_write_path` module:

- `a_resolved_display_name_and_handle_reach_the_roster` — a Slack group message with `display_name = "Ada Lovelace"` and `sender_username = "ada"` produces exactly `roster_upsert("slack", "C0DESIGN", "U09ABC", "Ada Lovelace", Some("ada"))`. Mutation-checked: rewriting the call to pass `user_id` in place of `&message.sender.display_name` fails this test and only this test.
- `an_unresolved_raw_id_is_still_rostered` — resolution is default-off, so membership must not depend on it; otherwise `channel_dm` would refuse everyone on a default install.
- `a_direct_message_is_not_rostered`, `a_group_message_with_no_sender_user_id_is_not_rostered`, `empty_ids_are_not_rostered` — the three skip conditions, with the `channel_dm` consequence spelled out in each.
- `the_roster_key_is_the_bare_channel_type` — a WhatsApp turn keys on `whatsapp`, matching the `channel_base` strip both read tools perform (#5227).

**Corrects three comments that describe the roster inaccurately.**

- `bridge.rs:2803` — `extract_group_members` claimed the bridge "persists them to the roster store for later queries". It does not: it fills `SenderContext.group_members` (`bridge.rs:2938`), which nothing outside `librefang-channels` reads, and no adapter on `main` emits the key. Bulk membership metadata is parsed and dropped. This one was flagged by the maintainer on #7086 as owed to whichever PR landed next; #7874 did not carry it.
- `crates/librefang-memory/src/roster_store.rs:4` — pointed at a `group_members` tool. It was named `channel_members` by the time it shipped in #7865, so a reader would hunt for a tool that does not exist.
- `slack.py:846` — said the adapter does not resolve display names and that operators wanting names set them in `[users]`. Half of that stopped being true in #7874. The stamp there is a placeholder that `_apply_identity` overwrites, and the comment now says so.

None of these is a typo. All three describe the roster as wider or narrower than it is, and `channel_dm` uses the roster as its authorization set.

## Privacy — what is stored, for how long, how to turn it off

Restated here because it is a standing property of the feature, not a one-time note, and #7874's PR body is the only place it currently lives.

- **What is stored**: one `group_roster` row per person observed speaking in a group — `channel_type`, `chat_id`, `user_id`, `display_name`, `username`, `first_seen`, `last_seen` — in `~/.librefang/memory.db`. This write predates #7086; with resolution off the `display_name` column holds the opaque platform id. Enabling resolution changes the content of a row already being written. No new table, no new column, no new write site — and this PR adds none either.
- **For how long**: indefinitely. `RosterStore` has `upsert` / `members` / `remove_member` and no expiry, no pruning, no retention setting.
- **How an operator turns it off**: `SLACK_RESOLVE_DISPLAY_NAMES` defaults to `false`, so an upgrade resolves nobody. Setting it back to `false` stops new resolutions immediately; rows already written keep the names they were written with, because nothing rewrites them and nothing prunes them.
- **The gap**: there is no retention control. A member who left a channel a year ago is still named in the database. #7874 surfaced this and asked for a maintainer call on the shape (global `config.toml` field plus a kernel sweeper, versus a manual removal route); it has not been answered, and it lives in `librefang-memory` rather than either crate this PR touches, so it stays surfaced rather than decided.

## What is still open on #7086, and what I deliberately did not do

Gap 1 as the reporter wrote it — "the Slack adapter never emits `group_members` metadata, so the agent cannot answer who is in this channel" — is **not** closed. `channel_members` answers "who has spoken here", not "who is a member". The reporter's proposal was `conversations.members`.

I did not implement it, and I do not think it should be implemented without a maintainer decision first. `channel_dm` authorizes a private message against exactly these rows (`crates/librefang-runtime/src/tool_runner/channel.rs:233`). Bulk-populating `group_roster` from `conversations.members` would silently widen that authorization set from "people this agent has interacted with" to "everyone the platform lists", letting an agent DM a channel member who has never spoken to it. #7874 declined it for that reason and said so. Doing it as a side effect of a close-out PR would be a security change smuggled in under a documentation heading.

If bulk enumeration is wanted, the honest shape is a second table (or a `source` column) so the observational set stays the `channel_dm` gate while `channel_members` can report the fuller list — which is a design decision, not a patch.

## Verification

- `cargo test -p librefang-channels --lib roster_write_path` — 6 passed.
- Mutation check: `&message.sender.display_name` → `user_id` in `upsert_sender_into_roster` fails `a_resolved_display_name_and_handle_reach_the_roster` with `left: "U09ABC"` / `right: "Ada Lovelace"`, and no other test. Reverted.
- `cargo check -p librefang-channels --lib`, `cargo check -p librefang-memory --lib` — clean.
- `cargo clippy -p librefang-channels --lib --tests -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `python3 -m pytest sdk/python/tests/test_slack_adapter.py` — 200 passed (unchanged; the edit there is a comment).
- `python3 scripts/check-changelog-attribution.py` — OK.
- No route added or rewired, so no `TestServer` test: the surfaces touched are a channel-bridge helper, a memory-crate module doc, and a sidecar comment. No daemon started.
