### PR TITLE
fix(docker): carry the Python SDK pyproject into the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -118,9 +118,8 @@ sdk/*
 sdk/python/*
 !sdk/python/librefang/
 !sdk/python/librefang/**
-# `pyproject.toml` is read with include_str! next to that include_dir!: the extracted tree cannot
-# report its own version, so the version is baked in at compile time instead. Excluding it fails
-# the build with "couldn't read sdk/python/pyproject.toml".
+# `pyproject.toml` is read with include_str! next to that include_dir!: the extracted tree cannot report its own version, so the version is baked in at compile time instead.
+# Excluding it fails the build with "couldn't read sdk/python/pyproject.toml".
 !sdk/python/pyproject.toml
 LICENSE-*
 CLAUDE.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -118,6 +118,10 @@ sdk/*
 sdk/python/*
 !sdk/python/librefang/
 !sdk/python/librefang/**
+# `pyproject.toml` is read with include_str! next to that include_dir!: the extracted tree cannot
+# report its own version, so the version is baked in at compile time instead. Excluding it fails
+# the build with "couldn't read sdk/python/pyproject.toml".
+!sdk/python/pyproject.toml
 LICENSE-*
 CLAUDE.md
 AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,11 @@ COPY packages ./packages
 # panics with "sdk/python/librefang is not a directory". Only this one
 # subtree is needed — .dockerignore keeps the rest of sdk/ out.
 COPY sdk/python/librefang ./sdk/python/librefang
+# The same module reads the SDK version out of `sdk/python/pyproject.toml` with include_str!,
+# because the extracted tree has neither a sibling pyproject.toml nor installed package metadata
+# and would answer `0+unknown`. Without this COPY the build fails with
+# "couldn't read crates/librefang-channels/src/../../../sdk/python/pyproject.toml".
+COPY sdk/python/pyproject.toml ./sdk/python/pyproject.toml
 # librefang-api uses include_str!("../../../deploy/...") to embed the
 # observability stack (prometheus / tempo / otel-collector / grafana
 # configs) at compile time — added in #3062. Without this COPY the

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,8 @@ COPY packages ./packages
 # panics with "sdk/python/librefang is not a directory". Only this one
 # subtree is needed — .dockerignore keeps the rest of sdk/ out.
 COPY sdk/python/librefang ./sdk/python/librefang
-# The same module reads the SDK version out of `sdk/python/pyproject.toml` with include_str!,
-# because the extracted tree has neither a sibling pyproject.toml nor installed package metadata
-# and would answer `0+unknown`. Without this COPY the build fails with
-# "couldn't read crates/librefang-channels/src/../../../sdk/python/pyproject.toml".
+# The same module reads the SDK version out of `sdk/python/pyproject.toml` with include_str!, because the extracted tree has neither a sibling pyproject.toml nor installed package metadata and would answer `0+unknown`.
+# Without this COPY the build fails with "couldn't read crates/librefang-channels/src/../../../sdk/python/pyproject.toml".
 COPY sdk/python/pyproject.toml ./sdk/python/pyproject.toml
 # librefang-api uses include_str!("../../../deploy/...") to embed the
 # observability stack (prometheus / tempo / otel-collector / grafana

--- a/changelog.d/fixed/7967-docker-sdk-pyproject.md
+++ b/changelog.d/fixed/7967-docker-sdk-pyproject.md
@@ -1,0 +1,3 @@
+The Docker image builds again.
+`librefang-channels` reads the Python SDK's version out of `sdk/python/pyproject.toml` with `include_str!`, but neither the `.dockerignore` allowlist nor the `Dockerfile` carried that file into the build context, so every image build failed at `couldn't read crates/librefang-channels/src/../../../sdk/python/pyproject.toml`.
+(#7967) (@houko)


### PR DESCRIPTION
`Docker Build` has failed on every `main` commit since at least 2026-08-26 — before the recent merge batch, and unrelated to it.

## Failure

```
error: couldn't read `crates/librefang-channels/src/../../../sdk/python/pyproject.toml`:
       No such file or directory (os error 2)
error: could not compile `librefang-channels` (lib) due to 1 previous error
ERROR: failed to build: ... cargo build --release --bin librefang --features telemetry
```

## Cause

`embedded_sdk.rs` does two compile-time reads of the Python SDK:

- `include_dir!(".../sdk/python/librefang")` embeds the package tree.
- `include_str!("../../../sdk/python/pyproject.toml")` bakes in the version, because the extracted tree has neither a sibling `pyproject.toml` nor installed package metadata and would otherwise report `0+unknown`.

The `.dockerignore` allowlist and the `Dockerfile` were both written for the first read alone. `sdk/*` and `sdk/python/*` exclude everything, and only `!sdk/python/librefang/**` is restored, so the manifest the second read needs never entered the build context.

## Fix

`.dockerignore` restores `sdk/python/pyproject.toml`, and the `Dockerfile` copies it next to the package tree — both alongside the comments that already explain why the sibling directory is carried.

## Verification

Checked against the real build context rather than by reading the rules. A throwaway `COPY sdk/python/pyproject.toml` under this repo's `.dockerignore`:

- on `main`: `ERROR: "/sdk/python/pyproject.toml": not found`
- with this change: `CONTEXT OK`

The full image build is what `Docker Build` runs on merge; this change is context-only, so nothing else in the Dockerfile is affected.

## Note

`Nix Build` is also red on `main` for an unrelated reason (the pinned rust-overlay resolves rustc 1.94.0 while the workspace requires 1.94.1). That is a separate PR.