### PR TITLE
fix(whatsapp-gateway): raise the declared Node floor to 20

### DIFF
--- a/changelog.d/fixed/8189-whatsapp-gateway-node-engine.md
+++ b/changelog.d/fixed/8189-whatsapp-gateway-node-engine.md
@@ -1,0 +1,3 @@
+Correct `@librefang/whatsapp-gateway`'s declared Node floor, which claimed `>=18` while two of its four direct dependencies had already excluded Node 18 — `@whiskeysockets/baileys` requires `>=20.0.0` and `better-sqlite3` requires `20.x` or newer.
+Installing on Node 18 produced an `EBADENGINE` warning naming a transitive package rather than a clear statement that the gateway does not support that runtime, and failed outright under `engine-strict` against a floor the package itself declared satisfied.
+No supported runtime loses support: the Dockerfile pins Node 22 and CI uses 24, so this corrects the declaration rather than dropping real support (#8189) (@houko)

--- a/docs/src/app/integrations/channels/core/page.mdx
+++ b/docs/src/app/integrations/channels/core/page.mdx
@@ -259,7 +259,7 @@ WhatsApp migrated from the in-process Rust adapter to a Python sidecar (`librefa
 ### Prerequisites
 
 - For Cloud API: a Meta Business account with WhatsApp Cloud API access (phone number ID, access token, app secret)
-- For Web/QR mode: Node.js >= 18 on the daemon host and a personal WhatsApp account
+- For Web/QR mode: Node.js >= 20 on the daemon host and a personal WhatsApp account
 - `python3` on the daemon host (no third-party Python packages required)
 
 ### Cloud API mode setup

--- a/packages/whatsapp-gateway/package-lock.json
+++ b/packages/whatsapp-gateway/package-lock.json
@@ -20,7 +20,7 @@
         "librefang-whatsapp-gateway": "index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@borewit/text-codec": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -27,7 +27,7 @@
     "link-preview-js": "^4.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## What

`packages/whatsapp-gateway` declared `"node": ">=18"` in both `package.json` and the root entry of `package-lock.json`, and the channels documentation repeated the same figure. Neither has been true for a while.

## Why

Two of the four direct dependencies already exclude Node 18:

- `@whiskeysockets/baileys@6.7.22` → `>=20.0.0`
- `better-sqlite3@^12.8.0` → `20.x || 22.x || 23.x || 24.x || 25.x || 26.x`

The `toml@^4.2.0` security bump in #8176 added a third `>=20`, which is what surfaced this, but it did not cause it — the declaration was already wrong before that PR.

The practical effect on Node 18 was an `EBADENGINE` warning naming a transitive package instead of a clear statement that this gateway does not support that runtime, and a hard install failure under `engine-strict` against a floor the package itself claimed was satisfied.

## Changes

- `packages/whatsapp-gateway/package.json`: `engines.node` `>=18` → `>=20`.
- `packages/whatsapp-gateway/package-lock.json`: the same field on the root (`packages[""]`) entry, so the lockfile does not disagree with the manifest. No dependency entry was touched and the resolved tree is unchanged.
- `docs/src/app/integrations/channels/core/page.mdx`: the Web/QR prerequisites line said `Node.js >= 18`.

## Why `>=20` and not `>=20.9.0`

`sharp` requires `>=20.9.0` and is present in the tree, but it arrives as a peer dependency of `baileys` rather than something this package declares. Pinning our own floor to a transitive peer's would emit a spurious `EBADENGINE` for anyone on 20.0-20.8 who does not install it, so the floor tracks the direct dependencies.

## Verification

- No supported runtime loses support: the `Dockerfile` pins `node:22.11.0-bookworm-slim` and CI's `setup-node` uses 24, so nothing in-repo runs on 18. This corrects a declaration rather than dropping real support.
- `package-lock.json` re-parsed as JSON after the edit; `git diff` confirms the only lockfile hunk is the root `engines` entry.
- Engine constraints above were read from the resolved entries in `package-lock.json`, not from memory.
- No Rust code touched.

## Deferred

Nothing.
