### PR TITLE
fix(nix): build with the toolchain the repo pins, not the overlay's latest

### DIFF
--- a/changelog.d/fixed/7968-nix-toolchain-msrv.md
+++ b/changelog.d/fixed/7968-nix-toolchain-msrv.md
@@ -1,0 +1,4 @@
+`nix build` works again.
+The flake compiled with `rust-bin.stable.latest`, resolved out of a pinned rust-overlay input five months behind the workspace, so every build was handed rustc 1.94.0 and rejected with "rustc 1.94.0 is not supported by the following packages ... requires rustc 1.94.1".
+The flake now reads its channel from `rust-toolchain.toml` like every other consumer of that pin, and `scripts/check-toolchain-versions.sh` — which had never covered the flake — keeps it that way.
+(#7968) (@houko)

--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773544328,
-        "narHash": "sha256-Iv+qez54LAz+isij4APBk31VWA//Go81hwFOXr5iWTw=",
+        "lastModified": 1787993548,
+        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4f977d776793c8bfbfdd7eca7835847ccc48874e",
+        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,15 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        # `stable.latest` resolves out of the pinned rust-overlay input, so a lock older than the
+        # workspace's MSRV silently hands the build a toolchain Cargo then rejects: every `nix
+        # build` on main failed with "rustc 1.94.0 is not supported by the following packages ...
+        # requires rustc 1.94.1" while the overlay lock sat five months behind.
+        # Read the channel the repo already declares instead, so the flake is bound by the same
+        # pin `scripts/check-toolchain-versions.sh` enforces across Cargo.toml, mise and rustup.
+        rustChannel =
+          (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
+        rustToolchain = pkgs.rust-bin.stable.${rustChannel}.default.override {
           extensions = [ "rust-src" "rust-analyzer" "clippy" ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,8 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        # `stable.latest` resolves out of the pinned rust-overlay input, so a lock older than the
-        # workspace's MSRV silently hands the build a toolchain Cargo then rejects: every `nix
-        # build` on main failed with "rustc 1.94.0 is not supported by the following packages ...
-        # requires rustc 1.94.1" while the overlay lock sat five months behind.
-        # Read the channel the repo already declares instead, so the flake is bound by the same
-        # pin `scripts/check-toolchain-versions.sh` enforces across Cargo.toml, mise and rustup.
+        # `stable.latest` resolves out of the pinned rust-overlay input, so a lock older than the workspace's MSRV silently hands the build a toolchain Cargo then rejects: every `nix build` on main failed with "rustc 1.94.0 is not supported by the following packages ... requires rustc 1.94.1" while the overlay lock sat five months behind.
+        # Read the channel the repo already declares instead, so the flake is bound by the same pin `scripts/check-toolchain-versions.sh` enforces across Cargo.toml, mise and rustup.
         rustChannel =
           (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
         rustToolchain = pkgs.rust-bin.stable.${rustChannel}.default.override {

--- a/scripts/check-toolchain-versions.sh
+++ b/scripts/check-toolchain-versions.sh
@@ -35,6 +35,20 @@ for entry in "mise.toml:$mise_rust" "rust-toolchain.toml:$toolchain_rust" "mise.
   }
 done
 
+# flake.nix is the fourth consumer of this pin and the one that used to escape it: it built with
+# `rust-bin.stable.latest`, resolved out of the pinned rust-overlay input, so a lock older than the
+# MSRV handed every `nix build` a toolchain Cargo then rejected — main was red for days with
+# "rustc 1.94.0 is not supported ... requires rustc 1.94.1" and nothing here noticed.
+# It now reads rust-toolchain.toml, and this keeps it that way.
+if ! grep -q 'builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)' flake.nix; then
+  echo 'flake.nix does not derive its Rust channel from rust-toolchain.toml' >&2
+  exit 1
+fi
+if grep -q 'rust-bin.stable.latest' flake.nix; then
+  echo 'flake.nix builds with rust-bin.stable.latest, which can drift below the MSRV' >&2
+  exit 1
+fi
+
 if [[ "${1:-}" == --print ]]; then
   printf '%s\n' "$cargo_msrv"
 else

--- a/scripts/check-toolchain-versions.sh
+++ b/scripts/check-toolchain-versions.sh
@@ -35,10 +35,7 @@ for entry in "mise.toml:$mise_rust" "rust-toolchain.toml:$toolchain_rust" "mise.
   }
 done
 
-# flake.nix is the fourth consumer of this pin and the one that used to escape it: it built with
-# `rust-bin.stable.latest`, resolved out of the pinned rust-overlay input, so a lock older than the
-# MSRV handed every `nix build` a toolchain Cargo then rejected — main was red for days with
-# "rustc 1.94.0 is not supported ... requires rustc 1.94.1" and nothing here noticed.
+# flake.nix is the fourth consumer of this pin and the one that used to escape it: it built with `rust-bin.stable.latest`, resolved out of the pinned rust-overlay input, so a lock older than the MSRV handed every `nix build` a toolchain Cargo then rejected — main was red for days with "rustc 1.94.0 is not supported ... requires rustc 1.94.1" and nothing here noticed.
 # It now reads rust-toolchain.toml, and this keeps it that way.
 if ! grep -q 'builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)' flake.nix; then
   echo 'flake.nix does not derive its Rust channel from rust-toolchain.toml' >&2


### PR DESCRIPTION
`Nix Build` has failed on every `main` commit since at least 2026-08-26 — before the recent merge batch, and unrelated to it.

## Failure

```
error: rustc 1.94.0 is not supported by the following packages:
  librefang-acp@2026.8.19 requires rustc 1.94.1
  librefang-api@2026.8.19 requires rustc 1.94.1
  librefang-channels@2026.8.19 requires rustc 1.94.1
  ...
error: Cannot build '/nix/store/...-librefang-cli-2026.8.19.drv'.
```

## Cause

The flake built with `pkgs.rust-bin.stable.latest`. That does not track anything live — it resolves out of the pinned `rust-overlay` input, which sat at **2026-03-15** while the workspace moved its MSRV to 1.94.1. So `latest` meant 1.94.0, and Cargo rejected the toolchain the flake had just handed it.

`rust-toolchain.toml` already declares `channel = "1.94.1"`, and `scripts/check-toolchain-versions.sh` already keeps `Cargo.toml`, `mise.toml`, `mise.lock` and `rust-toolchain.toml` agreeing on it. **The flake was the one consumer outside that contract**, which is exactly why the drift was silent for days.

## Fix

- `flake.nix` derives its channel from `rust-toolchain.toml` instead of `stable.latest`.
- `scripts/check-toolchain-versions.sh` now fails if the flake stops doing that, or goes back to `stable.latest`. That script already runs in the Quality job, so the next drift is caught at PR time rather than on `main`.
- `rust-overlay` is updated to 2026-08-29, because the old pin has no 1.94.1 to select.

## Verification

Run with nix (in a container — this machine has no nix), against the updated lock and the real `rust-toolchain.toml`:

```
channel=1.94.1  resolved rustc=1.94.1
```

and, separately, that the new overlay actually carries it: `latest=1.98.0 pinned=1.94.1`.

The consistency guard bites — reverting the flake to `stable.latest` gives:

```
flake.nix builds with rust-bin.stable.latest, which can drift below the MSRV
```

The full `nix build` is what this workflow runs on merge; the MSRV rejection happened at the toolchain-selection step this change fixes.

## Note

`Docker Build` is also red on `main` for an unrelated reason (`sdk/python/pyproject.toml` missing from the build context). That is #7967.