### PR TITLE
fix(runtime): stop warning that a tool is missing when the agent merely was not granted it

### DIFF
--- a/changelog.d/fixed/8225-native-tool-warning.md
+++ b/changelog.d/fixed/8225-native-tool-warning.md
@@ -1,0 +1,5 @@
+An agent deliberately configured without one of the always-native tools no longer logs a `WARN` claiming the tool is "missing from definitions".
+The definition was never missing — `select_native_tools` receives the set granted to one agent, not the global registry, so every always-native tool the agent was not granted produced a warning per turn.
+Chasing those in a production log cost a real misdiagnosis, sending the investigation after the tool registry and the manifest loader when the answer was an agent type that simply does not declare the tool.
+The two cases are now told apart: a name with no entry in `builtin_tool_definitions()` is still a `WARN`, because it means someone extended `ALWAYS_NATIVE_TOOLS` without a definition, while a name the agent merely was not granted drops to `debug!` and says what is actually true.
+(#PR) (@DaBlitzStein)

--- a/changelog.d/fixed/8225-native-tool-warning.md
+++ b/changelog.d/fixed/8225-native-tool-warning.md
@@ -2,4 +2,4 @@ An agent deliberately configured without one of the always-native tools no longe
 The definition was never missing — `select_native_tools` receives the set granted to one agent, not the global registry, so every always-native tool the agent was not granted produced a warning per turn.
 Chasing those in a production log cost a real misdiagnosis, sending the investigation after the tool registry and the manifest loader when the answer was an agent type that simply does not declare the tool.
 The two cases are now told apart: a name with no entry in `builtin_tool_definitions()` is still a `WARN`, because it means someone extended `ALWAYS_NATIVE_TOOLS` without a definition, while a name the agent merely was not granted drops to `debug!` and says what is actually true.
-(#PR) (@DaBlitzStein)
+(#8226) (@DaBlitzStein)

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -183,11 +183,38 @@ pub fn select_native_tools(all: &[ToolDefinition]) -> Vec<ToolDefinition> {
     let found_names: std::collections::HashSet<&str> =
         found.iter().map(|t| t.name.as_str()).collect();
     for &name in ALWAYS_NATIVE_TOOLS.iter() {
-        if !found_names.contains(name) {
-            tracing::warn!("native tool {name:?} missing from definitions");
+        if found_names.contains(name) {
+            continue;
+        }
+        // `all` is the set granted to one agent, not the global registry, so a
+        // name can be absent here for two very different reasons. Saying
+        // "missing from definitions" for both sent a production investigation
+        // after the tool registry when the real answer was an agent type that
+        // simply does not declare the tool (#8225).
+        if builtin_tool_names().contains(name) {
+            tracing::debug!(
+                "native tool {name:?} is not in this agent's granted set, so lazy mode will not ship it"
+            );
+        } else {
+            tracing::warn!("native tool {name:?} has no entry in builtin_tool_definitions()");
         }
     }
     found
+}
+
+/// Names of every built-in tool, memoized.
+///
+/// Only the names are kept: `builtin_tool_definitions()` hands back a clone of
+/// the whole catalog, schemas included, which is far too much to rebuild just
+/// to answer whether one name exists.
+fn builtin_tool_names() -> &'static std::collections::HashSet<String> {
+    static NAMES: OnceLock<std::collections::HashSet<String>> = OnceLock::new();
+    NAMES.get_or_init(|| {
+        builtin_tool_definitions()
+            .into_iter()
+            .map(|t| t.name)
+            .collect()
+    })
 }
 
 /// Get definitions for all built-in tools.

--- a/crates/librefang-runtime/src/tool_runner/tests/skills.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/skills.rs
@@ -331,6 +331,83 @@ fn test_select_native_tools_trims_to_native_set() {
     }
 }
 
+/// Counts WARN-level events so a test can assert on their absence.
+struct WarnCounter(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+impl tracing::Subscriber for WarnCounter {
+    fn enabled(&self, meta: &tracing::Metadata<'_>) -> bool {
+        *meta.level() <= tracing::Level::WARN
+    }
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, _: &tracing::Event<'_>) {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// An agent that was never granted one of the always-native tools is a
+/// supported configuration, not a defect, and must not produce a WARN.
+///
+/// It used to produce one per tool per turn, saying the tool was "missing from
+/// definitions". That is false — the definition exists, the agent just does not
+/// have the tool — and chasing those warnings in a production log cost a real
+/// misdiagnosis of the tool registry before the agent type turned out to be the
+/// answer (#8225).
+#[test]
+fn test_ungranted_native_tool_does_not_warn() {
+    let defs = builtin_tool_definitions();
+    // Drop one always-native tool that genuinely has a definition, so the only
+    // reason it is absent is that this agent was not granted it.
+    let dropped = ALWAYS_NATIVE_TOOLS
+        .iter()
+        .find(|n| defs.iter().any(|t| t.name == **n))
+        .expect("at least one always-native tool must have a definition");
+    let granted: Vec<_> = defs
+        .iter()
+        .filter(|t| t.name != *dropped)
+        .cloned()
+        .collect();
+
+    let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    tracing::subscriber::with_default(WarnCounter(count.clone()), || {
+        let native = select_native_tools(&granted);
+        assert!(
+            !native.iter().any(|t| t.name == *dropped),
+            "a tool the agent was not granted must not come back in the native set"
+        );
+    });
+
+    assert_eq!(
+        count.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "not granting {dropped:?} is a valid configuration and must not WARN"
+    );
+}
+
+/// The invariant the surviving WARN actually guards: every name listed in
+/// `ALWAYS_NATIVE_TOOLS` has a definition. If someone adds a constant without
+/// one, lazy mode silently ships a shorter list than it advertises, and this
+/// fails before the warning has to.
+#[test]
+fn test_every_always_native_tool_has_a_definition() {
+    let defs = builtin_tool_definitions();
+    let names: std::collections::HashSet<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+    let orphans: Vec<&str> = ALWAYS_NATIVE_TOOLS
+        .iter()
+        .copied()
+        .filter(|n| !names.contains(n))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        "listed in ALWAYS_NATIVE_TOOLS with no definition: {orphans:?}"
+    );
+}
+
 #[test]
 fn test_lazy_mode_reduces_serialized_tool_payload() {
     // Quantify the savings this PR is claiming (issue #3044). The lazy


### PR DESCRIPTION
Closes #8225.

## What was wrong

`select_native_tools` warns for every name in `ALWAYS_NATIVE_TOOLS` that is not in the slice it was handed, with the message "missing from definitions".
Its parameter is named `all`, and the message assumes `all` is the global registry — but the only production caller, `agent_loop/tool_resolution.rs:41`, passes `available_tools`, the set granted to *one* agent by its profile or its `capabilities.tools` allowlist.
So an agent type that deliberately does not declare a tool produced one `WARN` per missing tool, per turn, saying the definition was missing when it was not.

## Why it is worth fixing

The wording misdirects rather than merely being imprecise.
Fourteen of these in a production log sent an investigation after the tool registry, the manifest loader and tool-cache invalidation.
All three were fine; the emitter was an ephemeral worker whose agent type declares 81 tools and does not include `channel_send`, which is a correct configuration.
`tracing`'s multi-span output also made a second, correctly-configured agent look like the source, widening the hunt further.
A `WARN` that fires on a supported configuration teaches everyone to ignore the channel.

## Change

The two situations are now told apart at the check:

- a name with **no entry** in `builtin_tool_definitions()` stays a `WARN`, because it means `ALWAYS_NATIVE_TOOLS` gained a constant without a definition and lazy mode is silently shipping a shorter list than it advertises;
- a name that exists but was **not granted to this agent** drops to `debug!`, worded as what it is.

Only the tool *names* are memoized for the lookup. `builtin_tool_definitions()` returns a clone of the whole catalog, schemas included, which is far too much to rebuild to answer whether one name exists.

## Verification

- `cargo check -p librefang-runtime --all-targets` — clean.
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-runtime --lib native_tool` — 5 passed, 0 failed.

Both new tests were confirmed **red before the fix**, by reverting only `definitions.rs` and keeping the tests:

```
---- test_ungranted_native_tool_does_not_warn stdout ----
assertion `left == right` failed: not granting "tool_load" is a valid configuration and must not WARN
  left: 1
 right: 0
test result: FAILED. 0 passed; 1 failed
```

- `test_ungranted_native_tool_does_not_warn` — counts WARN-level events while resolving a granted set that omits one always-native tool, and asserts zero.
- `test_every_always_native_tool_has_a_definition` — pins the invariant the surviving `WARN` actually guards, so a constant added without a definition fails a test rather than only logging at runtime.

## Not done here

Nothing deferred.
