### PR TITLE
fix(api): report restored backup entries with archive separators

### DIFF
--- a/changelog.d/fixed/7965-backup-restore-entry-separators.md
+++ b/changelog.d/fixed/7965-backup-restore-entry-separators.md
@@ -1,0 +1,2 @@
+Backup restore now reports restored entries with the archive's `/` separators on Windows rather than the host's, so a client matching the reported list against the component names it asked for no longer sees every entry as unrecognised.
+(#7965) (@houko)

--- a/crates/librefang-api/src/routes/backup.rs
+++ b/crates/librefang-api/src/routes/backup.rs
@@ -980,7 +980,11 @@ fn restore_backup_blocking(
                 "archive exceeded the total decompression limit".to_string(),
             ));
         }
-        restored.push(entry_name.to_string_lossy().to_string());
+        // `entry_name` is a `Path`, so rendering it hands back `\` separators on Windows and the
+        // restored list stops matching the `/`-separated archive keys every caller compares
+        // against. `archive_entry_key` is the normalisation the classification filters above
+        // already go through.
+        restored.push(archive_entry_key(&entry_name));
     }
 
     Ok(RestoreOutcome {
@@ -1533,6 +1537,47 @@ mod tests {
                     .as_path()
             ),
             "data/cron_jobs.json"
+        );
+    }
+
+    /// The reported list is a contract, not a debug string: callers match it against the
+    /// `/`-separated archive keys. Building the expectation with `Path::join` makes the assertion
+    /// itself platform-agnostic, so a host that renders `\` cannot quietly agree with itself.
+    #[test]
+    fn restored_entries_are_reported_with_archive_separators() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive_path = temp.path().join("nested.zip");
+        let restore_dir = temp.path().join("restore");
+        std::fs::create_dir(&restore_dir).unwrap();
+
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("manifest.json", options).unwrap();
+        zip.write_all(
+            br#"{"version":1,"created_at":"now","hostname":"host","librefang_version":"test","components":["data"]}"#,
+        )
+        .unwrap();
+        zip.start_file("data/cron_jobs.json", options).unwrap();
+        zip.write_all(b"{}").unwrap();
+        zip.finish().unwrap();
+
+        let outcome = restore_backup_blocking(
+            archive_path,
+            restore_dir.clone(),
+            restore_dir.join("workspaces").join("agents"),
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.errors, Vec::<String>::new());
+        assert_eq!(outcome.restored, vec!["data/cron_jobs.json"]);
+        assert!(
+            !outcome.restored.iter().any(|entry| entry.contains('\\')),
+            "restored entries must never carry a host separator: {:?}",
+            outcome.restored
         );
     }
 }

--- a/crates/librefang-api/src/routes/backup.rs
+++ b/crates/librefang-api/src/routes/backup.rs
@@ -980,11 +980,9 @@ fn restore_backup_blocking(
                 "archive exceeded the total decompression limit".to_string(),
             ));
         }
-        // `entry_name` is a `Path`, so rendering it hands back `\` separators on Windows and the
-        // restored list stops matching the `/`-separated archive keys every caller compares
-        // against. `archive_entry_key` is the normalisation the classification filters above
-        // already go through.
-        restored.push(archive_entry_key(&entry_name));
+        // `entry_name` is a `Path`, so rendering it directly would hand back `\` separators on Windows and the restored list would stop matching the `/`-separated archive keys every caller compares against.
+        // `entry_key`, computed above for the classification filters, is already normalised to `/`.
+        restored.push(entry_key);
     }
 
     Ok(RestoreOutcome {
@@ -1540,9 +1538,8 @@ mod tests {
         );
     }
 
-    /// The reported list is a contract, not a debug string: callers match it against the
-    /// `/`-separated archive keys. Building the expectation with `Path::join` makes the assertion
-    /// itself platform-agnostic, so a host that renders `\` cannot quietly agree with itself.
+    /// The reported list is a contract, not a debug string: callers match it against the `/`-separated archive keys.
+    /// Building the expectation with `Path::join` makes the assertion itself platform-agnostic, so a host that renders `\` cannot quietly agree with itself.
     #[test]
     fn restored_entries_are_reported_with_archive_separators() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/librefang-api/tests/pairing_backup_extra_test.rs
+++ b/crates/librefang-api/tests/pairing_backup_extra_test.rs
@@ -43,10 +43,8 @@ fn default_model_cfg() -> librefang_types::config::DefaultModelConfig {
 
 /// Surface the restore handler's own diagnostics in the test output.
 ///
-/// A partial restore answers `500` with nothing but `restored_files` and `error_count` — the
-/// per-entry reasons go to `tracing::error!`, and with no subscriber installed a failure here
-/// says only that two entries failed, never which two or why. That is exactly the shape of the
-/// Windows-only failure this harness could not diagnose from CI logs.
+/// A partial restore answers `500` with nothing but `restored_files` and `error_count` — the per-entry reasons go to `tracing::error!`, and with no subscriber installed a failure here says only that two entries failed, never which two or why.
+/// That is exactly the shape of the Windows-only failure this harness could not diagnose from CI logs.
 fn capture_restore_diagnostics() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {

--- a/crates/librefang-api/tests/pairing_backup_extra_test.rs
+++ b/crates/librefang-api/tests/pairing_backup_extra_test.rs
@@ -41,7 +41,24 @@ fn default_model_cfg() -> librefang_types::config::DefaultModelConfig {
     }
 }
 
+/// Surface the restore handler's own diagnostics in the test output.
+///
+/// A partial restore answers `500` with nothing but `restored_files` and `error_count` — the
+/// per-entry reasons go to `tracing::error!`, and with no subscriber installed a failure here
+/// says only that two entries failed, never which two or why. That is exactly the shape of the
+/// Windows-only failure this harness could not diagnose from CI logs.
+fn capture_restore_diagnostics() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::ERROR)
+            .with_test_writer()
+            .try_init();
+    });
+}
+
 async fn boot(pairing_enabled: bool) -> Harness {
+    capture_restore_diagnostics();
     let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(move |cfg| {
         cfg.pairing = librefang_types::config::PairingConfig {
             enabled: pairing_enabled,


### PR DESCRIPTION
`main` is red on `Test / Windows` (shard 1/2) after #7174. This fixes one of the two defects and makes the other diagnosable.

## Fixed: restored entries carried the host separator

`restore_backup_blocking` pushed `entry_name.to_string_lossy()` onto the restored list. `entry_name` is a `Path`, so it renders with `\` on Windows and the reported entries stop matching the `/`-separated archive keys every caller compares against — `archive_entry_key` is the normalisation the classification filters in the same loop already go through.

```
routes::backup::tests::restore_accepts_a_small_highly_compressible_entry
  left: ["data\\a2a_tasks.db-shm"]
 right: ["data/a2a_tasks.db-shm"]
```

New `restored_entries_are_reported_with_archive_separators` drives a real archive through `restore_backup_blocking`, asserts the literal `data/cron_jobs.json`, and separately rejects any host separator in the result — so a platform that renders `\` cannot quietly agree with itself the way a `Path::join`-built expectation would.

## Not fixed yet, but no longer invisible

The same Windows run fails two round trips in `pairing_backup_extra_test`:

```
restore_round_trips_an_agent_workspace_file_to_its_original_path
restore_without_options_writes_every_component_back
  restore failed: {"error":"Backup restore incomplete","restored_files":20,"error_count":2}
```

Two entries fail their `create` or `extract` step. I could not determine which two: those reasons only reach `tracing::error!(errors = ?errors, ...)`, no subscriber is installed in the integration tests, and the 500 body deliberately carries counts only. The CI log therefore contains the count and nothing else.

Ruled out by reading the code rather than guessing:
- The compression-ratio and per-entry/total size guards return `Err` and abort the whole restore, so they cannot produce a partial result with `error_count: 2`.
- `prepare_restore_target` failures propagate with `?` — also an abort, not a per-entry error.
- `restore_root` uses `Path::strip_prefix`, which is component-based and correct on Windows.

So the failures are `open_restore_target` or `std::io::copy`. Rather than change security-sensitive extraction code on a hypothesis I cannot test — the Windows lane runs only on push to `main`, never on a PR — the harness now installs a `tracing_subscriber` at `ERROR` with a test writer. The next `main` run names both entries and their OS error.

## Verification

- `cargo test -p librefang-api --lib routes::backup` — 14 passed
- `cargo test -p librefang-api --test pairing_backup_extra_test` — 29 passed
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Windows is not reproducible locally; this change is separator-only plus test instrumentation, so Unix green is meaningful for the part it fixes.

## Deferred

The two `create`/`extract` failures, deliberately — with the evidence path landing in this PR rather than a guess.