### PR TITLE
fix(ci): keep a release in draft until its artifacts are signed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,11 +426,14 @@ jobs:
 
           if gh release view "$TAG" &>/dev/null; then
             echo "Release $TAG already exists, updating..."
-            gh release edit "$TAG" \
+            gh release edit "$TAG" --draft \
               --title "$TAG" \
               --notes-file /tmp/release-body.md
           else
-            gh release create "$TAG" \
+            # Created as a draft on purpose.
+            # A published release is what users and every mirror read, so publishing one before a single artifact exists means any job failure leaves a permanently public, incomplete, unsigned release — which is exactly what v2026.8.30 became.
+            # `publish_release` flips it once the artifacts are all there and signed.
+            gh release create "$TAG" --draft \
               --title "$TAG" \
               --notes-file /tmp/release-body.md
           fi
@@ -1285,6 +1288,30 @@ jobs:
             SHA256SUMS.pem \
             --clobber
 
+  # The release is a draft until here.
+  # `sign_release_artifacts` already waits for all eight CLI jobs and refuses to sign an incomplete platform set, but nothing depended on it, so its verdict changed nothing about what the world could already download.
+  # Gating publication on it is what turns that check into a gate.
+  #
+  # `desktop` joins it because its bundles are release assets too.
+  # `mobile_ios` and `mobile_android` deliberately do not: both are `continue-on-error`, so gating on them would let a best-effort job hold back a complete release.
+  # Neither do the distribution jobs — npm, PyPI, AUR and Homebrew publish to registries of their own, and a flaky mirror must not keep a finished release unpublished.
+  publish_release:
+    name: Publish release
+    needs: [create_release, sign_release_artifacts, desktop]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Flip the release out of draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release edit "$RELEASE_TAG" --draft=false
+          echo "Published $RELEASE_TAG"
+
   cli_npm:
     name: CLI / npm
     if: >
@@ -1369,7 +1396,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [cli_mac, cli_linux]
+    needs: [cli_mac, cli_linux, publish_release]
     steps:
       - name: Check out tap repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -2567,7 +2594,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [desktop]
+    needs: [desktop, publish_release]
     steps:
       - name: Check out tap repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/changelog.d/fixed/8009-release-draft-until-complete.md
+++ b/changelog.d/fixed/8009-release-draft-until-complete.md
@@ -1,0 +1,4 @@
+A GitHub Release stays a draft until its artifacts are all present and signed.
+It used to be published before a single job had run, so any failure left it permanently public, incomplete and unsigned — v2026.8.30 shipped that way with 23 of 48 assets and no `SHA256SUMS`, while the job that refuses to sign an incomplete platform set failed to no effect, because nothing depended on it.
+Publication now waits on the signature and the desktop bundles, and the two formulae that bake a public download URL wait on publication; best-effort mobile jobs and the package-registry mirrors deliberately do not gate it.
+(#8009) (@houko)

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -19,6 +19,7 @@ WORKFLOWS = (
     ROOT / ".github" / "workflows" / "release-cli.yml",
 )
 DESKTOP_WORKFLOW = ROOT / ".github" / "workflows" / "release-desktop.yml"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 INPUTS_TOKEN = re.compile(r"\binputs\b")
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 
@@ -1234,6 +1235,52 @@ def main() -> None:
         )
     ):
         raise SystemExit("release-cli workflow does not verify the exact release tag")
+
+    # A published GitHub Release is what every user and mirror reads, so it must not exist until
+    # the artifacts do. release.yml used to create it published before a single job had run, which
+    # is how v2026.8.30 stayed permanently public with 23 of 48 assets and no SHA256SUMS — and why
+    # `sign_release_artifacts` refusing to sign changed nothing that anyone could observe.
+    release_document = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    release_jobs = release_document.get("jobs", {})
+    create_steps = release_jobs.get("create_release", {}).get("steps", [])
+    create_script = "".join(
+        step.get("run", "") for step in create_steps if isinstance(step, dict)
+    )
+    if "gh release create" not in create_script:
+        raise SystemExit("release.yml no longer creates the release")
+    for command in ("gh release create", "gh release edit"):
+        for line in create_script.splitlines():
+            if command in line and "--draft" not in line:
+                raise SystemExit(f"release.yml runs `{command}` without --draft")
+
+    publish_job = release_jobs.get("publish_release")
+    if publish_job is None:
+        raise SystemExit("release.yml has no publish_release job to leave draft state")
+    publish_needs = publish_job.get("needs") or []
+    if isinstance(publish_needs, str):
+        publish_needs = [publish_needs]
+    # The gate is the signature plus the desktop bundles. `sign_release_artifacts` already waits on
+    # every CLI job and rejects an incomplete platform set, so requiring it requires them too.
+    for required in ("sign_release_artifacts", "desktop"):
+        if required not in publish_needs:
+            raise SystemExit(f"publish_release does not wait for {required}")
+    # Best-effort jobs must never hold a finished release back.
+    for optional in ("mobile_ios", "mobile_android"):
+        if optional in publish_needs:
+            raise SystemExit(f"publish_release gates on best-effort job {optional}")
+    publish_script = "".join(
+        step.get("run", "") for step in publish_job.get("steps", []) if isinstance(step, dict)
+    )
+    if "--draft=false" not in publish_script:
+        raise SystemExit("publish_release never leaves draft state")
+
+    # The two formulae that bake a public releases/download URL cannot run while it 404s.
+    for consumer in ("sync_homebrew", "sync_homebrew_cask"):
+        consumer_needs = release_jobs.get(consumer, {}).get("needs") or []
+        if isinstance(consumer_needs, str):
+            consumer_needs = [consumer_needs]
+        if "publish_release" not in consumer_needs:
+            raise SystemExit(f"{consumer} writes a download URL before the release is published")
 
     sign_job = release_cli_jobs.get("sign_release_artifacts", {})
     sign_steps = sign_job.get("steps", [])


### PR DESCRIPTION
Raised by the maintainer looking at v2026.8.30: if a broken run still publishes an unsigned release, what is the signing job's error for?

Nothing. That is the bug.

## What the pipeline did

```
t=0   gh release create        ← published, empty, public
      ├─ 18 jobs upload artifacts into it as they finish
      └─ sign_release_artifacts ← leaf; nothing depends on it
```

`create_release` ran `gh release create` with **no `--draft`**, so the release was public before a single build job started. Every failure after that point left a permanently public release that was incomplete and unsigned.

**v2026.8.30 is that release**: 23 of the 48 assets its predecessor shipped, and no `SHA256SUMS`, `SHA256SUMS.sig` or `SHA256SUMS.pem` at all. Users could download binaries from a page that looks official, with nothing to verify them against.

`sign_release_artifacts` behaved correctly throughout — it waits on all eight CLI jobs and refuses to sign a platform set that does not match, exactly as #7305 hardened it to. It is also a leaf: **nothing in the 36-job graph depends on it**, so refusing to sign changed nothing anyone could observe. A gate that runs after the thing it guards has already shipped is not a gate.

## What it does now

```
gh release create --draft
  ├─ artifacts …
  ├─ sign_release_artifacts
  └─ publish_release → gh release edit --draft=false
        └─ sync_homebrew, sync_homebrew_cask
```

**Gates publication:** `sign_release_artifacts` and `desktop`. The former already requires every CLI job and validates the exact checksum asset set, so requiring it requires them; the latter contributes bundles of its own.

**Deliberately does not gate:**
- `mobile_ios` / `mobile_android` — both are `continue-on-error`. A job the pipeline already treats as best-effort must not hold back a finished release. (This is also why the current iOS certificate failure would not block anything.)
- npm, PyPI, AUR, the Arch repo — each publishes to a registry of its own. A flaky mirror must not keep a complete release unpublished.

**Waits for publication:** `sync_homebrew` and `sync_homebrew_cask` only, because they bake a `releases/download/...` URL into a formula and that URL 404s while the release is a draft. No other distribution job reads release assets, so nothing else is serialised behind the gate for nothing.

An existing release being rebuilt is returned to draft too — otherwise re-running a broken release leaves the incomplete one public for the length of the rebuild.

## Verification

Topology asserted by parsing the workflow: the gate's ancestors include all eight CLI jobs, `sign_release_artifacts` and `desktop`; exclude both mobile jobs; both Homebrew jobs sit downstream of it; no dependency cycles anywhere in the 37 jobs.

`test_release_tag_workflow_safety.py` — already CI-gated — now covers it, and each assertion was confirmed against its regression rather than assumed:

| mutation | result |
|---|---|
| drop `--draft` | `release.yml runs `gh release create` without --draft` |
| delete `publish_release` | `release.yml has no publish_release job to leave draft state` |
| drop `desktop` from the gate | `publish_release does not wait for desktop` |
| cask jumps ahead of publication | `sync_homebrew_cask writes a download URL before the release is published` |

`actionlint` findings unchanged at 30.

## Behaviour change worth knowing

A failing release is now invisible rather than public-and-broken. That is the point, but it does mean the release page no longer fills in live during a run.

## Does not repair v2026.8.30

That release is already public. It is being repaired separately through `release-cli.yml` / `release-desktop.yml` (#8007), and its npm packages are already republished.