### PR TITLE
fix(ci): main red — an env guard disarmed the macOS offline registry switch

### DIFF
--- a/changelog.d/fixed/8058-env-guard-offline-registry-switch.md
+++ b/changelog.d/fixed/8058-env-guard-offline-registry-switch.md
@@ -1,4 +1,4 @@
 A test helper that overrode an environment variable erased it on cleanup instead of putting back what it held, which disarmed the `LIBREFANG_REGISTRY_OFFLINE=1` that CI sets for the whole macOS test job.
 The macOS lane's Mach-port guard runs every kernel unit test as threads in one process, so every kernel booted after that point performed a live registry sync, and the synced `researcher` agent type shadowed the deliberately-broken templates three step-agent tests seed — turning their expected errors into successful spawns and reddening `main`.
 Guards now restore the previous value, and the step-agent fixture freezes the registry sync in its own config rather than trusting the ambient environment.
-(#8058) (@e-hu)
+(#8058) (@houko)

--- a/changelog.d/fixed/8058-env-guard-offline-registry-switch.md
+++ b/changelog.d/fixed/8058-env-guard-offline-registry-switch.md
@@ -1,0 +1,4 @@
+A test helper that overrode an environment variable erased it on cleanup instead of putting back what it held, which disarmed the `LIBREFANG_REGISTRY_OFFLINE=1` that CI sets for the whole macOS test job.
+The macOS lane's Mach-port guard runs every kernel unit test as threads in one process, so every kernel booted after that point performed a live registry sync, and the synced `researcher` agent type shadowed the deliberately-broken templates three step-agent tests seed — turning their expected errors into successful spawns and reddening `main`.
+Guards now restore the previous value, and the step-agent fixture freezes the registry sync in its own config rather than trusting the ambient environment.
+(#8058) (@e-hu)

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -86,12 +86,22 @@ impl ChannelAdapter for RecordingChannelAdapter {
 
 struct EnvVarGuard {
     key: &'static str,
+    /// What the variable held before this guard overwrote it, so drop can put it back.
+    ///
+    /// Restoring the previous value — rather than unconditionally removing the variable — is what keeps one test from silently reconfiguring the rest of the process.
+    /// CI sets `LIBREFANG_REGISTRY_OFFLINE=1` for the whole `Test / macOS` job, and that lane's Mach-port guard step runs every kernel unit test as threads in ONE process, so a guard that removed the variable handed every later `boot_with_config` a live network registry sync.
+    /// That sync's fan-out writes `agent-types/<type>.toml` into the test's own home, which is the first candidate `load_agent_template` consults — shadowing the templates the step-agent tests seed under `workspaces/agents/`.
+    /// Nextest cannot observe the leak at all (one process per test), which is why it was macOS-guard-step-only.
+    previous: Option<String>,
 }
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // SAFETY: see set_test_env comment above.
-        unsafe { std::env::remove_var(self.key) };
+        match &self.previous {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
     }
 }
 
@@ -99,11 +109,37 @@ fn set_test_env(key: &'static str, value: &str) -> EnvVarGuard {
     // SAFETY: every caller is annotated `#[serial_test::serial(librefang_vault_key)]`,
     // so no two env-mutating tests in this file run concurrently — process-global
     // `set_var`/`remove_var` cannot race a `getenv` on another test thread. The
-    // guard removes the variable on drop so it never persists across tests.
+    // guard restores whatever the variable held before, so it neither persists across tests nor erases a value the surrounding environment set.
     // (The earlier claim that the default test runner is single-threaded was
     // incorrect: `cargo test` runs tests across multiple threads in one process.)
+    let previous = std::env::var(key).ok();
     unsafe { std::env::set_var(key, value) };
-    EnvVarGuard { key }
+    EnvVarGuard { key, previous }
+}
+
+/// `set_test_env` must put back whatever the variable held, not erase it.
+///
+/// The guard used to `remove_var` unconditionally, which is indistinguishable from "restore" only when the variable was unset to begin with.
+/// CI sets `LIBREFANG_REGISTRY_OFFLINE=1` for the whole `Test / macOS` job, so the first test to guard that variable disarmed the offline switch for every kernel boot that ran after it in the same process — see the `previous` field above.
+#[test]
+#[serial_test::serial(librefang_vault_key)]
+fn set_test_env_restores_the_previous_value_instead_of_removing_it() {
+    const KEY: &str = "LIBREFANG_TEST_ENV_GUARD_RESTORE";
+    let outer = set_test_env(KEY, "ambient");
+    {
+        let _inner = set_test_env(KEY, "overridden");
+        assert_eq!(std::env::var(KEY).as_deref(), Ok("overridden"));
+    }
+    assert_eq!(
+        std::env::var(KEY).as_deref(),
+        Ok("ambient"),
+        "the inner guard erased a value the surrounding scope had set"
+    );
+    drop(outer);
+    assert!(
+        std::env::var(KEY).is_err(),
+        "a guard over a variable that started out unset must leave it unset"
+    );
 }
 
 #[test]
@@ -16173,11 +16209,15 @@ fn boot_kernel_for_step_agent_tests(label: &str) -> (tempfile::TempDir, LibreFan
     let tmp = tempfile::tempdir().unwrap();
     let home_dir = tmp.path().join(label);
     std::fs::create_dir_all(home_dir.join("data")).unwrap();
-    let config = KernelConfig {
+    let mut config = KernelConfig {
         home_dir: home_dir.clone(),
         data_dir: home_dir.join("data"),
         ..KernelConfig::default()
     };
+    // These tests seed their own templates under `workspaces/agents/` and assert on which one `load_agent_template` picks.
+    // The boot registry sync fans registry content out into `agent-types/<type>.toml`, which is the *first* candidate that search consults — so a synced `researcher` (the registry ships one) shadows the seeded template and turns "malformed", "name_mismatch" and "spawn_failed" into a perfectly successful spawn.
+    // Freezing the sync per-config keeps the fixture hermetic without depending on `LIBREFANG_REGISTRY_OFFLINE` being set in the ambient environment.
+    config.registry.auto_sync = false;
     let kernel = LibreFangKernel::boot_with_config(config).expect("boot");
     (tmp, kernel)
 }


### PR DESCRIPTION
Closes #8037 — the auto-filed `[main red] CI failure on a511076` issue names this exact run and this exact step.

`main` is red on run [33315772071](https://github.com/librefang/librefang/actions/runs/33315772071): `Test / macOS` fails its Mach-port regression guard step with two kernel unit tests panicking on `unwrap_err()` over an `Ok((AgentId(b631fd28-…), "researcher", true))`.

## Root cause

`EnvVarGuard::drop` in `crates/librefang-kernel/src/kernel/tests.rs` called `std::env::remove_var`, which is equivalent to a restore only when the variable was unset before the guard took it.
CI sets `LIBREFANG_REGISTRY_OFFLINE: "1"` for the whole `test-macos` job, and `set_agent_model_rejects_only_against_a_fresh_openrouter_catalog` guards exactly that variable — so the moment it finished, the offline switch was gone for the remainder of the process.

The macOS lane's Mach-port guard runs `cargo test -p librefang-kernel --lib`, i.e. every kernel unit test as threads in ONE process, so every later `boot_with_config` performed a live registry sync.
`fanout_registry_content` writes each synced type to `agent-types/<type>.toml` in the booted home, and that path is the *first* candidate `load_agent_template` consults (#6699).
The registry ships a `researcher` agent type, which is the name the step-agent tests seed their fixtures under, so the synced copy shadowed the deliberately-broken template each test wrote to `workspaces/agents/researcher/agent.toml` and the expected `malformed` / `name_mismatch` / `spawn_failed` errors became successful spawns.

Nextest runs one process per test, so no other lane — including macOS's own full nextest run in the preceding step — could observe it. The three tests also failed on any developer machine that has never exported `LIBREFANG_REGISTRY_OFFLINE`.

## Changes

- `EnvVarGuard` records the variable's previous value and restores it on drop, removing it only when it really was unset.
- `boot_kernel_for_step_agent_tests` sets `registry.auto_sync = false`, so the fixture is hermetic by construction instead of depending on an ambient env var. Side benefit: the eight step-agent tests stop reaching the network, dropping the group from ~15s to ~1s.
- New `set_test_env_restores_the_previous_value_instead_of_removing_it` pins the restore contract in both directions (nested override restored; a variable that started unset left unset).

## Verification

- `cargo test -p librefang-kernel --lib` (single process, exactly what the macOS guard step runs) — **1710 passed, 0 failed** with `LIBREFANG_REGISTRY_OFFLINE=1` (62s), and 1710 passed, 0 failed without it (362s, network syncs live). On `main` the same command fails 3 tests without the env var.
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — clean.
- `cargo fmt -p librefang-kernel -- --check` — clean.

## Deferred

None.
