### PR TITLE
fix(deps): update yanked chacha20 0.10.0 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,9 +1037,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
@@ -9987,7 +9987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
## Summary

- Updates `chacha20` from yanked `0.10.0` to `0.10.2` in `Cargo.lock`.
- The yanked version causes `cargo-deny` CI to fail on any PR that resolves `Cargo.lock` from scratch.

## Verification

- `cargo update chacha20@0.10.0` resolved cleanly.
- Only `Cargo.lock` changed (3 lines).