### PR TITLE
fix(api): name the exceeded budget cap in the refusal message

### DIFF
--- a/changelog.d/fixed/7352-budget-error-names-the-cap.md
+++ b/changelog.d/fixed/7352-budget-error-names-the-cap.md
@@ -1,0 +1,4 @@
+A usage-budget refusal now tells the operator which cap was hit and what it is set to.
+The kernel already computed that detail — the agent, the window, the spend so far, this call's cost, and the limit — but the WebSocket surface matched on the error prefix and replaced the whole message with generic guidance, so an operator was told to "raise the matching limit" while the message withheld which limit that was.
+Reported after three requests produced an unexplained refusal, with no way to tell from the message whether the cap was hourly, daily, monthly or token-based.
+(#PR) (@houko)

--- a/changelog.d/fixed/7352-budget-error-names-the-cap.md
+++ b/changelog.d/fixed/7352-budget-error-names-the-cap.md
@@ -1,4 +1,4 @@
 A usage-budget refusal now tells the operator which cap was hit and what it is set to.
 The kernel already computed that detail — the agent, the window, the spend so far, this call's cost, and the limit — but the WebSocket surface matched on the error prefix and replaced the whole message with generic guidance, so an operator was told to "raise the matching limit" while the message withheld which limit that was.
 Reported after three requests produced an unexplained refusal, with no way to tell from the message whether the cap was hourly, daily, monthly or token-based.
-(#PR) (@houko)
+(#7907) (@houko)

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -2223,11 +2223,8 @@ fn classify_streaming_error(err: &dyn std::fmt::Display) -> ClassifiedStreamingE
     // exact thiserror Display prefix so provider strings fall through to the
     // classifier below (RateLimit / Billing), not this branch.
     if let Some(detail_start) = inner.find("Resource quota exceeded:") {
-        // The kernel already computed which cap was breached and by how much —
-        // "Agent <id> exceeded hourly cost quota: $0.0123 + $0.0045 / $0.0100",
-        // i.e. spent + this call / limit. Dropping that left the operator with
-        // advice to "raise the matching limit" and no way to learn which one or
-        // what it is currently set to (#7352).
+        // The kernel already computed which cap was breached and by how much — "Agent <id> exceeded hourly cost quota: $0.0123 + $0.0045 / $0.0100", i.e. spent + this call / limit.
+        // Dropping that left the operator with advice to "raise the matching limit" and no way to learn which one or what it is currently set to (#7352).
         let detail = inner[detail_start + "Resource quota exceeded:".len()..].trim();
         let guidance = "Usage budget reached for this window. This is a token, cost, or tool-call cap, not a full context window \u{2014} /compact will NOT help. Wait for the relevant window to reset, or raise the matching agent resource limit in its manifest or the matching [budget] limit in config.toml.";
         let message = if detail.is_empty() {
@@ -2495,9 +2492,7 @@ mod tests {
     }
 
     /// The kernel names the cap and its value; the surface must not drop that.
-    /// Without it the message tells an operator to raise "the matching limit"
-    /// while withholding which limit and what it is set to, which is what left
-    /// #7352 unanswerable from the error alone.
+    /// Without it the message tells an operator to raise "the matching limit" while withholding which limit and what it is set to, which is what left #7352 unanswerable from the error alone.
     #[test]
     fn test_classify_streaming_error_budget_names_the_cap_that_was_hit() {
         let error = classify_streaming_error(
@@ -2514,8 +2509,7 @@ mod tests {
         assert!(error.message.contains("scout"), "{}", error.message);
     }
 
-    /// A bare prefix with no detail must still produce the guidance alone,
-    /// never a dangling empty parenthetical.
+    /// A bare prefix with no detail must still produce the guidance alone, never a dangling empty parenthetical.
     #[test]
     fn test_classify_streaming_error_budget_without_detail_is_unchanged() {
         let error = classify_streaming_error(&"Resource quota exceeded:");

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -2222,11 +2222,20 @@ fn classify_streaming_error(err: &dyn std::fmt::Display) -> ClassifiedStreamingE
     // provider 429/billing error that merely contains the word "quota". Match the
     // exact thiserror Display prefix so provider strings fall through to the
     // classifier below (RateLimit / Billing), not this branch.
-    if inner.contains("Resource quota exceeded:") {
-        return streaming_error(
-            "Usage budget reached for this window. This is a token, cost, or tool-call cap, not a full context window \u{2014} /compact will NOT help. Wait for the relevant window to reset, or raise the matching agent resource limit in its manifest or the matching [budget] limit in config.toml.",
-            "budget_exceeded",
-        );
+    if let Some(detail_start) = inner.find("Resource quota exceeded:") {
+        // The kernel already computed which cap was breached and by how much —
+        // "Agent <id> exceeded hourly cost quota: $0.0123 + $0.0045 / $0.0100",
+        // i.e. spent + this call / limit. Dropping that left the operator with
+        // advice to "raise the matching limit" and no way to learn which one or
+        // what it is currently set to (#7352).
+        let detail = inner[detail_start + "Resource quota exceeded:".len()..].trim();
+        let guidance = "Usage budget reached for this window. This is a token, cost, or tool-call cap, not a full context window \u{2014} /compact will NOT help. Wait for the relevant window to reset, or raise the matching agent resource limit in its manifest or the matching [budget] limit in config.toml.";
+        let message = if detail.is_empty() {
+            guidance.to_string()
+        } else {
+            format!("{guidance} ({detail})")
+        };
+        return streaming_error(&message, "budget_exceeded");
     }
 
     // Use the LLM error classifier for everything else
@@ -2483,6 +2492,36 @@ mod tests {
         let error = classify_streaming_error(&E);
         assert!(error.message.to_lowercase().contains("usage budget"));
         assert_eq!(error.code, "budget_exceeded");
+    }
+
+    /// The kernel names the cap and its value; the surface must not drop that.
+    /// Without it the message tells an operator to raise "the matching limit"
+    /// while withholding which limit and what it is set to, which is what left
+    /// #7352 unanswerable from the error alone.
+    #[test]
+    fn test_classify_streaming_error_budget_names_the_cap_that_was_hit() {
+        let error = classify_streaming_error(
+            &"Resource quota exceeded: Agent scout exceeded hourly cost quota: $0.0123 + $0.0045 / $0.0100",
+        );
+        assert_eq!(error.code, "budget_exceeded");
+        assert!(error.message.contains("Usage budget"), "{}", error.message);
+        assert!(
+            error.message.contains("hourly cost quota"),
+            "{}",
+            error.message
+        );
+        assert!(error.message.contains("$0.0100"), "{}", error.message);
+        assert!(error.message.contains("scout"), "{}", error.message);
+    }
+
+    /// A bare prefix with no detail must still produce the guidance alone,
+    /// never a dangling empty parenthetical.
+    #[test]
+    fn test_classify_streaming_error_budget_without_detail_is_unchanged() {
+        let error = classify_streaming_error(&"Resource quota exceeded:");
+        assert_eq!(error.code, "budget_exceeded");
+        assert!(error.message.contains("Usage budget"));
+        assert!(!error.message.contains("()"), "{}", error.message);
     }
 
     #[test]


### PR DESCRIPTION
Closes #7352.

## The defect

The reporter hit a refusal after three requests and asked "что делать" — what do I do.
The message could not answer that, by construction.

`crates/librefang-api/src/ws.rs` matched the `"Resource quota exceeded:"` prefix on the kernel error and replaced the entire message with fixed guidance ending "raise the matching agent resource limit in its manifest or the matching `[budget]` limit in `config.toml`".
The kernel had already computed exactly which limit that was — `crates/librefang-memory/src/usage.rs:325-360` formats `"Agent scout exceeded hourly cost quota: $0.0123 + $0.0045 / $0.0100"`, i.e. agent, window, spend so far, this call's cost, and the cap.
The WebSocket surface discarded all of it.

So the operator was told to raise "the matching limit" by a message that withheld which limit matched, whether the window was hourly / daily / monthly, and what the cap was currently set to.

## Change

- `ws.rs`: keep the guidance, append the kernel's computed detail in parentheses. When the kernel produced no detail (empty tail), the message is byte-identical to before — no dangling `()`.

## Verification

- `cargo test -p librefang-api --lib classify_streaming_error` — 7 passed.
- Two new tests:
  - `test_classify_streaming_error_budget_names_the_cap_that_was_hit` — asserts the emitted message contains the window (`hourly cost quota`), the limit (`$0.0100`) and the agent (`scout`).
  - `test_classify_streaming_error_budget_without_detail_is_unchanged` — pins the empty-detail path.
- Negative control: restored the old detail-discarding branch and re-ran — `test_classify_streaming_error_budget_names_the_cap_that_was_hit` FAILED (`6 passed; 1 failed`). The test pins the bug rather than the implementation.
- `cargo clippy -p librefang-api --lib -- -D warnings` — clean.

## Not changed

The cap values themselves and the surfaces other than WebSocket. `budget_exceeded` remains the error code; only the human-readable message gains the detail.
