### PR TITLE
feat(channels): annotate commands with dashboard execution mode

### DIFF
--- a/crates/librefang-channels/src/commands/mod.rs
+++ b/crates/librefang-channels/src/commands/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! Single source of truth for every `/cmd` LibreFang understands. Every
 //! consumer (channel bridge dispatch / `/help` text, Telegram BotCommands menu,
-//! TUI chat runner, future Dashboard command palette) derives from
-//! [`COMMAND_REGISTRY`] instead of maintaining its own copy.
+//! TUI chat runner, and the dashboard chat catalog served by
+//! `GET /api/commands`) derives from [`COMMAND_REGISTRY`] instead of
+//! maintaining its own copy.
 //!
 //! See `.plans/slash-command-registry.md` for the design rationale and
 //! migration plan.
@@ -55,6 +56,31 @@ impl Category {
     }
 }
 
+/// How the dashboard chat runs a command that carries [`Scope::DASHBOARD`].
+///
+/// The SPA needs this to decide, per command, between answering locally and
+/// opening a `{"type":"command"}` frame on the chat WebSocket.
+/// Keeping the answer in the registry is what stops the dashboard from
+/// re-deriving its own hand-written command list (upstream #3355).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashboardExec {
+    /// Resolved entirely inside the SPA — no round-trip to the daemon.
+    Client,
+    /// Dispatched over the chat WebSocket and answered by
+    /// `librefang_api::ws::handle_command`.
+    Backend,
+}
+
+impl DashboardExec {
+    /// Stable wire token used by `GET /api/commands`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Client => "client",
+            Self::Backend => "backend",
+        }
+    }
+}
+
 /// One sub-form of a multi-action command (e.g. `/trigger add …` vs
 /// `/trigger del …`). Renders as its own `/help` line.
 #[derive(Debug, Clone, Copy)]
@@ -89,6 +115,13 @@ pub struct CommandDef {
     /// Whether to include this command in the Telegram BotCommands menu
     /// (the popup shown when the user types `/`). Telegram limits to 100.
     pub telegram_menu: bool,
+    /// How the dashboard chat executes this command.
+    ///
+    /// `None` means the command is listed in the `GET /api/commands` catalog
+    /// but is not offered in the chat slash menu, because no dashboard
+    /// execution path exists for it yet. Only meaningful together with
+    /// [`Scope::DASHBOARD`].
+    pub dashboard_exec: Option<DashboardExec>,
 }
 
 // Sub-command tables for multi-form commands.
@@ -133,11 +166,12 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         name: "agents",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "List running agents",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Client),
     },
     CommandDef {
         name: "agent",
@@ -148,80 +182,125 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "<name>",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "new",
         aliases: &[],
         category: Category::Session,
         // Also reachable from CLI/TUI chat surfaces; both reset the agent session the same way.
-        scope: Scope::CHANNEL.union(Scope::CLI),
+        scope: Scope::CHANNEL.union(Scope::CLI).union(Scope::DASHBOARD),
         description: "Reset session (clear messages)",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
+    },
+    CommandDef {
+        name: "reset",
+        aliases: &[],
+        category: Category::Session,
+        // Dashboard-only: channels spell the same action `/new`, which resets
+        // the channel-derived session instead of minting a new session id.
+        scope: Scope::DASHBOARD,
+        description: "Reset current session (clear history, same session id)",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "reboot",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Hard reset session (full context clear, no summary)",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "compact",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Trigger LLM session compaction",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "model",
         aliases: &[],
         category: Category::Session,
         // TUI uses /model for direct switch / picker; channels use it for show/switch.
-        scope: Scope::CHANNEL.union(Scope::CLI),
+        scope: Scope::CHANNEL.union(Scope::CLI).union(Scope::DASHBOARD),
         description: "Show or switch agent model",
         args_hint: "[name]",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "stop",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Cancel current agent run",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "usage",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Show session token usage and cost",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "think",
         aliases: &[],
         category: Category::Session,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Toggle extended thinking",
         args_hint: "[on|off]",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
+    },
+    CommandDef {
+        name: "verbose",
+        aliases: &[],
+        category: Category::Session,
+        // Tool-detail verbosity is a per-connection dashboard chat setting;
+        // channel adapters render tool output on their own terms.
+        scope: Scope::DASHBOARD,
+        description: "Cycle tool detail level",
+        args_hint: "[off|on|full]",
+        subcommands: &[],
+        telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     // ---- Info ----
+    CommandDef {
+        name: "info",
+        aliases: &[],
+        category: Category::Info,
+        scope: Scope::DASHBOARD,
+        description: "Show current agent info",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Client),
+    },
     CommandDef {
         name: "models",
         aliases: &[],
@@ -231,6 +310,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "providers",
@@ -241,6 +321,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "skills",
@@ -251,6 +332,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "hands",
@@ -261,17 +343,19 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "status",
         aliases: &[],
         category: Category::Info,
         // Channels show system status; TUI shows connection / agent info.
-        scope: Scope::CHANNEL.union(Scope::CLI),
+        scope: Scope::CHANNEL.union(Scope::CLI).union(Scope::DASHBOARD),
         description: "Show system status",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     // ---- Automation ----
     CommandDef {
@@ -283,6 +367,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "workflow",
@@ -293,6 +378,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "run <name> [input]",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "triggers",
@@ -303,6 +389,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "trigger",
@@ -313,6 +400,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: TRIGGER_SUBCOMMANDS,
         telegram_menu: false,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "schedules",
@@ -323,6 +411,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "schedule",
@@ -333,6 +422,18 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: SCHEDULE_SUBCOMMANDS,
         telegram_menu: false,
+        dashboard_exec: None,
+    },
+    CommandDef {
+        name: "goal",
+        aliases: &[],
+        category: Category::Automation,
+        scope: Scope::CHANNEL.union(Scope::CLI).union(Scope::DASHBOARD),
+        description: "Create and start an autonomous goal",
+        args_hint: "<description> [--loop-engineering]",
+        subcommands: &[],
+        telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "approvals",
@@ -343,6 +444,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "approve",
@@ -353,6 +455,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "<id>",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "reject",
@@ -363,37 +466,63 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "<id>",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
     // ---- Monitoring ----
     CommandDef {
         name: "budget",
         aliases: &[],
         category: Category::Monitoring,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Show spending limits and current costs",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Backend),
+    },
+    CommandDef {
+        name: "context",
+        aliases: &[],
+        category: Category::Monitoring,
+        scope: Scope::DASHBOARD,
+        description: "Show context window usage and pressure",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Backend),
+    },
+    CommandDef {
+        name: "queue",
+        aliases: &[],
+        category: Category::Monitoring,
+        scope: Scope::DASHBOARD,
+        description: "Check if the agent is processing",
+        args_hint: "",
+        subcommands: &[],
+        telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "peers",
         aliases: &[],
         category: Category::Monitoring,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "Show OFP peer network status",
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     CommandDef {
         name: "a2a",
         aliases: &[],
         category: Category::Monitoring,
-        scope: Scope::CHANNEL,
+        scope: Scope::CHANNEL.union(Scope::DASHBOARD),
         description: "List discovered external A2A agents",
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Backend),
     },
     // ---- Misc (no header in /help) ----
     CommandDef {
@@ -405,6 +534,7 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "<question>",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "start",
@@ -415,27 +545,30 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "help",
         aliases: &[],
         category: Category::Misc,
-        scope: Scope::CHANNEL.union(Scope::CLI),
+        scope: Scope::CHANNEL.union(Scope::CLI).union(Scope::DASHBOARD),
         description: "Show this help",
         args_hint: "",
         subcommands: &[],
         telegram_menu: true,
+        dashboard_exec: Some(DashboardExec::Client),
     },
     // ---- TUI-only control commands (Scope::CLI) ----
     CommandDef {
         name: "clear",
         aliases: &[],
         category: Category::Misc,
-        scope: Scope::CLI,
+        scope: Scope::CLI.union(Scope::DASHBOARD),
         description: "Clear chat history",
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: Some(DashboardExec::Client),
     },
     CommandDef {
         name: "kill",
@@ -446,18 +579,35 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
     CommandDef {
         name: "exit",
         aliases: &["quit"],
         category: Category::Misc,
-        scope: Scope::CLI,
+        scope: Scope::CLI.union(Scope::DASHBOARD),
         description: "End chat session",
         args_hint: "",
         subcommands: &[],
         telegram_menu: false,
+        dashboard_exec: None,
     },
 ];
+
+impl CommandDef {
+    /// One-line usage hint, e.g. `Usage: /goal <description> [--loop-engineering]`.
+    ///
+    /// Derived from [`args_hint`](Self::args_hint) so a surface rejecting a
+    /// malformed invocation cannot quote an arg list the registry no longer
+    /// describes.
+    pub fn usage(&self) -> String {
+        if self.args_hint.is_empty() {
+            format!("Usage: /{}", self.name)
+        } else {
+            format!("Usage: /{} {}", self.name, self.args_hint)
+        }
+    }
+}
 
 /// Look up a command by its bare name or any alias. The leading `/` is
 /// optional and stripped if present.
@@ -654,6 +804,7 @@ mod tests {
             "btw",
             "workflows",
             "workflow",
+            "goal",
             "triggers",
             "trigger",
             "schedules",
@@ -846,15 +997,18 @@ mod tests {
         // Running this alongside `channel_command_names_match_historical_set`
         // catches any future drift where someone adds a CLI-only command but
         // accidentally tags it `Scope::CHANNEL`.
-        let cli_only: Vec<&str> = COMMAND_REGISTRY
+        // Matches on "not channel-scoped" rather than "exactly Scope::CLI" so
+        // the guard keeps covering commands that also gained
+        // `Scope::DASHBOARD` (`/clear`, `/exit`).
+        let non_channel: Vec<&str> = COMMAND_REGISTRY
             .iter()
-            .filter(|c| c.scope == Scope::CLI)
+            .filter(|c| !c.scope.contains(Scope::CHANNEL))
             .map(|c| c.name)
             .collect();
-        for name in &cli_only {
+        for name in &non_channel {
             assert!(
                 !is_channel_command(name),
-                "CLI-only command `{name}` must not appear as channel command"
+                "non-channel command `{name}` must not appear as channel command"
             );
         }
     }
@@ -874,6 +1028,102 @@ mod tests {
         );
         // Non-empty so this test catches accidental empty registry.
         assert!(!menu.is_empty());
+    }
+
+    /// `/goal` must resolve on every chat surface, not just channels.
+    ///
+    /// Regression guard for the split-brain command catalog (upstream #3355).
+    /// `/goal` shipped with `Scope::CHANNEL` alone, so it worked in Telegram
+    /// while staying invisible in the TUI chat runner and in the dashboard
+    /// catalog served by `GET /api/commands`.
+    #[test]
+    fn goal_is_reachable_from_every_chat_surface() {
+        let def = lookup("goal").expect("/goal must be registered");
+        assert!(
+            def.scope.contains(Scope::CHANNEL),
+            "/goal must stay reachable from channels"
+        );
+        assert!(
+            def.scope.contains(Scope::CLI),
+            "/goal must be reachable from the TUI chat runner"
+        );
+        assert!(
+            def.scope.contains(Scope::DASHBOARD),
+            "/goal must be reachable from the dashboard chat"
+        );
+    }
+
+    /// Every command the hand-written `BUILTIN_COMMANDS` const in
+    /// `librefang-api/src/routes/commands.rs` used to serve must still be
+    /// reachable now that `GET /api/commands` derives from this registry.
+    /// This is the "nothing vanished from the catalog" golden assertion.
+    #[test]
+    fn dashboard_scope_covers_the_historical_builtin_catalog() {
+        let historical: &[&str] = &[
+            "help", "new", "reset", "reboot", "compact", "model", "stop", "usage", "think",
+            "context", "verbose", "queue", "status", "clear", "exit",
+        ];
+        let actual: std::collections::BTreeSet<&str> =
+            iter_for(Scope::DASHBOARD).map(|c| c.name).collect();
+        for name in historical {
+            assert!(
+                actual.contains(name),
+                "`/{name}` disappeared from the dashboard catalog"
+            );
+        }
+    }
+
+    /// The slash menu the dashboard chat used to hard-code in `ChatPage.tsx`
+    /// must survive the move to the server-served catalog, execution mode
+    /// included.
+    #[test]
+    fn dashboard_exec_matches_the_historical_chat_menu() {
+        let client: &[&str] = &["help", "clear", "agents", "info"];
+        let backend: &[&str] = &[
+            "new", "compact", "reset", "reboot", "stop", "model", "usage", "context", "verbose",
+            "budget", "peers", "a2a", "queue",
+        ];
+        for name in client {
+            let def = lookup(name).unwrap_or_else(|| panic!("`/{name}` must be registered"));
+            assert_eq!(
+                def.dashboard_exec,
+                Some(DashboardExec::Client),
+                "`/{name}` must stay client-resolved in the dashboard chat"
+            );
+        }
+        for name in backend {
+            let def = lookup(name).unwrap_or_else(|| panic!("`/{name}` must be registered"));
+            assert_eq!(
+                def.dashboard_exec,
+                Some(DashboardExec::Backend),
+                "`/{name}` must stay dispatched over the chat WebSocket"
+            );
+        }
+    }
+
+    /// `dashboard_exec` only means something under `Scope::DASHBOARD`; setting
+    /// it elsewhere would offer a command the catalog never serves.
+    #[test]
+    fn dashboard_exec_implies_dashboard_scope() {
+        for c in COMMAND_REGISTRY {
+            if c.dashboard_exec.is_some() {
+                assert!(
+                    c.scope.contains(Scope::DASHBOARD),
+                    "`/{}` sets dashboard_exec without Scope::DASHBOARD",
+                    c.name
+                );
+            }
+        }
+    }
+
+    /// `Scope::DASHBOARD` must stay a live flag rather than the dead bit it
+    /// was between its introduction and upstream #3355.
+    #[test]
+    fn dashboard_scope_is_not_a_dead_flag() {
+        assert!(
+            iter_for(Scope::DASHBOARD).count() > 0,
+            "no command carries Scope::DASHBOARD"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `DashboardExec` enum (`Client` / `Backend`) to the commands module so each command declares how the dashboard chat should execute it
- Each `CommandDef` gains an optional `dashboard_exec` field (`None` = not offered in the dashboard chat slash menu)
- Commands that make sense in the dashboard now carry `Scope::DASHBOARD` and an execution mode tag
- New dashboard-only commands: `/reset`, `/verbose`, `/info`, `/context`, `/queue`
- `/goal` registered with `Scope::CHANNEL | CLI | DASHBOARD` and `Backend` exec mode
- `CommandDef::usage()` helper derives a one-line usage hint from `args_hint`
- Six new tests: golden assertions for the historical dashboard catalog, exec-mode correctness, scope invariant, dead-flag guard, and `/goal` surface coverage

## Verification
- `cargo check -p librefang-channels --lib` passes
- `cargo test -p librefang-channels` — all 45 tests pass (32 unit + 7 sidecar protocol + 6 sidecar version)