### PR TITLE
feat(types,api,dashboard): track which template an agent was spawned from

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1389,6 +1389,7 @@ export interface AgentDetail {
   is_hand?: boolean;
   web_search_augmentation?: "off" | "auto" | "always";
   auto_evolve?: boolean;
+  source_template?: string;
 }
 
 export async function getAgentDetail(agentId: string): Promise<AgentDetail> {

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1161,6 +1161,7 @@ export function AgentsPage() {
                   ? ` · ${agent.model?.model || (agent as AgentView).model_name}`
                   : ""}
                 {(agent as AgentView).profile ? ` · ${(agent as AgentView).profile}` : ""}
+                {(agent as AgentView).source_template ? ` · from ${(agent as AgentView).source_template}` : ""}
               </p>
             </div>
             {/* Action cluster — labels collapse on mobile so the row keeps

--- a/crates/librefang-api/src/routes/agents/lifecycle.rs
+++ b/crates/librefang-api/src/routes/agents/lifecycle.rs
@@ -115,6 +115,10 @@ async fn resolve_manifest(
         }
     };
 
+    if let Some(ref tmpl_name) = req.template {
+        manifest.source_template = Some(tmpl_name.clone());
+    }
+
     // Allow callers to override the manifest name, enabling multiple agents
     // from the same template with distinct names.
     if let Some(ref custom_name) = req.name {

--- a/crates/librefang-api/src/routes/agents/mod.rs
+++ b/crates/librefang-api/src/routes/agents/mod.rs
@@ -386,6 +386,7 @@ pub(crate) fn enrich_agent_json(
         "resume_pending": e.resume_pending,
         "reset_reason": e.reset_reason,
         "has_processed_message": e.has_processed_message,
+        "source_template": e.manifest.source_template,
     })
 }
 

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -222,6 +222,7 @@ impl SetupWizard {
             triggers: vec![],
             reconcile_orphans: librefang_types::agent::OrphanPolicy::default(),
             async_tasks: librefang_types::agent::AsyncTasksConfig::default(),
+            source_template: None,
         };
 
         let skills_to_install: Vec<String> = intent

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -1495,6 +1495,8 @@ pub struct AgentManifest {
     /// kernel does not impose a hard ceiling.
     #[serde(default)]
     pub async_tasks: AsyncTasksConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_template: Option<String>,
 }
 
 /// Per-agent override for the kernel-global `[compaction]` configuration
@@ -1723,6 +1725,7 @@ impl Default for AgentManifest {
             triggers: Vec::new(),
             reconcile_orphans: OrphanPolicy::default(),
             async_tasks: AsyncTasksConfig::default(),
+            source_template: None,
         }
     }
 }

--- a/crates/librefang-types/src/agent_type.rs
+++ b/crates/librefang-types/src/agent_type.rs
@@ -192,6 +192,7 @@ impl AgentTypeSpec {
             triggers: Vec::new(),
             reconcile_orphans: Default::default(),
             async_tasks: Default::default(),
+            source_template: None,
         }
     }
 }

--- a/crates/librefang-types/src/manifest_privacy.rs
+++ b/crates/librefang-types/src/manifest_privacy.rs
@@ -334,6 +334,7 @@ pub fn sanitize_for_publication(manifest: &AgentManifest) -> AgentManifest {
         triggers: _,
         reconcile_orphans,
         async_tasks,
+        source_template: _,
     } = manifest.clone();
 
     // Exhaustive construction — no `..Default::default()`.
@@ -400,6 +401,7 @@ pub fn sanitize_for_publication(manifest: &AgentManifest) -> AgentManifest {
         triggers: Vec::new(),
         reconcile_orphans,
         async_tasks,
+        source_template: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `source_template: Option<String>` to `AgentManifest` so the system remembers which agent-type template produced a given agent.
- Set `source_template` during `resolve_manifest` in the spawn lifecycle when `req.template` is present.
- Expose the field in the agent detail JSON via `enrich_agent_json`.
- Show `· from {template_name}` in the dashboard agent description line.
- Wire the new field through `AgentTypeSpec::to_manifest()`, `sanitize_for_publication()`, and `SetupWizard` default so all exhaustive-construction sites compile.

Closes #8018

## Verification

- `cargo check --workspace --lib` — clean
- All exhaustive-struct sites updated (agent.rs Default, agent_type.rs, manifest_privacy.rs, wizard.rs)
- Dashboard `AgentDetail` interface extended, `AgentsPage` displays provenance inline

## Test plan

- [ ] Spawn an agent from a template via API, verify `source_template` appears in `GET /api/agents/{id}`
- [ ] Spawn an agent via wizard (no template), verify `source_template` is null
- [ ] Dashboard shows `· from template-name` next to agents spawned from templates