### PR TITLE
docs(workflows): drop the pre-change contract from persist_definition

### DIFF
--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -2217,16 +2217,13 @@ impl WorkflowEngine {
         }
     }
 
-    /// Write one workflow definition to `workflows_dir`.
+    /// Write one workflow definition to `workflows_dir`, reporting whether it landed.
     ///
     /// Persistence is atomic: serialise → write `<id>.workflow.json.tmp` →
     /// rename to `<id>.workflow.json`. A crash mid-write leaves the `.tmp`
     /// side-file (ignored by `load_from_dir_sync`'s extension filter) but
     /// never a half-written `<id>.workflow.json` that would later refuse to
     /// parse and stall startup.
-    ///
-    /// Every failure path is a `warn!` rather than an error return: refusing the registration because the disk write failed leaves the caller worse off than a workflow that is live now and does not survive a restart.
-    /// Write the definition to disk, reporting whether it landed.
     ///
     /// Returns `Ok(())` when there is no workflows directory configured: an
     /// in-memory engine is a deliberate configuration, not a failed write.


### PR DESCRIPTION
Follow-through on the one leftover noted while approving #6943, fixed here because that PR had already merged.

## Changes

- `crates/librefang-kernel/src/workflow.rs`: remove the paragraph on `persist_definition` that read *"Every failure path is a `warn!` rather than an error return: refusing the registration because the disk write failed leaves the caller worse off than a workflow that is live now and does not survive a restart."* #6943 replaced exactly that behaviour with a `Result`, so the line described a contract the function no longer has.
- Fold `"reporting whether it landed"` into the existing summary line. The doc item had two summary lines — the original `Write one workflow definition to workflows_dir.` and a second one added by #6943 sitting mid-comment — and merging them keeps what the new line said without the duplication.

No behaviour change; doc comment only. The untouched `Persistence is atomic:` paragraph keeps its existing wrapping rather than being reflowed.

## Verification

- `cargo check -p librefang-kernel --lib` — clean, and it genuinely recompiled the crate (`Checking librefang-kernel`) rather than replaying cached artifacts.

No changelog fragment: an internal doc comment with no user-visible effect has nothing to say in release notes.