### PR TITLE
fix(skills): name the real author in an evolved skill's manifest

### DIFF
--- a/changelog.d/fixed/skill-manifest-author.md
+++ b/changelog.d/fixed/skill-manifest-author.md
@@ -1,4 +1,4 @@
 An agent-created skill's manifest now names the agent that produced it, instead of the literal `agent-evolved`.
 `create_skill` was handed the author and passed it to the evolution history, then wrote a hardcoded string into `skill.toml` — so the provenance existed only in `.evolution.json`, which is not what the marketplace or the `librefang skill` surfaces read.
 Every skill approved through the skill workshop was affected, because that path passes the candidate's real agent id.
-(#PR) (@houko)
+(#7929) (@houko)

--- a/changelog.d/fixed/skill-manifest-author.md
+++ b/changelog.d/fixed/skill-manifest-author.md
@@ -1,0 +1,4 @@
+An agent-created skill's manifest now names the agent that produced it, instead of the literal `agent-evolved`.
+`create_skill` was handed the author and passed it to the evolution history, then wrote a hardcoded string into `skill.toml` — so the provenance existed only in `.evolution.json`, which is not what the marketplace or the `librefang skill` surfaces read.
+Every skill approved through the skill workshop was affected, because that path passes the candidate's real agent id.
+(#PR) (@houko)

--- a/crates/librefang-skills/src/evolution.rs
+++ b/crates/librefang-skills/src/evolution.rs
@@ -1048,7 +1048,13 @@ pub fn create_skill(
             name: name.to_string(),
             version: "0.1.0".to_string(),
             description: description.to_string(),
-            author: "agent-evolved".to_string(),
+            // The caller's `author` is the agent that produced the skill, and
+            // the skill-workshop approve path passes it (`storage.rs`, the
+            // `CandidateKind::Create` arm). Writing the literal here discarded
+            // it, so every approved skill's manifest claimed `agent-evolved`
+            // while the real provenance sat in `.evolution.json`, which is not
+            // what the marketplace or `librefang skill` surfaces read.
+            author: author.unwrap_or("agent-evolved").to_string(),
             license: String::new(),
             tags,
         },
@@ -2190,6 +2196,52 @@ mod tests {
         let content = "The cat walks home.";
         let result = fuzzy_find_and_replace(content, "cat walks", "dog runs", false).unwrap();
         assert_eq!(result.strategy, MatchStrategy::Exact);
+    }
+
+    /// The skill-workshop approve path hands `create_skill` the agent that
+    /// produced the candidate (`skill_workshop/storage.rs`, `CandidateKind::Create`).
+    /// That agent has to reach `skill.toml`, because the manifest is what the
+    /// marketplace and the `librefang skill` surfaces read; `.evolution.json`
+    /// records it too, but nothing user-facing looks there.
+    #[test]
+    fn create_skill_records_the_caller_as_the_manifest_author() {
+        let dir = TempDir::new().unwrap();
+        create_skill(
+            dir.path(),
+            "authored-skill",
+            "A skill with a real author",
+            "# Authored\n\nDo authored things.",
+            vec![],
+            Some("scout"),
+        )
+        .unwrap();
+
+        let toml_text =
+            std::fs::read_to_string(dir.path().join("authored-skill/skill.toml")).unwrap();
+        let manifest: SkillManifest = toml::from_str(&toml_text).unwrap();
+        assert_eq!(
+            manifest.skill.author, "scout",
+            "the manifest must name the agent that produced the skill, not a literal"
+        );
+    }
+
+    #[test]
+    fn create_skill_falls_back_when_no_author_is_supplied() {
+        let dir = TempDir::new().unwrap();
+        create_skill(
+            dir.path(),
+            "anonymous-skill",
+            "A skill with no author",
+            "# Anonymous\n\nDo anonymous things.",
+            vec![],
+            None,
+        )
+        .unwrap();
+
+        let toml_text =
+            std::fs::read_to_string(dir.path().join("anonymous-skill/skill.toml")).unwrap();
+        let manifest: SkillManifest = toml::from_str(&toml_text).unwrap();
+        assert_eq!(manifest.skill.author, "agent-evolved");
     }
 
     #[test]

--- a/crates/librefang-skills/src/evolution.rs
+++ b/crates/librefang-skills/src/evolution.rs
@@ -1048,12 +1048,8 @@ pub fn create_skill(
             name: name.to_string(),
             version: "0.1.0".to_string(),
             description: description.to_string(),
-            // The caller's `author` is the agent that produced the skill, and
-            // the skill-workshop approve path passes it (`storage.rs`, the
-            // `CandidateKind::Create` arm). Writing the literal here discarded
-            // it, so every approved skill's manifest claimed `agent-evolved`
-            // while the real provenance sat in `.evolution.json`, which is not
-            // what the marketplace or `librefang skill` surfaces read.
+            // The caller's `author` is the agent that produced the skill, and the skill-workshop approve path passes it (`storage.rs`, the `CandidateKind::Create` arm).
+            // Writing the literal here discarded it, so every approved skill's manifest claimed `agent-evolved` while the real provenance sat in `.evolution.json`, which is not what the marketplace or `librefang skill` surfaces read.
             author: author.unwrap_or("agent-evolved").to_string(),
             license: String::new(),
             tags,
@@ -2198,11 +2194,8 @@ mod tests {
         assert_eq!(result.strategy, MatchStrategy::Exact);
     }
 
-    /// The skill-workshop approve path hands `create_skill` the agent that
-    /// produced the candidate (`skill_workshop/storage.rs`, `CandidateKind::Create`).
-    /// That agent has to reach `skill.toml`, because the manifest is what the
-    /// marketplace and the `librefang skill` surfaces read; `.evolution.json`
-    /// records it too, but nothing user-facing looks there.
+    /// The skill-workshop approve path hands `create_skill` the agent that produced the candidate (`skill_workshop/storage.rs`, `CandidateKind::Create`).
+    /// That agent has to reach `skill.toml`, because the manifest is what the marketplace and the `librefang skill` surfaces read; `.evolution.json` records it too, but nothing user-facing looks there.
     #[test]
     fn create_skill_records_the_caller_as_the_manifest_author() {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Answers the question raised in #7928: this is the one-liner from `librefang-skills`, landed as its own PR rather than folded into the ownership work.

## The bug

`evolution::create_skill` takes `author: EvolutionAuthor<'_>` (= `Option<&str>`), passes it to the evolution-history recorder — so `.evolution.json` gets it — and then writes a hardcoded literal into the manifest:

```rust
author: "agent-evolved".to_string(),
```

The skill-workshop approve path passes the real producer: `crates/librefang-kernel/src/skill_workshop/storage.rs`, `CandidateKind::Create` arm, `Some(&candidate.agent_id)`. That id was discarded.

So every skill approved through the workshop shipped a `skill.toml` claiming `agent-evolved`, while the agent that actually produced it sat in `.evolution.json` — which is not a file the marketplace or the `librefang skill` surfaces read. Nothing was lost permanently; it was recorded where nobody looks and wrong where everybody does.

## Change

`author: author.unwrap_or("agent-evolved").to_string()`. The literal stays as the fallback for a caller with no author, which is what the existing tests and the CLI path pass.

## Verification

- `cargo test -p librefang-skills --lib` — 264 passed, 0 failed.
- `cargo clippy -p librefang-skills --all-targets -- -D warnings` — clean.
- New: `create_skill_records_the_caller_as_the_manifest_author`, `create_skill_falls_back_when_no_author_is_supplied`.
- **Negative control** — restored the literal and re-ran:

```
assertion `left == right` failed: the manifest must name the agent that produced the skill, not a literal
  left: "agent-evolved"    right: "scout"
test result: FAILED. 0 passed; 1 failed
```

## Why its own PR

It is a different crate and a different domain from #7928's ownership thread, which is the CLAUDE.md bar for asking rather than folding it in. #7928 asked; this is the answer.
