### PR TITLE
fix(test): keep template fixtures alive for the test body

### DIFF
--- a/changelog.d/fixed/7938-template-fixture-guard-discarded.md
+++ b/changelog.d/fixed/7938-template-fixture-guard-discarded.md
@@ -1,0 +1,4 @@
+Restore the `/api/templates` integration tests, which had been failing on `main` across every OS since #7648 introduced the `TemplateFixture` RAII guard.
+Eight call sites discarded the guard `write_template` returns, so its `Drop` deleted the template directory at the end of the very statement that wrote it and every later read of that template answered 404 — the assertion surfaced as `left: 404, right: 200` in tests that never mention cleanup.
+`write_template` is now `#[must_use]`, so discarding the guard is a compile error under `-D warnings` rather than a failure that lands in an unrelated assertion.
+Note that the compiler's suggested `let _ = ...` does not fix it: `_` drops immediately too, and only a named binding such as `let _fixture = ...` keeps the fixture alive for the test body. (#7938) (@e-hu)

--- a/crates/librefang-api/tests/profiles_templates_routes_integration.rs
+++ b/crates/librefang-api/tests/profiles_templates_routes_integration.rs
@@ -200,6 +200,10 @@ impl Drop for TemplateFixture {
     }
 }
 
+/// The returned guard owns the template directory on disk.
+/// Dropping it runs `remove_template`, so a caller that discards the return value deletes the fixture it just wrote and every later read of that template answers 404.
+/// `#[must_use]` turns that mistake into a compile error rather than a failure that surfaces in an unrelated assertion.
+#[must_use = "bind the guard to keep the template on disk; discarding it deletes the fixture immediately"]
 fn write_template(name: &str, body: &str) -> TemplateFixture {
     let root = templates_root();
     let dir = root.join(name);
@@ -290,7 +294,7 @@ async fn templates_list_carries_provider_and_model_from_the_manifest() {
     let _ = templates_root();
 
     let unique = "tmpl_list_provider";
-    write_template(
+    let _fixture = write_template(
         unique,
         r#"name = "delta"
 version = "0.1.0"
@@ -332,8 +336,8 @@ async fn templates_list_skips_a_malformed_manifest_instead_of_failing() {
 
     let good = "tmpl_skip_good";
     let bad = "tmpl_skip_bad";
-    write_template(good, &minimal_manifest_toml("echo", "Echo survives"));
-    write_template(bad, "this is not = = valid toml [[[");
+    let _good_fixture = write_template(good, &minimal_manifest_toml("echo", "Echo survives"));
+    let _bad_fixture = write_template(bad, "this is not = = valid toml [[[");
 
     let h = boot().await;
     let (status, body) = get_json(&h, "/api/templates").await;
@@ -363,7 +367,7 @@ async fn templates_list_omits_names_the_detail_routes_reject() {
     let _ = templates_root();
 
     let unusable = "tmpl.dotted.name";
-    write_template(unusable, &minimal_manifest_toml("dotted", "Dotted"));
+    let _fixture = write_template(unusable, &minimal_manifest_toml("dotted", "Dotted"));
 
     let h = boot().await;
     let (status, body) = get_json(&h, "/api/templates").await;
@@ -531,7 +535,7 @@ async fn templates_get_reports_what_promotion_would_strip() {
     let _ = templates_root();
 
     let unique = "tmpl_promo_leaky";
-    write_template(unique, &leaky_manifest_toml("researcher"));
+    let _fixture = write_template(unique, &leaky_manifest_toml("researcher"));
 
     let h = boot().await;
     let (status, body) = get_json(&h, &format!("/api/templates/{unique}")).await;
@@ -592,7 +596,7 @@ async fn templates_get_promotion_preview_omits_host_specifics_and_keeps_the_port
     let _ = templates_root();
 
     let unique = "tmpl_promo_scrub";
-    write_template(unique, &leaky_manifest_toml("researcher"));
+    let _fixture = write_template(unique, &leaky_manifest_toml("researcher"));
 
     let h = boot().await;
     let (status, body) = get_json(&h, &format!("/api/templates/{unique}")).await;
@@ -655,7 +659,7 @@ async fn templates_get_promotion_preview_flags_a_secret_inside_a_retained_prompt
     // A credential pasted into the system prompt sits inside a field promotion has to keep, so the operator has to edit it by hand.
     // The detector exists to say so rather than to silently keep it.
     let unique = "tmpl_promo_review";
-    write_template(
+    let _fixture = write_template(
         unique,
         r#"name = "leaky-prompt"
 version = "0.1.0"
@@ -698,7 +702,7 @@ async fn templates_get_promotion_preview_is_quiet_for_an_already_portable_templa
     let _ = templates_root();
 
     let unique = "tmpl_promo_clean";
-    write_template(unique, &minimal_manifest_toml("charlie", "Charlie type"));
+    let _fixture = write_template(unique, &minimal_manifest_toml("charlie", "Charlie type"));
 
     let h = boot().await;
     let (status, body) = get_json(&h, &format!("/api/templates/{unique}")).await;


### PR DESCRIPTION
Fixes the `/api/templates` integration failures that have kept `main` red since 07:52 on 2026-08-26.

Refs #7937 (the `[main red]` tracking issue, opened by Main Build Alert).

## Root cause

#7648 introduced `TemplateFixture`, an RAII guard whose `Drop` calls `remove_template`.
Eight of the twelve `write_template` call sites discarded the returned guard, so it was a temporary dropped at the end of the statement that created it — the template directory was deleted before the test booted the server, and every later read of that template answered 404.

The assertion surfaced as `left: 404, right: 200` in tests that say nothing about cleanup, e.g. `profiles_templates_routes_integration.rs:538`.

Two things made this hard to read from CI alone:

- The failing lane moved between runs (`Test / Ubuntu (shard 1/4)`, `shard 2/4`, `macOS`, `Windows`, …) because nextest distributed the affected tests differently each time. It looked flaky; it was deterministic per test.
- `19e4ff7` is recorded as a `success` on `main`, but every `Test / *` lane in that run is `skipped` — the `changes` gate skipped them. Bisecting on run conclusion alone points at #7916, which only touches memory crates and is not involved.

## Changes

- Bind all eight discarded `write_template` results to a named variable (12/12 call sites now bind).
- Mark `write_template` `#[must_use]`, so discarding the guard is a compile error under `-D warnings` instead of a failure that lands in an unrelated assertion.
- Document that the compiler's suggested `let _ = ...` does **not** fix this — `_` drops immediately too, and only a named binding keeps the fixture alive.
- Changelog fragment under `changelog.d/fixed/`.

## Verification

- `cargo test -p librefang-api --test profiles_templates_routes_integration` — **17 passed, 0 failed** (was 1 failed before the change).
- `cargo check -p librefang-api --tests` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean, exit 0.
- `#[must_use]` guard confirmed by reverting one call site: compilation fails with `error: unused return value of write_template that must be used`.

## Not covered

Only the `/api/templates` failures are addressed here.
Other `main` failures, if any remain once this lands, are out of scope for this PR and are not investigated.