### PR TITLE
fix(ci): give the macOS lane the same 90-minute cap as Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1179,7 +1179,10 @@ jobs:
     env:
       # Registry fetches in test-booted kernels are non-hermetic (network-dependent test outcomes, one git clone per kernel boot) — see #6404 and the PR #6384 CI failure this switch prevents.
       LIBREFANG_REGISTRY_OFFLINE: "1"
-    timeout-minutes: 60
+    # 90 minutes, matching `test-windows`. The lane runs 43-57 minutes in practice, so a 60-minute cap left 3-17 minutes of headroom and a slow runner spends it outright.
+    # `f7130c1` stopped at 60:28, `efa84ea` at 60:41 and `2b871dd` at 60:23 — three of the last ten pushes to main, every other lane green in each.
+    # GitHub reports a timeout as `cancelled`, and `CI Gate` fails on `cancelled` without re-evaluating, so each one files a `[main red]` issue against a tree that is fine and no re-run of the merged commit can clear it.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/changelog.d/fixed/7944-macos-lane-timeout.md
+++ b/changelog.d/fixed/7944-macos-lane-timeout.md
@@ -1,0 +1,4 @@
+Stop `main` going red on a timeout no code change causes.
+`Test / macOS` runs 43-57 minutes against a 60-minute cap, so a slow runner spends the whole 3-17 minute margin and the job is killed — three of the last ten pushes to `main` died that way, each within a minute of the cap (`f7130c1` at 60:28, `efa84ea` at 60:41, `2b871dd` at 60:23), every other lane in those runs green.
+GitHub reports a timeout as `cancelled`, `CI Gate` fails on `cancelled` without re-evaluating, and re-running the merged commit cannot clear it, so each occurrence files a `[main red]` issue against a tree that is fine.
+Raised to 90 minutes, the cap `Test / Windows` already carries — in one of those same runs Windows took 63 minutes and passed for no reason other than its more generous limit. (#7944) (@houko)


### PR DESCRIPTION
`Test / macOS` carries `timeout-minutes: 60` while running 43-57 minutes in practice. A slow runner spends the whole 3-17 minute margin and the job is killed.

Refs #7937.

## Evidence

Last ten pushes to `main`, `Test / macOS` duration:

| commit | result | duration |
|---|---|---|
| `f7130c1` | **killed** | **60:28** |
| `efa84ea` | **killed** | **60:41** |
| `2b871dd` | **killed** | **60:23** |
| `c6848a7` | success | 50:56 |
| `c4ae0ac` | success | 47:14 |
| `e311c2c` | success | 42:58 |
| `be650be` | success | 48:40 |
| `fbd784e` | success | 45:25 |
| `8c73f5f` | success | 56:39 |

All three failures land within a minute of the cap, and in each of those runs every other Test lane was green.

GitHub reports a timeout as `cancelled`. `CI Gate` fails on `cancelled` and does not re-evaluate, and re-running the merged commit cannot clear it — so each occurrence files a `[main red]` issue against a tree that is fine and keeps it open. **#7937 is open for exactly this reason and no code change can close it.**

## Why 90

It is the cap `test-windows` already carries, and Windows is the slower lane:

| lane | timeout | observed |
|---|---|---|
| test-unit | 20 | — |
| test-ubuntu | 45 | — |
| test-windows | 90 | ~60, 63 in `efa84ea` |
| test-macos | **60 → 90** | 43-57 |

In the `efa84ea` run `Test / Windows (shard 2/2)` took 63 minutes and passed while macOS was killed at 60:41 — same runners, same hour, differing only in the limit.

## Verification

- `scripts/check-workflow-timeouts.py` — passes, 139 jobs.
- `yaml.safe_load` on `ci.yml` — parses; `test-macos` and `test-windows` both report 90.

## Scope

Two files, eight lines. This is a cap, not a speed-up: if the lane starts genuinely needing more than 90 minutes that is a different problem and should be read as one.

An earlier revision of this branch also carried a `runtime-skills.test.tsx` typecheck fix. #7895 landed that same fix on its way in, so it is gone from here and the branch was rebuilt on current `main` to keep the diff to the one change.