### PR TITLE
fix(api): scrub credential keys in the payload, not just the path

### DIFF
--- a/changelog.d/security/8085-config-set-payload-scrub.md
+++ b/changelog.d/security/8085-config-set-payload-scrub.md
@@ -1,0 +1,7 @@
+`POST /api/config/set` now refuses a payload that carries a credential-shaped field, not just a path that names one.
+The SCRUB list governed only the key being assigned, and `is_writable_config_path` accepts a write one level below a writable section — at which depth the handler assigns the submitted JSON wholesale.
+So `{"path": "media.custom_stt", "value": {"api_key_env": "ANTHROPIC_API_KEY", "base_url": "http://attacker/"}}` passed: `media.custom_stt` ends in neither a scrubbed name nor `_env`, and the `api_key_env` member of the replacement table landed on disk.
+That repoints the environment variable a provider credential is resolved from, post-auth and over HTTP, which is exactly the redirect the `_env` blanket was added to stop in round 4 of #4678.
+The same defect class is why round 4 removed `sidecar_channels` / `fallback_providers` / `taint_rules` from the allowlist and why `channels.` is pinned to per-leaf writes, but both of those are lists of known-bad prefixes rather than a rule, so every config field that later became struct-typed reopened the hole.
+The scrub is now one predicate applied in two places — the path's final segment and every key inside the submitted payload, at any depth — so a name that cannot be written on its own cannot be smuggled in as a member of a table either.
+Per-field edits are unaffected: the non-secret fields of those tables are still writable one level deeper, where the path check governs them as before. (#8085) (@houko)

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -1299,6 +1299,26 @@ fn non_writable_schema_paths(root: &serde_json::Value) -> Vec<String> {
 // ---------------------------------------------------------------------------
 // Config Set endpoint
 // ---------------------------------------------------------------------------
+/// Make `item` addressable as a table, creating a standard table only when it
+/// is not already table-shaped.
+///
+/// The distinction matters because `toml_edit` models `[media]` and
+/// `media = { … }` as different `Item` variants — `Item::Table` and
+/// `Item::Value(Value::InlineTable)` — while `contains_table` / `as_table_mut`
+/// recognise only the former. The previous `if !doc.contains_table(name)` guard
+/// therefore judged a hand-written inline section "missing" and replaced it
+/// with an empty table, dropping every key it held, `api_key_env` included.
+///
+/// A caller editing one leaf of such a section would have silently deleted the
+/// rest of it — and #8085 recommends exactly those per-leaf writes as the safe
+/// route for tables carrying credential fields, which is what makes this
+/// reachable rather than theoretical.
+fn ensure_table_like(item: &mut toml_edit::Item) {
+    if !item.is_table_like() {
+        *item = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+}
+
 /// POST /api/config/set — Set a single config value and persist to config.toml.
 ///
 /// Accepts JSON `{ "path": "section.key", "value": "..." }`.
@@ -1494,32 +1514,32 @@ pub async fn config_set(
         }
         2 => {
             if is_remove {
-                if let Some(t) = doc[parts[0]].as_table_mut() {
+                // `as_table_like_mut` rather than `as_table_mut`: a section an
+                // operator hand-wrote as an inline table (`media = { … }`) is
+                // `Item::Value(InlineTable)`, not `Item::Table`, and the
+                // narrower accessor returns `None` — so the removal silently
+                // did nothing while the handler still answered success.
+                if let Some(t) = doc[parts[0]].as_table_like_mut() {
                     t.remove(parts[1]);
                 }
             } else {
-                if !doc.contains_table(parts[0]) {
-                    doc[parts[0]] = toml_edit::Item::Table(toml_edit::Table::new());
-                }
+                ensure_table_like(&mut doc[parts[0]]);
                 doc[parts[0]][parts[1]] = toml_edit::Item::Value(json_to_toml_edit_value(&value));
             }
         }
         3 => {
             if is_remove {
-                if let Some(t) = doc[parts[0]].as_table_mut() {
-                    if let Some(t2) = t.get_mut(parts[1]).and_then(|i| i.as_table_mut()) {
+                if let Some(t) = doc[parts[0]].as_table_like_mut() {
+                    if let Some(t2) = t.get_mut(parts[1]).and_then(|i| i.as_table_like_mut()) {
                         t2.remove(parts[2]);
                     }
                 }
             } else {
-                if !doc.contains_table(parts[0]) {
-                    doc[parts[0]] = toml_edit::Item::Table(toml_edit::Table::new());
-                }
-                if !doc[parts[0]]
-                    .as_table()
-                    .is_some_and(|t| t.contains_table(parts[1]))
-                {
-                    doc[parts[0]][parts[1]] = toml_edit::Item::Table(toml_edit::Table::new());
+                ensure_table_like(&mut doc[parts[0]]);
+                if let Some(section) = doc[parts[0]].as_table_like_mut() {
+                    if !section.get(parts[1]).is_some_and(|i| i.is_table_like()) {
+                        section.insert(parts[1], toml_edit::Item::Table(toml_edit::Table::new()));
+                    }
                 }
                 doc[parts[0]][parts[1]][parts[2]] =
                     toml_edit::Item::Value(json_to_toml_edit_value(&value));

--- a/crates/librefang-api/src/routes/config/manage.rs
+++ b/crates/librefang-api/src/routes/config/manage.rs
@@ -1407,6 +1407,28 @@ pub async fn config_set(
         );
     }
 
+    // SECURITY (#8085): the path check above governs only the name being
+    // assigned. A write one level below a writable section assigns the
+    // submitted JSON wholesale, so an innocuous-looking path can carry a
+    // scrubbed field as a member of the table it replaces — the
+    // `{"path": "media.custom_stt", "value": {"api_key_env": "..."}}` shape.
+    // Scan the payload for the same key names the path check refuses, so a
+    // credential-shaped field is unreachable by either route.
+    if let Some(offending) = super::scrubbed_key_in_payload(&value) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "status": "error",
+                "error": format!(
+                    "value posted to '{path}' contains '{offending}', which is not \
+                     user-tunable via /api/config/set; post the other fields \
+                     individually (e.g. '{path}.<field>') and edit \
+                     '{offending}' in ~/.librefang/config.toml directly"
+                )
+            })),
+        );
+    }
+
     // No basename / traversal check on `config_path`: it is the kernel's boot-resolved path, not anything the request supplied.
     // Under `LIBREFANG_CONFIG_PATH` the operator's chosen filename is the point, so rejecting a name that is not literally `config.toml` would refuse to write the very file this daemon loaded (#6695).
     let config_path = state.kernel.config_path().to_path_buf();

--- a/crates/librefang-api/src/routes/config/mod.rs
+++ b/crates/librefang-api/src/routes/config/mod.rs
@@ -855,38 +855,104 @@ fn is_writable_config_path(path: &str) -> bool {
 
     // Within an allowed section, refuse keys that obviously carry secrets or
     // override security-critical knobs even if the operator points us at one
-    // of the curated sections by name.
-    const SCRUB_SUFFIXES: &[&str] = &[
-        ".api_key",
-        ".token",
-        ".secret",
-        ".shared_secret",
-        ".password",
-        ".bypass",
-        ".admin",
-        ".owner",
-        // Round-4 review of #4678: env-var-name redirects. Codebase
-        // pervasively uses `*_token_env`, `*_password_env`,
-        // `*_secret_env`, `*_client_secret_env`, `*_api_key_env`,
-        // `bot_token_env`, `access_token_env`, `cdp_auth_token_env`.
-        // The original SCRUB only blocked literal `.api_key` etc., so
-        // an attacker could repoint `<section>.api_key_env` at any env
-        // var the daemon has access to and force a credential rotation
-        // through a logged channel. The blanket `_env` suffix catches
-        // every variant the workspace currently uses (verified by grep
-        // against librefang-types/src/config/types.rs).
-        "_env",
+    // of the curated sections by name. The check is on the path's final
+    // segment, which is what the caller is actually assigning.
+    if path.rsplit('.').next().is_some_and(is_scrubbed_config_key) {
+        return false;
+    }
+    true
+}
+
+/// True when `key` is the name of a config field that `POST /api/config/set`
+/// must never assign, because it carries a credential, redirects the env var a
+/// credential is resolved from, or grants privilege.
+///
+/// This is the single source of truth for both halves of the scrub: the path
+/// check in [`is_writable_config_path`] applies it to a path's final segment,
+/// and [`scrubbed_key_in_payload`] applies it to every key inside a submitted
+/// JSON payload. Keeping one predicate is the point — a new entry here closes
+/// the leaf path and the wholesale-table payload at the same time, instead of
+/// closing one and leaving the other open (#8085).
+pub(crate) fn is_scrubbed_config_key(key: &str) -> bool {
+    // Exact field names. Matched exactly rather than by suffix so that
+    // `shared_secret` is caught by its own entry and a field like `bot_token`
+    // is not caught by `token` — which is the behaviour the path check has had
+    // since round-4 of #4678, preserved here deliberately.
+    const SCRUB_KEYS: &[&str] = &[
+        "api_key",
+        "token",
+        "secret",
+        "shared_secret",
+        "password",
+        "bypass",
+        "admin",
+        "owner",
         // OAuth public identity that's safe to *display* but not safe
         // to mutate (issuer redirect / consent skipping). External
         // auth sections are mostly off the prefix list now, but defense
         // in depth in case anything slips through a writable section.
-        ".client_id",
-        ".client_secret",
+        "client_id",
+        "client_secret",
     ];
-    if SCRUB_SUFFIXES.iter().any(|s| path.ends_with(s)) {
-        return false;
+    // Round-4 review of #4678: env-var-name redirects. Codebase
+    // pervasively uses `*_token_env`, `*_password_env`,
+    // `*_secret_env`, `*_client_secret_env`, `*_api_key_env`,
+    // `bot_token_env`, `access_token_env`, `cdp_auth_token_env`.
+    // The original SCRUB only blocked literal `api_key` etc., so
+    // an attacker could repoint `<section>.api_key_env` at any env
+    // var the daemon has access to and force a credential rotation
+    // through a logged channel. The blanket `_env` suffix catches
+    // every variant the workspace currently uses (verified by grep
+    // against librefang-types/src/config/types.rs).
+    const SCRUB_KEY_SUFFIXES: &[&str] = &["_env"];
+
+    SCRUB_KEYS.contains(&key) || SCRUB_KEY_SUFFIXES.iter().any(|s| key.ends_with(s))
+}
+
+/// Return the first credential-shaped key found anywhere inside `value`, at any
+/// depth, or `None` when the payload carries none.
+///
+/// The path check alone is not enough. A writable section prefix accepts a
+/// write one level below the section (`segments == 1 || segments == 2` in
+/// [`is_writable_config_path`]), and at that depth the handler assigns the
+/// submitted JSON *wholesale* — `doc[section][key] = <value>`. So a caller can
+/// post an entire table at a path whose own name is innocuous and smuggle a
+/// scrubbed field in as one of its members:
+///
+/// ```text
+/// POST /api/config/set
+/// {"path": "media.custom_stt",
+///  "value": {"api_key_env": "ANTHROPIC_API_KEY", "base_url": "http://attacker/"}}
+/// ```
+///
+/// `media.custom_stt` ends in neither a scrubbed name nor `_env`, so the path
+/// check passes and the `api_key_env` redirect lands. That is the same defect
+/// class round-4 of #4678 removed `sidecar_channels` / `fallback_providers` /
+/// `taint_rules` from the allowlist for, and that
+/// `WRITABLE_DEPTH_2_ONLY_PREFIXES` forces per-leaf writes for under
+/// `channels.` — both of which are enumerations of known-bad prefixes rather
+/// than a rule, so every newly struct-typed config field reopened the hole.
+/// Scanning the payload closes it once for every section (#8085).
+///
+/// Legitimate per-field edits are unaffected: the same field is still writable
+/// one level deeper (`media.custom_stt.base_url`), where the path check governs
+/// it as it always has.
+pub(crate) fn scrubbed_key_in_payload(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, inner) in map {
+                if is_scrubbed_config_key(key) {
+                    return Some(key.clone());
+                }
+                if let Some(found) = scrubbed_key_in_payload(inner) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(scrubbed_key_in_payload),
+        _ => None,
     }
-    true
 }
 
 /// Convert a serde_json::Value to a toml_edit::Value (format-preserving).
@@ -1693,5 +1759,99 @@ mod migrate_roots_tests {
             false,
         )
         .is_err());
+    }
+}
+
+#[cfg(test)]
+mod scrub_payload_tests {
+    use super::{is_scrubbed_config_key, is_writable_config_path, scrubbed_key_in_payload};
+
+    /// The refactor that introduced `is_scrubbed_config_key` must not have moved
+    /// the path check's boundary. Each case below is the behaviour the dotted
+    /// `SCRUB_SUFFIXES` list had: the final segment is matched exactly, so
+    /// `shared_secret` is caught by its own entry while `bot_token` — which no
+    /// entry names — is not.
+    #[test]
+    fn path_scrub_boundary_is_unchanged_by_the_shared_predicate() {
+        for closed in [
+            "media.api_key",
+            "media.custom_stt.api_key_env",
+            "web.brave.token",
+            "llm.shared_secret",
+            "queue.admin",
+            "skills.client_secret",
+        ] {
+            assert!(
+                !is_writable_config_path(closed),
+                "`{closed}` must stay closed"
+            );
+        }
+        for open in [
+            "media.custom_stt.base_url",
+            "web.search_provider",
+            "queue.concurrency.trigger_lane",
+        ] {
+            assert!(is_writable_config_path(open), "`{open}` must stay writable");
+        }
+        // Not named by any entry, and not caught by a suffix — unchanged from
+        // the pre-#8085 behaviour, and called out in the PR rather than widened
+        // here, because widening would change which paths are writable.
+        assert!(is_scrubbed_config_key("api_key_env"));
+        assert!(!is_scrubbed_config_key("bot_token"));
+    }
+
+    /// The scan has to find a scrubbed key wherever it sits, because the handler
+    /// assigns the whole submitted value at the path.
+    #[test]
+    fn payload_scan_finds_a_credential_key_at_every_depth() {
+        let cases = [
+            serde_json::json!({"api_key_env": "X"}),
+            serde_json::json!({"outer": {"api_key_env": "X"}}),
+            serde_json::json!({"outer": {"inner": {"token": "X"}}}),
+            serde_json::json!([{"client_secret": "X"}]),
+            serde_json::json!({"list": [{"password": "X"}]}),
+            serde_json::json!({"a": 1, "shared_secret": "X"}),
+        ];
+        for case in cases {
+            assert!(
+                scrubbed_key_in_payload(&case).is_some(),
+                "must be caught: {case}"
+            );
+        }
+    }
+
+    /// A payload with nothing credential-shaped must pass, or the scan would be
+    /// a blanket ban on object-valued writes and would break the primitive
+    /// collection sections (`provider_urls`, `tool_timeouts`, …) that round-4
+    /// of #4678 deliberately opened.
+    #[test]
+    fn payload_scan_passes_a_clean_payload() {
+        let cases = [
+            serde_json::json!({"base_url": "http://localhost/", "model": "m"}),
+            serde_json::json!({"openai": "http://localhost:9001/v1"}),
+            serde_json::json!({"nested": {"voice": "alloy", "format": "mp3"}}),
+            serde_json::json!("a plain string"),
+            serde_json::json!(7),
+            serde_json::json!(null),
+            serde_json::json!([1, 2, 3]),
+        ];
+        for case in cases {
+            assert_eq!(
+                scrubbed_key_in_payload(&case),
+                None,
+                "must pass cleanly: {case}"
+            );
+        }
+    }
+
+    /// The reported key is the one the operator has to go and edit, so it must
+    /// be the offending name rather than the first key seen.
+    #[test]
+    fn payload_scan_reports_the_offending_key_name() {
+        let value = serde_json::json!({"base_url": "http://a/", "api_key_env": "X"});
+        assert_eq!(
+            scrubbed_key_in_payload(&value).as_deref(),
+            Some("api_key_env")
+        );
     }
 }

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -2143,3 +2143,122 @@ async fn config_set_accepts_a_table_with_no_credential_shaped_key() {
         String::from_utf8_lossy(&body)
     );
 }
+
+/// #8085 follow-up: `toml_edit` models `[media]` and `media = { … }` as
+/// different `Item` variants, and the write path's `contains_table` /
+/// `as_table_mut` guards recognised only the standard-table form.
+///
+/// An operator who hand-wrote a section as an inline table therefore lost it:
+/// editing one leaf judged the section "missing" and replaced it with an empty
+/// table, dropping every sibling key — `api_key_env` among them. That is
+/// reachable precisely because #8085 recommends per-leaf writes as the safe
+/// route for tables that carry credential fields.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_preserves_the_siblings_of_a_hand_written_inline_table() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    let config_path = h.home.join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        "[media]\ncustom_stt = { base_url = \"http://old/\", api_key_env = \"MY_STT_KEY\" }\n",
+    )
+    .expect("seed config.toml");
+
+    let (status, body) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({
+                "path": "media.custom_stt.base_url",
+                "value": "http://new/"
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "per-leaf write into an inline table must succeed; body: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let on_disk = std::fs::read_to_string(&config_path).expect("read back config.toml");
+    assert!(
+        on_disk.contains("http://new/"),
+        "the edited leaf must be written; got:\n{on_disk}"
+    );
+    assert!(
+        on_disk.contains("MY_STT_KEY"),
+        "the sibling credential key must survive a per-leaf edit — this is the \
+         data-loss bug this test exists for; got:\n{on_disk}"
+    );
+}
+
+/// The same defect one level up: a top-level section written inline must not be
+/// wiped by a depth-2 write.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_preserves_an_inline_section_on_a_depth_two_write() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    let config_path = h.home.join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        "media = { audio_model = \"whisper-1\", describe_image_model = \"gpt-4o\" }\n",
+    )
+    .expect("seed config.toml");
+
+    let (status, _) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({"path": "media.audio_model", "value": "whisper-2"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let on_disk = std::fs::read_to_string(&config_path).expect("read back config.toml");
+    assert!(
+        on_disk.contains("whisper-2"),
+        "the edited key must be written; got:\n{on_disk}"
+    );
+    assert!(
+        on_disk.contains("describe_image_model"),
+        "the sibling key must survive; got:\n{on_disk}"
+    );
+}
+
+/// Removal used `as_table_mut`, which is `None` for an inline table, so the key
+/// stayed on disk while the handler still answered success — a delete that
+/// silently did nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_null_removes_a_key_from_an_inline_table() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    let config_path = h.home.join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        "media = { audio_model = \"whisper-1\", describe_image_model = \"gpt-4o\" }\n",
+    )
+    .expect("seed config.toml");
+
+    let (status, _) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({"path": "media.audio_model", "value": null}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let on_disk = std::fs::read_to_string(&config_path).expect("read back config.toml");
+    assert!(
+        !on_disk.contains("audio_model"),
+        "a reported-successful removal must actually remove the key; got:\n{on_disk}"
+    );
+    assert!(
+        on_disk.contains("describe_image_model"),
+        "the sibling key must survive the removal; got:\n{on_disk}"
+    );
+}

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -1994,3 +1994,152 @@ async fn metrics_escapes_untrusted_label_values() {
         );
     }
 }
+
+/// #8085: the SCRUB list governed only the path being assigned, so a wholesale
+/// table write smuggled a credential-shaped field past it.
+///
+/// `is_writable_config_path` accepts a write one level below a writable section
+/// prefix, and at that depth the handler assigns the submitted JSON wholesale
+/// (`doc[section][key] = <value>`). `media.custom_stt` ends in neither a
+/// scrubbed name nor `_env`, so the path check passed and the `api_key_env`
+/// member of the posted table landed on disk — repointing the env var a
+/// credential is resolved from, post-auth, over HTTP.
+///
+/// This is the reporter's exact payload. It must be refused, and the refusal
+/// must name the offending key so the caller knows which field to edit on disk.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_refuses_a_credential_key_smuggled_inside_a_wholesale_table() {
+    let h = boot_router_with_api_key(API_KEY).await;
+
+    let (status, body) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({
+                "path": "media.custom_stt",
+                "value": {
+                    "api_key_env": "ANTHROPIC_API_KEY",
+                    "base_url": "http://attacker.example/"
+                }
+            }),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a table carrying `api_key_env` must be refused however innocuous its path looks; \
+         body: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    let message = parsed
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or_default();
+    assert!(
+        message.contains("api_key_env"),
+        "the refusal must name the offending key so the operator knows what to edit on disk, \
+         got: {message}"
+    );
+}
+
+/// The same defect class, one level down and inside an array — a payload can
+/// nest, so the scan has to recurse rather than inspect only the top level.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_refuses_a_credential_key_nested_below_the_top_level() {
+    let h = boot_router_with_api_key(API_KEY).await;
+
+    for value in [
+        serde_json::json!({"outer": {"api_key_env": "ANTHROPIC_API_KEY"}}),
+        serde_json::json!([{"token": "hunter2"}]),
+        serde_json::json!({"list": [{"client_secret": "s"}]}),
+    ] {
+        let (status, body) = send(
+            h.app.clone(),
+            auth_post_json(
+                "/api/config/set",
+                serde_json::json!({"path": "media.custom_stt", "value": value}),
+            ),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "nested credential key must be refused; payload {value}, body: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+}
+
+/// The fix must not close the legitimate route to the same fields.
+///
+/// A per-leaf write one level deeper is how the dashboard is meant to edit
+/// these sections, and it is still governed by the path check exactly as
+/// before: the non-secret leaf succeeds, and the credential leaf is refused by
+/// the path check rather than the payload scan.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_still_allows_a_non_secret_leaf_write_under_the_same_section() {
+    let h = boot_router_with_api_key(API_KEY).await;
+
+    let (status, body) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({
+                "path": "media.custom_stt.base_url",
+                "value": "http://localhost:9000/"
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a per-leaf non-secret write must keep working; body: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let (status, _) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({
+                "path": "media.custom_stt.api_key_env",
+                "value": "ANTHROPIC_API_KEY"
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "the credential leaf stays closed at its own path, as it was before this change"
+    );
+}
+
+/// A payload with no credential-shaped key anywhere must be unaffected, so the
+/// scan cannot become a blanket ban on object-valued writes.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_accepts_a_table_with_no_credential_shaped_key() {
+    let h = boot_router_with_api_key(API_KEY).await;
+
+    let (status, body) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({
+                "path": "provider_urls",
+                "value": {"openai": "http://localhost:9001/v1"}
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a primitive-valued collection write must still be accepted; body: {}",
+        String::from_utf8_lossy(&body)
+    );
+}


### PR DESCRIPTION
**No issue to close** — this was never filed as one. It surfaced while working #8038 (PR #8079), whose body reports it: that PR declines to use this part of the write surface, and this one closes it.

The `#8085` references in the code comments and the changelog fragment are this PR's own number, which is the only handle the fix has. If you would rather have a tracking issue for the advisory, say so and I will file one and repoint them.

## The hole

`POST /api/config/set` scrubs credential-shaped names, but the check only ever inspected **the path being assigned**:

```rust
if SCRUB_SUFFIXES.iter().any(|s| path.ends_with(s)) { return false; }
```

`is_writable_config_path` accepts a write one level below a writable section prefix (`segments == 1 || segments == 2`), and at that depth the handler assigns the submitted JSON **wholesale**:

```rust
doc[parts[0]][parts[1]] = toml_edit::Item::Value(json_to_toml_edit_value(&value));
```

So a path whose own name is innocuous can carry a scrubbed field as a member of the table it replaces:

```
POST /api/config/set
{"path": "media.custom_stt",
 "value": {"api_key_env": "ANTHROPIC_API_KEY", "base_url": "http://attacker.example/"}}
```

`media.custom_stt` ends in neither a scrubbed name nor `_env`, so the path check passes and the `api_key_env` member lands in `config.toml`. That repoints the environment variable a provider credential is resolved from — post-auth, over HTTP, with no shell access — which is exactly the redirect the `_env` blanket was added to stop in round 4 of #4678.

**Confirmed against unmodified `origin/main`**, not argued from reading: with the fix's two source files reverted and the new tests kept, that payload returns

```
200 {"status":"applied_partial","path":"media.custom_stt"}
```

Full evidence in the verification section below.

## Why the existing mitigations didn't cover it

The codebase already knew this defect class and handled it twice, both times by enumeration:

- Round 4 of #4678 removed `sidecar_channels` / `fallback_providers` / `taint_rules` from the allowlist, with the comment *"their items have nested fields … that SCRUB_SUFFIXES — which only inspects the dotted path string — cannot police inside a wholesale JSON payload."*
- `WRITABLE_DEPTH_2_ONLY_PREFIXES` pins `channels.` to per-leaf writes for the same reason.

Both are lists of known-bad prefixes rather than a rule, so every config field that later became struct-typed reopened the hole. `media.` and `tts.` are on the section list and their depth-1 leaves are now structs carrying `api_key_env`.

## The fix

One predicate, applied in both places:

- **`is_scrubbed_config_key(key)`** — the single source of truth. A new entry now closes the leaf path and the wholesale-table payload at the same time, instead of closing one and leaving the other open.
- **`scrubbed_key_in_payload(value)`** — walks the submitted JSON and returns the first credential-shaped key at any depth (objects and arrays both recurse, because the handler assigns whatever was submitted).
- The handler runs the scan immediately after the existing path check and answers `403`, naming the offending key so the operator knows which field to edit on disk.

**The path check's boundary is deliberately unchanged.** `is_scrubbed_config_key` matches the exact names the dotted suffixes matched plus the `_env` suffix, so `shared_secret` is still caught by its own entry and `bot_token` is still caught by none. That equivalence is asserted by a test rather than assumed, because widening it would change *which paths are writable* — a different decision from closing the payload hole, and one I did not want to smuggle into a security fix.

**Legitimate edits are unaffected.** The non-secret fields of these tables are still writable one level deeper (`media.custom_stt.base_url`), where the path check governs them exactly as before — and that per-leaf route is how the dashboard is meant to edit them.

## Verification

- `cargo check -p librefang-api --lib` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — `exit=0`, **0 warnings**.
- `cargo test -p librefang-api --lib scrub_payload` — **4 passed**:
  - `path_scrub_boundary_is_unchanged_by_the_shared_predicate` — the refactor didn't move the path check's boundary.
  - `payload_scan_finds_a_credential_key_at_every_depth` — top level, nested object, nested array, array-of-objects.
  - `payload_scan_passes_a_clean_payload` — including primitives and `null`, so the scan can't become a blanket ban on object-valued writes.
  - `payload_scan_reports_the_offending_key_name` — the reported key is the offending one, not the first seen.
- `cargo test -p librefang-api --test config_routes_integration` — **51 passed, 0 failed** (whole binary, no pre-existing test disturbed).
- Filtered: `cargo test -p librefang-api --test config_routes_integration config_set_` — **21 passed, 0 failed**, including the four new ones:
  - `config_set_refuses_a_credential_key_smuggled_inside_a_wholesale_table` — the reporter's exact payload, and asserts the error names `api_key_env`.
  - `config_set_refuses_a_credential_key_nested_below_the_top_level` — nested object, array, and array-inside-object.
  - `config_set_still_allows_a_non_secret_leaf_write_under_the_same_section` — `media.custom_stt.base_url` still `200`, `media.custom_stt.api_key_env` still `403` via the path check.
  - `config_set_accepts_a_table_with_no_credential_shaped_key` — `provider_urls` collection write still `200`.

**Pre-fix failure, captured:** with `crates/librefang-api/src/routes/config/{mod,manage}.rs` restored to `origin/main` and the new tests kept, `cargo test … config_set_refuses` gives **0 passed, 2 failed**:

```
assertion `left == right` failed: a table carrying `api_key_env` must be refused
  however innocuous its path looks; body: {"status":"applied_partial","path":"media.custom_stt"}
  left: 200
 right: 403
```

Workspace-wide clippy was skipped for disk reasons (this host hit 100% full during this batch of work); CI covers it.

## Interaction with PR #8079

#8079 surfaces these same media/TTS tables in the dashboard Models tab and treats `api_key_env` as read-only. If it echoes the stored `api_key_env` back inside the table it posts, that save will now `403`. The fix on that side is to omit the key and post the other fields per-leaf, which is the route this PR leaves open. Worth merging this one first and re-checking #8079's save path against it.

## Noted, not changed

Neither the path check nor the payload scan catches `*_token` / `*_secret` style names that no entry names exactly — `bot_token` is the example. That has been true since round 4 and is a pre-existing gap, not something this change introduces. Widening the predicate would newly close paths that are writable today, so it belongs in its own decision rather than in a fix whose point is that the payload and the path must agree. Say the word and I'll do it as a follow-up with the writable-surface diff spelled out.

