### PR TITLE
fix(plugins): probe runtimes concurrently and cache the doctor table

### DIFF
--- a/changelog.d/fixed/8142-plugin-doctor-probe-timeout.md
+++ b/changelog.d/fixed/8142-plugin-doctor-probe-timeout.md
@@ -1,0 +1,4 @@
+`GET /api/plugins/doctor` probes the twelve supported plugin runtimes concurrently instead of one after another, and caches the resulting availability table for 60 seconds.
+Each probe spawns `{launcher} --version` with a 5-second timeout of its own, and Python alone tries three candidates, so probing in sequence had a worst case near a minute — which made this the slowest route in the API and let it trip `route_smoke`'s flat 10-second per-request budget on a loaded CI runner (#8142).
+Fanning the probes out bounds the table by the slowest single probe rather than their sum; the cache means an operator refreshing the dashboard's plugin page no longer re-probes every interpreter on every request.
+The installed-plugin list is deliberately not cached alongside it, so a plugin installed a moment ago still appears immediately. (#8143) (@houko)

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -368,17 +368,83 @@ pub struct DoctorReport {
     pub plugins: Vec<PluginDoctorEntry>,
 }
 
-/// Probe the environment and return a diagnostic report.
+/// How long a probed runtime table stays usable before it is re-probed.
 ///
-/// Spawns one subprocess per runtime (`{launcher} --version`) — caller
-/// should wrap in `tokio::task::spawn_blocking` if used from async.
-pub fn run_doctor() -> DoctorReport {
+/// Runtime availability changes when an operator installs an interpreter, which is rare; the installed-plugin list changes whenever someone installs a plugin, which is not.
+/// So only the probe half is cached — [`run_doctor`] always re-reads the plugin list, and a freshly installed plugin still shows up immediately.
+const RUNTIME_PROBE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// A probe table plus the instant it was taken; `None` before the first probe.
+type CachedRuntimeProbe = Option<(
+    std::time::Instant,
+    Vec<crate::plugin_runtime::RuntimeStatus>,
+)>;
+
+/// Cached runtime probe table: when it was taken, and what it found.
+static RUNTIME_PROBE_CACHE: std::sync::OnceLock<std::sync::Mutex<CachedRuntimeProbe>> =
+    std::sync::OnceLock::new();
+
+/// Probe every supported runtime, concurrently, and cache the table for [`RUNTIME_PROBE_TTL`].
+///
+/// `PluginRuntime::all()` is 12 runtimes and Python alone tries three candidates (`python3` / `python` / `py`), each with a 5 s per-probe timeout in `probe_launcher_version`.
+/// Probing them in sequence therefore has a worst case near a minute, which is how `/api/plugins/doctor` became the slowest route in the API by a wide margin and started tripping `route_smoke`'s flat 10 s per-request budget on a loaded runner (#8142).
+///
+/// Fanning the probes out bounds the whole table by the slowest single probe instead of the sum, the same change #8094 made for sidecar schema probes.
+/// `std::thread::scope` rather than tokio because this runs on the blocking pool already and the probes are `std::process::Command`.
+///
+/// Order is preserved: handles are joined in `PluginRuntime::all()` order, so the reported table is byte-stable across calls regardless of which probe finishes first.
+fn probe_runtimes_cached() -> Vec<crate::plugin_runtime::RuntimeStatus> {
     use crate::plugin_runtime::{check_runtime_status, PluginRuntime};
 
-    let runtimes: Vec<_> = PluginRuntime::all()
-        .iter()
-        .map(|r| check_runtime_status(r.clone()))
-        .collect();
+    let cache = RUNTIME_PROBE_CACHE.get_or_init(|| std::sync::Mutex::new(None));
+    // Poison recovery: a panicked prior probe must not permanently disable the
+    // endpoint, and the cached value is plain data.
+    let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some((taken_at, table)) = guard.as_ref() {
+        if taken_at.elapsed() < RUNTIME_PROBE_TTL {
+            debug!("Using cached plugin runtime probe table");
+            return table.clone();
+        }
+    }
+
+    let table: Vec<_> = std::thread::scope(|scope| {
+        let handles: Vec<_> = PluginRuntime::all()
+            .iter()
+            .map(|r| scope.spawn(|| check_runtime_status(r.clone())))
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| {
+                // A probe thread panicking is a bug, not an environment
+                // condition — but the endpoint should still answer, so the
+                // runtime is reported unavailable rather than poisoning the
+                // whole report.
+                h.join().unwrap_or_else(|_| {
+                    warn!("A plugin runtime probe thread panicked");
+                    crate::plugin_runtime::RuntimeStatus {
+                        runtime: "unknown".to_string(),
+                        launcher: None,
+                        available: false,
+                        version: None,
+                        install_hint: String::new(),
+                    }
+                })
+            })
+            .collect()
+    });
+
+    *guard = Some((std::time::Instant::now(), table.clone()));
+    table
+}
+
+/// Probe the environment and return a diagnostic report.
+///
+/// Runtime probes are concurrent and cached for [`RUNTIME_PROBE_TTL`]; the installed-plugin list is always re-read.
+/// Caller should still wrap this in `tokio::task::spawn_blocking` if used from async — a cache miss spawns subprocesses.
+pub fn run_doctor() -> DoctorReport {
+    use crate::plugin_runtime::PluginRuntime;
+
+    let runtimes = probe_runtimes_cached();
 
     // Index by runtime tag so per-plugin entries can look up availability
     // without re-probing subprocesses.

--- a/crates/librefang-runtime/src/plugin_manager/tests.rs
+++ b/crates/librefang-runtime/src/plugin_manager/tests.rs
@@ -998,3 +998,90 @@ bootstrap = "hooks/bootstrap.py"
         "pack output must be byte-identical for identical inputs"
     );
 }
+
+// ── /api/plugins/doctor runtime probes (#8142) ─────────────────────────────
+
+/// The reported table covers every runtime `PluginRuntime::all()` declares, in that exact order.
+///
+/// Load-bearing because the probes now run concurrently: joining the handles out of order, or collecting from a `HashMap`, would make the endpoint's output vary between calls for an unchanged host — the #3298 problem, and also the thing that would make the `runtime` → availability index in `run_doctor` line up with the wrong entry.
+#[test]
+fn doctor_runtime_table_is_complete_and_in_declaration_order() {
+    use crate::plugin_runtime::PluginRuntime;
+
+    let report = run_doctor();
+    let expected: Vec<String> = PluginRuntime::all()
+        .iter()
+        .map(|r| r.label().to_string())
+        .collect();
+    let actual: Vec<String> = report.runtimes.iter().map(|s| s.runtime.clone()).collect();
+    assert_eq!(
+        actual, expected,
+        "the probe table must list every declared runtime in declaration order"
+    );
+}
+
+/// Two calls in a row must agree, and the second must be served from the cache rather than re-probing.
+///
+/// The timing assertion is deliberately loose — it only has to separate "did not spawn ~12 subprocesses" from "did".
+/// A cold call spawns one process per runtime (three for Python); the cached call does no I/O at all, so the gap is orders of magnitude rather than a few percent.
+#[test]
+fn doctor_runtime_probes_are_cached_between_calls() {
+    // Warm the cache and measure the cached read, not the cold one: another
+    // test in this binary may already have populated it, so timing the first
+    // call here would be measuring someone else's state.
+    let first = run_doctor();
+    let began = std::time::Instant::now();
+    let second = run_doctor();
+    let cached_elapsed = began.elapsed();
+
+    let names_first: Vec<_> = first.runtimes.iter().map(|s| &s.runtime).collect();
+    let names_second: Vec<_> = second.runtimes.iter().map(|s| &s.runtime).collect();
+    assert_eq!(
+        names_first, names_second,
+        "a cached read must return the same table"
+    );
+    assert!(
+        cached_elapsed < std::time::Duration::from_millis(500),
+        "a cached probe read must not spawn subprocesses; took {cached_elapsed:?}"
+    );
+}
+
+/// The plugin list is *not* cached alongside the probe table, so a plugin installed between two calls shows up immediately.
+///
+/// This is the half of the caching decision that could silently regress: it would be tempting to cache the whole `DoctorReport`, and nothing else in the suite would notice.
+#[test]
+fn doctor_reflects_a_newly_written_plugin_without_waiting_for_the_probe_ttl() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let prev_home = std::env::var_os("LIBREFANG_HOME");
+    std::env::set_var("LIBREFANG_HOME", tmp.path());
+
+    // Prime the probe cache while the plugins dir is empty.
+    let before = run_doctor();
+    let had = before
+        .plugins
+        .iter()
+        .any(|p| p.name == "doctor-cache-probe");
+    assert!(!had, "fixture name must not pre-exist");
+
+    let plugin_dir = plugins_dir().join("doctor-cache-probe");
+    std::fs::create_dir_all(plugin_dir.join("hooks")).unwrap();
+    std::fs::write(
+        plugin_dir.join("plugin.toml"),
+        "name = \"doctor-cache-probe\"\nversion = \"0.1.0\"\ndescription = \"fixture\"\n",
+    )
+    .unwrap();
+
+    let after = run_doctor();
+    let now_listed = after.plugins.iter().any(|p| p.name == "doctor-cache-probe");
+
+    match prev_home {
+        Some(v) => std::env::set_var("LIBREFANG_HOME", v),
+        None => std::env::remove_var("LIBREFANG_HOME"),
+    }
+
+    assert!(
+        now_listed,
+        "the plugin list must be re-read on every call, not cached with the probe table"
+    );
+}


### PR DESCRIPTION
Closes #8142.

## Mechanism

`run_doctor` probed `PluginRuntime::all()` sequentially:

```rust
let runtimes: Vec<_> = PluginRuntime::all()
    .iter()
    .map(|r| check_runtime_status(r.clone()))
    .collect();
```

That is twelve runtimes. `Native` and `Wasm` early-return with no launcher, and the other ten each spawn `{launcher} --version` through `probe_launcher_version`, which already has its own 5-second timeout (`plugin_runtime.rs:462`) — Python tries three candidates (`python3` / `python` / `py`), so the worst case is roughly twelve probes' timeouts added together, near a minute.

`route_smoke` walks all 111 GET routes with one flat 10-second per-request budget (`route_smoke.rs:73`), so `/api/plugins/doctor` is the route that exceeds it first on a loaded runner, and it takes `Test / Ubuntu (shard 1/4)` and therefore `CI Gate` with it — on whichever PR happens to be running. It landed on #8043 today.

## Change

**Probe concurrently** under `std::thread::scope`, which bounds the table by the slowest single probe instead of the sum. `std::thread::scope` rather than tokio because `run_doctor` already runs on the blocking pool (`plugins.rs` wraps it in `spawn_blocking`) and the probes are `std::process::Command`. Same shape as #8094 for sidecar schema probes.

**Cache the availability table for 60 s.** This is the part that helps real users: an operator refreshing the dashboard's plugin page was re-probing every interpreter on every request.

**The installed-plugin list is deliberately not cached.** Runtime availability changes when someone installs an interpreter — rare. The plugin list changes whenever someone installs a plugin — not rare. So `run_doctor` still calls `list_plugins()` every time, and a plugin installed a moment ago appears immediately.

**Failure handling**: a probe thread that panics reports its runtime unavailable rather than poisoning the whole report, and the cache mutex recovers from poisoning, so one bad probe cannot permanently disable the endpoint.

## Tests

Three, in `crates/librefang-runtime/src/plugin_manager/tests.rs`:

- `doctor_runtime_table_is_complete_and_in_declaration_order` — every declared runtime, in `PluginRuntime::all()` order. Load-bearing now that probes are concurrent: joining out of order would make the endpoint's output vary between calls for an unchanged host, and would also misalign the `runtime` → availability index `run_doctor` builds for the per-plugin entries.
- `doctor_runtime_probes_are_cached_between_calls` — a warmed read returns the same table and does no subprocess work. The timing bound is loose on purpose; it only has to separate "spawned a dozen processes" from "spawned none".
- `doctor_reflects_a_newly_written_plugin_without_waiting_for_the_probe_ttl` — the half of the caching decision that could regress silently. Caching the whole `DoctorReport` would be the tempting simplification and nothing else in the suite would notice.

## Verification

```
cargo check -p librefang-runtime --lib                            # clean
cargo clippy -p librefang-runtime --all-targets -- -D warnings    # exit 0
cargo test -p librefang-runtime --lib                             # 2487 passed, 0 failed
```

Exit codes taken from the commands directly, not through a pipe.

## What I could not verify locally, stated plainly

I cannot reproduce the slow case on this machine. A cold `run_doctor` here returns in 0.04 s, because every launcher is either present (a fast `--version`) or absent (`spawn()` fails immediately with ENOENT). The pathological case needs a launcher that exists but is slow to start, which is what a loaded CI runner produces and my laptop does not.

So the argument for this change is structural rather than measured: the worst case goes from the sum of the probes' timeouts to the largest of them. I did confirm the failure is not any one branch's — on the same machine, back to back:

```
origin/main (758ae2404)  cargo test -p librefang-api --test route_smoke  → 10 passed, 0 failed (32.66s)
PR #8043    (ef7d86431)  cargo test -p librefang-api --test route_smoke  → 10 passed, 0 failed (22.10s)
```

Both pass, including the two tests red in CI, which is why #8142 is filed against the harness rather than against a PR.

## Deliberately not done

#8142 also lists giving `route_smoke` a per-route timeout override, so `plugins/doctor` gets a larger budget than a route that should answer in milliseconds. That is worth doing and is independent of this change — the 10-second bar is a good guard for 110 of the 111 routes, and it should stay tight for them. I have left it in the issue rather than widening this PR into the test harness, since fixing the endpoint is what makes the tight bar reasonable in the first place.
