### PR TITLE
fix(api): refuse a channel instance that would take another's secret namespace

### DIFF
--- a/changelog.d/fixed/8104-sidecar-secret-prefix-collision.md
+++ b/changelog.d/fixed/8104-sidecar-secret-prefix-collision.md
@@ -1,0 +1,5 @@
+Refuse a channel instance name that would move into another instance's secret namespace, instead of silently overwriting its token.
+`instance_secret_prefix` uppercases and maps every non-alphanumeric character to `_`, so it is many-to-one: `bot-1`, `bot.1` and `BOT+1` all land on `BOT_1` and share one `<PREFIX>__KEY` namespace in `secrets.env`.
+Until #8046 a second instance meant hand-editing `config.toml` in front of the existing entries, and a `WARN` from the boot and config-reload loop was a reasonable safety net; a two-field form in the dashboard is not the same thing, because by the time that `WARN` appears the first bot's token is already gone.
+`POST /api/channels/sidecar/{name}/configure` now answers 409 `sidecar_secret_prefix_conflict` naming the shared prefix and the instances that hold it, before anything is written — so #8046's "two bots never share a token" is true rather than nearly true.
+Re-saving an existing instance is unaffected: that is the in-place update path, not a second instance moving in. (#8104) (@houko)

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1096,19 +1096,16 @@ enum ConfigureSidecarWriteError {
     /// same `secrets.env` snapshot the write uses — reading it earlier, outside
     /// `config_write_lock`, would be a TOCTOU against a concurrent save.
     MissingRequiredSecret(String),
-    /// `instance_name` normalizes to the same `<PREFIX>__` secret namespace as
-    /// one or more already-configured instances, so saving it would overwrite
-    /// their secrets. Carries the shared prefix and the colliding names.
+    /// `instance_name` normalizes to the same `<PREFIX>__` secret namespace as one or more already-configured instances, so saving it would overwrite their secrets.
+    /// Carries the shared prefix and the colliding names.
     SecretPrefixConflict {
         prefix: String,
         names: Vec<String>,
     },
 }
 
-/// Names of the configured `[[sidecar_channels]]` entries that keep their
-/// secrets in a `<PREFIX>__` namespace — that is, every entry whose `name`
-/// differs from its `channel_type`. The instance sharing the catalog's own
-/// name writes bare keys and so cannot collide through the prefix.
+/// Names of the configured `[[sidecar_channels]]` entries that keep their secrets in a `<PREFIX>__` namespace — that is, every entry whose `name` differs from its `channel_type`.
+/// The instance sharing the catalog's own name writes bare keys and so cannot collide through the prefix.
 fn namespaced_instance_names(config_content: &str) -> Result<Vec<String>, String> {
     if config_content.trim().is_empty() {
         return Ok(Vec::new());
@@ -1309,21 +1306,13 @@ fn write_sidecar_configuration(
         return Err(ConfigureSidecarWriteError::NameConflict(conflicting_type));
     }
 
-    // `instance_secret_prefix` uppercases and maps every non-alphanumeric
-    // character to `_`, so it is many-to-one: `bot-1`, `bot.1` and `BOT+1` all
-    // land on `BOT_1`. Two instances that collapse together share one
-    // `<PREFIX>__KEY` namespace in secrets.env, and the second save silently
-    // overwrites the first one's token — the opposite of the isolation this
-    // endpoint exists to provide.
+    // `instance_secret_prefix` uppercases and maps every non-alphanumeric character to `_`, so it is many-to-one: `bot-1`, `bot.1` and `BOT+1` all land on `BOT_1`.
+    // Two instances that collapse together share one `<PREFIX>__KEY` namespace in secrets.env, and the second save silently overwrites the first one's token — the opposite of the isolation this endpoint exists to provide.
     //
-    // `warn_secret_prefix_collisions` reports that from the boot / reload loop,
-    // which was enough while a second instance meant hand-editing config.toml
-    // in front of the existing entries. It is not enough for a two-field form:
-    // by the time the WARN appears the token is already gone. Refuse here, on
-    // the same "fail before the first mutation" contract as the checks above.
+    // `warn_secret_prefix_collisions` reports that from the boot / reload loop, which was enough while a second instance meant hand-editing config.toml in front of the existing entries.
+    // It is not enough for a two-field form: by the time the WARN appears the token is already gone. Refuse here, on the same "fail before the first mutation" contract as the checks above.
     //
-    // Only namespaced instances can collide this way — the one sharing the
-    // catalog's own name writes bare keys — so a default-named save skips it.
+    // Only namespaced instances can collide this way — the one sharing the catalog's own name writes bare keys — so a default-named save skips it.
     if instance_name != entry.name {
         let existing = namespaced_instance_names(original_config.as_deref().unwrap_or_default())
             .map_err(ConfigureSidecarWriteError::Write)?;

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1096,6 +1096,43 @@ enum ConfigureSidecarWriteError {
     /// same `secrets.env` snapshot the write uses — reading it earlier, outside
     /// `config_write_lock`, would be a TOCTOU against a concurrent save.
     MissingRequiredSecret(String),
+    /// `instance_name` normalizes to the same `<PREFIX>__` secret namespace as
+    /// one or more already-configured instances, so saving it would overwrite
+    /// their secrets. Carries the shared prefix and the colliding names.
+    SecretPrefixConflict {
+        prefix: String,
+        names: Vec<String>,
+    },
+}
+
+/// Names of the configured `[[sidecar_channels]]` entries that keep their
+/// secrets in a `<PREFIX>__` namespace — that is, every entry whose `name`
+/// differs from its `channel_type`. The instance sharing the catalog's own
+/// name writes bare keys and so cannot collide through the prefix.
+fn namespaced_instance_names(config_content: &str) -> Result<Vec<String>, String> {
+    if config_content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let document: toml_edit::DocumentMut = config_content
+        .parse()
+        .map_err(|error| format!("parse config.toml: {error}"))?;
+    let Some(array) = document
+        .get("sidecar_channels")
+        .and_then(|item| item.as_array_of_tables())
+    else {
+        return Ok(Vec::new());
+    };
+    Ok(array
+        .iter()
+        .filter_map(|table| {
+            let name = table.get("name").and_then(|item| item.as_str())?;
+            let channel_type = table
+                .get("channel_type")
+                .and_then(|item| item.as_str())
+                .unwrap_or(name);
+            (name != channel_type).then(|| name.to_string())
+        })
+        .collect())
 }
 
 /// Look for an existing `[[sidecar_channels]]` entry named `instance_name`
@@ -1270,6 +1307,33 @@ fn write_sidecar_configuration(
     .map_err(ConfigureSidecarWriteError::Write)?
     {
         return Err(ConfigureSidecarWriteError::NameConflict(conflicting_type));
+    }
+
+    // `instance_secret_prefix` uppercases and maps every non-alphanumeric
+    // character to `_`, so it is many-to-one: `bot-1`, `bot.1` and `BOT+1` all
+    // land on `BOT_1`. Two instances that collapse together share one
+    // `<PREFIX>__KEY` namespace in secrets.env, and the second save silently
+    // overwrites the first one's token — the opposite of the isolation this
+    // endpoint exists to provide.
+    //
+    // `warn_secret_prefix_collisions` reports that from the boot / reload loop,
+    // which was enough while a second instance meant hand-editing config.toml
+    // in front of the existing entries. It is not enough for a two-field form:
+    // by the time the WARN appears the token is already gone. Refuse here, on
+    // the same "fail before the first mutation" contract as the checks above.
+    //
+    // Only namespaced instances can collide this way — the one sharing the
+    // catalog's own name writes bare keys — so a default-named save skips it.
+    if instance_name != entry.name {
+        let existing = namespaced_instance_names(original_config.as_deref().unwrap_or_default())
+            .map_err(ConfigureSidecarWriteError::Write)?;
+        let names = librefang_channels::sidecar::secret_prefix_conflict(&existing, instance_name);
+        if !names.is_empty() {
+            return Err(ConfigureSidecarWriteError::SecretPrefixConflict {
+                prefix: librefang_channels::sidecar::instance_secret_prefix(instance_name),
+                names,
+            });
+        }
     }
 
     // A second (third, …) named instance of the same catalog type must not
@@ -1608,6 +1672,18 @@ pub async fn configure_sidecar_channel(
                 ApiErrorResponse::bad_request(format!(
                     "required field `{key}` is missing or empty"
                 ))
+                .into_json_tuple()
+            }
+            ConfigureSidecarWriteError::SecretPrefixConflict { prefix, names } => {
+                ApiErrorResponse::conflict(format!(
+                    "instance name `{instance_name}` normalizes to the same secret namespace `{prefix}__` as the configured instance(s) {}. Saving it would overwrite their `{prefix}__<KEY>` secrets in secrets.env. Pick a name that differs by more than punctuation or case.",
+                    names
+                        .iter()
+                        .map(|n| format!("`{n}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
+                .with_code("sidecar_secret_prefix_conflict")
                 .into_json_tuple()
             }
             ConfigureSidecarWriteError::Write(error) => {

--- a/crates/librefang-api/tests/channel_configure_test.rs
+++ b/crates/librefang-api/tests/channel_configure_test.rs
@@ -371,6 +371,86 @@ async fn configure_still_rejects_a_required_secret_that_was_never_stored() {
     );
 }
 
+/// `instance_secret_prefix` uppercases and maps every non-alphanumeric byte to
+/// `_`, so it is many-to-one. Two instances that collapse onto the same prefix
+/// share one `<PREFIX>__KEY` namespace in secrets.env, and the second save
+/// would overwrite the first one's token — which is the opposite of the
+/// isolation multi-instance support is for, and what the feature's own
+/// changelog promises ("so two bots never share a token").
+///
+/// `warn_secret_prefix_collisions` only reports this from the boot / reload
+/// loop, after the damage. The write path has to refuse it.
+#[tokio::test(flavor = "multi_thread")]
+async fn configure_refuses_an_instance_name_that_shares_a_secret_namespace() {
+    let harness = boot_router().await;
+
+    let (status, body) = configure(
+        &harness.app,
+        "telegram",
+        serde_json::json!({
+            "values": {"TELEGRAM_BOT_TOKEN": "first-token"},
+            "instance_name": "bot-1",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    // `bot.1` normalizes to `BOT_1`, exactly where `bot-1` keeps its secret.
+    let (status, body) = configure(
+        &harness.app,
+        "telegram",
+        serde_json::json!({
+            "values": {"TELEGRAM_BOT_TOKEN": "second-token"},
+            "instance_name": "bot.1",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body["code"], "sidecar_secret_prefix_conflict", "{body}");
+
+    // The refusal must land before the first mutation: the original token is
+    // still there and no second instance was created.
+    let secrets = std::fs::read_to_string(harness.home.join("secrets.env")).unwrap_or_default();
+    assert!(
+        secrets.contains("BOT_1__TELEGRAM_BOT_TOKEN=first-token"),
+        "the rejected save overwrote the first instance's secret: {secrets}"
+    );
+    assert!(
+        !secrets.contains("second-token"),
+        "the rejected save wrote its own token anyway: {secrets}"
+    );
+    let payload = get_channels(&harness.app).await;
+    assert!(
+        payload.to_string().contains("bot-1") && !payload.to_string().contains("bot.1"),
+        "the rejected instance must not have been created: {payload}"
+    );
+}
+
+/// Re-saving the same instance is `upsert_sidecar_block` editing it in place,
+/// not a second instance moving into its namespace, so it must still work.
+#[tokio::test(flavor = "multi_thread")]
+async fn configure_still_allows_reconfiguring_the_same_named_instance() {
+    let harness = boot_router().await;
+
+    for token in ["first-token", "second-token"] {
+        let (status, body) = configure(
+            &harness.app,
+            "telegram",
+            serde_json::json!({
+                "values": {"TELEGRAM_BOT_TOKEN": token},
+                "instance_name": "bot-1",
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+    }
+
+    let secrets = std::fs::read_to_string(harness.home.join("secrets.env")).unwrap_or_default();
+    assert!(
+        secrets.contains("BOT_1__TELEGRAM_BOT_TOKEN=second-token"),
+        "re-saving an instance must update its own secret: {secrets}"
+    );
+}
 #[tokio::test(flavor = "multi_thread")]
 async fn registry_returns_typed_metadata_array() {
     let harness = boot_router().await;

--- a/crates/librefang-api/tests/channel_configure_test.rs
+++ b/crates/librefang-api/tests/channel_configure_test.rs
@@ -370,16 +370,11 @@ async fn configure_still_rejects_a_required_secret_that_was_never_stored() {
         "a rejected save must not have written the instance block: {config}"
     );
 }
-
-/// `instance_secret_prefix` uppercases and maps every non-alphanumeric byte to
-/// `_`, so it is many-to-one. Two instances that collapse onto the same prefix
-/// share one `<PREFIX>__KEY` namespace in secrets.env, and the second save
-/// would overwrite the first one's token — which is the opposite of the
-/// isolation multi-instance support is for, and what the feature's own
-/// changelog promises ("so two bots never share a token").
+/// `instance_secret_prefix` uppercases and maps every non-alphanumeric byte to `_`, so it is many-to-one.
+/// Two instances that collapse onto the same prefix share one `<PREFIX>__KEY` namespace in secrets.env, and the second save would overwrite the first one's token — which is the opposite of the isolation multi-instance support is for, and what the feature's own changelog promises ("so two bots never share a token").
 ///
-/// `warn_secret_prefix_collisions` only reports this from the boot / reload
-/// loop, after the damage. The write path has to refuse it.
+/// `warn_secret_prefix_collisions` only reports this from the boot / reload loop, after the damage.
+/// The write path has to refuse it.
 #[tokio::test(flavor = "multi_thread")]
 async fn configure_refuses_an_instance_name_that_shares_a_secret_namespace() {
     let harness = boot_router().await;
@@ -408,8 +403,7 @@ async fn configure_refuses_an_instance_name_that_shares_a_secret_namespace() {
     assert_eq!(status, StatusCode::CONFLICT, "{body}");
     assert_eq!(body["code"], "sidecar_secret_prefix_conflict", "{body}");
 
-    // The refusal must land before the first mutation: the original token is
-    // still there and no second instance was created.
+    // The refusal must land before the first mutation: the original token is still there and no second instance was created.
     let secrets = std::fs::read_to_string(harness.home.join("secrets.env")).unwrap_or_default();
     assert!(
         secrets.contains("BOT_1__TELEGRAM_BOT_TOKEN=first-token"),
@@ -426,8 +420,7 @@ async fn configure_refuses_an_instance_name_that_shares_a_secret_namespace() {
     );
 }
 
-/// Re-saving the same instance is `upsert_sidecar_block` editing it in place,
-/// not a second instance moving into its namespace, so it must still work.
+/// Re-saving the same instance is `upsert_sidecar_block` editing it in place, not a second instance moving into its namespace, so it must still work.
 #[tokio::test(flavor = "multi_thread")]
 async fn configure_still_allows_reconfiguring_the_same_named_instance() {
     let harness = boot_router().await;

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -785,20 +785,13 @@ fn secret_prefix_collisions(names: &[String]) -> Vec<(String, Vec<String>)> {
 
 /// Which of `existing` would share `candidate`'s per-instance secret namespace.
 ///
-/// [`warn_secret_prefix_collisions`] reports this after the fact, from the boot
-/// and config-reload loop, which is the right place for a config an operator
-/// hand-edited. It is the wrong place for a config the dashboard just wrote:
-/// by the time the WARN appears the save has already happened, the first
-/// instance's `<PREFIX>__KEY` has already been overwritten with the second
-/// one's token, and the only signal is a log line on the next boot.
+/// [`warn_secret_prefix_collisions`] reports this after the fact, from the boot and config-reload loop, which is the right place for a config an operator hand-edited.
+/// It is the wrong place for a config the dashboard just wrote: by the time the WARN appears the save has already happened, the first instance's `<PREFIX>__KEY` has already been overwritten with the second one's token, and the only signal is a log line on the next boot.
 ///
-/// This is the same normalization asked as a question instead of an
-/// observation, so a writing surface can refuse before it clobbers anything.
-/// An exact name match is excluded: that is the same instance being
-/// reconfigured, which `upsert_sidecar_block` edits in place.
+/// This is the same normalization asked as a question instead of an observation, so a writing surface can refuse before it clobbers anything.
+/// An exact name match is excluded: that is the same instance being reconfigured, which `upsert_sidecar_block` edits in place.
 ///
-/// Returns the colliding names sorted, so a caller's error message is
-/// deterministic.
+/// Returns the colliding names sorted, so a caller's error message is deterministic.
 pub fn secret_prefix_conflict(existing: &[String], candidate: &str) -> Vec<String> {
     let wanted = instance_secret_prefix(candidate);
     let mut hits: Vec<String> = existing
@@ -4255,8 +4248,7 @@ mod tests {
             "BOT+1".to_string(),
             "telegram".to_string(),
         ];
-        // `bot.1` normalizes to `BOT_1`, which is where `bot-1` and `BOT+1`
-        // already keep their `<PREFIX>__KEY` secrets.
+        // `bot.1` normalizes to `BOT_1`, which is where `bot-1` and `BOT+1` already keep their `<PREFIX>__KEY` secrets.
         assert_eq!(
             secret_prefix_conflict(&existing, "bot.1"),
             vec!["BOT+1".to_string(), "bot-1".to_string()],
@@ -4268,8 +4260,7 @@ mod tests {
 
     #[test]
     fn secret_prefix_conflict_excludes_the_instance_being_reconfigured() {
-        // Saving `bot-1` again is `upsert_sidecar_block` editing it in place,
-        // not a second instance moving into its namespace.
+        // Saving `bot-1` again is `upsert_sidecar_block` editing it in place, not a second instance moving into its namespace.
         let existing = vec!["bot-1".to_string(), "telegram".to_string()];
         assert!(
             secret_prefix_conflict(&existing, "bot-1").is_empty(),

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -783,6 +783,35 @@ fn secret_prefix_collisions(names: &[String]) -> Vec<(String, Vec<String>)> {
         .collect()
 }
 
+/// Which of `existing` would share `candidate`'s per-instance secret namespace.
+///
+/// [`warn_secret_prefix_collisions`] reports this after the fact, from the boot
+/// and config-reload loop, which is the right place for a config an operator
+/// hand-edited. It is the wrong place for a config the dashboard just wrote:
+/// by the time the WARN appears the save has already happened, the first
+/// instance's `<PREFIX>__KEY` has already been overwritten with the second
+/// one's token, and the only signal is a log line on the next boot.
+///
+/// This is the same normalization asked as a question instead of an
+/// observation, so a writing surface can refuse before it clobbers anything.
+/// An exact name match is excluded: that is the same instance being
+/// reconfigured, which `upsert_sidecar_block` edits in place.
+///
+/// Returns the colliding names sorted, so a caller's error message is
+/// deterministic.
+pub fn secret_prefix_conflict(existing: &[String], candidate: &str) -> Vec<String> {
+    let wanted = instance_secret_prefix(candidate);
+    let mut hits: Vec<String> = existing
+        .iter()
+        .filter(|name| name.as_str() != candidate)
+        .filter(|name| instance_secret_prefix(name) == wanted)
+        .cloned()
+        .collect();
+    hits.sort();
+    hits.dedup();
+    hits
+}
+
 /// Emit a targeted WARN for each set of sidecar instance names that collapse
 /// to the same per-instance secret prefix (see [`secret_prefix_collisions`]).
 ///
@@ -4217,6 +4246,35 @@ mod tests {
             "a repeated identical name is not a prefix collision"
         );
         assert_eq!(warn_secret_prefix_collisions(&names), 0);
+    }
+
+    #[test]
+    fn secret_prefix_conflict_reports_names_that_would_share_the_namespace() {
+        let existing = vec![
+            "bot-1".to_string(),
+            "BOT+1".to_string(),
+            "telegram".to_string(),
+        ];
+        // `bot.1` normalizes to `BOT_1`, which is where `bot-1` and `BOT+1`
+        // already keep their `<PREFIX>__KEY` secrets.
+        assert_eq!(
+            secret_prefix_conflict(&existing, "bot.1"),
+            vec!["BOT+1".to_string(), "bot-1".to_string()],
+            "every name collapsing to the candidate's prefix must be reported, sorted"
+        );
+        // A name that normalizes somewhere else is not a conflict.
+        assert!(secret_prefix_conflict(&existing, "bot-2").is_empty());
+    }
+
+    #[test]
+    fn secret_prefix_conflict_excludes_the_instance_being_reconfigured() {
+        // Saving `bot-1` again is `upsert_sidecar_block` editing it in place,
+        // not a second instance moving into its namespace.
+        let existing = vec!["bot-1".to_string(), "telegram".to_string()];
+        assert!(
+            secret_prefix_conflict(&existing, "bot-1").is_empty(),
+            "an exact name match is the update path, not a collision"
+        );
     }
 
     /// Find python3 or python on PATH.


### PR DESCRIPTION
Follow-up to #8046, whose changelog says "namespaces a second-plus instance's secrets under `<INSTANCE>__<KEY>` in `secrets.env` … so two bots never share a token." They still can.

## The hole

`instance_secret_prefix` (`crates/librefang-channels/src/sidecar.rs:745`) uppercases and maps every non-alphanumeric character to `_`, so it is many-to-one. The codebase already says so, in `secret_prefix_collisions` right below it:

    `instance_secret_prefix` is many-to-one — `bot-1`, `bot.1`, `bot_1` and `BOT+1` all normalize to
    `BOT_1` — so two instances whose names collide share the `<PREFIX>__` per-instance secret
    namespace in `secrets.env`, and each child receives the others' `<PREFIX>__KEY` secrets.

`configure_sidecar` checked `find_conflicting_channel_type` — same name, different type — and nothing else. So with `bot-1` configured, saving `bot.1` was accepted, `upsert_secret` wrote `BOT_1__TELEGRAM_BOT_TOKEN`, and the first bot's token was replaced.

`warn_secret_prefix_collisions` reports this, but only from the boot and config-reload loop — after the damage, and only on the next boot. That was a reasonable safety net while adding a second instance meant hand-editing `config.toml` in front of the existing entries. It is not one for the two-field form #8046 added, where the operator never sees the normalized namespace.

## What this changes

- New `librefang_channels::sidecar::secret_prefix_conflict(existing, candidate)` — the same normalization asked as a question rather than reported as an observation, so a writing surface can refuse before it clobbers anything. Exact name matches are excluded: that is the in-place update path.
- `configure_sidecar` calls it after the existing name-conflict check and before any write, on the same fail-before-the-first-mutation contract, and returns 409 `sidecar_secret_prefix_conflict` naming the shared prefix and the instances that already hold it.
- Only namespaced instances can collide this way — the one sharing the catalog's own name writes bare keys — so a default-named save skips the check entirely.

## Verification

- `cargo test -p librefang-api --test channel_configure_test` — 7 passed, including #8046's own five, so the multi-instance path it added is unregressed.
  - `configure_refuses_an_instance_name_that_shares_a_secret_namespace` — configures `bot-1`, then `bot.1`; asserts 409 with the code, that `BOT_1__TELEGRAM_BOT_TOKEN` still holds the *first* token, that the second token was never written, and that no second instance was created.
  - `configure_still_allows_reconfiguring_the_same_named_instance` — saving `bot-1` twice updates its own secret, so the check does not break the update path.
- `cargo test -p librefang-channels --lib secret_prefix` — 4 passed, including two new unit tests for the helper (collision reporting is sorted and complete; an exact name match is excluded).
- `cargo check -p librefang-api --lib` and `cargo clippy -p librefang-channels -p librefang-api --all-targets -- -D warnings` — both clean, exit 0.

## Note on the alternative

The other way to close this is to make the namespace injective — a hash suffix, or rejecting names outside `[A-Za-z0-9_]`. That changes #6169's established key shape and would strand secrets operators have already written under the current spelling, so refusing at the API boundary is the smaller, reversible fix. If the injective namespace is wanted later, this check is what makes the migration safe to stage.

## Deferred

Nothing.
