### PR TITLE
fix(ci): restore pull-requests write on the review-label applier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           # `openapi-drift` job still gates direct edits.
           RUST=false;    has '^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)' && RUST=true
           DOCS=false;    has '^(docs/|.*\.md$)'                                       && DOCS=true
-          CI=false;      has '^(\.github/workflows/|\.devcontainer/|scripts/check-no-empty-string-sentinels\.sh$|scripts/tests/check-no-empty-string-sentinels\.sh$|scripts/tests/test_release_tag_workflow_safety\.py$|scripts/tests/test_issue_labels_workflow\.py$|scripts/run-xtask\.sh$|scripts/tests/run-xtask\.sh$|scripts/workers/|scripts/tests/install-redirect-workers\.mjs$|scripts/check-error-shape\.sh$|scripts/tests/check-error-shape\.sh$|scripts/codegen-sdks\.py$|scripts/tests/test_codegen_sdks\.py$|scripts/tests/test_pr_status_labels_workflow\.py$)' && CI=true
+          CI=false;      has '^(\.github/workflows/|\.devcontainer/|scripts/check-no-empty-string-sentinels\.sh$|scripts/tests/check-no-empty-string-sentinels\.sh$|scripts/tests/test_release_tag_workflow_safety\.py$|scripts/tests/test_issue_labels_workflow\.py$|scripts/run-xtask\.sh$|scripts/tests/run-xtask\.sh$|scripts/workers/|scripts/tests/install-redirect-workers\.mjs$|scripts/check-error-shape\.sh$|scripts/tests/check-error-shape\.sh$|scripts/codegen-sdks\.py$|scripts/tests/test_codegen_sdks\.py$|scripts/tests/test_pr_status_labels_workflow\.py$|scripts/tests/test_pr_review_label_workflows\.py$|scripts/tests/test_workflow_report_hardening\.py$)' && CI=true
           INSTALL=false; has '^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$' && INSTALL=true
           # The WASM-skill guest SDK and its example are independent
           # workspaces (own `[workspace]` roots), so the main RUST lane —
@@ -347,6 +347,8 @@ jobs:
           python3 -O scripts/tests/test_codegen_sdks.py
       - name: Check PR status-label reconciliation
         run: python3 scripts/tests/test_pr_status_labels_workflow.py
+      - name: Check PR review-label pipeline
+        run: python3 scripts/tests/test_pr_review_label_workflows.py
       - name: Test Docker xtask wrapper
         run: bash scripts/tests/run-xtask.sh
       - name: Test installer redirect workers

--- a/.github/workflows/pr-review-state-applier.yml
+++ b/.github/workflows/pr-review-state-applier.yml
@@ -72,8 +72,13 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      # Both are required, and `pull-requests: write` is the one that
+      # actually authorizes the writes here: the labels endpoint is under
+      # `/issues/{n}/labels`, but when `{n}` resolves to a pull request
+      # GitHub gates it on the pull_requests scope, so `issues: write`
+      # alone 403s with "Resource not accessible by integration".
       issues: write
-      pull-requests: read
+      pull-requests: write
     # `workflow_run.pull_requests` is empty for pull_request_review runs in
     # practice. Resolve the PR from the trusted collector artifact first, then
     # serialize the mutating job on that exact PR number.

--- a/changelog.d/fixed/8037-pr-review-label-applier-permissions.md
+++ b/changelog.d/fixed/8037-pr-review-label-applier-permissions.md
@@ -1,0 +1,4 @@
+The `ready-for-review` / `needs-changes` labels are applied again when a review is submitted.
+Splitting the applier's permissions per job in #7546 narrowed the mutating job to `pull-requests: read`, and since the labels endpoint is gated on the pull_requests scope when the issue number resolves to a pull request, every run since has failed with `Resource not accessible by integration` — 24 consecutive failures, and no PR has been labelled from a review since 2026-08-15.
+The guard script that was supposed to catch this was never wired into any workflow, so it is now run by CI's workflows lane alongside an assertion on the permission itself.
+(#8037) (@houko)

--- a/changelog.d/fixed/8061-pr-review-label-applier-permissions.md
+++ b/changelog.d/fixed/8061-pr-review-label-applier-permissions.md
@@ -1,4 +1,4 @@
 The `ready-for-review` / `needs-changes` labels are applied again when a review is submitted.
 Splitting the applier's permissions per job in #7546 narrowed the mutating job to `pull-requests: read`, and since the labels endpoint is gated on the pull_requests scope when the issue number resolves to a pull request, every run since has failed with `Resource not accessible by integration` — 24 consecutive failures, and no PR has been labelled from a review since 2026-08-15.
 The guard script that was supposed to catch this was never wired into any workflow, so it is now run by CI's workflows lane alongside an assertion on the permission itself.
-(#8037) (@houko)
+(#8061) (@houko)

--- a/scripts/tests/test_pr_review_label_workflows.py
+++ b/scripts/tests/test_pr_review_label_workflows.py
@@ -49,6 +49,21 @@ class PrReviewLabelWorkflowTests(unittest.TestCase):
         self.assertIn("freshLabels.includes('has-conflicts')", self.applier)
         self.assertIn("await removeLabel(READY)", self.applier)
 
+    def test_applier_job_can_write_pull_request_labels(self) -> None:
+        # The labels endpoint lives under `/issues/{n}/labels`, but GitHub gates it on the
+        # pull_requests scope when `{n}` is a pull request.
+        # #7546 moved permissions to the job level and narrowed this to `pull-requests: read`;
+        # every applier run 403'd with "Resource not accessible by integration" from then on.
+        apply_job = self.applier.split("\n  apply:\n", 1)[1]
+        self.assertIn("issues: write", apply_job)
+        self.assertIn("pull-requests: write", apply_job)
+        self.assertNotIn("pull-requests: read", apply_job)
+
+    def test_prepare_job_can_read_the_collector_artifact(self) -> None:
+        # `actions/download-artifact` needs `actions: read` to reach another run's artifact.
+        prepare_job = self.applier.split("\n  prepare:\n", 1)[1].split("\n  apply:\n", 1)[0]
+        self.assertIn("actions: read", prepare_job)
+
     def test_applier_reconciles_latest_review_instead_of_payload_order(self) -> None:
         self.assertIn("github.rest.pulls.listReviews", self.applier)
         self.assertIn("const latestReview = reviews", self.applier)

--- a/xtask/src/check_changed.rs
+++ b/xtask/src/check_changed.rs
@@ -105,7 +105,7 @@ struct LaneRegexes {
 /// `ci_lane_pattern_matches_the_workflow` fails the build when the two drift, because a local
 /// `cargo xtask check-changed` that routes differently from CI is worse than no local command at
 /// all — it reports a lane as skipped that CI is about to run, or the reverse.
-const CI_LANE_PATTERN: &str = r"^(\.github/workflows/|\.devcontainer/|scripts/check-no-empty-string-sentinels\.sh$|scripts/tests/check-no-empty-string-sentinels\.sh$|scripts/tests/test_release_tag_workflow_safety\.py$|scripts/tests/test_issue_labels_workflow\.py$|scripts/run-xtask\.sh$|scripts/tests/run-xtask\.sh$|scripts/workers/|scripts/tests/install-redirect-workers\.mjs$|scripts/check-error-shape\.sh$|scripts/tests/check-error-shape\.sh$|scripts/codegen-sdks\.py$|scripts/tests/test_codegen_sdks\.py$|scripts/tests/test_pr_status_labels_workflow\.py$)";
+const CI_LANE_PATTERN: &str = r"^(\.github/workflows/|\.devcontainer/|scripts/check-no-empty-string-sentinels\.sh$|scripts/tests/check-no-empty-string-sentinels\.sh$|scripts/tests/test_release_tag_workflow_safety\.py$|scripts/tests/test_issue_labels_workflow\.py$|scripts/run-xtask\.sh$|scripts/tests/run-xtask\.sh$|scripts/workers/|scripts/tests/install-redirect-workers\.mjs$|scripts/check-error-shape\.sh$|scripts/tests/check-error-shape\.sh$|scripts/codegen-sdks\.py$|scripts/tests/test_codegen_sdks\.py$|scripts/tests/test_pr_status_labels_workflow\.py$|scripts/tests/test_pr_review_label_workflows\.py$|scripts/tests/test_workflow_report_hardening\.py$)";
 
 fn lane_regexes() -> &'static LaneRegexes {
     // Same regexes as ci.yml's `Compute diff and route` step. Keep these
@@ -474,6 +474,8 @@ mod tests {
             "scripts/codegen-sdks.py",
             "scripts/tests/test_codegen_sdks.py",
             "scripts/tests/test_pr_status_labels_workflow.py",
+            "scripts/tests/test_pr_review_label_workflows.py",
+            "scripts/tests/test_workflow_report_hardening.py",
         ] {
             let lanes = lanes_from(&[path]);
             assert!(lanes.ci, "expected CI lane for {path}");


### PR DESCRIPTION
## Problem

`PR Review Sync (applier)` has failed on every actionable run since 2026-08-15 — 24 consecutive failures, most recently [run 33364846023](https://github.com/librefang/librefang/actions/runs/33364846023/job/99403641239):

```
##[error]Unhandled error: HttpError: Resource not accessible by integration
  url: 'https://api.github.com/repos/librefang/librefang/issues/8029/labels', status: 403
  x-accepted-github-permissions: 'issues=write; pull_requests=write'
```

#7546 moved the workflow-level `permissions:` block down to per-job blocks and, in doing so, narrowed the mutating `apply` job from `pull-requests: write` to `pull-requests: read`.
The labels endpoint is `/issues/{n}/labels`, but GitHub gates it on the pull_requests scope when `{n}` resolves to a pull request, so `issues: write` alone 403s.

Net effect: no PR has been labelled `ready-for-review` or `needs-changes` from a submitted review for two weeks.

## Changes

- `.github/workflows/pr-review-state-applier.yml`: `apply` job gets `pull-requests: write` back, with a comment naming why both scopes are required so the next narrowing pass doesn't repeat it.
- `scripts/tests/test_pr_review_label_workflows.py`: two new assertions — the `apply` job carries `issues: write` + `pull-requests: write` and not `pull-requests: read`, and the `prepare` job keeps the `actions: read` that `download-artifact` needs for a cross-run artifact.
- `.github/workflows/ci.yml`: run that guard from the workflows lane. It was added by #7546 but never wired into any workflow, which is exactly why the regression it guards against shipped green.
- `.github/workflows/ci.yml` + `xtask/src/check_changed.rs`: route `scripts/tests/test_pr_review_label_workflows.py` and `scripts/tests/test_workflow_report_hardening.py` into the CI lane. The latter is already executed by ci.yml but was missing from the routing pattern, so editing it alone skipped the lane that runs it.

## Verification

- `python3 scripts/tests/test_pr_review_label_workflows.py` → 9 tests pass on this branch.
- Same script against `origin/main`'s applier → `test_applier_job_can_write_pull_request_labels` fails on `pull-requests: write not found`, confirming the guard actually catches the shipped bug rather than only agreeing with the fix.
- `cargo test -p xtask check_changed` → 22 pass, including `ci_lane_pattern_matches_the_workflow`, the drift guard that compares the Rust mirror byte-for-byte against ci.yml's `has '…'` expression.
- All `.github/workflows/*.yml` re-parsed with `yaml.safe_load`; `jobs.apply.permissions` reads `{contents: read, issues: write, pull-requests: write}`.
- `scripts/check-changelog-attribution.py` clean.

## Not covered

The write itself can only be observed by submitting a real review on a PR after this merges — the 403 comes from GitHub's token minting, which no local or CI check can simulate.
The next approval on any open PR is the test.