### PR TITLE
fix(skills): stop reporting a frozen registry as a per-turn failure

### DIFF
--- a/changelog.d/fixed/7964-stable-mode-workspace-skill-warn.md
+++ b/changelog.d/fixed/7964-stable-mode-workspace-skill-warn.md
@@ -1,0 +1,6 @@
+Stable mode no longer logs a per-turn `WARN` for workspace skills when there is nothing to load, and no longer describes a frozen registry as a missing skill.
+`load_workspace_skills` checked the freeze before checking whether the call had any work to do, so an **empty** `<workspace>/skills` directory returned `Ok(0)` in normal mode and an error in Stable mode — for an outcome that is identical either way: zero skills loaded.
+Both call sites logged that at `WARN`, once per turn per agent, which produced 39-100 lines a day on one deployment, all of it describing a no-op that was skipped rather than a failure.
+The wording made it worse: the error reused `SkillError::NotFound`, so `Skill not found: Skill registry is frozen` read like a broken skill and invited exactly the wrong investigation — the reporter went looking for a skill that did not exist.
+A frozen registry is now its own `SkillError::RegistryFrozen`, reported only when a skill really would have been loaded, and logged at `debug` because a configured steady state is not a fault.
+So that a genuinely skipped workspace skill is not simply dropped in silence instead, spawn now warns once per agent naming the directories Stable mode will not pick up — the #6540 reload report covers the global `skills_dir` only, never per-agent workspaces. (#8076) (@houko)

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -14,6 +14,7 @@
 use super::*;
 use crate::kernel::llm_drivers::resolve_effective_fallbacks;
 use crate::MeteringSubsystemApi;
+use librefang_skills::SkillError;
 
 /// The agent a call's cost rolls up to (#7714).
 ///
@@ -1090,11 +1091,19 @@ impl LibreFangKernel {
             .unwrap_or_else(|e| e.into_inner())
             .snapshot();
 
-        // Load workspace-scoped skills (override global skills with same name)
+        // Load workspace-scoped skills (override global skills with same name).
+        // No `.exists()` guard: `load_workspace_skills` returns `Ok(0)` for a
+        // missing directory, and gating on existence made the log volume
+        // depend on whether an empty directory happened to be there (#7964).
         if let Some(ref workspace) = manifest.workspace {
-            let ws_skills = workspace.join("skills");
-            if ws_skills.exists() {
-                if let Err(e) = skill_snapshot.load_workspace_skills(&ws_skills) {
+            match skill_snapshot.load_workspace_skills(&workspace.join("skills")) {
+                Ok(_) => {}
+                // A frozen registry is a configured steady state (Stable mode),
+                // not a fault — debug, not warn, or it fires every turn forever.
+                Err(SkillError::RegistryFrozen(detail)) => {
+                    debug!(agent_id = %agent_id, "Stable mode: {detail}");
+                }
+                Err(e) => {
                     warn!(agent_id = %agent_id, "Failed to load workspace skills: {e}");
                 }
             }

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -1092,9 +1092,7 @@ impl LibreFangKernel {
             .snapshot();
 
         // Load workspace-scoped skills (override global skills with same name).
-        // No `.exists()` guard: `load_workspace_skills` returns `Ok(0)` for a
-        // missing directory, and gating on existence made the log volume
-        // depend on whether an empty directory happened to be there (#7964).
+        // No `.exists()` guard: `load_workspace_skills` returns `Ok(0)` for a missing directory, and gating on existence made the log volume depend on whether an empty directory happened to be there (#7964).
         if let Some(ref workspace) = manifest.workspace {
             match skill_snapshot.load_workspace_skills(&workspace.join("skills")) {
                 Ok(_) => {}

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -3051,10 +3051,8 @@ impl LibreFangKernel {
                 .unwrap_or_else(|e| e.into_inner())
                 .snapshot();
 
-            // Load workspace-scoped skills (override global skills with same
-            // name). See the non-streaming path in `agent_execution.rs` for why
-            // there is no `.exists()` guard and why a frozen registry is debug
-            // rather than warn (#7964).
+            // Load workspace-scoped skills (override global skills with same name).
+            // See the non-streaming path in `agent_execution.rs` for why there is no `.exists()` guard and why a frozen registry is debug rather than warn (#7964).
             if let Some(ref workspace) = manifest.workspace {
                 match skill_snapshot.load_workspace_skills(&workspace.join("skills")) {
                     Ok(_) => {}

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use librefang_channels::types::SenderContext;
 use librefang_runtime::agent_loop::{run_agent_loop, AgentLoopResult};
+use librefang_skills::SkillError;
 use librefang_types::agent::{AgentId, AgentState, SessionId};
 use librefang_types::error::LibreFangError;
 use tracing::info;
@@ -3050,11 +3051,17 @@ impl LibreFangKernel {
                 .unwrap_or_else(|e| e.into_inner())
                 .snapshot();
 
-            // Load workspace-scoped skills (override global skills with same name)
+            // Load workspace-scoped skills (override global skills with same
+            // name). See the non-streaming path in `agent_execution.rs` for why
+            // there is no `.exists()` guard and why a frozen registry is debug
+            // rather than warn (#7964).
             if let Some(ref workspace) = manifest.workspace {
-                let ws_skills = workspace.join("skills");
-                if ws_skills.exists() {
-                    if let Err(e) = skill_snapshot.load_workspace_skills(&ws_skills) {
+                match skill_snapshot.load_workspace_skills(&workspace.join("skills")) {
+                    Ok(_) => {}
+                    Err(SkillError::RegistryFrozen(detail)) => {
+                        tracing::debug!(agent_id = %agent_id, "Stable mode (streaming): {detail}");
+                    }
+                    Err(e) => {
                         warn!(agent_id = %agent_id, "Failed to load workspace skills (streaming): {e}");
                     }
                 }

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -288,14 +288,9 @@ impl LibreFangKernel {
         }
         manifest.workspace = Some(workspace_dir);
 
-        // #7964: Stable mode freezes the skill registry, so this agent's own
-        // `<workspace>/skills` can never load. The per-turn load path reports
-        // that at `debug` — a frozen registry is a configured steady state,
-        // not a fault, and reporting it per turn produced 39-100 WARN/day of
-        // pure noise — so a real workspace skill would otherwise be dropped
-        // without anyone being told. Say it exactly once, here, where the
-        // workspace is set up. The `#6540` reload report covers the global
-        // `skills_dir` only, not per-agent workspaces.
+        // #7964: Stable mode freezes the skill registry, so this agent's own `<workspace>/skills` can never load.
+        // The per-turn load path reports that at `debug` — a frozen registry is a configured steady state, not a fault, and reporting it per turn produced 39-100 WARN/day of pure noise — so a real workspace skill would otherwise be dropped without anyone being told.
+        // Say it exactly once, here, where the workspace is set up. The `#6540` reload report covers the global `skills_dir` only, not per-agent workspaces.
         if let Some(ref workspace) = manifest.workspace {
             let frozen = self
                 .skills

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -288,6 +288,42 @@ impl LibreFangKernel {
         }
         manifest.workspace = Some(workspace_dir);
 
+        // #7964: Stable mode freezes the skill registry, so this agent's own
+        // `<workspace>/skills` can never load. The per-turn load path reports
+        // that at `debug` — a frozen registry is a configured steady state,
+        // not a fault, and reporting it per turn produced 39-100 WARN/day of
+        // pure noise — so a real workspace skill would otherwise be dropped
+        // without anyone being told. Say it exactly once, here, where the
+        // workspace is set up. The `#6540` reload report covers the global
+        // `skills_dir` only, not per-agent workspaces.
+        if let Some(ref workspace) = manifest.workspace {
+            let frozen = self
+                .skills
+                .skill_registry
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_frozen();
+            if frozen {
+                let ws_skills = workspace.join("skills");
+                let mut pending: Vec<String> = std::fs::read_dir(&ws_skills)
+                    .into_iter()
+                    .flatten()
+                    .flatten()
+                    .filter(|entry| entry.path().is_dir())
+                    .map(|entry| entry.file_name().to_string_lossy().to_string())
+                    .collect();
+                pending.sort();
+                if !pending.is_empty() {
+                    warn!(
+                        agent = %name,
+                        ?pending,
+                        dir = %ws_skills.display(),
+                        "Skill registry frozen (Stable mode) — this agent's workspace skills will not be loaded; leaving Stable mode and restarting is required to pick them up"
+                    );
+                }
+            }
+        }
+
         // Register capabilities
         let caps = manifest_to_capabilities(&manifest);
         self.agents.capabilities.grant(agent_id, caps);

--- a/crates/librefang-skills/src/lib.rs
+++ b/crates/librefang-skills/src/lib.rs
@@ -45,6 +45,15 @@ pub(crate) fn resolve_parent_or_cwd(path: &Path) -> &Path {
 pub enum SkillError {
     #[error("Skill not found: {0}")]
     NotFound(String),
+    /// The registry is frozen (Stable mode, #6540) and the call would have
+    /// mutated it.
+    ///
+    /// Deliberately distinct from [`SkillError::NotFound`], which is what this
+    /// used to be reported as: a frozen registry is a configured steady state,
+    /// not a lookup that failed, and the `Skill not found:` prefix sent
+    /// operators looking for a broken skill that did not exist (#7964).
+    #[error("Skill registry is frozen (Stable mode): {0}")]
+    RegistryFrozen(String),
     #[error("Invalid skill manifest: {0}")]
     InvalidManifest(String),
     #[error("Skill already installed: {0}")]

--- a/crates/librefang-skills/src/lib.rs
+++ b/crates/librefang-skills/src/lib.rs
@@ -45,13 +45,9 @@ pub(crate) fn resolve_parent_or_cwd(path: &Path) -> &Path {
 pub enum SkillError {
     #[error("Skill not found: {0}")]
     NotFound(String),
-    /// The registry is frozen (Stable mode, #6540) and the call would have
-    /// mutated it.
+    /// The registry is frozen (Stable mode, #6540) and the call would have mutated it.
     ///
-    /// Deliberately distinct from [`SkillError::NotFound`], which is what this
-    /// used to be reported as: a frozen registry is a configured steady state,
-    /// not a lookup that failed, and the `Skill not found:` prefix sent
-    /// operators looking for a broken skill that did not exist (#7964).
+    /// Deliberately distinct from [`SkillError::NotFound`], which is what this used to be reported as: a frozen registry is a configured steady state, not a lookup that failed, and the `Skill not found:` prefix sent operators looking for a broken skill that did not exist (#7964).
     #[error("Skill registry is frozen (Stable mode): {0}")]
     RegistryFrozen(String),
     #[error("Invalid skill manifest: {0}")]

--- a/crates/librefang-skills/src/registry.rs
+++ b/crates/librefang-skills/src/registry.rs
@@ -834,6 +834,13 @@ impl SkillRegistry {
     /// logic as `load_all()`: auto-converts SKILL.md, runs prompt injection
     /// scan, blocks critical threats. Skills loaded here override global ones
     /// with the same name (insert semantics).
+    ///
+    /// In Stable mode the registry is frozen and cannot take new skills
+    /// (#6540). The freeze is reported only when this call would actually have
+    /// loaded something: an empty `<workspace>/skills` directory returns
+    /// `Ok(0)` either way, so reporting it as an error described a skipped
+    /// no-op as a failure, once per turn per agent, for the lifetime of the
+    /// daemon (#7964).
     pub fn load_workspace_skills(
         &mut self,
         workspace_skills_dir: &Path,
@@ -841,21 +848,27 @@ impl SkillRegistry {
         if !workspace_skills_dir.exists() {
             return Ok(0);
         }
+
+        let candidates: Vec<PathBuf> = std::fs::read_dir(workspace_skills_dir)?
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect();
+
+        if candidates.is_empty() {
+            return Ok(0);
+        }
         if self.frozen {
-            return Err(SkillError::NotFound(
-                "Skill registry is frozen (Stable mode)".to_string(),
-            ));
+            return Err(SkillError::RegistryFrozen(format!(
+                "{} workspace skill directory(ies) at {} were not loaded",
+                candidates.len(),
+                workspace_skills_dir.display()
+            )));
         }
 
         let mut count = 0;
-        let entries = std::fs::read_dir(workspace_skills_dir)?;
 
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-
+        for path in candidates {
             let manifest_path = path.join("skill.toml");
             if !manifest_path.exists() {
                 // Auto-detect SKILL.md and convert
@@ -1483,6 +1496,104 @@ input_schema = { type = "object" }
         let dir = TempDir::new().unwrap();
         let mut registry = SkillRegistry::new(dir.path().to_path_buf());
         assert_eq!(registry.load_all().unwrap(), 0);
+    }
+
+    // ── Stable-mode workspace-skill reporting (#7964) ────────────────
+    //
+    // The freeze is a configured steady state, so it must only be reported
+    // when this call would actually have loaded something. Reported
+    // unconditionally it produced 39-100 WARN/day on one deployment, all of it
+    // describing a no-op that was skipped.
+
+    #[test]
+    fn frozen_registry_accepts_an_empty_workspace_skills_dir() {
+        let dir = TempDir::new().unwrap();
+        let ws_skills = dir.path().join("workspace-skills");
+        std::fs::create_dir_all(&ws_skills).unwrap();
+
+        let mut registry = SkillRegistry::new(dir.path().to_path_buf());
+        registry.freeze();
+
+        assert_eq!(
+            registry.load_workspace_skills(&ws_skills).unwrap(),
+            0,
+            "an empty directory loads zero skills either way, so the freeze has nothing to report"
+        );
+    }
+
+    #[test]
+    fn an_empty_workspace_skills_dir_reads_the_same_frozen_or_not() {
+        let dir = TempDir::new().unwrap();
+        let ws_skills = dir.path().join("workspace-skills");
+        std::fs::create_dir_all(&ws_skills).unwrap();
+        // A stray file is not a loadable skill directory either.
+        std::fs::write(ws_skills.join("README.md"), "not a skill").unwrap();
+
+        let mut unfrozen = SkillRegistry::new(dir.path().to_path_buf());
+        let mut frozen = SkillRegistry::new(dir.path().to_path_buf());
+        frozen.freeze();
+
+        assert_eq!(
+            unfrozen.load_workspace_skills(&ws_skills).unwrap(),
+            frozen.load_workspace_skills(&ws_skills).unwrap()
+        );
+    }
+
+    #[test]
+    fn frozen_registry_reports_the_freeze_when_there_is_a_skill_to_load() {
+        let dir = TempDir::new().unwrap();
+        let ws_skills = dir.path().join("workspace-skills");
+        std::fs::create_dir_all(&ws_skills).unwrap();
+        create_test_skill(&ws_skills, "workspace-only");
+
+        let mut registry = SkillRegistry::new(dir.path().to_path_buf());
+        registry.freeze();
+
+        let err = registry
+            .load_workspace_skills(&ws_skills)
+            .expect_err("a skill that will not be loaded is worth reporting");
+        assert!(
+            matches!(err, SkillError::RegistryFrozen(_)),
+            "expected RegistryFrozen, got {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            !rendered.starts_with("Skill not found"),
+            "the message must not read like a missing skill, got: {rendered}"
+        );
+        assert!(
+            rendered.contains('1'),
+            "the message should say how many directories were skipped, got: {rendered}"
+        );
+        assert_eq!(registry.count(), 0, "nothing may be loaded while frozen");
+    }
+
+    #[test]
+    fn an_unfrozen_registry_still_loads_workspace_skills() {
+        let dir = TempDir::new().unwrap();
+        let ws_skills = dir.path().join("workspace-skills");
+        std::fs::create_dir_all(&ws_skills).unwrap();
+        create_test_skill(&ws_skills, "workspace-only");
+
+        let mut registry = SkillRegistry::new(dir.path().to_path_buf());
+        assert_eq!(registry.load_workspace_skills(&ws_skills).unwrap(), 1);
+        assert!(registry.get("workspace-only").is_some());
+    }
+
+    #[test]
+    fn a_missing_workspace_skills_dir_is_not_an_error_when_frozen() {
+        // The callers no longer guard on `.exists()`, so this path is now
+        // reached on every turn of every agent without a skills directory.
+        let dir = TempDir::new().unwrap();
+        let mut registry = SkillRegistry::new(dir.path().to_path_buf());
+        registry.freeze();
+
+        assert_eq!(
+            registry
+                .load_workspace_skills(&dir.path().join("does-not-exist"))
+                .unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/crates/librefang-skills/src/registry.rs
+++ b/crates/librefang-skills/src/registry.rs
@@ -835,12 +835,8 @@ impl SkillRegistry {
     /// scan, blocks critical threats. Skills loaded here override global ones
     /// with the same name (insert semantics).
     ///
-    /// In Stable mode the registry is frozen and cannot take new skills
-    /// (#6540). The freeze is reported only when this call would actually have
-    /// loaded something: an empty `<workspace>/skills` directory returns
-    /// `Ok(0)` either way, so reporting it as an error described a skipped
-    /// no-op as a failure, once per turn per agent, for the lifetime of the
-    /// daemon (#7964).
+    /// In Stable mode the registry is frozen and cannot take new skills (#6540).
+    /// The freeze is reported only when this call would actually have loaded something: an empty `<workspace>/skills` directory returns `Ok(0)` either way, so reporting it as an error described a skipped no-op as a failure, once per turn per agent, for the lifetime of the daemon (#7964).
     pub fn load_workspace_skills(
         &mut self,
         workspace_skills_dir: &Path,
@@ -1500,10 +1496,7 @@ input_schema = { type = "object" }
 
     // ── Stable-mode workspace-skill reporting (#7964) ────────────────
     //
-    // The freeze is a configured steady state, so it must only be reported
-    // when this call would actually have loaded something. Reported
-    // unconditionally it produced 39-100 WARN/day on one deployment, all of it
-    // describing a no-op that was skipped.
+    // The freeze is a configured steady state, so it must only be reported when this call would actually have loaded something. Reported unconditionally it produced 39-100 WARN/day on one deployment, all of it describing a no-op that was skipped.
 
     #[test]
     fn frozen_registry_accepts_an_empty_workspace_skills_dir() {


### PR DESCRIPTION
Closes #7964.

## Problem

`load_workspace_skills` checked the freeze **before** checking whether the call had any work to do:

```rust
if !workspace_skills_dir.exists() { return Ok(0); }   // missing dir: fine
if self.frozen { return Err(SkillError::NotFound(...)); }  // empty dir: error
let entries = std::fs::read_dir(workspace_skills_dir)?;   // never reached when frozen
```

So an **empty** `<workspace>/skills` directory returned `Ok(0)` in normal mode and an error in Stable mode — for an outcome that is identical either way: zero skills loaded. The error did not report a failure, it reported that a no-op had been skipped.

Both call sites logged that at `WARN`, once per turn per agent:

```
WARN Failed to load workspace skills: Skill not found: Skill registry is frozen (Stable mode) agent_id=<id>
WARN Failed to load workspace skills (streaming): Skill not found: Skill registry is frozen (Stable mode) agent_id=<id>
```

39–100 lines a day on the reporter's deployment, all of it noise. The wording compounded it: reusing `SkillError::NotFound` produced a `Skill not found:` prefix, so the line read like a missing skill and invited exactly the wrong investigation — the reporter went looking for a broken skill that did not exist.

The reporter confirmed empirically that deleting the empty directories stopped the warnings with no change to any agent's available skills.

## Changes

**`crates/librefang-skills/src/lib.rs`** — new `SkillError::RegistryFrozen`, distinct from `NotFound`. A frozen registry is a configured steady state, not a lookup that failed, and the doc comment says so and why the old variant misled.

**`crates/librefang-skills/src/registry.rs`** — `load_workspace_skills` now enumerates first and returns `Ok(0)` when there is no loadable skill directory, so the frozen path agrees with the unfrozen one whenever the outcome is the same. The freeze is reported only when a skill really would have been loaded, and the message says how many directories were skipped and where, instead of naming a skill that does not exist.

**Both kernel call sites** (`agent_execution.rs`, `messaging.rs`) — `RegistryFrozen` logs at `debug`; every other error still logs at `warn`. The redundant `ws_skills.exists()` guard is gone: `load_workspace_skills` already returns `Ok(0)` for a missing directory, and the guard's only real effect was to make log volume depend on whether an empty directory happened to exist.

**`crates/librefang-kernel/src/kernel/spawn.rs`** — this is the part the issue did not ask for, and it is why the `debug` downgrade is safe rather than merely quieter.

Downgrading the per-turn line means an agent that has a *real* workspace skill under Stable mode would have it silently ignored. #6540's frozen-reload report (`tools_and_skills.rs`, `unloaded_on_disk_dirs`) covers the global `skills_dir` only — never per-agent workspaces — so nothing else would have said it. Spawn now emits one `WARN` per agent naming the directories Stable mode will not load. Once per spawn is the right cardinality for a condition that cannot change without a restart; once per turn was not.

## Verification

- `cargo check -p librefang-kernel --lib` — clean.
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — zero warnings.
- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings.
- `cargo test -p librefang-skills --lib` — 279 passed, including 5 new tests.
- `cargo test -p librefang-kernel --lib` — 1709 passed, **3 failed**, and the 3 are pre-existing and unrelated to this change:

  ```
  kernel::tests::step_agent_by_type_distinguishes_a_corrupt_template_from_a_missing_one
  kernel::tests::step_agent_by_type_rejects_a_template_naming_a_different_agent
  kernel::tests::step_agent_by_type_surfaces_a_rejected_manifest_as_a_spawn_failure
  ```

  These are exactly the three #8058 diagnoses: `EnvVarGuard::drop` calls `remove_var` instead of restoring the previous value, so they fail on any machine that has never exported `LIBREFANG_REGISTRY_OFFLINE` — and they are the same failures behind the auto-filed main-red issue #8037.
  Proof rather than assertion: `LIBREFANG_REGISTRY_OFFLINE=1 cargo test -p librefang-kernel --lib step_agent_by_type` on this branch gives **9 passed, 0 failed**, including the exact test the macOS lane reports.
  Nothing in this PR touches templates, registry sync, or `EnvVarGuard`; the diff is the skills loader, its two call sites, and one spawn-time log line.

New tests in `registry.rs`:

- `frozen_registry_accepts_an_empty_workspace_skills_dir` — the core fix: an empty directory is `Ok(0)` while frozen.
- `an_empty_workspace_skills_dir_reads_the_same_frozen_or_not` — asserts the two modes agree, with a stray non-directory file present so "no loadable skill" is exercised rather than just "no entries".
- `frozen_registry_reports_the_freeze_when_there_is_a_skill_to_load` — asserts the variant is `RegistryFrozen`, that the rendered message does **not** start with `Skill not found`, that it names the count, and that nothing was loaded. The wording assertion is the point: the misleading prefix was half the reported problem.
- `an_unfrozen_registry_still_loads_workspace_skills` — the loader still works after the restructure, which is the regression the enumerate-first change could have introduced.
- `a_missing_workspace_skills_dir_is_not_an_error_when_frozen` — the callers no longer guard on `.exists()`, so this path is now reached on every turn of every agent without a skills directory.

## Not done, deliberately

`load_skill` (`registry.rs`) also reports its frozen check as `SkillError::NotFound`, and by the issue's own argument that variant is wrong there too. I left it alone: `librefang-api` maps `SkillError::NotFound` to `404` and everything else to `400` (`routes/skills/mod.rs`, `routes/skills/skill.rs`), so switching the variant silently changes HTTP status codes on skill endpoints, and neither `404` nor `400` is really right for "the registry is frozen" — `409` or `503` would be. That is a different crate and a public API contract, so it wants its own decision rather than being smuggled in here. Happy to do it as a separate PR if you want the status codes changed; the variant now exists, so it is a small change.
