### PR TITLE
fix(api): owner-scope the agent WebSocket upgrade

### DIFF
--- a/changelog.d/security/8137-ws-agent-owner-scope.md
+++ b/changelog.d/security/8137-ws-agent-owner-scope.md
@@ -1,0 +1,4 @@
+Closed a cross-user hole in the agent chat WebSocket: it authenticated the bearer but never checked that the caller owned the agent, so any `User`-role token could open a socket on an agent authored by someone else and drive full LLM turns on it — tool execution and provider spend included — by guessing or enumerating its UUID.
+The REST twin `POST /api/agents/{id}/message` has carried that ownership check since #6753; the upgrade path had only an existence check, and now runs the same one, refusing with the same not-found shape so a non-owner cannot use the status to confirm the id exists.
+Admins and the agent's own author are unaffected, as are loopback and no-auth deployments.
+(#8137) (@houko)

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -652,6 +652,22 @@ pub async fn agent_ws(
         }
     }
 
+    // Owner-scoping (#6753), mirroring `routes::agents::messaging::send_message`.
+    // `min_role_for_privileged_get` in `middleware.rs` lowers `/api/agents/{id}/ws` to `User` on the stated theory that the socket is equivalent to `POST /api/agents/{id}/message`, and it is — but the REST twin pairs that role with an explicit ownership check, and this handler had only an existence check.
+    // Without this a non-owner could drive a full LLM turn — tool execution and budget spend included — on another user's agent by guessing/enumerating its UUID, and over a socket that also carries the `/model`, `/new`, `/compact` and `/stop` commands.
+    // The refusal is the same not-found shape the REST twin returns rather than a 403, so a `User` who does not own the agent cannot use the status to confirm that the id exists.
+    {
+        let api_user = authenticated_user.clone().map(axum::Extension);
+        if !crate::routes::can_access_agent(&state, agent_id, api_user.as_ref()) {
+            warn!(
+                agent_id = %id,
+                user = authenticated_user.as_ref().map(|u| u.name.as_str()).unwrap_or("<none>"),
+                "WebSocket upgrade rejected: agent is not accessible to this user"
+            );
+            return axum::http::StatusCode::NOT_FOUND.into_response();
+        }
+    }
+
     // Optional per-connection explicit session_id override (issue #2959).
     // When present, every send on this socket targets the given session —
     // two browser tabs on the same agent with different `?session_id=` values

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -283,6 +283,28 @@ memory_read = ["*"]
 memory_write = ["self.*"]
 "#;
 
+/// `TEST_MANIFEST` with `author = "Eve"`, for tests whose subject is the attachment-ownership boundary rather than agent ownership.
+///
+/// Owner-scoping runs ahead of attachment resolution on both message paths — #6753 for `POST /api/agents/{id}/message`, #8137 for the `GET /api/agents/{id}/ws` upgrade — so a caller who does not author the agent is turned away before the attachment check ever runs: 404 `agent_not_found` on the REST route, 404 on the socket handshake.
+/// Isolating the attachment check therefore needs the caller to own the agent while somebody else owns the upload.
+const EVE_MANIFEST: &str = r#"
+name = "eve-agent"
+version = "0.1.0"
+description = "Integration test agent owned by Eve"
+author = "Eve"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent. Reply concisely."
+
+[capabilities]
+tools = ["file_read"]
+memory_read = ["*"]
+memory_write = ["self.*"]
+"#;
+
 /// Manifest that uses Groq for real LLM tests.
 const LLM_MANIFEST: &str = r#"
 name = "test-agent"
@@ -5248,31 +5270,8 @@ async fn test_upload_owner_metadata_survives_registry_miss() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn message_routes_reject_foreign_upload_attachments() {
-    // The agent is authored by Eve on purpose. The owner-scoping guard added in
-    // #6753 runs ahead of attachment resolution in `send_message`, so a caller
-    // who cannot reach the agent at all is turned away with 404
-    // `agent_not_found` (covered by `non_owner_cannot_message_another_users_agent`
-    // in `owner_scoped_routes_integration.rs`) and never reaches the check this
-    // test is about. Eve owning the agent while Alice owns the upload is what
-    // isolates the attachment-ownership boundary.
-    const EVE_MANIFEST: &str = r#"
-name = "eve-agent"
-version = "0.1.0"
-description = "Integration test agent owned by Eve"
-author = "Eve"
-module = "builtin:chat"
-
-[model]
-provider = "ollama"
-model = "test-model"
-system_prompt = "You are a test agent. Reply concisely."
-
-[capabilities]
-tools = ["file_read"]
-memory_read = ["*"]
-memory_write = ["self.*"]
-"#;
-
+    // Eve authors the agent so that the owner-scoping guard (#6753) admits her and the attachment check is what decides the outcome; `non_owner_cannot_message_another_users_agent` in `owner_scoped_routes_integration.rs` covers the guard itself.
+    // See `EVE_MANIFEST`.
     let server = start_test_server_with_rbac_users(
         "any-key",
         vec![
@@ -5437,6 +5436,8 @@ async fn websocket_rejects_foreign_attachment_with_structured_error() {
     use futures::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
 
+    // Eve authors the agent so the #8137 owner-scope guard on the upgrade admits her and the attachment check is what decides the outcome; `non_owner_user_cannot_upgrade_a_websocket_on_another_users_agent` in `ws_agent_owner_scope_test.rs` covers the guard itself.
+    // See `EVE_MANIFEST`.
     let server = start_test_server_with_rbac_users(
         "any-key",
         vec![
@@ -5449,7 +5450,7 @@ async fn websocket_rejects_foreign_attachment_with_structured_error() {
     let spawn = client
         .post(format!("{}/api/agents", server.base_url))
         .header("authorization", "Bearer any-key")
-        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .json(&serde_json::json!({"manifest_toml": EVE_MANIFEST}))
         .send()
         .await
         .unwrap();

--- a/crates/librefang-api/tests/ws_agent_owner_scope_test.rs
+++ b/crates/librefang-api/tests/ws_agent_owner_scope_test.rs
@@ -1,0 +1,173 @@
+//! Owner-scoping on the agent-chat WebSocket upgrade (#6753 follow-up).
+//!
+//! `middleware::min_role_for_privileged_get` lowers `/api/agents/{id}/ws` to `UserRole::User` because the socket grants the same capability as `POST /api/agents/{id}/message`.
+//! The REST twin pairs that role with an explicit `can_access_agent` call (`routes/agents/messaging.rs`), and the upgrade handler used to carry only an existence check — so any `User`-role token could open a socket on an agent authored by someone else and drive a full LLM turn on it.
+//! These tests pin the two halves of the rule the REST twin already satisfies: a non-owner `User` is refused, and the owner is still let through.
+//!
+//! The router mounts `agent_ws` **alone**, with no auth middleware layer, for the same reason `hash_only_master_key_ws_auth.rs` does: with the middleware in front a 404 could be attributed to either layer, and the handler's own authorization is the thing under test.
+//! `agent_ws` authenticates the bearer itself against the kernel's `[[users]]` snapshot, so the identity the assertions turn on is resolved entirely inside the handler.
+//!
+//! Raw TCP rather than an HTTP client because `axum::extract::WebSocketUpgrade` answers 426 before the handler body runs unless `Connection`, `Upgrade`, `Sec-WebSocket-Version` and `Sec-WebSocket-Key` are all intact, and a general-purpose client manages `Connection` itself.
+//! No `Origin` header is sent, which the `validate_ws_origin` step treats as a non-browser client and lets through, so every status below is the authorization verdict.
+
+use axum::routing::get;
+use axum::Router;
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_types::agent::{AgentId, AgentManifest};
+use librefang_types::config::UserConfig;
+use std::net::SocketAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const ALICE_KEY: &str = "alice-ws-owner-scope-key";
+const BOB_KEY: &str = "bob-ws-owner-scope-key";
+const ADMIN_KEY: &str = "admin-ws-owner-scope-key";
+
+/// The upgrade completed, so the caller reached the socket that drives agent turns.
+const UPGRADED: u16 = 101;
+/// The not-found shape the REST twin uses for a non-owner, deliberately not 403: a `User` who does not own the agent must not be able to confirm from the status that the id exists.
+const REFUSED: u16 = 404;
+
+struct TestServer {
+    addr: SocketAddr,
+    state: std::sync::Arc<librefang_api::routes::AppState>,
+    _test: TestAppState,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.state.kernel.shutdown();
+    }
+}
+
+/// Boot a daemon with three `[[users]]` api keys and no master credential.
+///
+/// The keys live in `KernelConfig.users`, not only on `AppState`, because the upgrade path resolves them through `server::configured_user_api_keys(&auth_snapshot)` rather than from the middleware's table.
+/// Leaving `api_key` empty keeps the master credential out of the picture while `auth_required` still holds — `master_auth_required` is satisfied by a non-empty user-key list — so the handler resolves a real named principal for every request below instead of the synthetic root `Owner`.
+async fn start() -> TestServer {
+    let users = [
+        ("Alice", "user", ALICE_KEY),
+        ("Bob", "user", BOB_KEY),
+        ("Admin", "admin", ADMIN_KEY),
+    ];
+    let configs: Vec<UserConfig> = users
+        .iter()
+        .map(|(name, role, key)| UserConfig {
+            name: name.to_string(),
+            role: role.to_string(),
+            api_key_hash: Some(
+                librefang_api::password_hash::hash_password(key).expect("hash test key"),
+            ),
+            ..Default::default()
+        })
+        .collect();
+
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(move |cfg| {
+        cfg.api_key = String::new();
+        cfg.api_key_hash = String::new();
+        cfg.users = configs;
+    }));
+    let state = test.state.clone();
+    state.kernel.clone().set_self_handle();
+
+    let app = Router::new()
+        .route("/api/agents/{id}/ws", get(librefang_api::ws::agent_ws))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    TestServer {
+        addr,
+        state,
+        _test: test,
+    }
+}
+
+/// Register an agent whose manifest `author` is `author` — the field `can_access_agent` compares against the authenticated user's name.
+fn spawn_authored(server: &TestServer, author: &str) -> AgentId {
+    server
+        .state
+        .kernel
+        .spawn_agent_typed(AgentManifest {
+            name: format!("ws-owner-scope-{}", uuid::Uuid::new_v4()),
+            source_template: None,
+            author: author.to_string(),
+            ..AgentManifest::default()
+        })
+        .expect("spawn authored test agent")
+}
+
+/// Perform a WebSocket handshake for `agent_id` as the holder of `bearer`, and return the HTTP status of the response.
+async fn ws_handshake_status(server: &TestServer, agent_id: AgentId, bearer: &str) -> u16 {
+    let mut stream = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect to test server");
+    let request = format!(
+        "GET /api/agents/{agent_id}/ws HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         Authorization: Bearer {bearer}\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write handshake");
+    let mut buf = [0u8; 256];
+    let read = stream.read(&mut buf).await.expect("read response");
+    let head = String::from_utf8_lossy(&buf[..read]);
+    let status_line = head.lines().next().unwrap_or_default().to_string();
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("no status code in response: {status_line:?}"))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn non_owner_user_cannot_upgrade_a_websocket_on_another_users_agent() {
+    // The gap itself. Pre-fix the handler checked only that the agent existed, so Bob's `User` key completed the handshake on Alice's agent and every message he sent afterwards ran a turn — tool execution and provider spend included — under her manifest.
+    let server = start().await;
+    let alices_agent = spawn_authored(&server, "Alice");
+    assert_eq!(
+        ws_handshake_status(&server, alices_agent, BOB_KEY).await,
+        REFUSED,
+        "a User-role token that does not author the agent must not reach the socket that drives its turns"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_user_can_still_upgrade_a_websocket_on_their_own_agent() {
+    // The other half of the rule: the check must not close the socket for the person it belongs to, which is what a blanket role bump to Admin would have done.
+    let server = start().await;
+    let alices_agent = spawn_authored(&server, "Alice");
+    assert_eq!(
+        ws_handshake_status(&server, alices_agent, ALICE_KEY).await,
+        UPGRADED,
+        "the agent's author must keep the dashboard chat socket"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_can_upgrade_a_websocket_on_any_agent() {
+    // `can_access_agent` lets `Admin`+ inspect every agent, and the WS path must adopt that whole rule rather than only its owner clause — operators drive other people's agents from the dashboard.
+    let server = start().await;
+    let alices_agent = spawn_authored(&server, "Alice");
+    assert_eq!(
+        ws_handshake_status(&server, alices_agent, ADMIN_KEY).await,
+        UPGRADED,
+        "an Admin key must not be owner-scoped out of an agent socket"
+    );
+}


### PR DESCRIPTION
## Mechanism

The agent chat WebSocket authenticates but never authorizes.

`crates/librefang-api/src/middleware.rs:474-482` (`min_role_for_privileged_get`) lowers `/api/agents/{id}/ws` to `UserRole::User`, on the stated theory that the socket is equivalent to `POST /api/agents/{id}/message`:

```rust
if path.starts_with("/api/agents/") && path.ends_with("/ws") {
    return Some(UserRole::User);
}
```

The theory is right, but the REST twin pairs that role with an explicit ownership check that the upgrade handler does not have — `crates/librefang-api/src/routes/agents/messaging.rs:87-93`:

```rust
// Owner-scoping (#6753): `agent_message` in `middleware::user_role_allows_request` deliberately lets any `User`-role caller POST `/message` on an arbitrary agent id.
// Without this check a non-owner could drive a full LLM turn — tool execution and budget spend included — on another user's agent by guessing/enumerating its UUID …
if !super::super::can_access_agent(&state, agent_id, api_user.as_ref()) { … not_found … }
```

`agent_ws` (`crates/librefang-api/src/ws.rs:433`) resolves the caller into `authenticated_user` and then only checks that the agent **exists** — the retry loop ending at `ws.rs:649-652` with `if !found { return NOT_FOUND }`.
`can_access_agent` is never called; `authenticated_user` is carried straight into `WsClientContext` and handed to `handle_agent_ws`.
So any `User`-role token completed the handshake on an agent authored by someone else and could then drive full LLM turns on it — tool execution and provider spend included — plus the socket's `/model`, `/new`, `/compact` and `/stop` commands.

## Fix

`crates/librefang-api/src/ws.rs`: after the existence lookup and before the upgrade, call `routes::can_access_agent` with the resolved principal and refuse with the same not-found shape the REST twin returns.
Not-found rather than forbidden is deliberate and matches `can_access_agent`'s own doc-comment: a `User` who does not own the agent must not be able to use the status to confirm that the id exists.

The check inherits the whole of `can_access_agent`, not just its owner clause:

- `Admin`/`Owner` still reach every agent.
- A principal of `None` is still allowed, which is the loopback / no-auth deployment contract; in that mode `agent_ws` already attributes the caller as the synthetic root `Owner` anyway.
- A dashboard session token whose `user_name`/`user_role` are unset resolves to `None` and is unaffected, so the single-user dashboard login keeps full access.

Paired mobile devices are not affected: `agent_ws` resolves user keys through `server::configured_user_api_keys(&auth_snap)` only, and `paired_device_user_keys` is merged solely into the middleware's table (`server.rs:1611`), which this handler does not read.
A `device:{id}` bearer therefore never authenticated this upgrade in the first place, before or after this change.

## Test

New `crates/librefang-api/tests/ws_agent_owner_scope_test.rs`, three `#[tokio::test]`s against a real axum server over a raw TCP handshake, following the conventions already established by `hash_only_master_key_ws_auth.rs` and `ws_origin_validation_test.rs` (raw bytes because `WebSocketUpgrade` answers 426 before the handler body runs unless the handshake headers are intact; `agent_ws` mounted alone with no auth middleware so every status is the handler's own verdict).

- `non_owner_user_cannot_upgrade_a_websocket_on_another_users_agent` — Bob's `User` key against an agent whose manifest `author` is Alice must get 404.
- `owner_user_can_still_upgrade_a_websocket_on_their_own_agent` — Alice's key against her own agent must still get 101.
- `admin_can_upgrade_a_websocket_on_any_agent` — an `Admin` key against Alice's agent must still get 101.

Why it would have caught this: the discriminator is 101-vs-404 on a real registered agent, so the first test asserts precisely the thing that was missing.
Verified failing on the base commit — with `ws.rs` reverted to `origin/main` it reports:

```
thread 'non_owner_user_cannot_upgrade_a_websocket_on_another_users_agent' panicked at
crates/librefang-api/tests/ws_agent_owner_scope_test.rs:144:5:
assertion `left == right` failed: a User-role token that does not author the agent must not reach the socket that drives its turns
  left: 101
 right: 404
```

The two positive tests pass on the base commit as well, which is the point — they are the regression guard against over-tightening.

## Verification

```
cargo fmt -p librefang-api
cargo check -p librefang-api --lib
cargo clippy -p librefang-api --all-targets -- -D warnings
cargo test -p librefang-api --test ws_agent_owner_scope_test   # 3 passed
```

`clippy` and `check` were each re-run after `touch`ing the changed sources, so the `Checking librefang-api` line is present rather than a cached green.

## Deliberately left out

The audit that produced this finding also suggested gating the socket's mutating command arms (`/model`, `/new`, `/compact`, `/stop`) at `Admin`+.
That is not done here: it changes what a paired mobile device or an ordinary `User` can do to their **own** agent, which is a product decision rather than a bug fix, and it needs a maintainer call.
This PR only closes the cross-user gap, and after it those commands are reachable only by a principal who already passes `can_access_agent` for that agent.

Not verified locally: the workspace-wide build and the full `librefang-api` test suite.
Both were scoped down because several agents share this machine's `target/` directory, and the run above filled the disk once already.
CI covers them.

## Collateral test fix (b24e6112b)

CI caught one existing test that depended on the hole this PR closes: `websocket_rejects_foreign_attachment_with_structured_error` in `crates/librefang-api/tests/api_integration_test.rs` spawned the agent from `TEST_MANIFEST` (`author = "test"`) and then opened the socket as Eve, a `user`-role principal, so with the guard in place Eve is refused at the handshake and the test panicked unwrapping a 404 upgrade response.

The REST twin already had to be written the other way round for exactly this reason: `message_routes_reject_foreign_upload_attachments` carries an Eve-authored manifest because #6753 put the owner-scope guard ahead of attachment resolution in `send_message`.
The socket test now takes the same shape — Eve authors the agent, Alice owns the upload — so the attachment-ownership boundary is what decides the outcome rather than agent ownership, and the assertion the test exists for (`upload_access_denied` with the structured error shape) is unchanged.

That this test needed updating is itself evidence for the fix: it was asserting attachment behaviour on a socket that a non-owner should never have reached.

The Eve-authored manifest moves to file scope as `EVE_MANIFEST` rather than being copied, since two tests now need it.

Verified:

```
cargo test -p librefang-api --test api_integration_test -- \
  websocket_rejects_foreign_attachment_with_structured_error \
  message_routes_reject_foreign_upload_attachments      # 2 passed
cargo clippy -p librefang-api --all-targets -- -D warnings   # exit 0
```
