### PR TITLE
fix(ci): post the first-PR greeting through the endpoint the token can reach

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -6,6 +6,8 @@ on:
   issues:
     types: [opened]
 
+# Deliberately minimal, and pinned by `scripts/tests/test_release_tag_workflow_safety.py`: this runs on `pull_request_target`, where the token carries base-repository access on an event a fork controls, so `pull-requests` stays read-only.
+# The pull-request greeting posts through the REST issue-comments endpoint, which a pull request shares with issues and which `issues: write` already covers — see the note above the call below.
 permissions:
   issues: write
   pull-requests: read
@@ -72,7 +74,10 @@ jobs:
 
           We aim to provide initial feedback within 7 days. See [CONTRIBUTING.md](https://github.com/librefang/librefang/blob/main/CONTRIBUTING.md) for details.
           MSG
-              gh pr comment "$NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
+              # Not `gh pr comment`: that issues the GraphQL `addComment` mutation, which on a pull request is gated on `pull-requests: write`, and this workflow deliberately keeps that scope read-only because it runs on `pull_request_target`.
+              # A pull request is an issue as far as the REST comment endpoint is concerned, so posting there needs only the `issues: write` this workflow already holds.
+              # The failure this replaces was invisible for the life of the workflow: the greeting is guarded on `PRIOR_COUNT -eq 0`, so every run by a returning contributor exits before reaching this line and reports success — 27 of 28 `pull_request_target` runs were green while the branch had never once posted anything, and the first genuine first-time pull request (#8203) died on `Resource not accessible by integration (addComment)`.
+              gh api --method POST "repos/$REPO/issues/$NUMBER/comments" -F "body=@$BODY_FILE" --silent
               rm -f "$BODY_FILE"
               trap - EXIT
             fi


### PR DESCRIPTION
## What

The pull-request branch of the welcome workflow posted with `gh pr comment`, which issues the GraphQL `addComment` mutation. On a pull request that mutation is gated on `pull-requests: write`, and this workflow holds `pull-requests: read` — so the greeting could never be posted.

It now posts through `POST /repos/{owner}/{repo}/issues/{number}/comments`. A pull request is an issue as far as that endpoint is concerned, so it reaches the same comment thread under the `issues: write` this workflow already holds. Permissions are unchanged.

## Why it was invisible

The call is guarded on `PRIOR_COUNT -eq 0`, so it is only reached for a genuine first-time contributor. Every run by a returning contributor exits before it and reports success.

| Trigger | Runs | Outcome |
| --- | --- | --- |
| `issues` | 12 | 12 success — this branch does reach `gh issue comment` |
| `pull_request_target` | 28 | 27 success (guard short-circuited), 1 failure |

The one failure is #8203, opened by an external first-time contributor:

```
GraphQL: Resource not accessible by integration (addComment)
##[error]Process completed with exit code 1.
```

So the workflow had never executed its only side effect, while looking green for its entire life. They received no greeting.

## The first attempt was wrong and the repo caught it

This PR originally widened `permissions` to `pull-requests: write`. `scripts/tests/test_release_tag_workflow_safety.py` failed it with `welcome workflow permissions are not minimal`, and it was right to: the workflow runs on `pull_request_target`, where the token carries base-repository access on an event a fork controls, and a write scope there is the classic escalation surface. The permission map is pinned on purpose.

Changing the endpoint instead fixes the greeting without touching the scope, which is the direction that should have been taken first.

## Verification

- `python3 scripts/tests/test_release_tag_workflow_safety.py` passes, including the pinned permission map it rejected the first attempt on.
- `scripts/check-workflow-timeouts.py` passes.
- `bash -n` over the extracted `run` script passes, which is also asserted by the guard.
- No live `gh pr comment` invocation remains; the only occurrence of that string is in the comment explaining why it is not used.
- Run history above read from the Actions API split by event, rather than the aggregate green count that hid the problem.
- Full confirmation needs the next genuine first-time pull request. #8203 is not re-greeted by this change; its run already failed and will not re-fire.

## Deferred

Nothing.
