### PR TITLE
fix(deps): move off the yanked der 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
@@ -2287,7 +2287,7 @@ version = "0.17.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
@@ -6890,7 +6890,7 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -6902,7 +6902,7 @@ checksum = "279a91971a1d8eb1260a30938eae3be9cb67b472dffecb222fbbbe2fd2dc1453"
 dependencies = [
  "aes 0.9.1",
  "cbc 0.2.1",
- "der 0.8.0",
+ "der 0.8.2",
  "pbkdf2",
  "rand_core 0.10.0",
  "scrypt",
@@ -6926,7 +6926,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.2",
  "pkcs5",
  "rand_core 0.10.0",
  "spki 0.8.0",
@@ -8137,7 +8137,7 @@ dependencies = [
  "curve25519-dalek 5.0.0-pre.6",
  "data-encoding",
  "delegate",
- "der 0.8.0",
+ "der 0.8.2",
  "digest 0.11.3",
  "ecdsa",
  "ed25519-dalek 3.0.0-pre.7",
@@ -8514,7 +8514,7 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
  "ctutils",
- "der 0.8.0",
+ "der 0.8.2",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -9215,7 +9215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der 0.8.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`der 0.8.0` is yanked on crates.io. `cargo-deny (advisories)` fails on sight of it:

```
error[yanked]: detected yanked crate (try `cargo update -p der`)
```

## Why it is not one PR's problem

The version is in `Cargo.lock` on `main`, so every pull request that runs the Rust lanes inherits it and goes red on a dependency its own diff never touched. It surfaced on #8049, whose `Cargo.lock` change contains no `der` entry at all — verified against the PR diff. `main`'s last green `cargo-deny` run predates the yank.

PRs carrying the `no-rust-required` label do not run `cargo-deny`, which is why #8189 and #8190 look unaffected — they are not, they simply never reach the check.

## Change

`cargo update -p der@0.8.0` → 0.8.2, a semver-compatible patch bump inside the same minor.

`Cargo.lock` only. The full diff is `der`'s `version` and `checksum` lines plus the seven dependents that name it; no other package moved and no `Cargo.toml` was touched.

The spec is `der@0.8.0` rather than `der` because the tree also carries `der 0.7.10`, a separate major that is not yanked — cargo refuses the unqualified form as ambiguous and names both candidates.

## Verification

- Yank status read from the crates.io versions API: `0.8.0 yanked=true`, `0.8.1` and `0.8.2` not yanked.
- `git diff Cargo.lock` inspected line by line; the only package name appearing in a changed stanza is `der`.
- No `Cargo.toml` in the diff, so no dependency requirement changed — resolution is free to pick 0.8.2 under the existing constraints.
- Compilation is CI's job; nothing here can be verified by building locally that the lockfile diff does not already show.

## Deferred

Nothing.
