### PR TITLE
ci: judge PR health from required checks only in the branch updater

### DIFF
--- a/.github/scripts/auto-update-branches.js
+++ b/.github/scripts/auto-update-branches.js
@@ -28,10 +28,23 @@ async function listCheckRuns(github, repo, ref) {
   });
 }
 
+// Only the checks the `main` ruleset actually requires get a vote on whether a PR is failing.
+// `CI Gate` is the sole entry in that ruleset's `required_status_checks`; every other check run on a PR is advisory and cannot block a merge, so it must not be able to trigger a branch update either.
+//
+// Reading every check run instead is what defeated the "only update failing PRs" guard below.
+// A bookkeeping workflow whose runs cancelled each other left a `cancelled` check on nearly every open pull request, `cancelled` is in FAIL_CONCLUSIONS, and so every PR read as failing — which turned each scheduled sweep into the full-repository cascade the guard exists to prevent, roughly thirty branch updates and thirty CI matrices per fire.
+// Narrowing the input is the durable half of that fix: even if another advisory check starts reporting `cancelled`, it can no longer reach this decision.
+//
+// `cancelled` deliberately stays in FAIL_CONCLUSIONS. A timeout-killed job reports as `cancelled` rather than `failure`, so dropping it would blind the updater to a genuinely stuck required check.
+const REQUIRED_CHECK_NAMES = new Set(['CI Gate']);
+
 function hasFailingStatus(checkRuns, combinedState) {
   return checkRuns.some(
-    (run) => run.conclusion && FAIL_CONCLUSIONS.has(run.conclusion),
+    (run) =>
+      run.conclusion &&
+      REQUIRED_CHECK_NAMES.has(run.name) &&
+      FAIL_CONCLUSIONS.has(run.conclusion),
   ) || combinedState === 'failure' || combinedState === 'error';
 }
 
-module.exports = { hasFailingStatus, listCheckRuns, listOpenPulls };
+module.exports = { REQUIRED_CHECK_NAMES, hasFailingStatus, listCheckRuns, listOpenPulls };

--- a/.github/scripts/tests/auto-update-branches.test.js
+++ b/.github/scripts/tests/auto-update-branches.test.js
@@ -44,12 +44,55 @@ const github = {
     filter: 'latest',
     per_page: 100,
   });
-  assert.equal(hasFailingStatus([{ conclusion: 'timed_out' }], 'success'), true);
-  assert.equal(hasFailingStatus([{ conclusion: 'stale' }], 'success'), true);
-  assert.equal(hasFailingStatus([{ conclusion: 'success' }], 'failure'), true);
+  const gate = (conclusion) => ({ name: 'CI Gate', conclusion });
+
+  assert.equal(hasFailingStatus([gate('timed_out')], 'success'), true);
+  assert.equal(hasFailingStatus([gate('stale')], 'success'), true);
+  assert.equal(hasFailingStatus([gate('success')], 'failure'), true);
   assert.equal(hasFailingStatus([], 'error'), true);
-  assert.equal(hasFailingStatus([{ conclusion: 'neutral' }], 'success'), false);
-  assert.equal(hasFailingStatus([{ conclusion: null }], 'pending'), false);
+  assert.equal(hasFailingStatus([gate('neutral')], 'success'), false);
+  assert.equal(hasFailingStatus([gate(null)], 'pending'), false);
+
+  // A timeout-killed required check reports as `cancelled`, not `failure`, and
+  // must still count — this is the signal the updater exists to react to.
+  assert.equal(hasFailingStatus([gate('cancelled')], 'success'), true);
+
+  // The regression this narrowing exists for: an advisory check that cannot
+  // block a merge must not be able to trigger a branch update either. Two
+  // bookkeeping workflows sharing one concurrency bucket left exactly this
+  // `cancelled` check on nearly every open PR, which turned each scheduled
+  // sweep into a full-repository CI cascade.
+  assert.equal(
+    hasFailingStatus([{ name: 'stale', conclusion: 'cancelled' }], 'success'),
+    false,
+  );
+  assert.equal(
+    hasFailingStatus([{ name: 'Issue-PR Link Labels', conclusion: 'cancelled' }], 'success'),
+    false,
+  );
+  // An advisory check that genuinely failed is still not a merge blocker.
+  assert.equal(
+    hasFailingStatus([{ name: 'cargo-deny (advisories)', conclusion: 'failure' }], 'success'),
+    false,
+  );
+  // Mixed: the advisory noise is ignored, the required check decides.
+  assert.equal(
+    hasFailingStatus(
+      [{ name: 'stale', conclusion: 'cancelled' }, gate('success')],
+      'success',
+    ),
+    false,
+  );
+  assert.equal(
+    hasFailingStatus(
+      [{ name: 'stale', conclusion: 'cancelled' }, gate('failure')],
+      'success',
+    ),
+    true,
+  );
+  // A check run with no name (older payloads / hand-built fixtures) is not a
+  // required check and must not decide anything.
+  assert.equal(hasFailingStatus([{ conclusion: 'failure' }], 'success'), false);
   console.log('auto-update-branches tests passed');
 })().catch((error) => {
   console.error(error);

--- a/changelog.d/fixed/8192-auto-update-required-checks-only.md
+++ b/changelog.d/fixed/8192-auto-update-required-checks-only.md
@@ -1,0 +1,4 @@
+Stop the scheduled branch updater from treating an advisory check as a failing one, which turned each sweep into a full-repository CI cascade.
+`auto-update-branches` deliberately updates only pull requests whose CI is failing, precisely so that a moving `main` does not re-run CI on every open PR, but it decided "failing" from every check run on the head commit rather than from the checks the `main` ruleset actually requires.
+Two bookkeeping workflows sharing one concurrency bucket left a `cancelled` check on nearly every open pull request, `cancelled` counts as a failure, and so every sweep updated roughly thirty branches and queued thirty CI matrices behind them — one such fire left `main`'s own CI queued for over an hour and a half.
+The decision now reads only `CI Gate`, the sole entry in that ruleset's required checks, so a check that cannot block a merge can no longer trigger a branch update either (#8192) (@houko)


### PR DESCRIPTION
## The loop

`auto-update-branches` updates only pull requests whose CI is failing, and its own comment says why:

> Only update PRs whose CI is currently failing. Skipping green / pending PRs avoids a cascade of redundant CI runs every time main moves — the previous unconditional update burnt CI minutes on every open PR after every merge.

That guard was being defeated, and the result re-armed itself every six hours:

1. `Stale PR` and `Issue-PR Link Labels` shared one concurrency bucket and cancelled each other's runs across unrelated pull requests, so nearly every open PR carried a `cancelled` check. (Fixed separately in #8190.)
2. `hasFailingStatus` read **every** check run on the head commit, and `FAIL_CONCLUSIONS` contains `cancelled` — so every one of those PRs read as failing.
3. Each sweep therefore updated roughly thirty branches instead of the handful that were actually red.
4. Each update pushed a commit and queued a full CI matrix. On 2026-09-05 that left 36 CI runs queued behind 2 executing ones, with `main`'s own run — created 13:28:59Z — still waiting at 15:10Z.
5. Each push re-fired the two bookkeeping workflows, which cancelled each other again, restoring the condition for the next sweep.

Three sweeps in the observed window match this shape, each one followed within minutes by a burst of cross-branch cancellations: schedule runs at `2026-09-04T15:17:17Z`, `2026-09-05T09:33:08Z` and `2026-09-05T14:06:05Z`. The `0 */6 * * *` cron fires late on a busy repository, which is why the wall-clock times are not on six-hour boundaries.

## Change

`hasFailingStatus` now considers only the checks the `main` ruleset requires. `CI Gate` is the sole entry in that ruleset's `required_status_checks` (ruleset `13809063`), so everything else on a PR is advisory: it cannot block a merge, and it should not be able to trigger a branch update either.

`cancelled` deliberately stays in `FAIL_CONCLUSIONS`. A timeout-killed job reports as `cancelled` rather than `failure` — that is exactly what the unit lane was doing against its old 20-minute cap in #8159 — and it is a real stuck-required-check signal the updater should still react to. The fix narrows *which* checks are consulted, not which conclusions count.

`REQUIRED_CHECK_NAMES` is exported so the constant is reachable from the tests rather than duplicated in them.

## Relationship to #8190

#8190 fixes step 1, the shared concurrency bucket. This fixes step 2 and is the half that holds regardless: even if some future advisory check starts reporting `cancelled`, it can no longer reach this decision.

It also matters on a shorter timescale. Merging #8190 does not retroactively clear the `cancelled` checks already sitting on ~30 open PRs — those persist until each branch is pushed again — so the next sweep would cascade one more time without this change.

## Verification

- `node .github/scripts/tests/auto-update-branches.test.js` passes.
- The new assertions were run against the pre-change implementation to confirm they actually pin the bug rather than passing either way:

```
old impl  stale/cancelled              -> true   (new test asserts false)
old impl  Issue-PR Link/cancelled      -> true   (new test asserts false)
old impl  cargo-deny/failure           -> true   (new test asserts false)
```

- Existing assertions were kept and given a `CI Gate` name so they still exercise the required-check path; new cases cover a cancelled required check (must still count), advisory noise alongside a green gate (must not), advisory noise alongside a red gate (must), and a nameless check run (must not).
- `node --check` on both files.

## Deferred

Nothing.
