### PR TITLE
fix(dashboard): cancel polling queries before deleting agent

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -64,6 +64,7 @@ import {
   type ManifestFormState,
 } from "../lib/agentManifest";
 import { generateManifestMarkdown } from "../lib/agentManifestMarkdown";
+import { agentKeys } from "../lib/queries/keys";
 import {
   agentQueries,
   useAgentEvents,
@@ -424,16 +425,20 @@ export function AgentsPage() {
       "error",
     );
   const deleteMutation = {
-    mutate: (agentId: string) =>
+    mutate: (agentId: string) => {
+      qc.cancelQueries({ queryKey: agentKeys.detail(agentId) });
       rawDeleteMutation.mutate(agentId, {
         onSuccess: () => handleDeleteSuccess(agentId),
         onError: handleDeleteError,
-      }),
-    mutateAsync: (agentId: string) =>
-      rawDeleteMutation.mutateAsync(agentId, {
+      });
+    },
+    mutateAsync: (agentId: string) => {
+      qc.cancelQueries({ queryKey: agentKeys.detail(agentId) });
+      return rawDeleteMutation.mutateAsync(agentId, {
         onSuccess: () => handleDeleteSuccess(agentId),
         onError: handleDeleteError,
-      }),
+      });
+    },
   };
 
   function mergeHandFlag(agent: AgentDetail, fallback?: boolean) {


### PR DESCRIPTION
## Summary

- Cancel all TanStack Query polling queries anchored at `agentKeys.detail(id)` before firing the delete mutation.
- Prevents a race where the `refetchInterval`-based polls for `/agents/:id/stats` (30s) and `/agents/:id/events` (15s) fire after the DELETE returns 200 but before React propagates `setDetailAgent(null)`, resulting in 404s that the error boundary renders as an error page.

## Verification

- `pnpm typecheck` passes clean
- Tested: delete agent → drawer closes immediately, no error flash from stale polls