### PR TITLE
ci: stop the bookkeeping workflows from cancelling their own runs

### DIFF
--- a/.github/workflows/issue-pr-link.yml
+++ b/.github/workflows/issue-pr-link.yml
@@ -16,14 +16,15 @@ on:
 permissions:
   contents: read
 
-# Each run re-derives the linked-issue set from the PR body and the PR's current open/closed state, so the newest run converges on the correct `has-pr` labels whatever a cancelled predecessor had applied so far.
-# `pull_request_target` reports `github.ref` as the base branch for every PR, so the group must key on something PR-specific to stay collision-free across PRs.
+# Each run re-derives the linked-issue set from the PR body and the PR's current open/closed state, so every run converges on the correct `has-pr` labels on its own and serialising them costs only time.
+# `pull_request_target` reports `github.ref` as the base branch for every PR, so the group keys on `github.head_ref`, which is PR-specific.
 #
-# That something is `github.head_ref`, not `github.event.pull_request.number`, which did not isolate PRs in practice: on 2026-09-05 a three-PR merge sweep produced runs on three distinct branches between 13:28:59 and 13:29:09 and cancelled the middle one, and the same shape recurs on every burst of opens or closes.
-# A cancelled run reports its check as failed, which left open PRs sitting at `mergeStateStatus = UNSTABLE` over a bookkeeping label job while `CI Gate` was green.
+# Cancellation is off for the same reason as in `stale-pr.yml`: a cancelled run reports its check as failed, and a bookkeeping label job has no business putting a red check on a pull request whose required `CI Gate` is green.
+# Runs on unrelated pull requests were observed cancelling one another — a three-PR merge sweep on 2026-09-05 produced runs on three distinct branches between 13:28:59 and 13:29:09 and cancelled the middle one — and the same shape recurred on every burst of opens or closes.
+# #8190 read that as a group-key collision and changed the key; the cancellations continued afterwards, so the cause is not established and only the harm is removed here.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.event.pull_request.number || 'reconcile' }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -19,17 +19,22 @@ permissions:
   contents: read
 
 # Two paths with different safety properties share this workflow.
-# The `pull_request_target` path only removes `stale-pr` from the single PR that was pushed to, so it is idempotent and safe to cancel — the newer push repeats the same removal.
-# The `schedule` / `workflow_dispatch` path sweeps up to 100 open PRs and adds or removes a label one PR at a time, so cancelling it mid-flight would leave a partially swept repository; every sweep shares the constant `sweep` group key and is never cancelled, which makes two overlapping cron fires serialise instead of racing.
+# The `pull_request_target` path only removes `stale-pr` from the single PR that was pushed to, so it is idempotent: repeating it is free and skipping a superseded one saves nothing worth having.
+# The `schedule` / `workflow_dispatch` path sweeps up to 100 open PRs and adds or removes a label one PR at a time, so cancelling it mid-flight would leave a partially swept repository; every sweep shares the constant `sweep` group key.
 #
-# The per-PR key is `github.head_ref` and not `github.event.pull_request.number` (#7837), because in practice the number did not isolate PRs from one another and every `pull_request_target` run landed in one bucket.
-# On 2026-09-04 a single `auto-update-branches` sweep created 33 runs across 33 distinct branches between 15:53:25 and 15:55:47, and 31 of them were cancelled — each new run killing the previous, which is what a shared group key with `cancel-in-progress` does and is impossible if the key varies per PR.
-# The damage was not functional (the label removal is idempotent) but informational: a cancelled run reports its check as failed, so nearly every open PR sat at `mergeStateStatus = UNSTABLE` with `CI Gate` green, and a real failure was indistinguishable from this bookkeeping noise at a glance.
-# `head_ref` is set on `pull_request` / `pull_request_target` and empty elsewhere, so the sweep still falls through to the constant `sweep` key.
-# It is distinct from `github.ref`, which #7837 correctly rejected because `pull_request_target` reports it as a branch of the base repository and would bucket every PR together.
+# Nothing here is ever cancelled, and that is the point.
+# A cancelled run reports its check as failed, so a workflow that cancels its own runs stamps a red check on pull requests whose required `CI Gate` is green — which is how nearly every open PR came to sit at `mergeStateStatus = UNSTABLE` over label bookkeeping, making a real failure indistinguishable from this noise at a glance.
+# Runs on unrelated pull requests were observed cancelling one another in bursts: on 2026-09-04 a single `auto-update-branches` sweep produced 33 runs across 33 distinct branches between 15:53:25 and 15:55:47 and cancelled 31 of them.
+#
+# #8190 attributed that to the group key — `github.event.pull_request.number` failing to vary per PR — and switched to `github.head_ref`.
+# It did not stop: bursts on 2026-09-05 after 18:13 still cancelled runs on distinct branches with the new key live on `main`, and `Issue-PR Link Labels` showed identical behaviour under a third spelling.
+# Two different key expressions producing the same result is evidence against the key being the cause, so that explanation is unconfirmed and should not be repeated as fact.
+# `head_ref` is kept because it is the more likely-correct spelling for a per-PR key regardless, and because it is empty outside pull-request events so the sweep still falls through to `sweep`.
+#
+# Turning cancellation off removes the mechanism instead of trying to aim it. The cost is that two pushes to one PR run this twice, roughly fifteen seconds each; the benefit is that no run of this workflow can ever report a red check again.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.event.pull_request.number || 'sweep' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/changelog.d/fixed/8202-bookkeeping-no-cancel.md
+++ b/changelog.d/fixed/8202-bookkeeping-no-cancel.md
@@ -1,0 +1,4 @@
+Stop the `Stale PR` and `Issue-PR Link Labels` workflows from cancelling their own runs, so a bookkeeping label job can no longer stamp a red check on a pull request whose required check is green.
+A cancelled run reports its check as failed, and runs on unrelated pull requests were cancelling one another in bursts — one sweep produced 33 runs across 33 distinct branches and cancelled 31 — which left nearly every open PR at `mergeStateStatus = UNSTABLE` over label bookkeeping and made a genuine failure indistinguishable from the noise at a glance.
+#8190 attributed this to the concurrency group key and changed it; the cancellations continued with the new key live, so that explanation is not established and the comments no longer assert it.
+Both workflows recompute their desired state from the pull request on every run, so serialising them is free apart from a few seconds of runner time, and it removes the mechanism rather than trying to aim it (#8202) (@houko)


### PR DESCRIPTION
## What

`cancel-in-progress` is now `false` on `Stale PR` and `Issue-PR Link Labels`.

## Why

A cancelled run reports its check as failed. Both workflows were cancelling their own runs, so two label-bookkeeping jobs were putting red checks on pull requests whose required `CI Gate` was green. At the time of writing, 38 of 50 open PRs carry such a check and therefore sit at `mergeStateStatus = UNSTABLE` — which makes a pull request with a genuine failure indistinguishable from one with none, and is exactly what misled a triage pass on 2026-09-05 into writing off sixteen mergeable PRs as "CI failing".

The cancellations crossed pull requests. One `auto-update-branches` sweep on 2026-09-04 produced 33 `Stale PR` runs across 33 distinct branches between 15:53:25 and 15:55:47 and cancelled 31 of them, first and last surviving.

## This corrects #8190, which did not work

#8190 attributed the cross-branch cancellation to the concurrency group key — `github.event.pull_request.number` failing to vary per pull request — and switched to `github.head_ref`.

It did not stop. With the new key live on `main` (merged 17:31), the burst after 18:13 on 2026-09-05 still cancelled `Stale PR` runs on distinct branches:

```
18:13:38  cancelled  fix/llm-driver-streaming-and-backoff
18:13:45  cancelled  fix/memory-scope-and-fts
18:14:27  cancelled  fix/kernel-config-correctness
18:15:19  cancelled  fix/channel-sidecar-backpressure
```

Each of those branches has exactly one `Stale PR` run, so these are not the legitimate same-branch supersessions that appear elsewhere in the same window — several PRs were pushed twice within seconds, and those earlier runs being cancelled is correct behaviour that has to be excluded before reading the rest.

`Issue-PR Link Labels` had already shown the same shape under a third key spelling. Two different expressions producing identical behaviour is evidence against the key being the cause, so #8190's explanation is unconfirmed. Its comments asserted it as established fact; this PR rewrites them to say what is actually known.

## Why removal rather than a third guess at the key

Both workflows recompute their desired state from the pull request on every run. #8190 relied on exactly that property to argue cancellation was safe; the same property makes serialising them free. Two pushes to one PR now run each workflow twice, at roughly fifteen seconds a run.

In exchange, no run of either workflow can report a red check again — whatever is doing the cancelling.

`head_ref` is kept as the group key. It is the more likely-correct spelling for a per-PR bucket regardless of whether it was the problem, and it is empty outside pull-request events, so the scheduled sweep still falls through to its constant key and keeps serialising rather than racing.

## This is also the experiment

Stated in advance so the result cannot be read either way after the fact:

- If cancelled runs disappear from these two workflows, concurrency was the mechanism and #8190 simply picked the wrong key.
- If runs continue to be cancelled with `cancel-in-progress: false`, something outside these workflows is cancelling runs in this repository. No workflow in `.github/` calls the cancel API — that was checked — so that outcome would need its own investigation, and it would be a larger finding than label bookkeeping.

## Not affected

The `auto-update-branches` cascade this noise used to trigger is already bounded independently by #8192, which judges PR health from `CI Gate` alone. Measured on the current 50 open PRs: the pre-#8192 logic would update 38 branches, the current logic updates 2. That holds regardless of how this PR turns out.

## Verification

- Both files re-parsed with `yaml.safe_load`; the resulting `concurrency` mappings printed and inspected.
- `scripts/check-workflow-timeouts.py` passes (149 jobs).
- The behavioural claim is only checkable after merge, by watching whether these two workflows produce any further cancelled runs.

## Deferred

The cause of the cancellation is not identified. That is deliberate — see the experiment above.
