### PR TITLE
fix(api): detect a non-directory .identity when cloning

### DIFF
--- a/changelog.d/fixed/7961-clone-identity-windows-notdir.md
+++ b/changelog.d/fixed/7961-clone-identity-windows-notdir.md
@@ -1,0 +1,3 @@
+Cloning an agent whose `.identity` had been replaced by a file no longer reports a complete clone on Windows.
+The check relied on `Path::try_exists()` returning an error for a non-directory path component, which is Unix behaviour; Windows reduces the same condition to "does not exist", so the clone silently fell back to the pre-migration workspace-root identity files instead of flagging the failure.
+(#7961) (@houko)

--- a/crates/librefang-api/src/routes/agents/cloning.rs
+++ b/crates/librefang-api/src/routes/agents/cloning.rs
@@ -184,8 +184,25 @@ fn copy_clone_identity_files(
     let src_identity = src_can.join(".identity");
     let dst_identity = dst_can.join(".identity");
     std::fs::create_dir_all(&dst_identity)?;
+    // A `.identity` that exists but is not a directory has to be detected here, not through the per-file `try_exists()` below.
+    // Unix surfaces the bad path component as ENOTDIR, but Windows reports ERROR_PATH_NOT_FOUND, which std maps to `NotFound` and `try_exists()` reduces to `Ok(false)` — the clone would then silently fall back to the legacy workspace-root copy and report success (#7547).
+    let migrated_identity_is_not_a_directory = std::fs::metadata(&src_identity)
+        .map(|metadata| !metadata.is_dir())
+        .unwrap_or(false);
     let mut first_error = None;
     for &filename in KNOWN_IDENTITY_FILES {
+        if migrated_identity_is_not_a_directory {
+            first_error.get_or_insert_with(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotADirectory,
+                    format!(
+                        "failed to inspect migrated identity file {filename}: {} is not a directory",
+                        src_identity.display()
+                    ),
+                )
+            });
+            continue;
+        }
         // Source: prefer .identity/ (post-migration), fall back to workspace root.
         let migrated_source = src_identity.join(filename);
         let source = match migrated_source.try_exists() {
@@ -289,6 +306,12 @@ mod tests {
         let error = copy_clone_identity_files(&source, &destination)
             .expect_err("malformed migrated identity path must be reported");
         assert!(error.to_string().contains("migrated identity file SOUL.md"));
+        // The legacy root copy must not stand in for an unreadable `.identity`: a clone that
+        // quietly resurrects a pre-migration file is worse than one that reports the failure.
+        assert!(
+            !destination.join(".identity/SOUL.md").exists(),
+            "unreadable .identity must not fall back to the legacy workspace-root file"
+        );
     }
 
     #[test]

--- a/crates/librefang-api/src/routes/agents/cloning.rs
+++ b/crates/librefang-api/src/routes/agents/cloning.rs
@@ -306,8 +306,7 @@ mod tests {
         let error = copy_clone_identity_files(&source, &destination)
             .expect_err("malformed migrated identity path must be reported");
         assert!(error.to_string().contains("migrated identity file SOUL.md"));
-        // The legacy root copy must not stand in for an unreadable `.identity`: a clone that
-        // quietly resurrects a pre-migration file is worse than one that reports the failure.
+        // The legacy root copy must not stand in for an unreadable `.identity`: a clone that quietly resurrects a pre-migration file is worse than one that reports the failure.
         assert!(
             !destination.join(".identity/SOUL.md").exists(),
             "unreadable .identity must not fall back to the legacy workspace-root file"


### PR DESCRIPTION
`main` has been red on the Windows lane since #7547 (4c3059e47) — both test shards, five commits.

## Root cause

`copy_clone_identity_files` used `Path::try_exists()` on `.identity/<file>` to detect a `.identity` that exists but is not a directory.
That only works on Unix, which reports the bad path component as ENOTDIR.
Windows reports ERROR_PATH_NOT_FOUND, which std maps to `NotFound` and `try_exists()` reduces to `Ok(false)` — so the clone silently fell back to the pre-migration workspace-root copy and reported a complete, non-partial clone instead of an error.

Failing tests:

- `librefang-api routes::agents::cloning::tests::clone_identity_files_report_source_inspection_errors` (shard 1) — `expect_err` panicked because the call succeeded.
- `librefang-api::agents_clone_bulk_integration test_clone_identity_copy_failure_returns_partial_creation` (shard 2) — `partial` was `false`.

## Changes

- `crates/librefang-api/src/routes/agents/cloning.rs`: probe `.identity` once with `std::fs::metadata` before the copy loop; when it exists and is not a directory, record a `NotADirectory` error per identity file and skip the legacy fallback. Both platforms now take the same branch, so the behaviour no longer depends on how the OS reports a non-directory path component.
- Same file, unit test: additionally assert the destination `.identity/SOUL.md` was *not* written — the silent legacy fallback is the actual defect, and this is the assertion that fails on Windows pre-fix regardless of how the error surfaces.

## Verification

- `cargo check -p librefang-api --lib`
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean
- `cargo test -p librefang-api --lib routes::agents::cloning` — 5 passed
- `cargo test -p librefang-api --test agents_clone_bulk_integration` — 28 passed

Windows itself is not reproducible locally; the fix removes the platform-dependent branch rather than special-casing Windows, and CI on this PR covers the lane.

## Deferred

None.