### PR TITLE
fix(kernel): keep the resolved exec_policy across manifest replacement

### DIFF
--- a/changelog.d/fixed/8138-exec-policy-survives-manifest-replacement.md
+++ b/changelog.d/fixed/8138-exec-policy-survives-manifest-replacement.md
@@ -1,0 +1,4 @@
+Hot-reloading an agent's `agent.toml`, or saving its manifest from the dashboard, no longer clears the shell policy the agent was running under.
+`exec_policy` is resolved once from your global `[exec_policy]` when the agent starts and is not written into the manifest file you edit, so both of those paths used to replace it with "unset" — and nothing downstream reads "unset" as deny, which handed a `deny` agent the `shell_exec` tool back and skipped the allowlist on every command until the daemon was restarted.
+An `[exec_policy]` you write in `agent.toml` still takes precedence, as before.
+(#8138) (@houko)

--- a/crates/librefang-kernel/src/kernel/agent_state.rs
+++ b/crates/librefang-kernel/src/kernel/agent_state.rs
@@ -56,6 +56,22 @@ fn patch_mcp_servers(source: &str, servers: &[String]) -> Result<String, String>
     Ok(patched)
 }
 
+/// Carry a resolved `exec_policy` from the running registry entry onto a replacement manifest that leaves it unset.
+///
+/// `exec_policy` is normally absent from `agent.toml`.
+/// It is materialized once, when the agent enters the registry, by `spawn_agent_inner`, the boot restore loop, or hand activation — each of which stamps the global `[exec_policy]` when the manifest carries `None`.
+/// Every consumer downstream reads `None` as "no policy declared", not as "deny": `available_tools` strips `shell_exec` only when the mode is explicitly `Deny`, and the runtime's `shell_exec` dispatch runs the deny / allowlist check inside an `if let Some(policy)`.
+/// A manifest replacement that dropped the resolved policy back to `None` therefore handed a `Deny` agent the `shell_exec` tool definition again and skipped the allowlist on every command it ran, self-healing only at the next daemon restart.
+///
+/// Preserving the previous value rather than re-stamping the global config is deliberate.
+/// The three materialization sites disagree on purpose — hand activation inherits the global mode and raises the exec timeouts to their hand floors, where `spawn_agent_inner` promotes to `Full` for an agent that declares `shell_exec` — so recomputing from the global config here would rewrite a hand agent's policy on an unrelated reload.
+/// An operator who wants a different policy writes `[exec_policy]` into `agent.toml`, which wins because it arrives as `Some`.
+fn preserve_resolved_exec_policy(incoming: &mut AgentManifest, current: &AgentManifest) {
+    if incoming.exec_policy.is_none() {
+        incoming.exec_policy = current.exec_policy.clone();
+    }
+}
+
 impl LibreFangKernel {
     fn agent_manifest_path(
         &self,
@@ -323,13 +339,8 @@ impl LibreFangKernel {
 
     /// Reload an agent's manifest from its source agent.toml on disk.
     ///
-    /// At boot the kernel reads agent.toml and syncs it into the in-memory
-    /// registry, but runtime edits to the file are otherwise invisible until
-    /// the next restart. This method re-reads the file, preserves
-    /// runtime-only fields that TOML doesn't carry (workspace path, tags,
-    /// current enabled state), replaces the in-memory manifest, persists it
-    /// to the DB, and invalidates the tool cache so the updated skill / MCP
-    /// allowlists take effect on the next message.
+    /// At boot the kernel reads agent.toml and syncs it into the in-memory registry, but runtime edits to the file are otherwise invisible until the next restart.
+    /// This method re-reads the file, preserves the runtime-only fields that TOML doesn't carry (workspace path, tags, current enabled state, resolved `exec_policy`), replaces the in-memory manifest, persists it to the DB, and invalidates the tool cache so the updated skill / MCP allowlists take effect on the next message.
     pub fn reload_agent_from_disk(&self, agent_id: AgentId) -> KernelResult<()> {
         let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
@@ -402,6 +413,7 @@ impl LibreFangKernel {
         if disk_manifest.workspace.is_none() {
             disk_manifest.workspace = entry.manifest.workspace.clone();
         }
+        preserve_resolved_exec_policy(&mut disk_manifest, &entry.manifest);
         // Always preserve the name. Renaming would also need to update
         // `entry.name` and the registry's `name_index`, which reload does
         // not touch — a renamed manifest without those updates would
@@ -496,6 +508,7 @@ impl LibreFangKernel {
     ///   from the incoming manifest, the system-owned `hand:*` half stays
     ///   pinned to the running agent (#7742)
     /// - `workspace` is preserved when the incoming manifest leaves it unset
+    /// - `exec_policy` is preserved on the same terms — see `preserve_resolved_exec_policy`
     pub fn update_manifest(
         &self,
         agent_id: AgentId,
@@ -517,6 +530,7 @@ impl LibreFangKernel {
         if new_manifest.workspace.is_none() {
             new_manifest.workspace = entry.manifest.workspace.clone();
         }
+        preserve_resolved_exec_policy(&mut new_manifest, &entry.manifest);
         new_manifest.name = entry.manifest.name.clone();
         // Before #7742 this was an unconditional `= entry.manifest.tags`, which made `tags` the one manifest field no API route could reach.
         // The dashboard, `PATCH /api/agents/{id}` with `manifest_toml` and the CLI all funnel here, so every one of them reported a successful save and changed nothing.

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2893,6 +2893,113 @@ fn test_shell_exec_available_when_declared_in_tools_without_explicit_exec_policy
     kernel.shutdown();
 }
 
+/// A spawn-resolved `exec_policy` must survive both manifest-replacement paths: `reload_agent_from_disk` and `update_manifest`.
+///
+/// `exec_policy` is materialized when the agent enters the registry and is not part of the `agent.toml` an operator maintains, so both paths parsed a policy-less manifest and assigned it verbatim, blanking the field.
+/// `None` does not mean "deny" to any consumer: `available_tools` strips `shell_exec` only on an explicit `Deny`, and the runtime's `shell_exec` dispatch gates the whole deny / allowlist check on `if let Some(policy)`.
+/// So a hot-reload — or any `PATCH /api/agents/{id}` with a `manifest_toml`, which routes through `update_manifest` — silently un-restricted the agent's shell until the next daemon restart re-stamped the policy.
+///
+/// The global policy here is `Allowlist` rather than the compiled default `Deny` so a blanked field cannot be mistaken for a correctly inherited one, and `allowed_commands` is asserted too: preserving only the mode would still drop the operator's command list.
+#[tokio::test(flavor = "multi_thread")]
+async fn resolved_exec_policy_survives_reload_and_update_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-kernel-exec-policy-restamp");
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let global_policy = librefang_types::config::ExecPolicy {
+        mode: librefang_types::config::ExecSecurityMode::Allowlist,
+        allowed_commands: vec!["git".to_string(), "ls".to_string()],
+        ..Default::default()
+    };
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        exec_policy: global_policy.clone(),
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    // The on-disk manifest carries no `[exec_policy]`, which is the normal case — the field is a resolved runtime value, not something an operator writes.
+    let toml_path = home_dir.join("agent-src").join("agent.toml");
+    std::fs::create_dir_all(toml_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &toml_path,
+        "name = \"exec-policy-agent\"\n\
+         description = \"agent that declares no exec_policy of its own\"\n\
+         author = \"test\"\n\
+         module = \"builtin:chat\"\n",
+    )
+    .unwrap();
+
+    let manifest = AgentManifest {
+        name: "exec-policy-agent".to_string(),
+        description: "agent that declares no exec_policy of its own".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        exec_policy: None,
+        ..Default::default()
+    };
+
+    let agent_id = kernel
+        .spawn_agent_with_source(manifest, Some(toml_path.clone()))
+        .expect("spawn should succeed");
+
+    let resolved_policy = |stage: &str| {
+        let entry = kernel
+            .agents
+            .registry
+            .get(agent_id)
+            .unwrap_or_else(|| panic!("agent must still be registered {stage}"));
+        let policy = entry
+            .manifest
+            .exec_policy
+            .clone()
+            .unwrap_or_else(|| panic!("exec_policy must still be resolved {stage}"));
+        (policy.mode, policy.allowed_commands)
+    };
+
+    let expected = (
+        librefang_types::config::ExecSecurityMode::Allowlist,
+        vec!["git".to_string(), "ls".to_string()],
+    );
+
+    assert_eq!(
+        resolved_policy("after spawn"),
+        expected,
+        "spawn must materialize the global exec_policy onto a manifest that declares none"
+    );
+
+    kernel
+        .reload_agent_from_disk(agent_id)
+        .expect("hot-reload should succeed");
+    assert_eq!(
+        resolved_policy("after reload_agent_from_disk"),
+        expected,
+        "hot-reload must not drop the resolved exec_policy — None re-exposes shell_exec and skips the allowlist"
+    );
+
+    let mut replacement = kernel
+        .agents
+        .registry
+        .get(agent_id)
+        .expect("agent must be registered")
+        .manifest
+        .clone();
+    replacement.exec_policy = None;
+    kernel
+        .update_manifest(agent_id, replacement)
+        .expect("manifest update should succeed");
+    assert_eq!(
+        resolved_policy("after update_manifest"),
+        expected,
+        "update_manifest must not drop the resolved exec_policy either"
+    );
+
+    kernel.shutdown();
+}
+
 #[test]
 fn test_should_reuse_cached_route_for_brief_follow_up() {
     assert!(LibreFangKernel::should_reuse_cached_route("fix that"));


### PR DESCRIPTION
## Mechanism

`exec_policy` is not normally written in `agent.toml`.
It is materialized when the agent enters the registry, at three sites that each stamp the global `[exec_policy]` when the manifest carries `None`:

- `crates/librefang-kernel/src/kernel/spawn.rs:225-239` — stamps `cfg.exec_policy`, promoting to `Full` when `capabilities.tools` declares `shell_exec` or `*`.
- `crates/librefang-kernel/src/kernel/boot.rs:2636-2651` — same rule for agents restored from SQLite at boot.
- `crates/librefang-kernel/src/kernel/hands_lifecycle.rs:372-390` — hand activation, which deliberately inherits the *global* mode rather than promoting, and raises the two exec timeouts to their hand floors.

Both manifest-replacement paths then threw that resolved value away.

- `crates/librefang-kernel/src/kernel/agent_state.rs:398-413` (`reload_agent_from_disk`) replaces the whole manifest with the disk parse and re-pins only `workspace`, `name` and `tags` before `replace_manifest_and_retag`, which is a plain `entry.manifest = manifest` (`crates/librefang-kernel/src/registry.rs:425`).
- `crates/librefang-kernel/src/kernel/agent_state.rs:517-524` (`update_manifest`) has the identical omission. This is where `PATCH /api/agents/{id}` with a `manifest_toml`, the dashboard editor, the CLI, and `apply_provisioning` (`crates/librefang-kernel/src/kernel/provisioning_ops.rs:87`) all land.

An `agent.toml` with no `[exec_policy]` is the normal case, so both paths parse `None` and the registry entry ends up with `exec_policy = None`.

`None` is not read as "deny" by any consumer:

- `crates/librefang-kernel/src/kernel/tools_and_skills.rs:500-506` removes `shell_exec` from `available_tools` only via `is_some_and(|p| p.mode == Deny)`, so a `Deny` agent is handed the `shell_exec` tool definition again.
- `crates/librefang-runtime/src/tool_runner/dispatch.rs:802` gates the entire deny / allowlist check on `if let Some(policy)`, so with `None` neither the `Deny` rejection nor `validate_command_allowlist` runs. The policy reaching that call is `ctx.manifest.exec_policy` (`crates/librefang-runtime/src/agent_loop/tool_call.rs:1060`) — i.e. the registry entry's manifest.

Net effect: one hot-reload or one manifest save silently un-restricts a `Deny` or `Allowlist` agent's shell, and it self-heals only at the next daemon restart.

## Fix

`crates/librefang-kernel/src/kernel/agent_state.rs`

- New module-private helper `preserve_resolved_exec_policy(incoming, current)`, called from `reload_agent_from_disk` and `update_manifest` right after the existing `workspace` preservation — the same treatment, on the same terms.
- Preserving rather than re-resolving from the global config is deliberate, and documented on the helper. The three materialization sites disagree on purpose: recomputing with the spawn rule would promote a hand agent that declares `tools = ["*"]` from its inherited `Deny` straight to `Full` and drop the hand timeout floors, on an unrelated reload. An operator who wants a different policy writes `[exec_policy]` into `agent.toml`, which still wins because it arrives as `Some`.
- Corrected the `reload_agent_from_disk` doc comment, which claimed to preserve "runtime-only fields that TOML doesn't carry" and listed workspace / tags / enabled state. `exec_policy` is exactly such a field and was missing from both the list and the code. That paragraph is rewrapped to one sentence per line since it was being edited.
- Added the matching bullet to `update_manifest`'s invariant list.

## Test

`kernel::tests::resolved_exec_policy_survives_reload_and_update_manifest` in `crates/librefang-kernel/src/kernel/tests.rs`.

Boots a kernel whose global `[exec_policy]` is `mode = "allowlist"` with `allowed_commands = ["git", "ls"]`, spawns an agent from a manifest with no `exec_policy` and an on-disk `agent.toml` that also declares none, then asserts `(mode, allowed_commands)` on the registry entry at three points: after spawn, after `reload_agent_from_disk`, and after `update_manifest` with a manifest whose `exec_policy` is `None`.

Why it would have caught this:

- The global policy is `Allowlist`, not the compiled default `Deny`, so a blanked field cannot be mistaken for a correctly inherited one.
- `allowed_commands` is asserted alongside the mode, so a fix that preserved only the mode and dropped the operator's command list would still fail.
- Both replacement paths are covered independently — I verified each half separately by disabling one helper call at a time: with only `update_manifest` broken the test fails at `after update_manifest`, with both broken it fails at `after reload_agent_from_disk`.

It has to be `#[tokio::test(flavor = "multi_thread")]`: `reload_agent_from_disk` reads the file under `tokio::task::block_in_place`, which panics outside a multi-thread runtime.

## Verification

```
cargo fmt -p librefang-kernel
cargo check -p librefang-kernel --lib
cargo clippy -p librefang-kernel --all-targets -- -D warnings
cargo test -p librefang-kernel --lib resolved_exec_policy_survives   # 1 passed
cargo test -p librefang-kernel --lib                                 # 1728 passed, 0 failed, 1 ignored
```

Fail-on-main was demonstrated by reverting the two helper calls in place rather than by checking out `main`, so the test binary was otherwise identical.

## Deliberately left out

- **`crates/librefang-runtime/src/tool_runner/dispatch.rs:802` still fails open on `None`.** Making that call site treat an absent policy as "deny" — rather than skipping the deny / allowlist check entirely — is a real defence-in-depth improvement, and it would have contained this bug instead of letting it reach a shell. It is a different crate, so per `CLAUDE.md` it is not bundled here. Same for the `is_some_and` at `dispatch.rs:1763` and `:1780`. Flagging for a maintainer decision: those three sites are the only remaining places where `exec_policy = None` means "unchecked" instead of "no shell".
- **No change to the three materialization sites.** They are correct as written; the bug was only in the replacement paths. Unifying them behind one helper would have to reconcile three intentionally different rules (spawn's `Full` promotion vs. hand activation's inherit-plus-floors), which is a behaviour change, not a refactor.
- **`persist_manifest_to_disk` now writes the preserved `exec_policy` into `agent.toml`** on the `update_manifest` path, because it serializes the whole entry manifest. That is not new — `set_agent_model` and every other persist path already wrote the stamped policy — but it does mean a manifest saved through the API materializes the field on disk. Called out in case a reviewer would rather it stayed absent.
