### PR TITLE
fix(ci): give the coverage job room to write its report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,6 +65,29 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # The instrumented workspace build does not fit the runner's default free space.
+      # `cargo llvm-cov nextest --workspace` writes a debug + coverage-instrumented target tree
+      # for ~12k tests, and this job has failed intermittently on `main` at the very last step —
+      # every test passing, then `failed to write to file lcov.info: No space left on device
+      # (os error 28)`. Alternating success and failure on neighbouring commits is the signature
+      # of a capacity race, not a regression, so the fix belongs here rather than in the report.
+      # None of the preinstalled SDKs removed below are used by this job; together they are the
+      # bulk of the image, with the Android SDK alone around 9 GB.
+      - name: Free runner disk space
+        run: |
+          echo "before: $(df -h --output=avail / | tail -1 | tr -d ' ') available"
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/share/boost \
+            /usr/share/swift
+          if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          fi
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "after:  $(df -h --output=avail / | tail -1 | tr -d ' ') available"
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,13 +66,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # The instrumented workspace build does not fit the runner's default free space.
-      # `cargo llvm-cov nextest --workspace` writes a debug + coverage-instrumented target tree
-      # for ~12k tests, and this job has failed intermittently on `main` at the very last step —
-      # every test passing, then `failed to write to file lcov.info: No space left on device
-      # (os error 28)`. Alternating success and failure on neighbouring commits is the signature
-      # of a capacity race, not a regression, so the fix belongs here rather than in the report.
-      # None of the preinstalled SDKs removed below are used by this job; together they are the
-      # bulk of the image, with the Android SDK alone around 9 GB.
+      # `cargo llvm-cov nextest --workspace` writes a debug + coverage-instrumented target tree for ~12k tests, and this job has failed intermittently on `main` at the very last step — every test passing, then `failed to write to file lcov.info: No space left on device (os error 28)`.
+      # Alternating success and failure on neighbouring commits is the signature of a capacity race, not a regression, so the fix belongs here rather than in the report.
+      # None of the preinstalled SDKs removed below are used by this job; together they are the bulk of the image, with the Android SDK alone around 9 GB.
       - name: Free runner disk space
         run: |
           echo "before: $(df -h --output=avail / | tail -1 | tr -d ' ') available"

--- a/changelog.d/fixed/8001-coverage-disk-space.md
+++ b/changelog.d/fixed/8001-coverage-disk-space.md
@@ -1,0 +1,3 @@
+The coverage job stops failing at the finish line.
+The instrumented workspace build filled the runner's disk, so `cargo llvm-cov` ran every test to completion and then died writing the report with "No space left on device"; the job now reclaims the preinstalled SDKs it never uses before building.
+(#8001) (@houko)


### PR DESCRIPTION
[Run 33256929586](https://github.com/librefang/librefang/actions/runs/33256929586/job/99112190728) — `Coverage` on `main`.

## What happened

Every one of the ~12k tests passed. The job then died writing the report:

```
error: failed to generate report: failed to write to file `lcov.info`:
       No space left on device (os error 28)
```

## Why it is a capacity race, not a regression

Coverage on `main` alternates:

```
14:11  7ce0eda77  failure
12:42  d0befb113  success
12:41  e21dbe69a  success
11:20  fe56e5360  success
09:47  05fd80f71  failure
08:39  46f8c21e2  success
```

Neighbouring commits succeeding and failing is what a disk running out looks like, not what a code defect looks like. `cargo llvm-cov nextest --workspace` writes a debug **and** coverage-instrumented target tree for the entire workspace, which does not fit alongside the runner image's preinstalled toolchains — and the failure lands at the end, where the report needs its last few hundred MB.

## Fix

Reclaim the preinstalled SDKs this job never touches, before the build starts. The Android SDK alone is around 9 GB. Available space is printed either side, so a future failure reports how much was actually there instead of leaving the next reader to guess.

Fixing the space rather than the report is deliberate: a full disk is not a stable place to have been running tests from either, even though the report is the only visible casualty today.

## Verification

- The workflow parses and `actionlint` is clean.
- The step's shell body passes `bash -n`, and `df -h --output=avail /` — a GNU coreutils flag — was checked on `ubuntu:24.04` rather than assumed.
- The `AGENT_TOOLSDIRECTORY` guard was exercised with the variable empty, confirming it skips rather than issuing `rm -rf ""`.

The real proof is the next `main` run, which will print the before/after figures.

## Scope

`Coverage` is report-only and gates no merge; this does not change what it measures.