### PR TITLE
fix(ci): deploy the demo from the image the release just pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3088,10 +3088,11 @@ jobs:
         # Keep that exception out of fly.toml so user deployments remain secure by default and must explicitly provision authentication.
         # The image is pinned to the tag being released for the same reason the auth exception lives here: fly.toml is a file users copy, and a release-specific tag baked into it goes stale the moment the next release lands.
         # `docker-manifest`, which this job needs, has just pushed both `:$VERSION` and `:latest`, so the tag is guaranteed to exist.
+        # `${RELEASE_TAG#v}` strips the `v` prefix to match `$VERSION` as pushed by `docker-manifest` — `RELEASE_TAG` itself (e.g. `v2026.7.31`) was never a tag pushed to the registry.
         # `--image` means there is nothing to build, which is why `--remote-only` is gone rather than merely unused.
         run: >-
           flyctl deploy --config deploy/fly/fly.toml
-          --image "ghcr.io/librefang/librefang:${RELEASE_TAG}"
+          --image "ghcr.io/librefang/librefang:${RELEASE_TAG#v}"
           --env LIBREFANG_ALLOW_NO_AUTH=1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3086,8 +3086,12 @@ jobs:
       - name: Deploy public demo
         # This job owns the intentionally unauthenticated official demo.
         # Keep that exception out of fly.toml so user deployments remain secure by default and must explicitly provision authentication.
+        # The image is pinned to the tag being released for the same reason the auth exception lives here: fly.toml is a file users copy, and a release-specific tag baked into it goes stale the moment the next release lands.
+        # `docker-manifest`, which this job needs, has just pushed both `:$VERSION` and `:latest`, so the tag is guaranteed to exist.
+        # `--image` means there is nothing to build, which is why `--remote-only` is gone rather than merely unused.
         run: >-
-          flyctl deploy --remote-only --config deploy/fly/fly.toml
+          flyctl deploy --config deploy/fly/fly.toml
+          --image "ghcr.io/librefang/librefang:${RELEASE_TAG}"
           --env LIBREFANG_ALLOW_NO_AUTH=1
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -2,7 +2,11 @@ app = "librefang"
 primary_region = "nrt"
 
 [build]
-image = "ghcr.io/librefang/librefang:v2026.7.31"
+# `:latest` rather than a pinned release, because a pinned one rots: this line sat at v2026.7.31
+# until that image was gone from ghcr.io and the demo deploy failed with "Could not find image".
+# The release workflow passes `--image` with the exact tag it just pushed, so the official demo is
+# still deployed deterministically; this value is what a user copying the file gets.
+image = "ghcr.io/librefang/librefang:latest"
 
 [env]
   LIBREFANG_HOME = "/data"

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -2,10 +2,8 @@ app = "librefang"
 primary_region = "nrt"
 
 [build]
-# `:latest` rather than a pinned release, because a pinned one rots: this line sat at v2026.7.31
-# until that image was gone from ghcr.io and the demo deploy failed with "Could not find image".
-# The release workflow passes `--image` with the exact tag it just pushed, so the official demo is
-# still deployed deterministically; this value is what a user copying the file gets.
+# `:latest` rather than a pinned release, because a pinned one rots: this line sat at v2026.7.31 until that image was gone from ghcr.io and the demo deploy failed with "Could not find image".
+# The release workflow passes `--image` with the exact tag it just pushed, so the official demo is still deployed deterministically; this value is what a user copying the file gets.
 image = "ghcr.io/librefang/librefang:latest"
 
 [env]


### PR DESCRIPTION
[Run 33283348874](https://github.com/librefang/librefang/actions/runs/33283348874) — `Deploy to Fly.io` on `v2026.8.30`.

## Failure

```
Error: failed to fetch an image or build from source: failed to run query ...
Could not find image "ghcr.io/librefang/librefang:v2026.7.31"
```

## Cause

`deploy/fly/fly.toml` pinned the image to `v2026.7.31`. That is two releases stale, and the image is no longer in ghcr.io, so the deploy had nothing to pull.

The pin was wrong even while that image existed: the official public demo has been serving July's build after every release since.

## Fix

The workflow passes `--image` with the tag being released. `docker-manifest` — which this job already `needs` — has just pushed both `:$VERSION` and `:latest`, so the tag is guaranteed to exist by the time the deploy runs.

The release-specific tag belongs in the workflow for the same reason the `LIBREFANG_ALLOW_NO_AUTH` exception already lives there, per the comment above it: `fly.toml` is a file users copy, and a release tag baked into it goes stale the moment the next release lands.

`fly.toml` itself moves to `:latest` — what a user copying the file should get, and a value that cannot rot the way the pin did.

`--remote-only` is removed rather than left in place: with `--image` there is nothing to build, so the flag had no meaning.

## Verification

- `fly.toml` parses and resolves to `ghcr.io/librefang/librefang:latest`.
- The rendered command is `flyctl deploy --config deploy/fly/fly.toml --image "ghcr.io/librefang/librefang:${RELEASE_TAG}" --env LIBREFANG_ALLOW_NO_AUTH=1`.
- `actionlint` findings on `release.yml` are unchanged at 30 — the first draft left `${RELEASE_TAG}` unquoted and added an SC2086; it is quoted now.

## Related

The cross-target build failures in the same run are #8007.