### PR TITLE
fix(tui): report why a memory-config or goal-run fetch produced nothing

### DIFF
--- a/changelog.d/fixed/8141-tui-silent-fetch-helpers.md
+++ b/changelog.d/fixed/8141-tui-silent-fetch-helpers.md
@@ -1,0 +1,4 @@
+The TUI's Memory screen and the goals detail pane now say why they are empty instead of silently showing nothing.
+`spawn_fetch_memory_config` and `spawn_fetch_goal_run` returned without sending any event when the TUI was attached to an in-process kernel, when the request failed, or when the body would not decode — so a 5xx, an unsupported backend and a genuinely empty answer all rendered as the same blank panel, indistinguishable from still-loading.
+Both now report a `FetchFailure`, and the status line distinguishes "this data lives behind the daemon API" (which retrying will never fix) from a transport or decode error (which retrying usually will).
+The goal case keeps its last known run state rather than blanking it, because the start/stop toggle keys off the live phase and a stale reading with a status line beats no reading at all. (#8144) (@houko)

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -2509,3 +2509,9 @@ tui-event-channels-not-available-in-process = Channel management needs a running
 tui-event-channel-save-failed = Failed to save channel instance { $name }: { $error }
 tui-event-channel-delete-failed = Failed to delete channel instance { $name }: { $error }
 tui-event-channels-reload-failed = Failed to reload channels: { $error }
+
+# --- TUI fetch failures that used to be silent (#8141) ---
+tui-memory-config-requires-daemon = Memory settings come from the daemon API — not available when the TUI is attached in-process.
+tui-memory-config-fetch-failed = Could not read the memory settings: { $error }
+tui-goals-run-requires-daemon = Run state comes from the daemon API — not available when the TUI is attached in-process.
+tui-goals-run-fetch-failed = Could not read the run state for { $id }: { $error }

--- a/crates/librefang-cli/locales/ko/main.ftl
+++ b/crates/librefang-cli/locales/ko/main.ftl
@@ -2508,3 +2508,9 @@ tui-event-channels-not-available-in-process = 채널 관리에는 실행 중인 
 tui-event-channel-save-failed = 채널 인스턴스 { $name } 저장 실패: { $error }
 tui-event-channel-delete-failed = 채널 인스턴스 { $name } 삭제 실패: { $error }
 tui-event-channels-reload-failed = 채널 재로드 실패: { $error }
+
+# --- TUI fetch failures that used to be silent (#8141) ---
+tui-memory-config-requires-daemon = 메모리 설정은 데몬 API에서 가져옵니다 — TUI가 인프로세스로 연결된 경우 사용할 수 없습니다.
+tui-memory-config-fetch-failed = 메모리 설정을 읽을 수 없습니다: { $error }
+tui-goals-run-requires-daemon = 실행 상태는 데몬 API에서 가져옵니다 — TUI가 인프로세스로 연결된 경우 사용할 수 없습니다.
+tui-goals-run-fetch-failed = { $id }의 실행 상태를 읽을 수 없습니다: { $error }

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -2532,3 +2532,9 @@ tui-event-channels-not-available-in-process = Керування каналам�
 tui-event-channel-save-failed = Не вдалося зберегти екземпляр каналу { $name }: { $error }
 tui-event-channel-delete-failed = Не вдалося видалити екземпляр каналу { $name }: { $error }
 tui-event-channels-reload-failed = Не вдалося перезавантажити канали: { $error }
+
+# --- TUI fetch failures that used to be silent (#8141) ---
+tui-memory-config-requires-daemon = Налаштування пам'яті надходять з API демона — недоступні, коли TUI підключено в межах процесу.
+tui-memory-config-fetch-failed = Не вдалося прочитати налаштування пам'яті: { $error }
+tui-goals-run-requires-daemon = Стан запуску надходить з API демона — недоступний, коли TUI підключено в межах процесу.
+tui-goals-run-fetch-failed = Не вдалося прочитати стан запуску для { $id }: { $error }

--- a/crates/librefang-cli/locales/zh-CN/main.ftl
+++ b/crates/librefang-cli/locales/zh-CN/main.ftl
@@ -2462,3 +2462,9 @@ tui-event-channels-not-available-in-process = 通道管理需要正在运行的�
 tui-event-channel-save-failed = 保存通道实例 { $name } 失败：{ $error }
 tui-event-channel-delete-failed = 删除通道实例 { $name } 失败：{ $error }
 tui-event-channels-reload-failed = 重载通道失败：{ $error }
+
+# --- TUI fetch failures that used to be silent (#8141) ---
+tui-memory-config-requires-daemon = 记忆设置来自守护进程 API —— TUI 以进程内方式接入时不可用。
+tui-memory-config-fetch-failed = 无法读取记忆设置：{ $error }
+tui-goals-run-requires-daemon = 运行状态来自守护进程 API —— TUI 以进程内方式接入时不可用。
+tui-goals-run-fetch-failed = 无法读取 { $id } 的运行状态：{ $error }

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -48,6 +48,25 @@ pub enum BackendRef {
     InProcess(Arc<LibreFangKernel>),
 }
 
+/// Why a TUI fetch produced no data.
+///
+/// The two arms need different words in front of the operator, which is the
+/// whole reason they are separate: `RequiresDaemon` will never succeed while
+/// the TUI is attached to an in-process kernel, so advising a retry is wrong,
+/// whereas `Error` is exactly the case where retrying is right. Collapsing
+/// them — or sending nothing, which is what these helpers used to do — leaves
+/// one blank screen meaning all of "failed", "unsupported here" and
+/// "genuinely empty" (#8141).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FetchFailure {
+    /// The data lives behind the daemon HTTP API and the TUI is attached
+    /// in-process, so there is nothing to reach.
+    RequiresDaemon,
+    /// The request went out and did not come back usable — transport error,
+    /// non-success status, or a body that would not decode.
+    Error(String),
+}
+
 // ── AppEvent ────────────────────────────────────────────────────────────────
 
 /// Unified application event.
@@ -155,6 +174,12 @@ pub enum AppEvent {
     /// Memory agents loaded (for agent selector).
     MemoryAgentsLoaded(Vec<AgentEntry>),
     MemoryConfigLoaded(crate::tui::screens::memory::MemoryConfigView),
+    /// The memory config could not be read — see [`FetchFailure`].
+    ///
+    /// Sent instead of staying silent: without it the Memory screen keeps
+    /// whatever it had (usually nothing) and the operator cannot tell a 5xx
+    /// from an empty config from a request that never went out (#8141).
+    MemoryConfigFailed(FetchFailure),
     /// Memory KV pairs loaded.
     MemoryKvLoaded(Vec<KvPair>),
     /// Memory KV saved.
@@ -240,6 +265,17 @@ pub enum AppEvent {
     /// Goals loaded.
     GoalsLoaded(Vec<GoalInfo>),
     /// Live run state fetched for one goal.
+    /// The goal's run state could not be read — see [`FetchFailure`].
+    ///
+    /// Distinct from `GoalRunLoaded` with an absent run: a goal that never
+    /// ran legitimately answers `{"running": false}`, whereas this means the
+    /// answer never arrived. The start/stop toggle keys off the live phase,
+    /// so conflating the two leaves the operator unable to tell a finished
+    /// run from a failed fetch (#8141).
+    GoalRunFailed {
+        goal_id: String,
+        failure: FetchFailure,
+    },
     GoalRunLoaded {
         goal_id: String,
         phase: Option<String>,
@@ -2258,32 +2294,61 @@ pub fn spawn_delete_session(backend: BackendRef, session_id: String, tx: mpsc::S
 ///
 /// Daemon-only. The in-process backend has no HTTP surface to ask, and the
 /// panel says so rather than showing a blank as if it were configuration.
+/// Fetch `[memory]` config for the Memory screen.
+///
+/// Every exit path sends an event. The screen renders `config: None`
+/// identically for "not fetched yet", "the daemon refused" and "we are
+/// in-process", so a silent return is indistinguishable from still-loading
+/// (#8141).
 pub fn spawn_fetch_memory_config(backend: BackendRef, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || {
-        if let BackendRef::Daemon { base_url, api_key } = backend {
-            let client = make_daemon_client(api_key.as_deref());
-            if let Ok(resp) = client.get(format!("{base_url}/api/memory/config")).send() {
-                if let Ok(body) = resp.json::<serde_json::Value>() {
-                    let pm = &body["proactive_memory"];
-                    let view = crate::tui::screens::memory::MemoryConfigView {
-                        embedding_provider: body["embedding_provider"]
-                            .as_str()
-                            .unwrap_or("")
-                            .to_string(),
-                        embedding_model: body["embedding_model"].as_str().unwrap_or("").to_string(),
-                        auto_memorize: pm["auto_memorize"].as_bool().unwrap_or(false),
-                        auto_retrieve: pm["auto_retrieve"].as_bool().unwrap_or(false),
-                        effective_extraction_model: pm["effective_extraction_model"]
-                            .as_str()
-                            .unwrap_or("")
-                            .to_string(),
-                        extraction_model_inherited: pm["extraction_model_source"].as_str()
-                            == Some("inherited_default"),
-                    };
-                    let _ = tx.send(AppEvent::MemoryConfigLoaded(view));
-                }
+        let BackendRef::Daemon { base_url, api_key } = backend else {
+            let _ = tx.send(AppEvent::MemoryConfigFailed(FetchFailure::RequiresDaemon));
+            return;
+        };
+        let client = make_daemon_client(api_key.as_deref());
+        let resp = match client.get(format!("{base_url}/api/memory/config")).send() {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = tx.send(AppEvent::MemoryConfigFailed(FetchFailure::Error(
+                    e.to_string(),
+                )));
+                return;
             }
+        };
+        let status = resp.status();
+        if !status.is_success() {
+            let _ = tx.send(AppEvent::MemoryConfigFailed(FetchFailure::Error(
+                status.to_string(),
+            )));
+            return;
         }
+        let body = match resp.json::<serde_json::Value>() {
+            Ok(b) => b,
+            Err(e) => {
+                let _ = tx.send(AppEvent::MemoryConfigFailed(FetchFailure::Error(
+                    e.to_string(),
+                )));
+                return;
+            }
+        };
+        let pm = &body["proactive_memory"];
+        let view = crate::tui::screens::memory::MemoryConfigView {
+            embedding_provider: body["embedding_provider"]
+                .as_str()
+                .unwrap_or("")
+                .to_string(),
+            embedding_model: body["embedding_model"].as_str().unwrap_or("").to_string(),
+            auto_memorize: pm["auto_memorize"].as_bool().unwrap_or(false),
+            auto_retrieve: pm["auto_retrieve"].as_bool().unwrap_or(false),
+            effective_extraction_model: pm["effective_extraction_model"]
+                .as_str()
+                .unwrap_or("")
+                .to_string(),
+            extraction_model_inherited: pm["extraction_model_source"].as_str()
+                == Some("inherited_default"),
+        };
+        let _ = tx.send(AppEvent::MemoryConfigLoaded(view));
     });
 }
 
@@ -3809,23 +3874,48 @@ fn goal_from_json(g: &serde_json::Value) -> GoalInfo {
 }
 
 /// Fetch the live run state for a single goal.
+/// Fetch one goal's live run state for the detail pane.
+///
+/// Every exit path sends an event. The start/stop toggle keys off the live
+/// phase rather than the goal document's `status`, so a silent return leaves
+/// the toggle acting on a stale or absent phase and the operator cannot tell
+/// a finished run from a failed fetch (#8141).
 pub fn spawn_fetch_goal_run(backend: BackendRef, goal_id: String, tx: mpsc::Sender<AppEvent>) {
     std::thread::spawn(move || {
+        let fail = |tx: &mpsc::Sender<AppEvent>, goal_id: String, failure: FetchFailure| {
+            let _ = tx.send(AppEvent::GoalRunFailed { goal_id, failure });
+        };
+
         let BackendRef::Daemon { base_url, api_key } = backend else {
+            fail(&tx, goal_id, FetchFailure::RequiresDaemon);
             return;
         };
         let client = make_daemon_client(api_key.as_deref());
-        let Ok(resp) = client
+        let resp = match client
             .get(format!("{base_url}/api/goals/{goal_id}/run"))
             .send()
-        else {
-            return;
+        {
+            Ok(r) => r,
+            Err(e) => {
+                fail(&tx, goal_id, FetchFailure::Error(e.to_string()));
+                return;
+            }
         };
-        let Ok(body) = resp.json::<serde_json::Value>() else {
+        let status = resp.status();
+        if !status.is_success() {
+            fail(&tx, goal_id, FetchFailure::Error(status.to_string()));
             return;
+        }
+        let body = match resp.json::<serde_json::Value>() {
+            Ok(b) => b,
+            Err(e) => {
+                fail(&tx, goal_id, FetchFailure::Error(e.to_string()));
+                return;
+            }
         };
         // A goal that never ran answers `{"running": false}` with no `run`
-        // object, which correctly leaves every field `None`.
+        // object, which correctly leaves every field `None`. That is a
+        // successful read of "no run", not a failure — hence `GoalRunLoaded`.
         let run = &body["run"];
         let _ = tx.send(AppEvent::GoalRunLoaded {
             goal_id,
@@ -4786,6 +4876,77 @@ pub fn spawn_fetch_agents_for_chat(
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
+
+    // ── fetch helpers must never exit silently (#8141) ─────────────────────
+
+    /// Port 1 on loopback refuses immediately, so this exercises the
+    /// transport-error path without a mock server and without a timeout.
+    fn unreachable_daemon() -> BackendRef {
+        BackendRef::Daemon {
+            base_url: "http://127.0.0.1:1".to_string(),
+            api_key: None,
+        }
+    }
+
+    /// A memory-config fetch that cannot reach the daemon must say so.
+    ///
+    /// Before #8141 this returned without sending anything, and the Memory
+    /// screen kept its spinner and its empty `config` — visually identical to
+    /// "still loading" and to "the daemon says there is no config".
+    #[test]
+    fn memory_config_fetch_reports_an_unreachable_daemon() {
+        let (tx, rx) = mpsc::channel();
+        spawn_fetch_memory_config(unreachable_daemon(), tx);
+
+        let ev = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("an unreachable daemon must still produce an event");
+        match ev {
+            AppEvent::MemoryConfigFailed(FetchFailure::Error(reason)) => {
+                assert!(!reason.is_empty(), "the failure must carry a reason");
+            }
+            // `AppEvent` has no `Debug` (it carries `Arc<LibreFangKernel>` and
+            // `AgentLoopResult`), so the wrong-variant message cannot print it.
+            _ => panic!("expected MemoryConfigFailed(FetchFailure::Error), got another AppEvent"),
+        }
+    }
+
+    /// Same for a goal's run state, and the event must name the goal so the
+    /// status line can be specific about which row is stale.
+    #[test]
+    fn goal_run_fetch_reports_an_unreachable_daemon() {
+        let (tx, rx) = mpsc::channel();
+        spawn_fetch_goal_run(unreachable_daemon(), "goal-42".to_string(), tx);
+
+        let ev = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("an unreachable daemon must still produce an event");
+        match ev {
+            AppEvent::GoalRunFailed { goal_id, failure } => {
+                assert_eq!(goal_id, "goal-42");
+                assert!(
+                    matches!(failure, FetchFailure::Error(ref r) if !r.is_empty()),
+                    "expected a transport error carrying a reason, got {failure:?}"
+                );
+            }
+            _ => panic!("expected GoalRunFailed, got another AppEvent"),
+        }
+    }
+
+    /// The two failure kinds must stay distinguishable at the type level.
+    ///
+    /// This is the whole reason `FetchFailure` is an enum rather than a
+    /// `String`: `RequiresDaemon` will never succeed on retry and `Error`
+    /// usually will, so the handler picks different words for each. A later
+    /// refactor that collapses them to one string would compile fine and
+    /// quietly restore the "one blank screen means three things" problem.
+    #[test]
+    fn the_two_fetch_failure_kinds_are_not_interchangeable() {
+        assert_ne!(
+            FetchFailure::RequiresDaemon,
+            FetchFailure::Error("connection refused".to_string())
+        );
+    }
 
     /// `GET /api/channels` mixes configured instances and catalog adapters in
     /// one array, and `name` means a different thing in each. Getting the

--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -2294,7 +2294,6 @@ pub fn spawn_delete_session(backend: BackendRef, session_id: String, tx: mpsc::S
 ///
 /// Daemon-only. The in-process backend has no HTTP surface to ask, and the
 /// panel says so rather than showing a blank as if it were configuration.
-/// Fetch `[memory]` config for the Memory screen.
 ///
 /// Every exit path sends an event. The screen renders `config: None`
 /// identically for "not fetched yet", "the daemon refused" and "we are
@@ -3874,7 +3873,6 @@ fn goal_from_json(g: &serde_json::Value) -> GoalInfo {
 }
 
 /// Fetch the live run state for a single goal.
-/// Fetch one goal's live run state for the detail pane.
 ///
 /// Every exit path sends an event. The start/stop toggle keys off the live
 /// phase rather than the goal document's `status`, so a silent return leaves

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -553,6 +553,20 @@ impl App {
                 self.goals
                     .apply_run_state(&goal_id, phase, iteration, max_iterations);
             }
+            AppEvent::GoalRunFailed { goal_id, failure } => {
+                // Deliberately does NOT touch the cached run state: the last
+                // known phase is more useful than blanking it, and the status
+                // line is what says the reading is stale.
+                self.goals.status_msg = match failure {
+                    event::FetchFailure::RequiresDaemon => {
+                        crate::i18n::t("tui-goals-run-requires-daemon")
+                    }
+                    event::FetchFailure::Error(reason) => crate::i18n::t_args(
+                        "tui-goals-run-fetch-failed",
+                        &[("id", &goal_id), ("error", &reason)],
+                    ),
+                };
+            }
             AppEvent::GoalCreated(id) => {
                 self.goals.status_msg = crate::i18n::t_args("tui-goal-created", &[("id", &id)]);
                 self.refresh_goals();
@@ -593,6 +607,19 @@ impl App {
             AppEvent::MemoryConfigLoaded(config) => {
                 self.memory.config = Some(config);
                 self.memory.loading = false;
+            }
+            AppEvent::MemoryConfigFailed(failure) => {
+                // Clear `loading` on the failure path too, or the screen sits
+                // on its spinner forever and the message never gets read.
+                self.memory.loading = false;
+                self.memory.status_msg = match failure {
+                    event::FetchFailure::RequiresDaemon => {
+                        crate::i18n::t("tui-memory-config-requires-daemon")
+                    }
+                    event::FetchFailure::Error(reason) => {
+                        crate::i18n::t_args("tui-memory-config-fetch-failed", &[("error", &reason)])
+                    }
+                };
             }
             AppEvent::MemoryAgentsLoaded(agents) => {
                 self.memory.agents = agents;


### PR DESCRIPTION
Closes #8141.

## Mechanism

Two helpers in `crates/librefang-cli/src/tui/event.rs` had three silent exits each.

`spawn_fetch_memory_config` (`:2261` on `main`) — no `else` on the backend match, plus `if let Ok(...)` swallowing both the request and the decode:

```rust
if let BackendRef::Daemon { base_url, api_key } = backend {
    if let Ok(resp) = client.get(format!("{base_url}/api/memory/config")).send() {
        if let Ok(body) = resp.json::<serde_json::Value>() {
```

`spawn_fetch_goal_run` (`:3812`) — same shape with `let … else { return; }`.

Nothing reached the channel on any of those paths, so the Memory screen and the goals detail pane rendered the same blank panel for a 5xx, for in-process mode, and for a genuinely empty answer — and that panel is also what "still loading" looks like.

## Change

Both report a `FetchFailure`, and the two arms are deliberately distinct rather than one string:

```rust
pub enum FetchFailure {
    RequiresDaemon,
    Error(String),
}
```

`RequiresDaemon` will never succeed while the TUI is attached to an in-process kernel, so telling the operator to retry is wrong. `Error` is exactly where retrying is the right advice. The handler picks different wording for each, in all four locales.

Two decisions worth flagging because they are not obvious:

- **`MemoryConfigFailed` clears `loading`.** Without it the screen keeps its spinner and the status message never gets read.
- **`GoalRunFailed` deliberately does not clear the cached run state.** The start/stop toggle keys off the live phase rather than the goal document's `status`, so a stale phase plus a status line saying the reading failed is more useful than blanking the row.

A goal that never ran still answers `{"running": false}` with no `run` object. That is a *successful* read of "no run" and keeps going through `GoalRunLoaded` with empty fields — it does not become a failure.

## Scope

Of the 86 `spawn_*` helpers in this file, 74 already handled `BackendRef::InProcess`. These were the two that did not. I went looking for a systemic gap and there isn't one, which is why this is two functions rather than a sweep — worth saying because #8141's title could be read as the larger thing.

## On matching #7998

#7998 introduced `WorkflowParamsFetch` with `Loaded` / `None` / `Failed`, where `Failed` covers in-process *and* transport failure in one arm — its doc comment says so. I raised the same in-process-versus-error distinction on that PR, and this change makes it rather than repeating the conflation.

That does mean two shapes in the tree for one week. `WorkflowParamsFetch::Failed` splitting into the same two arms would be a small follow-up and I would rather do it as one change across both call sites than pre-emptively here, since #7998's third state (`None`, "the workflow declares no parameters") has no analogue in either of these two helpers.

## Tests

Three, in `event.rs`'s existing `mod tests`:

- `memory_config_fetch_reports_an_unreachable_daemon` and `goal_run_fetch_reports_an_unreachable_daemon` — point at `127.0.0.1:1`, which refuses immediately, and assert an event arrives carrying a non-empty reason. These are the regression: before this change both returned silently. The goal one also asserts the event names the goal, so the status line can say which row is stale.
- `the_two_fetch_failure_kinds_are_not_interchangeable` — pins the enum split. Collapsing `FetchFailure` to a `String` would compile fine and quietly restore "one blank panel means three things".

`AppEvent` has no `Debug` (it carries `Arc<LibreFangKernel>` and `AgentLoopResult`), so the wrong-variant assertions cannot print the event they got; the panic messages say so rather than looking like an oversight.

## Verification

```
cargo clippy -p librefang-cli --all-targets -- -D warnings   # exit 0
cargo test -p librefang-cli --bins                           # exit 0
cargo test -p librefang-cli --test i18n_checks                # exit 0 — 3 passed
```

The i18n run is the one that matters for the locale half: `test_locales_cover_used_i18n_keys`, `test_no_dead_locale_keys` and `test_no_untranslated_strings` all pass, so the four new keys exist in all four locales and no hardcoded English slipped into the handler.

Exit codes taken from each command directly, not through a pipe.
