### PR TITLE
perf(api): probe sidecar schemas concurrently instead of one at a time

### DIFF
--- a/changelog.d/fixed/8094-parallel-sidecar-schema-probes.md
+++ b/changelog.d/fixed/8094-parallel-sidecar-schema-probes.md
@@ -1,0 +1,4 @@
+Cold start no longer pays every channel adapter's Python startup one after another.
+`populate_sidecar_schema_cache` probes each of the 20-plus catalog adapters with `--describe`, and it is awaited from `build_router` *before* the listener binds — so a serial loop meant the API port stayed closed for the sum of every interpreter spawn, reported as a 30-second boot on an Orange Pi 5 Plus.
+The probes now run concurrently, capped between 2 and 8 in flight: a cap rather than an unbounded fan-out because each probe is a `python3` process, and starting one per adapter at once would trade a slow boot on a small ARM board for a thrashing one.
+Nothing about the cached result changes — both caches are keyed by adapter name, so the same set lands whatever order the probes finish in; only the `adapter=` log lines now interleave (#8094) (@houko)

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -752,17 +752,9 @@ fn write_cache_recover<'a, T>(
 
 /// How many `--describe` probes may be in flight at once.
 ///
-/// The catalog is 20-plus adapters and every probe spawns a `python3`
-/// interpreter, so this is a subprocess-count cap rather than a throughput
-/// knob: unbounded fan-out would start one interpreter per catalog entry
-/// simultaneously, which on the small ARM boards LibreFang is deployed to
-/// (the report in #8094 came from an Orange Pi 5 Plus) trades a slow boot for
-/// a thrashing one.
+/// The catalog is 20-plus adapters and every probe spawns a `python3` interpreter, so this is a subprocess-count cap rather than a throughput knob: unbounded fan-out would start one interpreter per catalog entry simultaneously, which on the small ARM boards LibreFang is deployed to (the report in #8094 came from an Orange Pi 5 Plus) trades a slow boot for a thrashing one.
 ///
-/// Derived from the host's parallelism and clamped: at least 2, so a
-/// single-core container still overlaps process spawn with interpreter
-/// startup, and at most 8, because the work is dominated by Python's import
-/// time rather than by anything that scales past a handful of cores.
+/// Derived from the host's parallelism and clamped: at least 2, so a single-core container still overlaps process spawn with interpreter startup, and at most 8, because the work is dominated by Python's import time rather than by anything that scales past a handful of cores.
 fn sidecar_probe_concurrency() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
@@ -772,10 +764,7 @@ fn sidecar_probe_concurrency() -> usize {
 
 /// Record one adapter's probe outcome in the schema / schema-error caches.
 ///
-/// Split out of [`populate_sidecar_schema_cache`] so the probes can run
-/// concurrently while every cache write stays synchronous and short — no lock
-/// is ever held across an `.await` — and so the three outcomes are unit
-/// testable without a working Python installation.
+/// Split out of [`populate_sidecar_schema_cache`] so the probes can run concurrently while every cache write stays synchronous and short — no lock is ever held across an `.await` — and so the three outcomes are unit testable without a working Python installation.
 fn apply_sidecar_probe_outcome(
     entry: &'static SidecarCatalogEntry,
     result: Result<SidecarSchema, super::sidecar_describe::DescribeSidecarError>,
@@ -848,16 +837,11 @@ fn apply_sidecar_probe_outcome(
 /// `home_dir` must be the kernel's `KernelConfig.home_dir`
 /// (`KernelApi::home_dir()`); it locates the embedded-SDK extraction dir.
 ///
-/// The probes run concurrently, capped at [`sidecar_probe_concurrency`]. They
-/// used to run one at a time, and because this is awaited from
-/// `server::build_router` *before* the listener binds, every adapter's Python
-/// startup was paid serially on the boot path — 20-plus sequential
-/// interpreter spawns, which is the 30-second cold start reported in #8094.
+/// The probes run concurrently, capped at [`sidecar_probe_concurrency`].
+/// They used to run one at a time, and because this is awaited from `server::build_router` *before* the listener binds, every adapter's Python startup was paid serially on the boot path — 20-plus sequential interpreter spawns, which is the 30-second cold start reported in #8094.
 ///
-/// Order is not load-bearing: both caches are keyed by
-/// `SidecarCatalogEntry::name`, so the completed set is identical whatever
-/// order the probes finish in. The `adapter=` log lines interleave now, which
-/// is the one observable difference.
+/// Order is not load-bearing: both caches are keyed by `SidecarCatalogEntry::name`, so the completed set is identical whatever order the probes finish in.
+/// The `adapter=` log lines interleave now, which is the one observable difference.
 pub async fn populate_sidecar_schema_cache(home_dir: &std::path::Path) {
     use futures::StreamExt;
 
@@ -2843,9 +2827,7 @@ mod sidecar_probe_outcome_tests {
             .unwrap_or_else(|| panic!("catalog must contain `{name}`"))
     }
 
-    /// The cap is a subprocess-count bound, so what matters is that it never
-    /// degenerates to 1 (which is the serial boot #8094 reports) and never
-    /// grows with core count past the point where Python startup dominates.
+    /// The cap is a subprocess-count bound, so what matters is that it never degenerates to 1 (which is the serial boot #8094 reports) and never grows with core count past the point where Python startup dominates.
     #[test]
     fn probe_concurrency_stays_within_its_bounds() {
         let n = sidecar_probe_concurrency();
@@ -2855,10 +2837,7 @@ mod sidecar_probe_outcome_tests {
         );
     }
 
-    // All three outcomes in ONE test: the schema / error caches are
-    // process-wide and the seeders clear-then-set, so splitting these into
-    // parallel tests would race on the shared maps — same reason
-    // `schema_error_discovery_tests` keeps its halves together.
+    // All three outcomes in ONE test: the schema / error caches are process-wide and the seeders clear-then-set, so splitting these into parallel tests would race on the shared maps — same reason `schema_error_discovery_tests` keeps its halves together.
     #[test]
     fn each_probe_outcome_lands_in_exactly_one_cache() {
         __test_seed_sidecar_schema_cache(&[]);
@@ -2874,8 +2853,7 @@ mod sidecar_probe_outcome_tests {
         };
         apply_sidecar_probe_outcome(entry("gotify"), Ok(live));
 
-        // --- describe failed WITH a compile-time fallback: schema cache gets
-        // the static fields, and no version, because nothing reported one ---
+        // --- describe failed WITH a compile-time fallback: schema cache gets the static fields, and no version, because nothing reported one ---
         apply_sidecar_probe_outcome(
             entry("telegram"),
             Err(DescribeSidecarError::SdkMissing(
@@ -2883,8 +2861,7 @@ mod sidecar_probe_outcome_tests {
             )),
         );
 
-        // --- describe failed WITHOUT a fallback: the reason is cached so the
-        // row can explain the empty form instead of just being empty ---
+        // --- describe failed WITHOUT a fallback: the reason is cached so the row can explain the empty form instead of just being empty ---
         apply_sidecar_probe_outcome(
             entry("ntfy"),
             Err(DescribeSidecarError::SdkMissing(

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -750,6 +750,91 @@ fn write_cache_recover<'a, T>(
     })
 }
 
+/// How many `--describe` probes may be in flight at once.
+///
+/// The catalog is 20-plus adapters and every probe spawns a `python3`
+/// interpreter, so this is a subprocess-count cap rather than a throughput
+/// knob: unbounded fan-out would start one interpreter per catalog entry
+/// simultaneously, which on the small ARM boards LibreFang is deployed to
+/// (the report in #8094 came from an Orange Pi 5 Plus) trades a slow boot for
+/// a thrashing one.
+///
+/// Derived from the host's parallelism and clamped: at least 2, so a
+/// single-core container still overlaps process spawn with interpreter
+/// startup, and at most 8, because the work is dominated by Python's import
+/// time rather than by anything that scales past a handful of cores.
+fn sidecar_probe_concurrency() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(2)
+        .clamp(2, 8)
+}
+
+/// Record one adapter's probe outcome in the schema / schema-error caches.
+///
+/// Split out of [`populate_sidecar_schema_cache`] so the probes can run
+/// concurrently while every cache write stays synchronous and short — no lock
+/// is ever held across an `.await` — and so the three outcomes are unit
+/// testable without a working Python installation.
+fn apply_sidecar_probe_outcome(
+    entry: &'static SidecarCatalogEntry,
+    result: Result<SidecarSchema, super::sidecar_describe::DescribeSidecarError>,
+) {
+    match result {
+        Ok(schema) => {
+            tracing::info!(
+                adapter = entry.name,
+                fields = schema.fields.len(),
+                sdk_version = schema.sdk_version.as_deref().unwrap_or("unreported"),
+                "sidecar schema cached"
+            );
+            write_cache_recover(schema_cache(), "schema").insert(entry.name, schema);
+        }
+        Err(e) => {
+            if let Some(static_fields) = entry.static_fields {
+                // Use the compile-time fallback so the configure form is
+                // usable even without a working Python SDK installation.
+                let fallback = SidecarSchema {
+                    name: entry.name.to_string(),
+                    display_name: entry.display_name.to_string(),
+                    description: entry.description.to_string(),
+                    fields: static_fields
+                        .iter()
+                        .map(|f| SidecarSchemaField {
+                            key: f.key.to_string(),
+                            label: f.label.to_string(),
+                            field_type: f.field_type.to_string(),
+                            required: f.required,
+                            placeholder: f.placeholder.to_string(),
+                            advanced: f.advanced,
+                            options: None,
+                        })
+                        .collect(),
+                    // The fallback exists precisely because `--describe`
+                    // failed, so no adapter reported a version here.
+                    sdk_version: None,
+                };
+                tracing::warn!(
+                    adapter = entry.name,
+                    error = %e,
+                    fields = fallback.fields.len(),
+                    "sidecar --describe failed; using compile-time fallback schema"
+                );
+                write_cache_recover(schema_cache(), "schema").insert(entry.name, fallback);
+            } else {
+                tracing::warn!(
+                    adapter = entry.name,
+                    error = %e,
+                    "sidecar --describe failed; channel cards will have no form fields"
+                );
+                // Stash the failure reason so every row for this adapter — the discovery card and each configured `[[sidecar_channels]]` instance of the type (#8063) — can tell the operator *why* the form is empty (typically: Python sidecar SDK not installed).
+                write_cache_recover(schema_error_cache(), "schema error")
+                    .insert(entry.name, e.to_string());
+            }
+        }
+    }
+}
+
 /// Spawn `<command> <args> --describe` for every catalog entry and cache
 /// the resulting schemas. Called once at daemon boot from
 /// `server::build_router`. `describe_sidecar` injects the binary-embedded
@@ -762,63 +847,32 @@ fn write_cache_recover<'a, T>(
 /// compile-time fields seed the form instead of leaving an empty `fields[]`.
 /// `home_dir` must be the kernel's `KernelConfig.home_dir`
 /// (`KernelApi::home_dir()`); it locates the embedded-SDK extraction dir.
+///
+/// The probes run concurrently, capped at [`sidecar_probe_concurrency`]. They
+/// used to run one at a time, and because this is awaited from
+/// `server::build_router` *before* the listener binds, every adapter's Python
+/// startup was paid serially on the boot path — 20-plus sequential
+/// interpreter spawns, which is the 30-second cold start reported in #8094.
+///
+/// Order is not load-bearing: both caches are keyed by
+/// `SidecarCatalogEntry::name`, so the completed set is identical whatever
+/// order the probes finish in. The `adapter=` log lines interleave now, which
+/// is the one observable difference.
 pub async fn populate_sidecar_schema_cache(home_dir: &std::path::Path) {
-    for entry in SIDECAR_CATALOG {
+    use futures::StreamExt;
+
+    futures::stream::iter(SIDECAR_CATALOG.iter().map(|entry| async move {
         let args: Vec<String> = entry.args.iter().map(|s| s.to_string()).collect();
-        match describe_sidecar(entry.command, &args, home_dir).await {
-            Ok(schema) => {
-                tracing::info!(
-                    adapter = entry.name,
-                    fields = schema.fields.len(),
-                    sdk_version = schema.sdk_version.as_deref().unwrap_or("unreported"),
-                    "sidecar schema cached"
-                );
-                write_cache_recover(schema_cache(), "schema").insert(entry.name, schema);
-            }
-            Err(e) => {
-                if let Some(static_fields) = entry.static_fields {
-                    // Use the compile-time fallback so the configure form is
-                    // usable even without a working Python SDK installation.
-                    let fallback = SidecarSchema {
-                        name: entry.name.to_string(),
-                        display_name: entry.display_name.to_string(),
-                        description: entry.description.to_string(),
-                        fields: static_fields
-                            .iter()
-                            .map(|f| SidecarSchemaField {
-                                key: f.key.to_string(),
-                                label: f.label.to_string(),
-                                field_type: f.field_type.to_string(),
-                                required: f.required,
-                                placeholder: f.placeholder.to_string(),
-                                advanced: f.advanced,
-                                options: None,
-                            })
-                            .collect(),
-                        // The fallback exists precisely because `--describe`
-                        // failed, so no adapter reported a version here.
-                        sdk_version: None,
-                    };
-                    tracing::warn!(
-                        adapter = entry.name,
-                        error = %e,
-                        fields = fallback.fields.len(),
-                        "sidecar --describe failed; using compile-time fallback schema"
-                    );
-                    write_cache_recover(schema_cache(), "schema").insert(entry.name, fallback);
-                } else {
-                    tracing::warn!(
-                        adapter = entry.name,
-                        error = %e,
-                        "sidecar --describe failed; channel cards will have no form fields"
-                    );
-                    // Stash the failure reason so every row for this adapter — the discovery card and each configured `[[sidecar_channels]]` instance of the type (#8063) — can tell the operator *why* the form is empty (typically: Python sidecar SDK not installed).
-                    write_cache_recover(schema_error_cache(), "schema error")
-                        .insert(entry.name, e.to_string());
-                }
-            }
-        }
-    }
+        (
+            entry,
+            describe_sidecar(entry.command, &args, home_dir).await,
+        )
+    }))
+    .buffer_unordered(sidecar_probe_concurrency())
+    .for_each(|(entry, result)| async move {
+        apply_sidecar_probe_outcome(entry, result);
+    })
+    .await;
 }
 
 /// Test-only seeder for the sidecar schema cache. Wipes any existing
@@ -2770,5 +2824,111 @@ mod sidecar_configuration_write_tests {
             "update in place, not a second block: {config}"
         );
         assert!(config.contains("ROOM = \"updated\""));
+    }
+}
+
+#[cfg(test)]
+mod sidecar_probe_outcome_tests {
+    use super::{
+        __test_seed_sidecar_schema_cache, __test_seed_sidecar_schema_error_cache,
+        apply_sidecar_probe_outcome, read_cache_recover, schema_cache, schema_error_cache,
+        sidecar_probe_concurrency, SidecarSchema, SIDECAR_CATALOG,
+    };
+    use crate::routes::sidecar_describe::DescribeSidecarError;
+
+    fn entry(name: &str) -> &'static super::SidecarCatalogEntry {
+        SIDECAR_CATALOG
+            .iter()
+            .find(|e| e.name == name)
+            .unwrap_or_else(|| panic!("catalog must contain `{name}`"))
+    }
+
+    /// The cap is a subprocess-count bound, so what matters is that it never
+    /// degenerates to 1 (which is the serial boot #8094 reports) and never
+    /// grows with core count past the point where Python startup dominates.
+    #[test]
+    fn probe_concurrency_stays_within_its_bounds() {
+        let n = sidecar_probe_concurrency();
+        assert!(
+            (2..=8).contains(&n),
+            "concurrency must stay in 2..=8 so a big host cannot fan out one interpreter per adapter, got {n}"
+        );
+    }
+
+    // All three outcomes in ONE test: the schema / error caches are
+    // process-wide and the seeders clear-then-set, so splitting these into
+    // parallel tests would race on the shared maps — same reason
+    // `schema_error_discovery_tests` keeps its halves together.
+    #[test]
+    fn each_probe_outcome_lands_in_exactly_one_cache() {
+        __test_seed_sidecar_schema_cache(&[]);
+        __test_seed_sidecar_schema_error_cache(&[]);
+
+        // --- describe succeeded: the live schema is cached verbatim ---
+        let live = SidecarSchema {
+            name: "gotify".to_string(),
+            display_name: "Gotify".to_string(),
+            description: "probed".to_string(),
+            fields: vec![],
+            sdk_version: Some("9.9.9".to_string()),
+        };
+        apply_sidecar_probe_outcome(entry("gotify"), Ok(live));
+
+        // --- describe failed WITH a compile-time fallback: schema cache gets
+        // the static fields, and no version, because nothing reported one ---
+        apply_sidecar_probe_outcome(
+            entry("telegram"),
+            Err(DescribeSidecarError::SdkMissing(
+                "no sdk (test)".to_string(),
+            )),
+        );
+
+        // --- describe failed WITHOUT a fallback: the reason is cached so the
+        // row can explain the empty form instead of just being empty ---
+        apply_sidecar_probe_outcome(
+            entry("ntfy"),
+            Err(DescribeSidecarError::SdkMissing(
+                "no sdk (test)".to_string(),
+            )),
+        );
+
+        let schemas = read_cache_recover(schema_cache(), "schema");
+        let errors = read_cache_recover(schema_error_cache(), "schema error");
+
+        assert_eq!(
+            schemas.get("gotify").and_then(|s| s.sdk_version.as_deref()),
+            Some("9.9.9"),
+            "a successful probe must cache the adapter's own reported version"
+        );
+        assert!(
+            !errors.contains_key("gotify"),
+            "a success must not also leave an error behind"
+        );
+
+        let telegram = schemas
+            .get("telegram")
+            .expect("an entry with static_fields must fall back into the schema cache");
+        assert!(
+            !telegram.fields.is_empty(),
+            "the compile-time fallback must seed the form"
+        );
+        assert_eq!(
+            telegram.sdk_version, None,
+            "the fallback exists because --describe failed, so no version was reported"
+        );
+        assert!(
+            !errors.contains_key("telegram"),
+            "a usable fallback is not a schema error the operator needs to see"
+        );
+
+        assert!(
+            !schemas.contains_key("ntfy"),
+            "no fallback means no schema — the form is genuinely empty"
+        );
+        assert_eq!(
+            errors.get("ntfy").map(String::as_str),
+            Some("no sdk (test)"),
+            "the failure reason must reach the row so the empty form is explained"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `populate_sidecar_schema_cache` probed the 20-plus `SIDECAR_CATALOG` adapters one at a time, and `server.rs:1575` awaits it inside `build_router` **before** the listener binds — so the API port stayed closed for the sum of every `python3 --describe` spawn. #8094 reports a 30-second cold start on an Orange Pi 5 Plus.
- The probes now run concurrently through `futures::stream::buffer_unordered`, capped by a new `sidecar_probe_concurrency()`.
- The cap is `available_parallelism().clamp(2, 8)`, deliberately a bound rather than unbounded fan-out: each probe is a Python interpreter, and starting one per catalog entry at once would trade a slow boot on a small ARM board for a thrashing one. The floor of 2 keeps a single-core container from regressing to the serial behaviour this PR removes; the ceiling of 8 reflects that the work is dominated by Python import time, not by anything that scales past a handful of cores.
- The per-adapter decision logic moved into `apply_sidecar_probe_outcome`, so no cache lock is held across an `.await` and the three outcomes became unit testable without a working Python install.

## Behaviour

Unchanged, with one observable exception. `SIDECAR_SCHEMA_CACHE` and `SIDECAR_SCHEMA_ERROR_CACHE` are both `HashMap` keyed by `SidecarCatalogEntry::name`, so the completed set is identical regardless of probe completion order. The `adapter=` log lines now interleave instead of appearing in catalog order — noted in the function's doc comment.

No new dependency: `futures` was already a direct dependency of `librefang-api`.

## Verification

- `cargo fmt -p librefang-api`
- `cargo check -p librefang-api --lib` — clean, no new warnings
- `cargo test -p librefang-api --lib sidecar_probe_outcome_tests` — new tests pass

New tests in `sidecar_probe_outcome_tests`:

- `probe_concurrency_stays_within_its_bounds` — asserts the cap never degenerates to 1 (the serial boot this fixes) and never grows past 8.
- `each_probe_outcome_lands_in_exactly_one_cache` — a successful probe caches the adapter's reported `sdk_version` and leaves no error; a failure on an entry *with* `static_fields` lands the compile-time fallback in the schema cache with `sdk_version: None` and no error row; a failure on an entry *without* `static_fields` lands only the reason in the error cache. All three in one test because the caches are process-wide and the seeders clear-then-set, matching the reason `schema_error_discovery_tests` already keeps its halves together.

## Not addressed

#8094 also mentions the model-catalog sync (57 files, also sequential) in the same startup timeline. That lives in a different crate and a different subsystem, so it is not in this diff — the issue's own log shows it costing about one second against the schemas' six, so it is a much smaller share of the reported total.

Closes #8094
