### PR TITLE
feat(cli): add models overrides subcommand

### DIFF
--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -1119,6 +1119,13 @@ model-header-auth = AUTH
 model-header-models = MODELS
 model-header-base-url = BASE URL
 model-picker-item =     { $idx }. { $id } { $tier }
+model-overrides-cleared = Overrides cleared for model { $model }.
+model-overrides-clear-failed = Failed to clear overrides for { $model }: { $status }
+model-overrides-header-field = FIELD
+model-overrides-header-value = VALUE
+model-overrides-none-set = No overrides set for { $model }.
+model-overrides-saved = Overrides saved for { $model }.
+model-overrides-save-failed = Failed to save overrides for { $model }: { $status }
 
 # Approvals command specific keys
 approval-none-pending = No pending approvals.

--- a/crates/librefang-cli/locales/ko/main.ftl
+++ b/crates/librefang-cli/locales/ko/main.ftl
@@ -1118,6 +1118,13 @@ model-header-resolves-to = 확인 대상
 model-header-auth = 인증
 model-header-models = 모델
 model-header-base-url = BASE URL
+model-overrides-cleared = 모델 { $model }의 오버라이드가 초기화되었습니다.
+model-overrides-clear-failed = { $model }의 오버라이드 초기화 실패: { $status }
+model-overrides-header-field = 필드
+model-overrides-header-value = 값
+model-overrides-none-set = 모델 { $model }에 설정된 오버라이드가 없습니다.
+model-overrides-saved = 모델 { $model }의 오버라이드가 저장되었습니다.
+model-overrides-save-failed = { $model }의 오버라이드 저장 실패: { $status }
 model-picker-item =     { $idx }. { $id } { $tier }
 
 # Approvals command specific keys

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -1132,6 +1132,13 @@ model-header-resolves-to = ВКАЗУЄ НА
 model-header-auth = АВТОРИЗАЦІЯ
 model-header-models = МОДЕЛІ
 model-header-base-url = БАЗОВИЙ URL
+model-overrides-cleared = Перевизначення для моделі { $model } очищено.
+model-overrides-clear-failed = Не вдалося очистити перевизначення для { $model }: { $status }
+model-overrides-header-field = ПОЛЕ
+model-overrides-header-value = ЗНАЧЕННЯ
+model-overrides-none-set = Для моделі { $model } не встановлено перевизначень.
+model-overrides-saved = Перевизначення для моделі { $model } збережено.
+model-overrides-save-failed = Не вдалося зберегти перевизначення для { $model }: { $status }
 model-picker-item =     { $idx }. { $id } { $tier }
 
 # Approvals command specific keys

--- a/crates/librefang-cli/locales/zh-CN/main.ftl
+++ b/crates/librefang-cli/locales/zh-CN/main.ftl
@@ -2134,6 +2134,13 @@ model-header-resolves-to = 解析到
 model-header-auth = 认证
 model-header-models = 模型
 model-header-base-url = 基础 URL
+model-overrides-cleared = 已清除模型 { $model } 的覆盖设置。
+model-overrides-clear-failed = 清除 { $model } 的覆盖设置失败：{ $status }
+model-overrides-header-field = 字段
+model-overrides-header-value = 值
+model-overrides-none-set = 模型 { $model } 未设置覆盖。
+model-overrides-saved = 已保存模型 { $model } 的覆盖设置。
+model-overrides-save-failed = 保存 { $model } 的覆盖设置失败：{ $status }
 model-picker-item =     { $idx }. { $id } { $tier }
 # Approvals command specific keys
 approval-none-pending = 没有待处理的批准请求。

--- a/crates/librefang-cli/src/cli.rs
+++ b/crates/librefang-cli/src/cli.rs
@@ -1391,6 +1391,26 @@ pub(crate) enum ModelsCommands {
         /// Model ID or alias (e.g. "gpt-4o", "claude-sonnet"). Interactive picker if omitted.
         model: Option<String>,
     },
+    /// View, set, or clear per-model inference overrides (context_window, max_output_tokens).
+    #[command(
+        long_about = "View, set, or clear per-model inference parameter overrides.\n\nUseful when a self-hosted gateway misreports context_window or max_output_tokens.\n\nExamples:\n  librefang models overrides gpt-4o\n  librefang models overrides gpt-4o --context-window 131072\n  librefang models overrides gpt-4o --max-output-tokens 16384\n  librefang models overrides gpt-4o --clear\n  librefang models overrides gpt-4o --json"
+    )]
+    Overrides {
+        /// Model ID to view or modify overrides for.
+        model: String,
+        /// Override the model's context window size.
+        #[arg(long)]
+        context_window: Option<u64>,
+        /// Override the model's max output tokens.
+        #[arg(long)]
+        max_output_tokens: Option<u64>,
+        /// Remove all overrides for this model.
+        #[arg(long)]
+        clear: bool,
+        /// Output as JSON for scripting.
+        #[arg(long)]
+        json: bool,
+    },
     /// Register an external AI gateway as an LLM provider.
     #[command(
         long_about = "Register an external AI gateway as a custom LLM provider.\n\nReads the gateway's own credentials file, fetches its live model list, and writes a provider entry plus the API key into the LibreFang home directory.\n\nSupported targets:\n  everyapi  # reads ~/.config/everyapi/credentials.json\n\nExamples:\n  librefang models connect everyapi\n  librefang models connect everyapi --set-default"

--- a/crates/librefang-cli/src/commands/models.rs
+++ b/crates/librefang-cli/src/commands/models.rs
@@ -272,6 +272,82 @@ pub(crate) fn cmd_models_set(model: Option<String>) {
     }
 }
 
+pub(crate) fn cmd_models_overrides(
+    model: &str,
+    context_window: Option<u64>,
+    max_output_tokens: Option<u64>,
+    clear: bool,
+    json: bool,
+) {
+    let base = require_daemon("models overrides");
+    let client = daemon_client();
+    let url = format!("{base}/api/models/overrides/{model}");
+
+    if clear {
+        let (status, _) = daemon_json_checked(client.delete(&url).send());
+        if status.is_success() {
+            ui::success(&i18n::t_args(
+                "model-overrides-cleared",
+                &[("model", model)],
+            ));
+        } else {
+            ui::error(&i18n::t_args(
+                "model-overrides-clear-failed",
+                &[("model", model), ("status", &status.to_string())],
+            ));
+        }
+        return;
+    }
+
+    if context_window.is_none() && max_output_tokens.is_none() {
+        let body = daemon_json(client.get(&url).send());
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&body).unwrap_or_default()
+            );
+            return;
+        }
+        let header_field = i18n::t("model-overrides-header-field");
+        let header_value = i18n::t("model-overrides-header-value");
+        let mut t = crate::table::Table::new(&[&header_field, &header_value]);
+        if let Some(obj) = body.as_object() {
+            if obj.is_empty() {
+                ui::hint(&i18n::t_args(
+                    "model-overrides-none-set",
+                    &[("model", model)],
+                ));
+                return;
+            }
+            for (field, value) in obj {
+                t.add_row(&[field.as_str(), &value.to_string()]);
+            }
+        }
+        t.print();
+        return;
+    }
+
+    let mut overrides = daemon_json(client.get(&url).send());
+    if !overrides.is_object() {
+        overrides = serde_json::json!({});
+    }
+    if let Some(cw) = context_window {
+        overrides["context_window"] = serde_json::json!(cw);
+    }
+    if let Some(mot) = max_output_tokens {
+        overrides["max_output_tokens"] = serde_json::json!(mot);
+    }
+    let (status, _) = daemon_json_checked(client.put(&url).json(&overrides).send());
+    if status.is_success() {
+        ui::success(&i18n::t_args("model-overrides-saved", &[("model", model)]));
+    } else {
+        ui::error(&i18n::t_args(
+            "model-overrides-save-failed",
+            &[("model", model), ("status", &status.to_string())],
+        ));
+    }
+}
+
 /// Interactive model picker — shows numbered list, accepts number or model ID.
 pub(crate) fn pick_model() -> String {
     let catalog = librefang_runtime::model_catalog::ModelCatalog::default();

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -585,6 +585,13 @@ fn main() {
             ModelsCommands::Aliases { json } => cmd_models_aliases(json),
             ModelsCommands::Providers { json } => cmd_models_providers(json),
             ModelsCommands::Set { model } => cmd_models_set(model),
+            ModelsCommands::Overrides {
+                model,
+                context_window,
+                max_output_tokens,
+                clear,
+                json,
+            } => cmd_models_overrides(&model, context_window, max_output_tokens, clear, json),
             ModelsCommands::Connect {
                 target,
                 set_default,

--- a/crates/librefang-cli/tests/i18n_checks.rs
+++ b/crates/librefang-cli/tests/i18n_checks.rs
@@ -118,6 +118,7 @@ fn is_potential_untranslated_literal(lit: &str) -> bool {
         "pip install librefang-sdk",
         "models list",
         "models set",
+        "models overrides",
         "models aliases",
         "models providers",
         "models connect",


### PR DESCRIPTION
## Summary
- Adds `librefang models overrides <model>` CLI subcommand to view, set, and clear per-model inference parameter overrides (context_window, max_output_tokens)
- The API routes already exist (`GET/PUT/DELETE /api/models/overrides/{id}`) — this PR adds the missing CLI surface
- Full i18n coverage across all 4 locales (en, ko, uk, zh-CN)

## Verification
- `cargo check -p librefang-cli` passes