### PR TITLE
fix(llm-drivers): preserve streamed tool calls and 429 recovery

### DIFF
--- a/changelog.d/fixed/8195-claude-code-cache-tokens.md
+++ b/changelog.d/fixed/8195-claude-code-cache-tokens.md
@@ -1,0 +1,4 @@
+Fold the Claude CLI's prompt-cache token buckets into the reported prompt total for the `claude-code` driver.
+The driver read only `input_tokens` and `output_tokens` from the CLI's Anthropic-shaped usage object, and Anthropic reports `input_tokens` as new input only, so a cache-heavy turn — the normal case for that CLI — was recorded as a handful of prompt tokens instead of tens of thousands.
+Cost estimates, per-agent budget caps, the hourly token quota, the per-minute burst window and RL-export rows all under-counted this provider by orders of magnitude, and the quotas effectively never gated it.
+`cache_creation_input_tokens` and `cache_read_input_tokens` are now parsed and added into `input_tokens`, matching the normalisation the Anthropic HTTP driver already performs; CLI builds that omit the fields keep their previous numbers rather than failing to parse (#8195) (@houko)

--- a/changelog.d/fixed/8195-recovered-429-no-lockout.md
+++ b/changelog.d/fixed/8195-recovered-429-no-lockout.md
@@ -1,0 +1,4 @@
+Stop persisting a cross-process rate-limit lockout for a 429 the driver recovers from on its own retry.
+The Anthropic, OpenAI-compatible and Gemini drivers recorded the lockout before deciding whether to retry, and nothing but wall-clock expiry ever clears one — there is no success-based clear and the on-disk merge keeps the longest window.
+A single transient 429 that the very next attempt rode out therefore failed every later turn's pre-request check, in this process and in every sibling process sharing the key, for the provider's whole reset window: up to five minutes for a header-less 429 such as Gemini's `RESOURCE_EXHAUSTED`, and long enough in every case to exceed the fallback chain's 10-second sleep cap and mark the slot exhausted without an HTTP request.
+The lockout is now written only once the driver has exhausted its retries; the retry path still counts the 429 for metrics and still honours its `Retry-After` for backoff (#8195) (@houko)

--- a/changelog.d/fixed/8195-streamed-tool-call-index-truncation.md
+++ b/changelog.d/fixed/8195-streamed-tool-call-index-truncation.md
@@ -1,0 +1,4 @@
+Stop the OpenAI-compatible streaming driver from silently discarding a parallel tool call when the provider sends a `tool_call` delta for an index it has already moved past.
+The accumulator grew with `Vec::resize_with`, which shrinks as well as grows, so a late `id`, a trailing `arguments` fragment, or two entries in one frame in descending index order truncated every slot above the referenced index.
+The consumer had already been told those calls started, so a dashboard or ACP client was left rendering a tool call that never completes, and the model's request was never executed.
+Growth is now one-directional, keeping the single-allocation sparse growth without the truncation (#8195) (@houko)

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -546,10 +546,28 @@ impl LlmDriver for AnthropicDriver {
             let status = resp.status().as_u16();
 
             if status == 429 || status == 529 {
-                // Persist 429 lockouts only — 529 (overloaded) is a
-                // server-capacity issue, not an account-level rate
-                // limit, so it must not lock the key out across
-                // processes.
+                if attempt < max_retries {
+                    // Retry path: count a 429 but persist no lockout.
+                    // A lockout is only cleared by expiry, so recording one for a 429 the next attempt rides out would block this and every sibling process against a provider we are about to prove healthy.
+                    let retry_after = if status == 429 {
+                        crate::shared_rate_guard::note_429_from_headers(
+                            guard_provider,
+                            resp.headers(),
+                        )
+                    } else {
+                        crate::retry_after::parse_retry_after(resp.headers(), 0)
+                    };
+                    let delay = standard_retry_delay(attempt + 1, retry_after);
+                    warn!(
+                        status,
+                        delay_ms = delay.as_millis(),
+                        "Rate limited, retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                // Retries exhausted.
+                // Persist 429 lockouts only — 529 (overloaded) is a server-capacity issue, not an account-level rate limit, so it must not lock the key out across processes.
                 let retry_after = if status == 429 {
                     crate::shared_rate_guard::record_429_from_headers(
                         guard_provider,
@@ -560,16 +578,6 @@ impl LlmDriver for AnthropicDriver {
                 } else {
                     crate::retry_after::parse_retry_after(resp.headers(), 0)
                 };
-                if attempt < max_retries {
-                    let delay = standard_retry_delay(attempt + 1, retry_after);
-                    warn!(
-                        status,
-                        delay_ms = delay.as_millis(),
-                        "Rate limited, retrying"
-                    );
-                    tokio::time::sleep(delay).await;
-                    continue;
-                }
                 // Honor the server-supplied Retry-After when surfacing
                 // the final error after retries are exhausted; fall
                 // back to 5 s when the header was absent, invalid, or
@@ -718,9 +726,27 @@ impl LlmDriver for AnthropicDriver {
             let status = resp.status().as_u16();
 
             if status == 429 || status == 529 {
-                // 529 (overloaded) is a server-capacity issue, not an
-                // account-level rate limit — don't persist a key-wide
-                // lockout for it.
+                if attempt < max_retries {
+                    // Retry path: count a 429 without persisting a lockout that only expiry could clear.
+                    let retry_after = if status == 429 {
+                        crate::shared_rate_guard::note_429_from_headers(
+                            guard_provider,
+                            resp.headers(),
+                        )
+                    } else {
+                        crate::retry_after::parse_retry_after(resp.headers(), 0)
+                    };
+                    let delay = standard_retry_delay(attempt + 1, retry_after);
+                    warn!(
+                        status,
+                        delay_ms = delay.as_millis(),
+                        "Rate limited (stream), retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                // Retries exhausted.
+                // 529 (overloaded) is a server-capacity issue, not an account-level rate limit — don't persist a key-wide lockout for it.
                 let retry_after = if status == 429 {
                     crate::shared_rate_guard::record_429_from_headers(
                         guard_provider,
@@ -731,16 +757,6 @@ impl LlmDriver for AnthropicDriver {
                 } else {
                     crate::retry_after::parse_retry_after(resp.headers(), 0)
                 };
-                if attempt < max_retries {
-                    let delay = standard_retry_delay(attempt + 1, retry_after);
-                    warn!(
-                        status,
-                        delay_ms = delay.as_millis(),
-                        "Rate limited (stream), retrying"
-                    );
-                    tokio::time::sleep(delay).await;
-                    continue;
-                }
                 // Honor the server-supplied Retry-After when surfacing
                 // the final error after retries are exhausted; fall
                 // back to 5 s when the header was absent, invalid, or

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -878,12 +878,34 @@ struct ClaudeJsonOutput {
 }
 
 /// Usage stats from Claude CLI JSON output.
+///
+/// The CLI reports the Anthropic API shape, where `input_tokens` counts only the NEW input and the cached prompt is reported separately.
+/// `#[serde(default)]` on the cache buckets keeps older CLI builds that omit them parsing.
 #[derive(Debug, Deserialize, Default)]
 struct ClaudeUsage {
     #[serde(default)]
     input_tokens: u64,
     #[serde(default)]
     output_tokens: u64,
+    #[serde(default)]
+    cache_creation_input_tokens: u64,
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+}
+
+impl ClaudeUsage {
+    /// Normalise to the workspace `TokenUsage` convention: `input_tokens` is the TOTAL prompt count with the two cache buckets as subsets of it.
+    /// Same fold the Anthropic HTTP driver applies in `convert_response`; without it a cache-heavy Claude CLI turn reports a handful of prompt tokens instead of tens of thousands, and every consumer downstream — cost estimates, the hourly token quota, the per-minute burst window, RL export — under-counts by orders of magnitude.
+    fn to_token_usage(&self) -> TokenUsage {
+        TokenUsage {
+            input_tokens: self.input_tokens
+                + self.cache_read_input_tokens
+                + self.cache_creation_input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation_input_tokens: self.cache_creation_input_tokens,
+            cache_read_input_tokens: self.cache_read_input_tokens,
+        }
+    }
 }
 
 /// Stream JSON event from `claude -p --output-format stream-json`.
@@ -1186,11 +1208,7 @@ impl LlmDriver for ClaudeCodeDriver {
                 }],
                 stop_reason: StopReason::EndTurn,
                 tool_calls: Vec::new(),
-                usage: TokenUsage {
-                    input_tokens: usage.input_tokens,
-                    output_tokens: usage.output_tokens,
-                    ..Default::default()
-                },
+                usage: usage.to_token_usage(),
                 actual_provider: None,
                 actual_model: parsed.model,
             });
@@ -1498,11 +1516,7 @@ impl LlmDriver for ClaudeCodeDriver {
                                         }
                                     }
                                     if let Some(usage) = event.usage {
-                                        final_usage = TokenUsage {
-                                            input_tokens: usage.input_tokens,
-                                            output_tokens: usage.output_tokens,
-                                            ..Default::default()
-                                        };
+                                        final_usage = usage.to_token_usage();
                                     }
                                 }
                                 _ => {
@@ -2211,6 +2225,60 @@ mod tests {
         let parsed: ClaudeJsonOutput =
             serde_json::from_str(with_model).expect("result json deserializes");
         assert_eq!(parsed.model.as_deref(), Some("claude-opus-4-1-20250805"));
+    }
+
+    #[test]
+    fn cli_usage_folds_cache_buckets_into_total_input_tokens() {
+        // The CLI reports the Anthropic API shape (`input_tokens` = new input only), so both driver paths must normalise to the workspace `TokenUsage` convention where `input_tokens` is the TOTAL prompt count.
+        // Without the fold a cache-heavy turn reports 4 prompt tokens instead of 29204, `burst_tokens()` drops from 1504 to 304 and `cache_hit_ratio()` is `None`, so cost estimates and the token quotas silently under-count this provider.
+        let result_line = r#"{"type":"result","subtype":"success","is_error":false,"result":"hi","usage":{"input_tokens":4,"cache_creation_input_tokens":1200,"cache_read_input_tokens":28000,"output_tokens":300}}"#;
+        let parsed: ClaudeJsonOutput =
+            serde_json::from_str(result_line).expect("result json deserializes");
+        let usage = parsed.usage.expect("usage present").to_token_usage();
+        assert_eq!(usage.input_tokens, 29204);
+        assert_eq!(usage.output_tokens, 300);
+        assert_eq!(usage.cache_creation_input_tokens, 1200);
+        assert_eq!(usage.cache_read_input_tokens, 28000);
+        assert_eq!(usage.burst_tokens(), 1504);
+        let ratio = usage.cache_hit_ratio().expect("cache activity reported");
+        assert!(
+            (ratio - 28000.0 / 29200.0).abs() < 1e-4,
+            "unexpected cache hit ratio: {ratio}"
+        );
+
+        // Same shape over stream-json, where the buckets arrive on the result event.
+        let stream_line = r#"{"type":"result","result":"hi","usage":{"input_tokens":4,"cache_creation_input_tokens":1200,"cache_read_input_tokens":28000,"output_tokens":300}}"#;
+        let event: ClaudeStreamEvent =
+            serde_json::from_str(stream_line).expect("stream result event deserializes");
+        let stream_usage = event.usage.expect("usage present").to_token_usage();
+        assert_eq!(stream_usage.input_tokens, 29204);
+        assert_eq!(stream_usage.cache_read_input_tokens, 28000);
+
+        // An older CLI build that omits the cache fields must still parse and degrade to plain new-input accounting rather than failing.
+        let no_cache = r#"{"input_tokens":10,"output_tokens":5}"#;
+        let legacy: ClaudeUsage =
+            serde_json::from_str(no_cache).expect("legacy usage deserializes");
+        let legacy = legacy.to_token_usage();
+        assert_eq!(legacy.input_tokens, 10);
+        assert_eq!(legacy.cache_read_input_tokens, 0);
+        assert_eq!(legacy.cache_hit_ratio(), None);
+    }
+
+    #[test]
+    fn cli_usage_fold_is_wired_into_both_driver_paths() {
+        // The fold only matters if `complete` and `stream` actually route through it; an inline `TokenUsage { input_tokens: usage.input_tokens, .. }` at either site reintroduces the under-count.
+        let Some(source) = read_claude_code_source() else {
+            return;
+        };
+        let tests_marker = source
+            .find("#[cfg(test)]\nmod tests")
+            .expect("test module marker must exist");
+        let impl_body = &source[..tests_marker];
+        assert_eq!(
+            impl_body.matches(".to_token_usage()").count(),
+            2,
+            "both CLI result paths (json + stream-json) must build their TokenUsage via ClaudeUsage::to_token_usage",
+        );
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -1002,12 +1002,21 @@ impl LlmDriver for GeminiDriver {
                 // lockout for it.
                 let retry_after_ms = crate::retry_after::parse_retry_after_ms(resp.headers(), 5000);
                 if status == 429 {
-                    crate::shared_rate_guard::record_429_from_headers(
-                        guard_provider,
-                        &guard_key_id,
-                        resp.headers(),
-                        "Gemini HTTP 429",
-                    );
+                    if attempt < max_retries {
+                        // Retry path: count the 429 but persist no lockout.
+                        // Nothing clears one except expiry, and a Gemini RESOURCE_EXHAUSTED carries no reset headers, so a 429 we ride out here would blackhole the key for the full 5-minute default in this and every sibling process.
+                        crate::shared_rate_guard::note_429_from_headers(
+                            guard_provider,
+                            resp.headers(),
+                        );
+                    } else {
+                        crate::shared_rate_guard::record_429_from_headers(
+                            guard_provider,
+                            &guard_key_id,
+                            resp.headers(),
+                            "Gemini HTTP 429",
+                        );
+                    }
                 }
                 if attempt < max_retries {
                     let delay = standard_retry_delay(
@@ -1156,12 +1165,20 @@ impl LlmDriver for GeminiDriver {
                 // lockout for it.
                 let retry_after_ms = crate::retry_after::parse_retry_after_ms(resp.headers(), 5000);
                 if status == 429 {
-                    crate::shared_rate_guard::record_429_from_headers(
-                        guard_provider,
-                        &guard_key_id,
-                        resp.headers(),
-                        "Gemini HTTP 429 (stream)",
-                    );
+                    if attempt < max_retries {
+                        // Retry path: count the 429 without persisting a lockout that only expiry could clear.
+                        crate::shared_rate_guard::note_429_from_headers(
+                            guard_provider,
+                            resp.headers(),
+                        );
+                    } else {
+                        crate::shared_rate_guard::record_429_from_headers(
+                            guard_provider,
+                            &guard_key_id,
+                            resp.headers(),
+                            "Gemini HTTP 429 (stream)",
+                        );
+                    }
                 }
                 if attempt < max_retries {
                     let delay = standard_retry_delay(

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1640,16 +1640,12 @@ impl LlmDriver for OpenAIDriver {
 
             let status = resp.status().as_u16();
             if status == 429 {
-                // Persist the lockout (honors RPH > RPM > retry-after >
-                // 5min default precedence) and reuse the parsed
-                // retry-after for the in-process backoff.
-                let retry_after = crate::shared_rate_guard::record_429_from_headers(
-                    guard_provider,
-                    &guard_key_id,
-                    resp.headers(),
-                    &format!("HTTP 429 from {}", self.base_url),
-                );
                 if attempt < max_retries {
+                    // Count the 429 and reuse its retry-after for the in-process backoff, but do not persist a lockout: nothing clears one except expiry, so a 429 we ride out here would still block this and every sibling process against a provider we are about to prove healthy.
+                    let retry_after = crate::shared_rate_guard::note_429_from_headers(
+                        guard_provider,
+                        resp.headers(),
+                    );
                     let delay = standard_retry_delay(attempt + 1, retry_after);
                     warn!(
                         status,
@@ -1659,6 +1655,13 @@ impl LlmDriver for OpenAIDriver {
                     tokio::time::sleep(delay).await;
                     continue;
                 }
+                // Retries exhausted: persist the lockout (honors RPH > RPM > retry-after > 5min default precedence) so a restart and sibling processes observe it too.
+                let retry_after = crate::shared_rate_guard::record_429_from_headers(
+                    guard_provider,
+                    &guard_key_id,
+                    resp.headers(),
+                    &format!("HTTP 429 from {}", self.base_url),
+                );
                 return Err(LlmError::RateLimited {
                     retry_after_ms: retry_after.as_millis().min(u64::MAX as u128) as u64,
                     message: None,
@@ -2098,13 +2101,12 @@ impl LlmDriver for OpenAIDriver {
 
             let status = resp.status().as_u16();
             if status == 429 {
-                let retry_after = crate::shared_rate_guard::record_429_from_headers(
-                    guard_provider,
-                    &guard_key_id,
-                    resp.headers(),
-                    &format!("HTTP 429 (stream) from {}", self.base_url),
-                );
                 if attempt < max_retries {
+                    // Retry path: count the 429 without persisting a lockout that only expiry could clear.
+                    let retry_after = crate::shared_rate_guard::note_429_from_headers(
+                        guard_provider,
+                        resp.headers(),
+                    );
                     let delay = standard_retry_delay(attempt + 1, retry_after);
                     warn!(
                         status,
@@ -2114,6 +2116,12 @@ impl LlmDriver for OpenAIDriver {
                     tokio::time::sleep(delay).await;
                     continue;
                 }
+                let retry_after = crate::shared_rate_guard::record_429_from_headers(
+                    guard_provider,
+                    &guard_key_id,
+                    resp.headers(),
+                    &format!("HTTP 429 (stream) from {}", self.base_url),
+                );
                 return Err(LlmError::RateLimited {
                     retry_after_ms: retry_after.as_millis().min(u64::MAX as u128) as u64,
                     message: None,
@@ -2514,7 +2522,10 @@ impl LlmDriver for OpenAIDriver {
 
                                 // Grow to a sparse provider-supplied index in
                                 // one allocation rather than one push per slot.
-                                tool_accum.resize_with(idx + 1, StreamedToolCall::default);
+                                // Growth has to stay one-directional: `resize_with` also shrinks, so a delta for a lower index — a late `id`, a trailing `arguments` fragment, or two entries in one frame in descending order — would truncate the slots already accumulated above it and silently drop a parallel tool call the model asked for.
+                                if tool_accum.len() < idx + 1 {
+                                    tool_accum.resize_with(idx + 1, StreamedToolCall::default);
+                                }
 
                                 // ID (sent in first chunk for this tool)
                                 if let Some(id) = call["id"].as_str() {
@@ -5540,6 +5551,61 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    /// Regression: a tool_call delta for an already-seen lower index must not discard the higher slots accumulated after it.
+    /// The accumulator grows with `resize_with`, which shrinks as well as grows, so the trailing `arguments` fragment for index 0 below used to truncate the Vec back to one element and lose the second parallel call entirely.
+    #[tokio::test]
+    async fn streamed_tool_call_delta_for_earlier_index_keeps_later_calls() {
+        let sse_body = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"function\":{\"name\":\"first_tool\",\"arguments\":\"{\\\"x\\\":1}\"}}]}}]}\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_b\",\"function\":{\"name\":\"second_tool\",\"arguments\":\"{\\\"y\\\":2}\"}}]}}]}\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\"}}]}}]}\n\
+             data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\
+             data: [DONE]\n"
+            .to_string();
+        let base = spawn_sse_server(sse_body).await;
+        let driver = OpenAIDriver::new("test-key".to_string(), base);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let response = driver
+            .stream(transport_retry_request(), tx)
+            .await
+            .expect("stream with a back-referencing tool_call delta must complete");
+
+        assert_eq!(
+            response.tool_calls.len(),
+            2,
+            "both parallel tool calls must survive a delta for the earlier index: {:?}",
+            response.tool_calls
+        );
+        assert_eq!(response.tool_calls[0].id, "call_a");
+        assert_eq!(response.tool_calls[0].name, "first_tool");
+        assert_eq!(response.tool_calls[0].input["x"], 1);
+        assert_eq!(response.tool_calls[1].id, "call_b");
+        assert_eq!(response.tool_calls[1].name, "second_tool");
+        assert_eq!(response.tool_calls[1].input["y"], 2);
+
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        // Every started tool call must also be ended, or ACP / dashboard consumers keep rendering it as still running.
+        let started: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::ToolUseStart { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+        let ended: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::ToolUseEnd { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(started, vec!["call_a", "call_b"]);
+        assert_eq!(ended, vec!["call_a", "call_b"]);
     }
 
     /// Regression: an OpenAI-compatible provider (OpenRouter / Groq) can send a terminal error as an SSE `data:` frame over an already-HTTP-200 body instead of a non-2xx status.

--- a/crates/librefang-llm-drivers/src/shared_rate_guard.rs
+++ b/crates/librefang-llm-drivers/src/shared_rate_guard.rs
@@ -374,29 +374,11 @@ pub fn pre_request_check(
     Ok(())
 }
 
-/// Persist a 429 lockout from a `reqwest` response's headers and return
-/// the parsed `Retry-After` so the caller can reuse it for backoff.
+/// Count a 429 for observability and return the parsed `Retry-After` for in-process backoff, **without** persisting a cross-process lockout.
 ///
-/// Header parsing precedence (RPH > RPM > Retry-After > 5min default) is
-/// delegated to [`record_from_snapshot`].
-pub fn record_429_from_headers(
-    provider: &str,
-    key_id: &str,
-    headers: &reqwest::header::HeaderMap,
-    reason: &str,
-) -> Duration {
-    // 0 fallback preserves the existing precedence semantics
-    // (RPH > RPM > Retry-After > 5min default) — a missing or
-    // unparseable header means "no Retry-After signal", not "5 s".
-    let retry_after = crate::retry_after::parse_retry_after(headers, 0);
-    let snap = crate::rate_limit_tracker::RateLimitSnapshot::from_headers(headers);
-    record_from_snapshot(
-        provider,
-        key_id,
-        snap.as_ref(),
-        Some(retry_after),
-        Some(reason.to_string()),
-    );
+/// This is the right call for a 429 the driver is about to retry itself.
+/// A lockout is only honest once the driver has given up: nothing clears a persisted lockout except wall-clock expiry (there is no success-based clear, and the max-merge in [`record`] keeps the longest window), so recording one for a 429 the very next attempt rides out would fail every subsequent [`pre_request_check`] in this and every sibling process for the whole recorded window — against a provider that was just proven healthy.
+pub fn note_429_from_headers(provider: &str, headers: &reqwest::header::HeaderMap) -> Duration {
     // Cardinality: provider is a fixed enum (anthropic/openai/gemini/…),
     // status is the bare HTTP status code as string. We never include
     // key_id or reason text. (#3495)
@@ -406,6 +388,34 @@ pub fn record_429_from_headers(
         "status" => "429",
     )
     .increment(1);
+    // 0 fallback preserves the existing precedence semantics
+    // (RPH > RPM > Retry-After > 5min default) — a missing or
+    // unparseable header means "no Retry-After signal", not "5 s".
+    crate::retry_after::parse_retry_after(headers, 0)
+}
+
+/// Persist a 429 lockout from a `reqwest` response's headers and return
+/// the parsed `Retry-After` so the caller can reuse it for backoff.
+///
+/// Call this only on the terminal attempt — see [`note_429_from_headers`] for the retry path.
+///
+/// Header parsing precedence (RPH > RPM > Retry-After > 5min default) is
+/// delegated to [`record_from_snapshot`].
+pub fn record_429_from_headers(
+    provider: &str,
+    key_id: &str,
+    headers: &reqwest::header::HeaderMap,
+    reason: &str,
+) -> Duration {
+    let retry_after = note_429_from_headers(provider, headers);
+    let snap = crate::rate_limit_tracker::RateLimitSnapshot::from_headers(headers);
+    record_from_snapshot(
+        provider,
+        key_id,
+        snap.as_ref(),
+        Some(retry_after),
+        Some(reason.to_string()),
+    );
     retry_after
 }
 
@@ -679,6 +689,45 @@ mod tests {
         record_from_snapshot("openai", &key_id, Some(&snap), None, Some("429".into()));
 
         let remaining = check("openai", &key_id).expect("locked out");
+        assert!(
+            remaining.as_secs() > 3500,
+            "must record full RPH cooldown, got {}s",
+            remaining.as_secs()
+        );
+
+        // SAFETY: guarded by ENV_GUARD mutex.
+        unsafe { std::env::remove_var("LIBREFANG_HOME") };
+    }
+
+    #[test]
+    fn note_429_returns_retry_after_without_writing_a_lockout() {
+        // The retry path needs the parsed Retry-After for its backoff but must leave no lockout behind: a 429 the driver rides out cannot be allowed to blackhole the key, because only wall-clock expiry ever clears a recorded lockout.
+        let _g = ENV_GUARD.lock().unwrap();
+        let home = fresh_home();
+        // SAFETY: guarded by ENV_GUARD mutex; no concurrent thread reads this var.
+        unsafe { std::env::set_var("LIBREFANG_HOME", home.path()) };
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("retry-after", "7".parse().unwrap());
+        headers.insert("x-ratelimit-reset-requests-1h", "3540".parse().unwrap());
+        headers.insert("x-ratelimit-limit-requests-1h", "1000".parse().unwrap());
+        headers.insert("x-ratelimit-remaining-requests-1h", "0".parse().unwrap());
+
+        let key_id = key_id_hash("sk-note-429");
+        let retry_after = note_429_from_headers("openai", &headers);
+        assert_eq!(retry_after, Duration::from_secs(7));
+        assert!(
+            check("openai", &key_id).is_none(),
+            "note must not persist a lockout"
+        );
+        assert!(
+            !lockout_path("openai", &key_id).exists(),
+            "note must not create a lockout file"
+        );
+
+        // The terminal-attempt helper still persists, and honours RPH over the shorter Retry-After.
+        record_429_from_headers("openai", &key_id, &headers, "test 429");
+        let remaining = check("openai", &key_id).expect("record must persist a lockout");
         assert!(
             remaining.as_secs() > 3500,
             "must record full RPH cooldown, got {}s",

--- a/crates/librefang-llm-drivers/tests/anthropic_retry.rs
+++ b/crates/librefang-llm-drivers/tests/anthropic_retry.rs
@@ -68,9 +68,10 @@ async fn aa1_429_retry_then_success() {
     let result = dk.driver.complete(simple_request("claude-test")).await;
     assert!(result.is_ok(), "expected Ok, got {:?}", result);
     assert_eq!(server.received_requests().await.unwrap().len(), 3);
+    // A 429 the driver rode out itself must not persist a lockout: the call returned Ok, and only wall-clock expiry ever clears a recorded lockout, so keeping it would block this and every sibling process against a provider that is demonstrably healthy.
     assert!(
-        lockout_file_exists("anthropic", &dk.api_key),
-        "lockout file should exist after 429"
+        !lockout_file_exists("anthropic", &dk.api_key),
+        "a recovered 429 must not persist a cross-process lockout"
     );
 }
 
@@ -181,4 +182,37 @@ async fn aa5_stream_429_retry() {
     assert!(result.is_ok(), "expected Ok, got {:?}", result);
     assert!(!events.is_empty(), "stream events should not be empty");
     assert_eq!(server.received_requests().await.unwrap().len(), 3);
+    assert!(
+        !lockout_file_exists("anthropic", &dk.api_key),
+        "a recovered 429 must not persist a cross-process lockout on the streaming path either"
+    );
+}
+
+/// The streaming twin of `aa2`: the stream path has its own 429 handling, so the persisting half of the behaviour needs its own assertion here.
+#[tokio::test]
+#[serial_test::serial]
+async fn aa6_stream_429_exhaustion() {
+    let _env = isolated_env();
+    let server = MockServer::start().await;
+    let dk = driver_with_key(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(anthropic_429_fast_retry())
+        .up_to_n_times(4)
+        .mount(&server)
+        .await;
+
+    let (result, events) = collect_stream(&dk.driver, simple_request("claude-test")).await;
+    assert!(
+        matches!(result, Err(LlmError::RateLimited { .. })),
+        "expected RateLimited, got {:?}",
+        result
+    );
+    assert!(events.is_empty(), "expected no events, got {:?}", events);
+    assert_eq!(server.received_requests().await.unwrap().len(), 4);
+    assert!(
+        lockout_file_exists("anthropic", &dk.api_key),
+        "exhausted 429 on the streaming path must persist a cross-process lockout"
+    );
 }

--- a/crates/librefang-llm-drivers/tests/gemini_retry.rs
+++ b/crates/librefang-llm-drivers/tests/gemini_retry.rs
@@ -74,6 +74,8 @@ fn gemini_403() -> ResponseTemplate {
 #[tokio::test]
 #[serial_test::serial]
 async fn ag1_429_retry_then_success() {
+    // Needs the isolated LIBREFANG_HOME so the lockout assertion below reads this run's rate_limits dir rather than whatever a previous run left in the real one.
+    let _env = isolated_env();
     let server = MockServer::start().await;
     let api_key = "test-ag1-key".to_string();
     let driver = GeminiDriver::with_proxy_and_timeout(api_key.clone(), server.uri(), None, Some(5));
@@ -93,7 +95,11 @@ async fn ag1_429_retry_then_success() {
     let result = driver.complete(simple_request("gpt-test")).await;
     assert!(result.is_ok(), "expected Ok, got {:?}", result);
     assert_eq!(counter.load(Ordering::SeqCst), 3);
-    assert!(lockout_file_exists("gemini", &api_key));
+    // A 429 the driver rode out itself must not persist a lockout: the call returned Ok, and only wall-clock expiry ever clears a recorded lockout, so keeping it would block this and every sibling process against a provider that is demonstrably healthy.
+    assert!(
+        !lockout_file_exists("gemini", &api_key),
+        "a recovered 429 must not persist a cross-process lockout"
+    );
 }
 
 #[tokio::test]
@@ -124,6 +130,12 @@ async fn ag2_429_exhaustion() {
         result
     );
     assert_eq!(counter.load(Ordering::SeqCst), 4);
+    // The other half of the behaviour this PR redefined: once the driver has given up, the lockout must persist, so a sibling process short-circuits in `pre_request_check` instead of re-running the same four doomed requests.
+    // Without this assertion, deleting the terminal `record_429_from_headers` branch would leave the whole suite green.
+    assert!(
+        lockout_file_exists("gemini", &api_key),
+        "exhausted 429 must persist a cross-process lockout"
+    );
 }
 
 #[tokio::test]
@@ -203,4 +215,44 @@ async fn ag5_stream_429_retry() {
     assert!(result.is_ok(), "expected Ok, got {:?}", result);
     assert!(!events.is_empty(), "stream should emit events");
     assert_eq!(counter.load(Ordering::SeqCst), 3);
+    assert!(
+        !lockout_file_exists("gemini", &api_key),
+        "a recovered 429 must not persist a cross-process lockout on the streaming path either"
+    );
+}
+
+/// The streaming twin of `ag2`: the stream path has its own 429 handling, so it needs its own assertion that the terminal attempt still persists the lockout.
+#[tokio::test]
+#[serial_test::serial]
+async fn ag6_stream_429_exhaustion() {
+    let _env = isolated_env();
+    let server = MockServer::start().await;
+    let api_key = "test-ag6-key".to_string();
+    let driver = GeminiDriver::with_proxy_and_timeout(api_key.clone(), server.uri(), None, Some(5));
+
+    let (responder, counter) = SequencedResponder::new(vec![
+        fast_gemini_429(),
+        fast_gemini_429(),
+        fast_gemini_429(),
+        fast_gemini_429(),
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/v1beta/models/gpt-test:streamGenerateContent"))
+        .respond_with(responder)
+        .mount(&server)
+        .await;
+
+    let (result, events) = collect_stream(&driver, simple_request("gpt-test")).await;
+    assert!(
+        matches!(result, Err(LlmError::RateLimited { .. })),
+        "expected RateLimited, got {:?}",
+        result
+    );
+    assert!(events.is_empty(), "expected no events, got {:?}", events);
+    assert_eq!(counter.load(Ordering::SeqCst), 4);
+    assert!(
+        lockout_file_exists("gemini", &api_key),
+        "exhausted 429 on the streaming path must persist a cross-process lockout"
+    );
 }

--- a/crates/librefang-llm-drivers/tests/openai_retry_complete.rs
+++ b/crates/librefang-llm-drivers/tests/openai_retry_complete.rs
@@ -57,9 +57,66 @@ async fn oc1_429_retry_then_success() {
     let requests = server.received_requests().await.unwrap();
     assert_eq!(requests.len(), 3, "expected 3 requests (2x429 + 1x200)");
 
+    // A 429 the driver rode out on its own retry must leave no persisted lockout: the call returned Ok, so the provider is proven healthy, and nothing but wall-clock expiry ever clears a recorded lockout.
     assert!(
-        lockout_file_exists(provider_for_openai_mock(), &api_key),
-        "lockout file should exist"
+        !lockout_file_exists(provider_for_openai_mock(), &api_key),
+        "a recovered 429 must not persist a cross-process lockout"
+    );
+}
+
+/// A 429 from an hour-bucket gateway (OpenAI tier-1, Nous Portal): the RPH bucket is exhausted and no `Retry-After` is sent.
+/// The recorded cooldown is then the full bucket reset instead of a couple of seconds, which is what makes a stale lockout observable at all — a one-second lockout would expire during the driver's own backoff and hide the defect rather than expose it.
+fn openai_429_hour_bucket_exhausted() -> ResponseTemplate {
+    ResponseTemplate::new(429)
+        .insert_header("x-ratelimit-limit-requests-1h", "1000")
+        .insert_header("x-ratelimit-remaining-requests-1h", "0")
+        .insert_header("x-ratelimit-reset-requests-1h", "3540")
+        .set_body_json(serde_json::json!({
+            "error": {"message": "rate limited", "type": "rate_limit_error"}
+        }))
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn oc1b_recovered_429_leaves_sibling_process_able_to_call() {
+    // The user-visible half of the same defect: the lockout file is shared across processes, so a stale one from a recovered 429 made the next driver instance (daemon fork, `librefang agent chat`, cron) fail `pre_request_check` with RateLimited before opening a socket.
+    let _env = isolated_env();
+    let server = MockServer::start().await;
+
+    let api_key = "sk-test-oc1b".to_string();
+    let driver_a =
+        OpenAIDriver::with_proxy_and_timeout(api_key.clone(), server.uri(), None, Some(5));
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(openai_429_hour_bucket_exhausted())
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(openai_200_body("recovered")))
+        .with_priority(2)
+        .mount(&server)
+        .await;
+
+    let first = driver_a.complete(simple_request("gpt-test")).await;
+    assert!(first.is_ok(), "expected Ok after retry, got {:?}", first);
+
+    let driver_b =
+        OpenAIDriver::with_proxy_and_timeout(api_key.clone(), server.uri(), None, Some(5));
+    let second = driver_b.complete(simple_request("gpt-test")).await;
+    assert!(
+        second.is_ok(),
+        "sibling process must still reach a provider that already recovered, got {:?}",
+        second
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        3,
+        "the second call must actually hit the network (1x429 + 1x200 + 1x200)"
     );
 }
 

--- a/crates/librefang-llm-drivers/tests/openai_retry_stream.rs
+++ b/crates/librefang-llm-drivers/tests/openai_retry_stream.rs
@@ -2,6 +2,7 @@ mod common;
 
 use common::*;
 use librefang_llm_driver::{LlmError, StreamEvent};
+use librefang_llm_drivers::drivers::openai::OpenAIDriver;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -95,7 +96,9 @@ async fn os2_stream_options_strip() {
 async fn os3_429_exhaustion_stream() {
     let _env = isolated_env();
     let server = MockServer::start().await;
-    let driver = mock_openai_driver(&server);
+    // Built with an explicit key rather than `mock_openai_driver`, whose key is a random UUID the test cannot name — the lockout assertion below has to hash the same key the driver used.
+    let api_key = "sk-test-os3".to_string();
+    let driver = OpenAIDriver::with_proxy_and_timeout(api_key.clone(), server.uri(), None, Some(5));
 
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
@@ -116,6 +119,11 @@ async fn os3_429_exhaustion_stream() {
         requests.len(),
         4,
         "expected 4 requests (initial + 3 retries)"
+    );
+    // The streaming path has its own 429 handling, so the persisting half of the behaviour needs its own assertion here: once the driver has given up, a sibling process must short-circuit in `pre_request_check` rather than repeat the same four doomed requests.
+    assert!(
+        lockout_file_exists(provider_for_openai_mock(), &api_key),
+        "exhausted 429 on the streaming path must persist a cross-process lockout"
     );
 }
 


### PR DESCRIPTION
Three driver-layer defects, two of which silently corrupt a turn rather than failing it.

## Streamed tool calls were truncated by a delta for an earlier index

The OpenAI streaming accumulator grew its slot vector with a bare `tool_accum.resize_with(idx + 1, …)`.
`resize_with` shrinks as readily as it grows, so a delta carrying a lower index than one already seen truncated the vector and permanently discarded every later tool call — after `ToolUseStart` and `ToolInputDelta` for those calls had already been emitted to the consumer.

If that index then received a further delta, the slot was recreated as a default: `start_emitted` was false again, producing a duplicate `ToolUseStart`, and the accumulated argument prefix was gone, leaving JSON that fails to parse and degrades to `malformed_tool_input`.

Providers are not required to order `index` monotonically, and the driver's own test suite already covers a late field arriving for an earlier index.
Growth is now one-directional (`if tool_accum.len() < idx + 1`), keeping the single-allocation sparse growth that introduced the regression.

## A recovered 429 left a cross-process lockout nothing ever cleared

The 429 handler wrote a shared lockout file before the driver's own retry, so a rate limit the driver successfully recovered from still left a five-minute lockout on disk.
The file is shared across processes, so the next driver instance — a daemon fork, `librefang agent chat`, a cron fire — failed `pre_request_check` with `RateLimited` before opening a socket, for a limit that no longer applied.

A new `note_429_from_headers` records the metric and parses `Retry-After` without writing a lockout, and the recovery path uses it.
`record_429_from_headers` delegates to the same helper, so metric semantics are unchanged for the paths that genuinely need to persist a lockout.

## claude-code driver dropped the Anthropic cache token buckets

`ClaudeUsage` did not deserialize `cache_creation_input_tokens` or `cache_read_input_tokens`, so `input_tokens` reported new input only.
That violates the documented `TokenUsage` contract and understates billed input on every cache-hit turn, which propagates into metering and budget accounting.

Both buckets are now deserialized with `#[serde(default)]` and folded into `input_tokens` while being carried through as subsets — byte-for-byte the normalisation `anthropic.rs` already applies, so the two providers agree.

## Notes

Comment prose in the touched 429 blocks of `anthropic.rs` and `openai.rs` was unwrapped from hard column wraps to one sentence per line, per the repo's prose rule for paragraphs already being edited.
`anthropic.rs`, `gemini.rs` and `shared_rate_guard.rs` are in the diff because they are callers of the changed rate-guard helper, not as independent changes.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean, and `cargo fmt --all --check` and `scripts/check-changelog-attribution.py` clean.

One caveat worth recording, because it produced a false result first time round: these worktrees initially shared one `CARGO_TARGET_DIR`, and cargo served one worktree another's `librefang-*` artifacts — which manufactured an error in a file this branch never touched, and could equally have manufactured a pass.
Every clippy result quoted here was re-run after deleting the workspace-member artifacts, so all 29 workspace crates were genuinely recompiled from this tree.

Full test suites run in CI.
