### PR TITLE
fix(ci): install cross targets on the toolchain that builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,10 @@ jobs:
         with:
           components: clippy, rustfmt
           targets: wasm32-unknown-unknown
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           workspaces: |
@@ -466,6 +470,10 @@ jobs:
         with:
           components: clippy, rustfmt
           targets: aarch64-unknown-linux-musl
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add aarch64-unknown-linux-musl
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           # Both workspaces — the adapter and the sibling SDK it depends on.

--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -84,6 +84,10 @@ jobs:
         with:
           targets: aarch64-linux-android
 
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add aarch64-linux-android
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
@@ -175,6 +179,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-apple-ios-sim
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add aarch64-apple-ios-sim
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -122,6 +122,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-${{ matrix.target }}-${{ inputs.tag }}
@@ -188,6 +192,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
       - name: Install cross
@@ -307,6 +315,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
@@ -358,6 +370,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - name: Install cross
         run: cargo install cross --locked
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
@@ -431,6 +447,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-${{ matrix.target }}-${{ inputs.tag }}
@@ -487,6 +507,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-mini-${{ matrix.target }}-${{ inputs.tag }}
@@ -539,6 +563,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-mini-${{ matrix.target }}-${{ inputs.tag }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -99,6 +99,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.platform.rust_target }}
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.platform.rust_target }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1941,6 +1941,10 @@ jobs:
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi
 
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
@@ -2168,6 +2172,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      # The pinned toolchain needs the target too — see the note in release.yml's `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,6 +575,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # `rust-toolchain.toml` pins the workspace to its MSRV, so cargo builds with that toolchain no matter which one the step above installed.
+      # `targets:` adds the target to `stable`, leaving the pinned toolchain with no std for it, so every cross target fails with "can't find crate for `std`" while the native ones pass — which is exactly how v2026.8.30 shipped 23 of its 48 assets.
+      # rustup names the trap itself in that log: "the toolchain '1.94.1-aarch64-apple-darwin' is currently in use (overridden by .../rust-toolchain.toml)".
+      # `rustup target add` with no `--toolchain` applies to the overridden toolchain, which is the one that builds. A native target already has its std, so this is a no-op there.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-${{ matrix.target }}-${{ env.RELEASE_TAG }}
@@ -665,6 +672,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - name: Install build deps
         # libdbus-1-dev is required by libdbus-sys, pulled in transitively
         # by the keyring crate's secret-service backend on glibc Linux
@@ -815,6 +826,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - name: Install build deps
         # libdbus-1-dev is required by libdbus-sys, pulled in transitively
         # by the keyring crate's secret-service backend on glibc Linux.
@@ -872,6 +887,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - name: Install cross
         run: cargo install cross --locked
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
@@ -949,6 +968,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-${{ matrix.target }}-${{ env.RELEASE_TAG }}
@@ -1009,6 +1032,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-mini-${{ matrix.target }}-${{ env.RELEASE_TAG }}
@@ -1065,6 +1092,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2
         with:
           key: cli-mini-${{ matrix.target }}-${{ env.RELEASE_TAG }}
@@ -1685,6 +1716,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.platform.rust_target }}
+
+      # The pinned toolchain needs the target too — see the note in the `cli_mac` job.
+      - name: Add the target to the pinned toolchain
+        run: rustup target add ${{ matrix.platform.rust_target }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -579,7 +579,8 @@ jobs:
       # `rust-toolchain.toml` pins the workspace to its MSRV, so cargo builds with that toolchain no matter which one the step above installed.
       # `targets:` adds the target to `stable`, leaving the pinned toolchain with no std for it, so every cross target fails with "can't find crate for `std`" while the native ones pass — which is exactly how v2026.8.30 shipped 23 of its 48 assets.
       # rustup names the trap itself in that log: "the toolchain '1.94.1-aarch64-apple-darwin' is currently in use (overridden by .../rust-toolchain.toml)".
-      # `rustup target add` with no `--toolchain` applies to the overridden toolchain, which is the one that builds. A native target already has its std, so this is a no-op there.
+      # `rustup target add` with no `--toolchain` applies to the overridden toolchain, which is the one that builds.
+      # A native target already has its std, so this is a no-op there.
       - name: Add the target to the pinned toolchain
         run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2

--- a/changelog.d/fixed/8007-release-cross-target-toolchain.md
+++ b/changelog.d/fixed/8007-release-cross-target-toolchain.md
@@ -1,0 +1,4 @@
+Release builds produce their cross-compiled artifacts again.
+`dtolnay/rust-toolchain` installed each target on `stable`, but `rust-toolchain.toml` pins the workspace to its MSRV and cargo builds with that toolchain instead, so every cross target failed with "can't find crate for `std`" while the native ones passed — v2026.8.30 shipped 23 of the 48 assets its predecessor did.
+The target is now added to the toolchain that actually builds.
+(#8007) (@houko)

--- a/changelog.d/fixed/8007-release-cross-target-toolchain.md
+++ b/changelog.d/fixed/8007-release-cross-target-toolchain.md
@@ -1,4 +1,4 @@
 Release builds produce their cross-compiled artifacts again.
 `dtolnay/rust-toolchain` installed each target on `stable`, but `rust-toolchain.toml` pins the workspace to its MSRV and cargo builds with that toolchain instead, so every cross target failed with "can't find crate for `std`" while the native ones passed — v2026.8.30 shipped 23 of the 48 assets its predecessor did.
-The target is now added to the toolchain that actually builds.
+The target is now added to the toolchain that actually builds, in every workflow that declares one — including the manual re-release workflows any repair of a broken release has to run through.
 (#8007) (@houko)

--- a/changelog.d/fixed/8008-fly-deploy-release-image.md
+++ b/changelog.d/fixed/8008-fly-deploy-release-image.md
@@ -1,0 +1,3 @@
+The official Fly demo deploys the release being cut instead of a hardcoded July build.
+`deploy/fly/fly.toml` pinned `ghcr.io/librefang/librefang:v2026.7.31`, which had since been removed from the registry, so the deploy failed with "Could not find image" — and while it existed, the demo served that stale build after every release.
+(#8008) (@houko)


### PR DESCRIPTION
[Run 33283348874](https://github.com/librefang/librefang/actions/runs/33283348874) — `Release` on `v2026.8.30`.

**The release published with 23 assets. v2026.8.19 published 48.** Every cross-compiled artifact is missing.

## Failure

`CLI / x86_64-apple-darwin`, `CLI / x86_64-apple-darwin (mini)`, `CLI / aarch64-pc-windows-msvc`, `Desktop / macOS x86_64`, `Desktop / Windows ARM64`:

```
error[E0463]: can't find crate for `std`
```

Every **native** target passed. That split is the whole diagnosis.

## Cause

`dtolnay/rust-toolchain`'s `targets:` input installs the target on the toolchain *it* installs — `stable`, currently 1.98.0. `rust-toolchain.toml` pins the workspace to **1.94.1**, and that is the toolchain cargo actually builds with. It has no std for any target but the host.

rustup states it outright in the failing log, immediately before the build:

```
info: note that the toolchain '1.94.1-aarch64-apple-darwin' is currently in use
      (overridden by /Users/runner/work/librefang/librefang/rust-toolchain.toml)
```

**Why it is new:** at `v2026.8.19` the file read `channel = "stable"`, so installing the target on `stable` *was* installing it on the build toolchain. #7255 changed it to the MSRV and the two silently came apart — invisibly, because native targets kept working and only a tag push exercises the cross ones.

## Fix

`rustup target add` with no `--toolchain` applies to the overridden toolchain, so the target lands where the build looks for it.

**All twenty-two declarations, across five workflows** — not only the five jobs that failed:

- **`release-cli.yml` (7) and `release-desktop.yml` (1)** carry the same defect, and they are the workflows a broken release is repaired *through*. Leaving them would have made the repair path fail exactly the same way — this is the reason the PR is not scoped to `release.yml`.
- **`ci.yml`'s `WASM Skill SDK`** builds `wasm32-unknown-unknown` from a plain cargo invocation and is latently broken. It has been skipped on eleven of the last twelve CI runs, which is the only reason nobody has hit it.
- **`ci.yml`'s Telegram sidecar and the musl jobs** build through `cross`, whose Docker toolchain is unaffected — that is why `Rust Telegram Sidecar` is green today. Included anyway: the `targets:` line already declares the intent, and a job that later stops using `cross` should not silently reacquire the bug.

Comma-separated declarations expand to the several arguments `rustup target add` expects. Adding a target the toolchain already has is a no-op, which is what makes this safe to apply uniformly.

## Verification

- All 22 new steps are asserted to sit immediately after their `dtolnay/rust-toolchain` step, by parsing each workflow.
- `actionlint` findings are unchanged per file: release.yml 30→30, release-cli.yml 2→2, release-desktop.yml 6→6, ci.yml 10→10, mobile-smoke.yml 0→0. None introduced.

The real proof is a tag build; cross jobs do not run on a PR.

## This does not repair v2026.8.30

The published release is still missing its assets. Once this is on `main`, the artifacts need rebuilding through `release-cli.yml` / `release-desktop.yml` against that tag — which is why those two workflows had to be fixed here.

## Separate failures in the same run

- `SDK / CLI npm` and `SDK / JavaScript (npm)` — `npm error 404 ... PUT https://registry.npmjs.org/@librefang%2fcli`. Both packages exist and were last published at `2026.8.19`, by the same workflow, so this was the token rather than the config. **The maintainer has since rotated `NPM_TOKEN`**; those two jobs need only a re-run.
- `Deploy to Fly.io` — `Could not find image "ghcr.io/librefang/librefang:v2026.7.31"`. A stale hardcoded tag in `deploy/fly/fly.toml`; fixed separately in #8008.
- `Mobile / iOS (ipa)` — `Signing certificate is invalid. Signing certificate "Apple Distribution ..."`. An expired or revoked Apple distribution certificate; only the maintainer can replace it.