### PR TITLE
fix(memory): record migration v50 under its own version

### DIFF
--- a/changelog.d/fixed/7924-migration-v50-audit-version.md
+++ b/changelog.d/fixed/7924-migration-v50-audit-version.md
@@ -1,0 +1,4 @@
+Migration v50 — the FTS5 index over `memories.content` — recorded its audit row under version 49, which version 49 already held, so `INSERT OR IGNORE` dropped it and the audit-consistency backfill supplied a placeholder in its place.
+The DDL always applied correctly; what was lost was the record of it, and the side effect was that every brand-new database logged "Migration audit drift detected and self-healed" on its first boot — a warning meant to tell an operator that an old database was being repaired, fired for everyone, which is how a real drift warning stops being read.
+The existing guard could not catch this because it asserted that every applied version has an audit row, and the backfill created the missing row before the assertion ran; the new one pins the invariant the backfill's own comment claims, that a clean database needs no backfill at all.
+(#7925) (@houko)

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -1035,7 +1035,7 @@ fn migrate_v50(conn: &Connection) -> Result<(), rusqlite::Error> {
 
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
-         VALUES (49, datetime('now'), 'Add memories_fts FTS5 index over memories.content so search without embeddings is a real index, not a LIKE scan (#7808)')",
+         VALUES (50, datetime('now'), 'Add memories_fts FTS5 index over memories.content so search without embeddings is a real index, not a LIKE scan (#7808)')",
         [],
     )?;
     Ok(())
@@ -2179,6 +2179,75 @@ mod tests {
                 "migration v{v} is applied (user_version={user_version}) but has no audit row"
             );
         }
+    }
+
+    /// Companion to `test_every_migration_records_audit_row`, and the guard that test could not be (#7924).
+    ///
+    /// That test asserts every applied version *has* an audit row, but the #3538 backfill at the end of
+    /// `run_migrations` creates any missing row before the assertion runs — so a migration that stamps the
+    /// wrong version number passes it, rescued by the repair path.
+    /// `migrate_v50` did exactly that: it recorded under version 49, where `INSERT OR IGNORE` silently
+    /// dropped it against `migrate_v49`'s row, and every fresh database then warned about historical drift
+    /// on its first boot.
+    ///
+    /// The invariant the backfill's own doc comment already claims is the stronger one and is what this
+    /// pins: on a clean database the backfill inserts nothing, because every migration recorded itself.
+    /// A placeholder description surviving a fresh `run_migrations` means some migration is stamping a
+    /// version that is not its own.
+    #[test]
+    fn no_migration_relies_on_the_audit_backfill() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let mut stmt = conn
+            .prepare("SELECT version, description FROM migrations ORDER BY version")
+            .unwrap();
+        let rescued: Vec<u32> = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .map(|row| row.unwrap())
+            .filter(|(_, description)| description.contains("audit-row backfill"))
+            .map(|(version, _)| version)
+            .collect();
+
+        assert!(
+            rescued.is_empty(),
+            "these versions were rescued by the #3538 backfill on a clean database, which means the \
+             migration that applied their DDL stamped a version that is not its own: {rescued:?}"
+        );
+    }
+
+    /// The specific collision from #7924, pinned by description rather than by presence.
+    ///
+    /// Both rows existing is not enough — that was already true, because the backfill supplied the missing
+    /// one. What has to hold is that each version's description names the DDL that version actually applied.
+    #[test]
+    fn v49_and_v50_each_describe_their_own_ddl() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let description = |version: u32| -> String {
+            conn.query_row(
+                "SELECT description FROM migrations WHERE version = ?1",
+                [version],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap_or_else(|e| panic!("no audit row for v{version}: {e}"))
+        };
+
+        assert!(
+            description(49).contains("owner_agent_id"),
+            "v49 must describe the run-ownership columns it adds (#7714), got: {}",
+            description(49)
+        );
+        assert!(
+            description(50).contains("memories_fts"),
+            "v50 must describe the FTS5 index it adds (#7808), not a backfill placeholder or v49's \
+             description, got: {}",
+            description(50)
+        );
     }
 
     /// Boot-time ladder invariant: a DB whose `migrations` audit table

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -2183,17 +2183,11 @@ mod tests {
 
     /// Companion to `test_every_migration_records_audit_row`, and the guard that test could not be (#7924).
     ///
-    /// That test asserts every applied version *has* an audit row, but the #3538 backfill at the end of
-    /// `run_migrations` creates any missing row before the assertion runs — so a migration that stamps the
-    /// wrong version number passes it, rescued by the repair path.
-    /// `migrate_v50` did exactly that: it recorded under version 49, where `INSERT OR IGNORE` silently
-    /// dropped it against `migrate_v49`'s row, and every fresh database then warned about historical drift
-    /// on its first boot.
+    /// That test asserts every applied version *has* an audit row, but the #3538 backfill at the end of `run_migrations` creates any missing row before the assertion runs — so a migration that stamps the wrong version number passes it, rescued by the repair path.
+    /// `migrate_v50` did exactly that: it recorded under version 49, where `INSERT OR IGNORE` silently dropped it against `migrate_v49`'s row, and every fresh database then warned about historical drift on its first boot.
     ///
-    /// The invariant the backfill's own doc comment already claims is the stronger one and is what this
-    /// pins: on a clean database the backfill inserts nothing, because every migration recorded itself.
-    /// A placeholder description surviving a fresh `run_migrations` means some migration is stamping a
-    /// version that is not its own.
+    /// The invariant the backfill's own doc comment already claims is the stronger one and is what this pins: on a clean database the backfill inserts nothing, because every migration recorded itself.
+    /// A placeholder description surviving a fresh `run_migrations` means some migration is stamping a version that is not its own.
     #[test]
     fn no_migration_relies_on_the_audit_backfill() {
         let conn = Connection::open_in_memory().unwrap();
@@ -2221,8 +2215,8 @@ mod tests {
 
     /// The specific collision from #7924, pinned by description rather than by presence.
     ///
-    /// Both rows existing is not enough — that was already true, because the backfill supplied the missing
-    /// one. What has to hold is that each version's description names the DDL that version actually applied.
+    /// Both rows existing is not enough — that was already true, because the backfill supplied the missing one.
+    /// What has to hold is that each version's description names the DDL that version actually applied.
     #[test]
     fn v49_and_v50_each_describe_their_own_ddl() {
         let conn = Connection::open_in_memory().unwrap();

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -293,10 +293,10 @@ impl ProactiveMemoryStore {
     /// "popular memories stick around longer" intent while keeping decay
     /// strictly monotonic (per tick, confidence never increases).
     ///
-    /// Runs the decay pass immediately on every call — there is no internal
-    /// throttle. The once-per-hour cadence is enforced by the periodic
-    /// maintenance scheduler (see `run_periodic_maintenance`), so a direct
-    /// call (e.g. a manual `/decay` endpoint or a test) decays right away.
+    /// Runs the decay pass immediately on every call — there is no internal throttle.
+    /// The once-per-hour cadence lives in `maybe_decay_confidence`, which `maybe_run_maintenance` calls from the search / auto_retrieve / consolidate paths.
+    /// It is not a scheduler: nothing decays while an agent is idle, and a direct call (a manual `/decay` endpoint, a test) decays right away.
+    /// That throttle is also process-local, so a restart clears it — which no longer changes the total, because `last_decayed_at` is durable and an interval already charged cannot be charged again.
     pub fn decay_confidence(&self) -> LibreFangResult<()> {
         let decay_rate = self.read_config().confidence_decay_rate;
         if decay_rate <= 0.0 {


### PR DESCRIPTION
Closes #7924. Found while verifying the memory-subsystem defect list on #7756.

## The defect

`migrate_v50` — the `memories_fts` FTS5 index added by #7808 — stamped its audit row with version **49**:

```rust
"INSERT OR IGNORE INTO migrations (version, applied_at, description) \
 VALUES (49, datetime('now'), 'Add memories_fts FTS5 index over memories.content …')"
```

`migrate_v49` (`migration.rs:962`, #7714) had already inserted version 49 moments earlier in the same `run_migrations` call, so `INSERT OR IGNORE` did exactly what it says and discarded the row silently.

The DDL was never affected. `CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts`, its three sync triggers and `rebuild_memories_fts` all applied correctly and `pragma user_version` reached 50. What was lost is the record of what v50 did, and the visible symptom is worse than the missing description:

**Every brand-new database logged historical audit drift on its first boot.** With no row for version 50, the #3538 audit-consistency backfill (`migration.rs:246-296`) inserted the placeholder `'audit-row backfill (#3538)'` and emitted `WARN Migration audit drift detected and self-healed: inserted missing audit rows for migrations that previously applied DDL without recording their audit row`. That warning exists to tell an operator an old database is being repaired. Firing it for everyone, on a clean install, is how a real drift warning stops being read.

The backfill's own doc comment states the invariant that had been false since #7808 merged: *"Idempotent: a clean DB inserts nothing because every version already has its row."*

## Why the existing guard missed it

`test_every_migration_records_audit_row` asserts that every version in `1..=user_version` has *an* audit row. The backfill creates the missing row before the assertion runs, so the test measured the post-repair state rather than whether a repair had been needed. A migration that stamps the wrong version passes it, rescued by the very path that hides the bug.

## Changes

- `crates/librefang-memory/src/migration.rs:1038` — the literal is `50`.
- `migration::tests::no_migration_relies_on_the_audit_backfill` — after `run_migrations` on a clean in-memory database, no row's description may be the backfill placeholder. This pins the invariant the backfill comment already claims, and it generalises: any future migration stamping someone else's version fails here rather than being silently repaired.
- `migration::tests::v49_and_v50_each_describe_their_own_ddl` — pins the specific collision by description rather than by presence, since presence was already satisfied. v49 must name `owner_agent_id` (#7714), v50 must name `memories_fts` (#7808).

One drive-by in the same crate, listed separately because it is not part of the defect: the doc comment on `decay_confidence` (`proactive.rs:296`) pointed readers at `run_periodic_maintenance`, which does not exist — the function is `maybe_run_maintenance` — and described it as a scheduler, which it is not. It runs from the search / auto_retrieve / consolidate paths, so nothing decays while an agent is idle, which is exactly the behaviour @nevgenov measured on #7756 (663 untouched rows across a 68-minute idle window). The corrected comment also records why the process-local throttle stopped mattering after #7864.

Both new tests fail against the previous literal, with `… rescued by the #3538 backfill on a clean database … [50]` and `v50 must describe the FTS5 index it adds (#7808) … got: audit-row backfill (#3538)` respectively.

## Migration numbering

**None.** `SCHEMA_VERSION` stays 50 and no `run_step!` is added — this corrects the version *recorded by* an existing step, not the ladder. It therefore does not contend with #7916 (v51), #7919 (v52), #7904 (v53) or anything after them, and can merge in any order relative to them.

Existing deployments already carry the backfilled row for version 50 and are not rewritten; the correction changes only what a fresh database records. No data migration either way.

## Verification

- `cargo test -p librefang-memory --lib` — 395 passed, 0 failed, 0 ignored.
- `cargo clippy -p librefang-memory --all-targets -- -D warnings` — zero warnings.
- `cargo check --workspace --lib` — clean.
- Both new tests verified to fail against the pre-fix literal and pass after, so they are guards rather than assertions of current behaviour.
- Nothing was run against a live daemon.

No config field, so no `build_reload_plan` classification, no `docs/operations/config-reload.md` row and no golden-schema regeneration.
