### PR TITLE
fix(goals): normalise empty-string UUID fields before deserialising a stored goal

### DIFF
--- a/crates/librefang-kernel/src/goal_runner.rs
+++ b/crates/librefang-kernel/src/goal_runner.rs
@@ -146,6 +146,18 @@ fn load_goal(substrate: &MemorySubstrate, goal_id: GoalId) -> Option<Goal> {
     let target = goal_id.to_string();
     arr.into_iter()
         .find(|g| g.get("id").and_then(|v| v.as_str()) == Some(target.as_str()))
+        .map(|mut v| {
+            // Goals written before the loop-engineering PR may store
+            // UUID-typed Option fields as "" instead of null.  An empty
+            // string fails UUID parsing and silently drops the whole
+            // Goal via the downstream `.ok()`.  Normalise here.
+            for key in ["verify_agent_id", "agent_id", "parent_id"] {
+                if v.get(key).and_then(|s| s.as_str()) == Some("") {
+                    v[key] = serde_json::Value::Null;
+                }
+            }
+            v
+        })
         .and_then(|v| serde_json::from_value(v).ok())
 }
 


### PR DESCRIPTION
## Summary

- Goals written before the loop-engineering PR may store UUID-typed `Option` fields (`verify_agent_id`, `agent_id`, `parent_id`) as `""` instead of `null`.
- An empty string fails UUID parsing inside `serde_json::from_value`, and the downstream `.ok()` silently swallows the error — `load_goal` returns `None` and every operation that touches the goal (start, pause, resume) returns a bare 500.
- This patch normalises the three fields to `null` before deserialisation so the existing goals survive the round-trip.

## Verification

- Reproduced: `POST /api/goals/{id}/start` → 500 on a goal with `"verify_agent_id": ""`
- After fix: `load_goal` correctly deserialises the goal and the run starts
- `cargo check --workspace --lib` passes
- `cargo clippy -p librefang-kernel -- -D warnings` clean

## Files changed

- `crates/librefang-kernel/src/goal_runner.rs` — 12 lines added in `load_goal()`