### PR TITLE
feat(runtime,kernel): deliver precise time-of-day as a per-turn message, not the cached system prompt

### DIFF
--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -869,6 +869,15 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
+                // Minute-resolution counterpart to `current_date` above, delivered
+                // via `current_time_msg` metadata (see below) instead of the
+                // cached system prompt, so it doesn't pay the cache-invalidation
+                // cost `current_date` deliberately avoids (#8131).
+                current_time_precise: Some(
+                    chrono::Local::now()
+                        .format("%A, %B %d, %Y %H:%M %Z")
+                        .to_string(),
+                ),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,
@@ -888,6 +897,17 @@ impl LibreFangKernel {
                 manifest.metadata.insert(
                     "canonical_context_msg".to_string(),
                     serde_json::Value::String(cc_msg),
+                );
+            }
+            // Same rationale as canonical_context_msg above: precise time
+            // travels as a per-turn user message, not the cached system
+            // prompt (#8131).
+            if let Some(time_msg) =
+                librefang_runtime::prompt_builder::build_current_time_message(&prompt_ctx)
+            {
+                manifest.metadata.insert(
+                    "current_time_msg".to_string(),
+                    serde_json::Value::String(time_msg),
                 );
             }
 

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -871,13 +871,18 @@ impl LibreFangKernel {
                 ),
                 // Minute-resolution counterpart to `current_date` above, delivered
                 // via `current_time_msg` metadata (see below) instead of the
-                // cached system prompt, so it doesn't pay the cache-invalidation
-                // cost `current_date` deliberately avoids (#8131).
-                current_time_precise: Some(
-                    chrono::Local::now()
-                        .format("%A, %B %d, %Y %H:%M %Z")
-                        .to_string(),
-                ),
+                // cached system prompt. Gated the same way as `canonical_context`
+                // above: `stable_prefix_mode` operators have explicitly opted out
+                // of volatile per-turn message-tail content (#8131).
+                current_time_precise: if stable_prefix_mode {
+                    None
+                } else {
+                    Some(
+                        chrono::Local::now()
+                            .format("%A, %B %d, %Y %H:%M %Z")
+                            .to_string(),
+                    )
+                },
                 active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -13,6 +13,7 @@
 
 use super::*;
 use crate::kernel::llm_drivers::resolve_effective_fallbacks;
+use crate::kernel::prompt_context::{attach_current_time_msg, current_time_precise_for_prompt};
 use crate::MeteringSubsystemApi;
 use librefang_skills::SkillError;
 
@@ -869,20 +870,7 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                // Minute-resolution counterpart to `current_date` above, delivered
-                // via `current_time_msg` metadata (see below) instead of the
-                // cached system prompt. Gated the same way as `canonical_context`
-                // above: `stable_prefix_mode` operators have explicitly opted out
-                // of volatile per-turn message-tail content (#8131).
-                current_time_precise: if stable_prefix_mode {
-                    None
-                } else {
-                    Some(
-                        chrono::Local::now()
-                            .format("%A, %B %d, %Y %H:%M %Z")
-                            .to_string(),
-                    )
-                },
+                current_time_precise: current_time_precise_for_prompt(stable_prefix_mode),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,
@@ -907,14 +895,7 @@ impl LibreFangKernel {
             // Same rationale as canonical_context_msg above: precise time
             // travels as a per-turn user message, not the cached system
             // prompt (#8131).
-            if let Some(time_msg) =
-                librefang_runtime::prompt_builder::build_current_time_message(&prompt_ctx)
-            {
-                manifest.metadata.insert(
-                    "current_time_msg".to_string(),
-                    serde_json::Value::String(time_msg),
-                );
-            }
+            attach_current_time_msg(&mut manifest, &prompt_ctx);
 
             // Pass prompt_caching config to the agent loop via metadata.
             manifest.metadata.insert(

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -13,6 +13,7 @@
 
 use std::sync::Arc;
 
+use crate::kernel::prompt_context::{attach_current_time_msg, current_time_precise_for_prompt};
 use librefang_channels::types::SenderContext;
 use librefang_runtime::agent_loop::{run_agent_loop, AgentLoopResult};
 use librefang_skills::SkillError;
@@ -628,27 +629,13 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                // Minute-resolution counterpart to `current_date` above,
-                // delivered via `current_time_msg` metadata (see below)
-                // instead of the cached system prompt (#8131). This
-                // ephemeral (`/btw`) path DOES run through
+                // This ephemeral (`/btw`) path DOES run through
                 // `agent_loop::prepare_llm_messages` (via `run_agent_loop`
-                // below), same as the other two call sites — round 1 of
-                // this PR's review (F3) found the field populated but never
-                // wired to `current_time_msg`; round 2 wired it but dropped
-                // the `stable_prefix_mode` gate the other two call sites
-                // carry, unconditionally re-adding volatile per-turn
-                // content on a path operators may have opted out of
-                // (caught by adversarial review round 3 on #8132).
-                current_time_precise: if self.config.load_full().stable_prefix_mode {
-                    None
-                } else {
-                    Some(
-                        chrono::Local::now()
-                            .format("%A, %B %d, %Y %H:%M %Z")
-                            .to_string(),
-                    )
-                },
+                // below), same as the other two call sites, so it gets the
+                // same treatment (#8131).
+                current_time_precise: current_time_precise_for_prompt(
+                    self.config.load_full().stable_prefix_mode,
+                ),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 is_group: false,
                 was_mentioned: false,
@@ -657,14 +644,7 @@ impl LibreFangKernel {
             };
             manifest.model.system_prompt =
                 librefang_runtime::prompt_builder::build_system_prompt(&prompt_ctx);
-            if let Some(time_msg) =
-                librefang_runtime::prompt_builder::build_current_time_message(&prompt_ctx)
-            {
-                manifest.metadata.insert(
-                    "current_time_msg".to_string(),
-                    serde_json::Value::String(time_msg),
-                );
-            }
+            attach_current_time_msg(&mut manifest, &prompt_ctx);
         }
 
         // #5980: pre-dispatch per-provider budget gate on the ephemeral
@@ -2758,20 +2738,7 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                // Minute-resolution counterpart to `current_date` above, delivered
-                // via `current_time_msg` metadata (see below) instead of the
-                // cached system prompt. Gated the same way as `canonical_context`
-                // above: `stable_prefix_mode` operators have explicitly opted out
-                // of volatile per-turn message-tail content (#8131).
-                current_time_precise: if stable_prefix_mode {
-                    None
-                } else {
-                    Some(
-                        chrono::Local::now()
-                            .format("%A, %B %d, %Y %H:%M %Z")
-                            .to_string(),
-                    )
-                },
+                current_time_precise: current_time_precise_for_prompt(stable_prefix_mode),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,
@@ -2796,14 +2763,7 @@ impl LibreFangKernel {
             // Same rationale as canonical_context_msg above: precise time
             // travels as a per-turn user message, not the cached system
             // prompt (#8131).
-            if let Some(time_msg) =
-                librefang_runtime::prompt_builder::build_current_time_message(&prompt_ctx)
-            {
-                manifest.metadata.insert(
-                    "current_time_msg".to_string(),
-                    serde_json::Value::String(time_msg),
-                );
-            }
+            attach_current_time_msg(&mut manifest, &prompt_ctx);
 
             // Pass prompt_caching config to the agent loop via metadata.
             manifest.metadata.insert(

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -633,16 +633,22 @@ impl LibreFangKernel {
                 // instead of the cached system prompt (#8131). This
                 // ephemeral (`/btw`) path DOES run through
                 // `agent_loop::prepare_llm_messages` (via `run_agent_loop`
-                // below), same as the other two call sites — an earlier
-                // version of this comment claimed otherwise and left the
-                // field populated but never wired to `current_time_msg`,
-                // silently leaving `/btw` turns without precise time
-                // (caught by adversarial review round 2 on #8132).
-                current_time_precise: Some(
-                    chrono::Local::now()
-                        .format("%A, %B %d, %Y %H:%M %Z")
-                        .to_string(),
-                ),
+                // below), same as the other two call sites — round 1 of
+                // this PR's review (F3) found the field populated but never
+                // wired to `current_time_msg`; round 2 wired it but dropped
+                // the `stable_prefix_mode` gate the other two call sites
+                // carry, unconditionally re-adding volatile per-turn
+                // content on a path operators may have opted out of
+                // (caught by adversarial review round 3 on #8132).
+                current_time_precise: if self.config.load_full().stable_prefix_mode {
+                    None
+                } else {
+                    Some(
+                        chrono::Local::now()
+                            .format("%A, %B %d, %Y %H:%M %Z")
+                            .to_string(),
+                    )
+                },
                 active_goals: self.active_goals_for_prompt(agent_id),
                 is_group: false,
                 was_mentioned: false,

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -628,14 +628,11 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                // Minute-resolution counterpart to `current_date` above, delivered
-                // via `current_time_msg` metadata instead of the cached system
-                // prompt (#8131).
-                current_time_precise: Some(
-                    chrono::Local::now()
-                        .format("%A, %B %d, %Y %H:%M %Z")
-                        .to_string(),
-                ),
+                // This ephemeral (`/btw`) path never runs through
+                // `agent_loop::prepare_llm_messages`, so there is no per-turn
+                // message tail to deliver `current_time_msg` through — same
+                // reasoning as `canonical_context: None` above (#8131).
+                current_time_precise: None,
                 active_goals: self.active_goals_for_prompt(agent_id),
                 is_group: false,
                 was_mentioned: false,
@@ -2738,13 +2735,19 @@ impl LibreFangKernel {
                         .to_string(),
                 ),
                 // Minute-resolution counterpart to `current_date` above, delivered
-                // via `current_time_msg` metadata instead of the cached system
-                // prompt (#8131).
-                current_time_precise: Some(
-                    chrono::Local::now()
-                        .format("%A, %B %d, %Y %H:%M %Z")
-                        .to_string(),
-                ),
+                // via `current_time_msg` metadata (see below) instead of the
+                // cached system prompt. Gated the same way as `canonical_context`
+                // above: `stable_prefix_mode` operators have explicitly opted out
+                // of volatile per-turn message-tail content (#8131).
+                current_time_precise: if stable_prefix_mode {
+                    None
+                } else {
+                    Some(
+                        chrono::Local::now()
+                            .format("%A, %B %d, %Y %H:%M %Z")
+                            .to_string(),
+                    )
+                },
                 active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -628,11 +628,21 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
-                // This ephemeral (`/btw`) path never runs through
-                // `agent_loop::prepare_llm_messages`, so there is no per-turn
-                // message tail to deliver `current_time_msg` through — same
-                // reasoning as `canonical_context: None` above (#8131).
-                current_time_precise: None,
+                // Minute-resolution counterpart to `current_date` above,
+                // delivered via `current_time_msg` metadata (see below)
+                // instead of the cached system prompt (#8131). This
+                // ephemeral (`/btw`) path DOES run through
+                // `agent_loop::prepare_llm_messages` (via `run_agent_loop`
+                // below), same as the other two call sites — an earlier
+                // version of this comment claimed otherwise and left the
+                // field populated but never wired to `current_time_msg`,
+                // silently leaving `/btw` turns without precise time
+                // (caught by adversarial review round 2 on #8132).
+                current_time_precise: Some(
+                    chrono::Local::now()
+                        .format("%A, %B %d, %Y %H:%M %Z")
+                        .to_string(),
+                ),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 is_group: false,
                 was_mentioned: false,
@@ -641,6 +651,14 @@ impl LibreFangKernel {
             };
             manifest.model.system_prompt =
                 librefang_runtime::prompt_builder::build_system_prompt(&prompt_ctx);
+            if let Some(time_msg) =
+                librefang_runtime::prompt_builder::build_current_time_message(&prompt_ctx)
+            {
+                manifest.metadata.insert(
+                    "current_time_msg".to_string(),
+                    serde_json::Value::String(time_msg),
+                );
+            }
         }
 
         // #5980: pre-dispatch per-provider budget gate on the ephemeral

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -628,6 +628,14 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
+                // Minute-resolution counterpart to `current_date` above, delivered
+                // via `current_time_msg` metadata instead of the cached system
+                // prompt (#8131).
+                current_time_precise: Some(
+                    chrono::Local::now()
+                        .format("%A, %B %d, %Y %H:%M %Z")
+                        .to_string(),
+                ),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 is_group: false,
                 was_mentioned: false,
@@ -2729,6 +2737,14 @@ impl LibreFangKernel {
                         .format("%A, %B %d, %Y (%Y-%m-%d %Z)")
                         .to_string(),
                 ),
+                // Minute-resolution counterpart to `current_date` above, delivered
+                // via `current_time_msg` metadata instead of the cached system
+                // prompt (#8131).
+                current_time_precise: Some(
+                    chrono::Local::now()
+                        .format("%A, %B %d, %Y %H:%M %Z")
+                        .to_string(),
+                ),
                 active_goals: self.active_goals_for_prompt(agent_id),
                 context_md,
                 dynamic_sections,
@@ -2748,6 +2764,17 @@ impl LibreFangKernel {
                 manifest.metadata.insert(
                     "canonical_context_msg".to_string(),
                     serde_json::Value::String(cc_msg),
+                );
+            }
+            // Same rationale as canonical_context_msg above: precise time
+            // travels as a per-turn user message, not the cached system
+            // prompt (#8131).
+            if let Some(time_msg) =
+                librefang_runtime::prompt_builder::build_current_time_message(&prompt_ctx)
+            {
+                manifest.metadata.insert(
+                    "current_time_msg".to_string(),
+                    serde_json::Value::String(time_msg),
                 );
             }
 

--- a/crates/librefang-kernel/src/kernel/prompt_context.rs
+++ b/crates/librefang-kernel/src/kernel/prompt_context.rs
@@ -400,6 +400,12 @@ impl LibreFangKernel {
 /// Paired with [`attach_current_time_msg`] — the gate here and the metadata
 /// write there were previously inlined at each dispatch site, and review of
 /// #8132 caught a path that wired one without the other.
+///
+/// **Timezone is the daemon host's, deliberately** (`chrono::Local`), not the
+/// requesting user's — a self-hosted agent's "now" is its own wall clock, and
+/// the daemon has no reliable per-user timezone to prefer anyway. The rendered
+/// `%Z` offset ships with the value, so a user in another timezone reads an
+/// unambiguous timestamp rather than a silently wrong one.
 pub(crate) fn current_time_precise_for_prompt(stable_prefix_mode: bool) -> Option<String> {
     if stable_prefix_mode {
         return None;

--- a/crates/librefang-kernel/src/kernel/prompt_context.rs
+++ b/crates/librefang-kernel/src/kernel/prompt_context.rs
@@ -390,6 +390,98 @@ impl LibreFangKernel {
     }
 }
 
+/// Build the per-turn precise-time value for [`PromptContext::current_time_precise`].
+///
+/// Minute-resolution counterpart to `current_date`, which stays date-only so
+/// the cached system prefix is byte-stable across a day (#3700). Suppressed
+/// under `stable_prefix_mode` for the same reason `canonical_context` is:
+/// that mode is an operator opt-out from volatile per-turn content (#8131).
+///
+/// Paired with [`attach_current_time_msg`] — the gate here and the metadata
+/// write there were previously inlined at each dispatch site, and review of
+/// #8132 caught a path that wired one without the other.
+pub(crate) fn current_time_precise_for_prompt(stable_prefix_mode: bool) -> Option<String> {
+    if stable_prefix_mode {
+        return None;
+    }
+    Some(
+        chrono::Local::now()
+            .format("%A, %B %d, %Y %H:%M %Z")
+            .to_string(),
+    )
+}
+
+/// Attach the per-turn precise-time message to `manifest.metadata` so
+/// `agent_loop::prepare_llm_messages` can append it to the message tail.
+///
+/// Deliberately not part of the system prompt: the tail changes every turn
+/// anyway, so a volatile value there costs nothing, while the same value in
+/// the cached prefix would invalidate it every 60 s (#8131).
+pub(crate) fn attach_current_time_msg(
+    manifest: &mut AgentManifest,
+    prompt_ctx: &librefang_runtime::prompt_builder::PromptContext,
+) {
+    if let Some(time_msg) =
+        librefang_runtime::prompt_builder::build_current_time_message(prompt_ctx)
+    {
+        manifest.metadata.insert(
+            "current_time_msg".to_string(),
+            serde_json::Value::String(time_msg),
+        );
+    }
+}
+
+#[cfg(test)]
+mod current_time_prompt_tests {
+    use super::*;
+
+    #[test]
+    fn precise_time_is_suppressed_under_stable_prefix_mode() {
+        assert_eq!(current_time_precise_for_prompt(true), None);
+    }
+
+    #[test]
+    fn precise_time_carries_minute_resolution_when_enabled() {
+        let value = current_time_precise_for_prompt(false).expect("time present");
+        // Minute resolution is the whole point — `current_date` already
+        // covers the date, and the locked prompt-builder test forbids HH:MM
+        // in the cached system prompt.
+        let has_hh_mm = value.as_bytes().windows(5).any(|w| {
+            w[2] == b':'
+                && w[0].is_ascii_digit()
+                && w[1].is_ascii_digit()
+                && w[3].is_ascii_digit()
+                && w[4].is_ascii_digit()
+        });
+        assert!(has_hh_mm, "expected an HH:MM timestamp, got {value:?}");
+    }
+
+    #[test]
+    fn attach_writes_metadata_only_when_precise_time_present() {
+        let mut ctx = librefang_runtime::prompt_builder::PromptContext {
+            agent_name: "tester".to_string(),
+            ..Default::default()
+        };
+
+        let mut manifest = AgentManifest::default();
+        attach_current_time_msg(&mut manifest, &ctx);
+        assert!(
+            !manifest.metadata.contains_key("current_time_msg"),
+            "no metadata when current_time_precise is None (stable_prefix_mode)"
+        );
+
+        ctx.current_time_precise = Some("Wednesday, September 02, 2026 07:29 GMT+3".to_string());
+        attach_current_time_msg(&mut manifest, &ctx);
+        assert_eq!(
+            manifest
+                .metadata
+                .get("current_time_msg")
+                .and_then(serde_json::Value::as_str),
+            Some("[Current date/time: Wednesday, September 02, 2026 07:29 GMT+3]")
+        );
+    }
+}
+
 #[cfg(test)]
 mod goal_prompt_tests {
     use super::*;

--- a/crates/librefang-runtime/src/agent_loop/prompt.rs
+++ b/crates/librefang-runtime/src/agent_loop/prompt.rs
@@ -860,21 +860,29 @@ pub(super) fn prepare_llm_messages(
 
     // Precise (minute-resolution) current time, kept out of the cached
     // system prompt so it doesn't invalidate provider prompt caching
-    // (#8131). Inserted AFTER the trim above (unlike canonical_context_msg
-    // and mem_msg, which are inserted at the head before trimming) and
-    // right before the current turn — the whole point of this channel is
-    // to survive exactly the long/autonomous sessions that `max_history`
-    // trims down, where the system prompt's date-only field is most likely
-    // to have gone stale. A head insertion here would be the first thing
-    // `safe_trim_messages` drains once a session crosses `max_history`.
+    // (#8131). Appended AFTER the trim above (unlike canonical_context_msg
+    // and mem_msg, which are inserted at the head before trimming) — the
+    // whole point of this channel is to survive exactly the long/autonomous
+    // sessions that `max_history` trims down, where the system prompt's
+    // date-only field is most likely to have gone stale. A head insertion
+    // here would be the first thing `safe_trim_messages` drains once a
+    // session crosses `max_history`.
+    //
+    // Appended strictly AFTER the last message (not inserted before it):
+    // `session_repair::insert_synthetic_results` folds a synthetic
+    // `ToolResult` into an orphaned `ToolUse`'s next user message, which can
+    // be exactly the current-turn message that ends up last here. Inserting
+    // before that message would land this text between the `ToolUse` and
+    // its `ToolResult`, breaking the immediate-adjacency contract every
+    // provider requires (Anthropic/Gemini both 400 on it) — caught by
+    // adversarial review round 2 on #8132.
     if let Some(time_msg) = manifest
         .metadata
         .get("current_time_msg")
         .and_then(|v| v.as_str())
     {
         if !time_msg.is_empty() {
-            let insert_at = messages.len().saturating_sub(1);
-            messages.insert(insert_at, Message::user(time_msg));
+            messages.push(Message::user(time_msg));
         }
     }
     let _working_stripped = strip_prior_image_data(&mut messages);

--- a/crates/librefang-runtime/src/agent_loop/prompt.rs
+++ b/crates/librefang-runtime/src/agent_loop/prompt.rs
@@ -840,6 +840,19 @@ pub(super) fn prepare_llm_messages(
         }
     }
 
+    // Precise (minute-resolution) current time, injected per-turn like
+    // canonical_context_msg above — kept out of the cached system prompt
+    // so it doesn't invalidate provider prompt caching (#8131).
+    if let Some(time_msg) = manifest
+        .metadata
+        .get("current_time_msg")
+        .and_then(|v| v.as_str())
+    {
+        if !time_msg.is_empty() {
+            messages.insert(0, Message::user(time_msg));
+        }
+    }
+
     if let Some(mem_msg) = memory_context_msg {
         messages.insert(
             0,

--- a/crates/librefang-runtime/src/agent_loop/prompt.rs
+++ b/crates/librefang-runtime/src/agent_loop/prompt.rs
@@ -840,19 +840,6 @@ pub(super) fn prepare_llm_messages(
         }
     }
 
-    // Precise (minute-resolution) current time, injected per-turn like
-    // canonical_context_msg above — kept out of the cached system prompt
-    // so it doesn't invalidate provider prompt caching (#8131).
-    if let Some(time_msg) = manifest
-        .metadata
-        .get("current_time_msg")
-        .and_then(|v| v.as_str())
-    {
-        if !time_msg.is_empty() {
-            messages.insert(0, Message::user(time_msg));
-        }
-    }
-
     if let Some(mem_msg) = memory_context_msg {
         messages.insert(
             0,
@@ -870,6 +857,26 @@ pub(super) fn prepare_llm_messages(
         max_history,
     );
     let new_messages_start = session.messages.len().saturating_sub(1);
+
+    // Precise (minute-resolution) current time, kept out of the cached
+    // system prompt so it doesn't invalidate provider prompt caching
+    // (#8131). Inserted AFTER the trim above (unlike canonical_context_msg
+    // and mem_msg, which are inserted at the head before trimming) and
+    // right before the current turn — the whole point of this channel is
+    // to survive exactly the long/autonomous sessions that `max_history`
+    // trims down, where the system prompt's date-only field is most likely
+    // to have gone stale. A head insertion here would be the first thing
+    // `safe_trim_messages` drains once a session crosses `max_history`.
+    if let Some(time_msg) = manifest
+        .metadata
+        .get("current_time_msg")
+        .and_then(|v| v.as_str())
+    {
+        if !time_msg.is_empty() {
+            let insert_at = messages.len().saturating_sub(1);
+            messages.insert(insert_at, Message::user(time_msg));
+        }
+    }
     let _working_stripped = strip_prior_image_data(&mut messages);
     let session_stripped = strip_prior_image_data(&mut session.messages);
     if session_trimmed || session_stripped {

--- a/crates/librefang-runtime/src/agent_loop/tests/sender.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/sender.rs
@@ -1331,15 +1331,105 @@ fn test_prepare_llm_messages_current_time_msg_survives_trim_in_long_session() {
             .map(|m| m.content.text_content())
             .collect::<Vec<_>>()
     );
-    // Must sit right before the current turn, not buried in trimmed history.
+    // Must sit strictly after the current turn (appended, not inserted
+    // before it) — not buried in trimmed history, and never positioned
+    // where it could land between a ToolUse and its ToolResult.
     assert_eq!(
-        messages.last().unwrap().content.text_content(),
+        messages[messages.len() - 2].content.text_content(),
         "current turn"
     );
-    assert!(messages[messages.len() - 2]
+    assert!(messages
+        .last()
+        .unwrap()
         .content
         .text_content()
         .contains("22:41"));
+}
+
+/// Regression for adversarial review round 2 on #8132: `current_time_msg`
+/// must never be inserted between an assistant's `ToolUse` and the user
+/// message carrying its `ToolResult` — `session_repair::insert_synthetic_results`
+/// folds a synthetic `ToolResult` into the next user message after an
+/// orphaned `ToolUse` (e.g. after a crash mid tool-call), which can be
+/// exactly the current-turn message. An earlier version of this fix
+/// inserted `current_time_msg` immediately before the last message, which
+/// split exactly this pair and would 400 against Anthropic/Gemini on the
+/// very next turn.
+#[test]
+fn test_prepare_llm_messages_current_time_msg_never_splits_tool_use_result_pair() {
+    let mut manifest = test_manifest();
+    manifest.metadata.insert(
+        "current_time_msg".to_string(),
+        serde_json::json!("[Current date/time: Tuesday, September 1, 2026 23:00 GMT+3]"),
+    );
+
+    let agent_id = librefang_types::agent::AgentId::new();
+    let mut session = librefang_memory::session::Session {
+        id: librefang_types::agent::SessionId::new(),
+        agent_id,
+        messages: Vec::new(),
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+
+        messages_generation: 0,
+        last_repaired_generation: None,
+        peer_id: None,
+    };
+
+    session.messages.push(Message::user("earlier"));
+    // An orphaned ToolUse (e.g. daemon crashed mid tool-call) with no
+    // ToolResult yet in the session.
+    session.messages.push(Message {
+        role: Role::Assistant,
+        content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+            id: "tu_1".to_string(),
+            name: "noop".to_string(),
+            input: serde_json::json!({}),
+            provider_metadata: None,
+        }]),
+        pinned: false,
+        timestamp: None,
+    });
+    session.messages.push(Message::user("current turn"));
+
+    let PreparedMessages { messages, .. } = prepare_llm_messages(
+        &manifest,
+        &mut session,
+        "current turn",
+        None,
+        DEFAULT_MAX_HISTORY_MESSAGES,
+    );
+
+    // session_repair synthesizes a ToolResult for tu_1 into the next user
+    // message. Find the ToolUse and confirm the very next message carries
+    // its ToolResult — nothing (like current_time_msg) may sit between them.
+    let tool_use_idx = messages
+        .iter()
+        .position(|m| {
+            matches!(&m.content, MessageContent::Blocks(blocks)
+                if blocks.iter().any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "tu_1")))
+        })
+        .expect("orphaned ToolUse present in prepared messages");
+
+    let next = messages
+        .get(tool_use_idx + 1)
+        .expect("a message immediately follows the ToolUse");
+    let carries_result = matches!(&next.content, MessageContent::Blocks(blocks)
+        if blocks.iter().any(|b| matches!(b, ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "tu_1")));
+    assert!(
+        carries_result,
+        "message immediately after ToolUse must carry its ToolResult; got: {:?}",
+        messages
+            .iter()
+            .map(|m| m.content.text_content())
+            .collect::<Vec<_>>()
+    );
+
+    // current_time_msg must still be present somewhere (appended at the end).
+    assert!(messages
+        .iter()
+        .any(|msg| msg.content.text_content().contains("23:00")));
 }
 
 fn orphan_tool_result_message(tool_use_id: &str) -> Message {

--- a/crates/librefang-runtime/src/agent_loop/tests/sender.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/sender.rs
@@ -1277,6 +1277,71 @@ fn test_prepare_llm_messages_new_messages_start_ignores_trimmed_context_injectio
     assert_eq!(new_messages_start, session.messages.len().saturating_sub(1));
 }
 
+/// Regression for #8131: `current_time_msg`, unlike `canonical_context_msg`
+/// and the memory-context injection, must survive `safe_trim_messages` —
+/// it exists specifically to give long/autonomous sessions (the ones most
+/// likely to get trimmed) an accurate clock. A head insertion made before
+/// the trim call would be the first thing drained once the session crosses
+/// `max_history`, silently reintroducing the bug this channel exists to fix.
+#[test]
+fn test_prepare_llm_messages_current_time_msg_survives_trim_in_long_session() {
+    let mut manifest = test_manifest();
+    manifest.metadata.insert(
+        "current_time_msg".to_string(),
+        serde_json::json!("[Current date/time: Tuesday, September 1, 2026 22:41 GMT+3]"),
+    );
+
+    let agent_id = librefang_types::agent::AgentId::new();
+    let mut session = librefang_memory::session::Session {
+        id: librefang_types::agent::SessionId::new(),
+        agent_id,
+        messages: Vec::new(),
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+
+        messages_generation: 0,
+        last_repaired_generation: None,
+        peer_id: None,
+    };
+
+    // Well past DEFAULT_MAX_HISTORY_MESSAGES (60) — a long-running session,
+    // exactly the case this channel targets.
+    for i in 0..40 {
+        session.messages.push(Message::user(format!("q{i}")));
+        session.messages.push(Message::assistant(format!("a{i}")));
+    }
+    session.messages.push(Message::user("current turn"));
+
+    let PreparedMessages { messages, .. } = prepare_llm_messages(
+        &manifest,
+        &mut session,
+        "current turn",
+        None,
+        DEFAULT_MAX_HISTORY_MESSAGES,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|msg| msg.content.text_content().contains("22:41")),
+        "current_time_msg must survive trim in a long session; got: {:?}",
+        messages
+            .iter()
+            .map(|m| m.content.text_content())
+            .collect::<Vec<_>>()
+    );
+    // Must sit right before the current turn, not buried in trimmed history.
+    assert_eq!(
+        messages.last().unwrap().content.text_content(),
+        "current turn"
+    );
+    assert!(messages[messages.len() - 2]
+        .content
+        .text_content()
+        .contains("22:41"));
+}
+
 fn orphan_tool_result_message(tool_use_id: &str) -> Message {
     Message {
         role: Role::User,

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -208,6 +208,12 @@ pub struct PromptContext {
     pub peer_agents: Vec<(String, String, String)>,
     /// Current date/time string for temporal awareness.
     pub current_date: Option<String>,
+    /// Precise current date/time (minute resolution + timezone), delivered
+    /// out-of-band from `current_date` via [`build_current_time_message`] as a
+    /// per-turn user message instead of the cached system prompt — so agents
+    /// get an accurate clock without invalidating provider prompt caching
+    /// (see #8131; sibling mechanism to `canonical_context`).
+    pub current_time_precise: Option<String>,
     /// Active goals (pending/in_progress) assigned to the agent.
     pub active_goals: Vec<ActiveGoalPrompt>,
     /// Current on-disk `context.md` content for the agent (see `agent_context`).
@@ -596,6 +602,21 @@ pub fn build_canonical_context_message(ctx: &PromptContext) -> Option<String> {
         .as_ref()
         .filter(|c| !c.is_empty())
         .map(|c| format!("[Previous conversation context]\n{}", cap_str(c, 2000)))
+}
+
+/// Build the precise current time as a standalone user message (instead of system prompt).
+///
+/// `current_date` in the system prompt is deliberately date-only (see
+/// `current_date_section_omits_minute_precision_timestamp`) to keep the cached
+/// prefix byte-stable across turns. This delivers minute-resolution time the
+/// same way `build_canonical_context_message` delivers canonical context —
+/// as a per-turn, non-cached user message — so agents get an accurate clock
+/// without paying for cache invalidation (#8131).
+pub fn build_current_time_message(ctx: &PromptContext) -> Option<String> {
+    ctx.current_time_precise
+        .as_ref()
+        .filter(|t| !t.is_empty())
+        .map(|t| format!("[Current date/time: {t}]"))
 }
 
 /// Build the memory section (Section 4).

--- a/crates/librefang-runtime/src/prompt_builder/tests.rs
+++ b/crates/librefang-runtime/src/prompt_builder/tests.rs
@@ -1451,3 +1451,27 @@ fn current_date_section_omits_minute_precision_timestamp() {
         "## Current Date section must not embed a HH:MM timestamp. Got: {date_section:?}"
     );
 }
+
+#[test]
+fn current_time_message_carries_minute_precision_outside_system_prompt() {
+    let mut ctx = basic_ctx();
+    ctx.current_date = Some("Wednesday, April 29, 2026 (2026-04-29 UTC)".to_string());
+    ctx.current_time_precise = Some("Wednesday, April 29, 2026 14:37 UTC".to_string());
+
+    // The system prompt itself stays untouched — precision lives only in
+    // the side-channel message (#8131).
+    let prompt = build_system_prompt(&ctx);
+    assert!(!prompt.contains("14:37"));
+
+    let time_msg = build_current_time_message(&ctx).expect("time message present");
+    assert_eq!(
+        time_msg,
+        "[Current date/time: Wednesday, April 29, 2026 14:37 UTC]"
+    );
+}
+
+#[test]
+fn current_time_message_absent_when_unset() {
+    let ctx = basic_ctx();
+    assert_eq!(build_current_time_message(&ctx), None);
+}

--- a/crates/librefang-runtime/src/silent_response.rs
+++ b/crates/librefang-runtime/src/silent_response.rs
@@ -859,6 +859,7 @@ mod tests {
             tools_md: Some("tools".to_string()),
             peer_agents: vec![("peer".to_string(), "Idle".to_string(), "haiku".to_string())],
             current_date: Some("Friday, 2026-05-16".to_string()),
+            current_time_precise: Some("Friday, May 16, 2026 14:30 UTC".to_string()),
             active_goals: vec![crate::prompt_builder::ActiveGoalPrompt {
                 id: "cc016c43-b781-4434-aeb7-f87d56af1522".to_string(),
                 title: "goal".to_string(),


### PR DESCRIPTION
Fixes #8131.

## What

`current_date` stays date-only in the system prompt (per #3700 / #3956, locked by `current_date_section_omits_minute_precision_timestamp`) so the cached prefix stays byte-stable across turns. But there was never a replacement channel for minute-resolution time, so agents have no reliable clock — this surfaces as confusing "today" vs "yesterday" in long-running/autonomous sessions.

## How

Mirrors the existing `canonical_context` / `build_canonical_context_message` mechanism, which already solves this exact class of problem for cross-channel context:

- `PromptContext.current_time_precise: Option<String>` (new field, minute + timezone resolution) alongside the existing `current_date`.
- `build_current_time_message()` in `prompt_builder.rs` — formats it as `[Current date/time: ...]`, analogous to `build_canonical_context_message`.
- Populated at the two call sites that already wire `canonical_context_msg` (`kernel/agent_execution.rs`, `kernel/messaging.rs`), stored in `manifest.metadata["current_time_msg"]`.
- Consumed in `agent_loop/prompt.rs::prepare_llm_messages` the same way `canonical_context_msg` is: inserted as a synthetic, non-persisted `user` message ahead of history — never entering the cached `system` block.

The system prompt and its locked byte-stability contract are untouched — `current_date_section_omits_minute_precision_timestamp` and `build_system_prompt_is_byte_stable_for_fixed_current_date` both still pass unmodified.

## Testing

- `cargo test -p librefang-runtime --lib prompt_builder` — 103 passed, including both pre-existing locked tests plus 2 new ones (`current_time_message_carries_minute_precision_outside_system_prompt`, `current_time_message_absent_when_unset`)
- `cargo test -p librefang-runtime --lib agent_loop::prompt` and `agent_loop::tests::sender` — unaffected, all green
- `cargo check -p librefang-runtime -p librefang-kernel --tests` — clean
- `cargo fmt --check` on touched files — clean

Happy to adjust the message format/wording if maintainers prefer something different.