### PR TITLE
feat(agents): report an agent's injected token footprint

### DIFF
--- a/crates/librefang-api/src/routes/agents/lifecycle.rs
+++ b/crates/librefang-api/src/routes/agents/lifecycle.rs
@@ -1062,6 +1062,18 @@ pub async fn get_agent(
             entry.manifest.model.model.as_str()
         };
 
+    // Static footprint every request to this agent carries before the first
+    // user message: system prompt plus the assembled tool definitions
+    // (skills, MCP servers, built-ins — `available_tools` is the exact list
+    // that travels in the prompt). Same heuristic the compactor uses to
+    // decide when to fold history, so this number cannot drift from that one.
+    let tools = state.kernel.available_tools(agent_id);
+    let injected_footprint_tokens = librefang_kernel::compactor::estimate_token_count(
+        &[],
+        Some(&entry.manifest.model.system_prompt),
+        Some(tools.as_slice()),
+    );
+
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -1109,6 +1121,7 @@ pub async fn get_agent(
             "fallback_models": entry.manifest.fallback_models,
             "auto_evolve": entry.manifest.auto_evolve,
             "web_search_augmentation": entry.manifest.web_search_augmentation,
+            "injected_footprint_tokens": injected_footprint_tokens,
         })),
     )
         .into_response()

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -255,6 +255,52 @@ async fn test_get_agent_happy_path() {
 
 /// #6565: a consumer deciding whether an MCP server is reachable needs both halves of the kernel's gate (`!mcp_disabled && !mcp_servers.is_empty()`).
 /// `mcp_servers` / `mcp_servers_mode` were already emitted; `mcp_disabled` was not, so `mcp_servers = ["*"]` on a disabled agent looked like a live grant.
+/// `injected_footprint_tokens` is the static cost every request to this
+/// agent carries before a single user message — system prompt plus tool
+/// definitions. A longer system prompt must estimate to more tokens than a
+/// short one, and the value must not be a fixed placeholder.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_agent_reports_injected_footprint_tokens_from_system_prompt() {
+    let h = boot(TEST_TOKEN).await;
+    let short_id = h
+        .state
+        .kernel
+        .spawn_agent_typed(AgentManifest {
+            name: "footprint-short".to_string(),
+            ..AgentManifest::default()
+        })
+        .expect("spawn_agent");
+    let long_id = h
+        .state
+        .kernel
+        .spawn_agent_typed(AgentManifest {
+            name: "footprint-long".to_string(),
+            model: librefang_types::agent::ModelConfig {
+                system_prompt: "You are a helpful AI agent. ".repeat(200),
+                ..Default::default()
+            },
+            ..AgentManifest::default()
+        })
+        .expect("spawn_agent");
+
+    let (status, short_body) = send(h.app.clone(), get(&format!("/api/agents/{}", short_id))).await;
+    assert_eq!(status, StatusCode::OK);
+    let short_tokens = short_body["injected_footprint_tokens"]
+        .as_u64()
+        .expect("injected_footprint_tokens must be a number");
+    assert!(short_tokens > 0);
+
+    let (status, long_body) = send(h.app.clone(), get(&format!("/api/agents/{}", long_id))).await;
+    assert_eq!(status, StatusCode::OK);
+    let long_tokens = long_body["injected_footprint_tokens"]
+        .as_u64()
+        .expect("injected_footprint_tokens must be a number");
+    assert!(
+        long_tokens > short_tokens,
+        "a longer system prompt must estimate to more tokens: long={long_tokens} short={short_tokens}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_agent_exposes_the_full_mcp_grant_state_6565() {
     let h = boot(TEST_TOKEN).await;


### PR DESCRIPTION
## Summary
- `GET /api/agents/{id}` now includes `injected_footprint_tokens` — the static system-prompt-plus-tool-definitions token cost every request to that agent carries before a single user message.
- Computed from the agent's system prompt and `available_tools` (the exact tool list assembled into the prompt: skills, MCP servers, built-ins) via the existing `librefang_kernel::compactor::estimate_token_count` heuristic — the same one the compactor uses to decide when to fold history, so the number cannot drift from that one.
- Per-call visibility into recent LLM calls (timestamp, model, provider, input/output tokens, cost, tool_calls, latency) already exists via `GET /api/agents/{id}/events`, backed by `UsageStore::list_agent_events_recent`. This PR intentionally does not duplicate that endpoint or store method.

## Verification
- `cargo check -p librefang-memory -p librefang-kernel -p librefang-api --lib`
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — no issues
- `cargo test -p librefang-api --test agents_routes_integration` — 65 passed, including new `test_get_agent_reports_injected_footprint_tokens_from_system_prompt`
- `cargo test -p librefang-api --test openapi_spec_test` — no drift (response body is the existing untyped `JsonObject`, no schema change)

## Out-of-scope follow-ups
None — the recent-calls half of this feature already exists (`GET /api/agents/{id}/events`), so there is no deferred work.