### PR TITLE
fix(dashboard): probe the chat socket on tab return instead of trusting readyState

### DIFF
--- a/changelog.d/fixed/8275-chat-half-open-socket-on-tab-return.md
+++ b/changelog.d/fixed/8275-chat-half-open-socket-on-tab-return.md
@@ -1,0 +1,5 @@
+Returning to a chat tab whose WebSocket died while it was hidden no longer swallows the next message (#8273).
+  A half-open socket never fires `onclose`, so the browser kept reporting `readyState === OPEN` and the frame was written into a connection whose bytes went nowhere: the turn spun forever, and reloading showed neither the question nor an answer, because nothing had reached the daemon to persist.
+  The `visibilitychange` wake-up added in #4063 could not help, since it was gated on the retries-exhausted flag that only a disconnect the browser actually noticed can set — leaving the one case the listener existed for as the one case it could not act on.
+  Coming back to the tab now probes the link with the `{"type":"ping"}` / `{"type":"pong"}` exchange the daemon has answered since the socket was first written and no client had ever sent, and hands a socket that does not answer to the reconnect path that already exists.
+  A probe is skipped while a turn is in flight, because the daemon stops reading the socket for the duration of a turn and could not answer one. (#8275) (@DaBlitzStein)

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.liveness.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.liveness.test.tsx
@@ -1,0 +1,305 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { AgentItem } from "../api";
+import { useChatMessages } from "./ChatPage";
+
+// `t` and the object wrapping it must be referentially stable: the history-load
+// effect lists `t` in its dependency array, so a fresh lambda per render re-runs
+// the effect on every render and spins the hook forever.
+const translation = { t: (key: string) => key };
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return { ...actual, useTranslation: () => translation };
+});
+
+vi.mock("../lib/queries/commands", () => ({
+  useChatCommands: () => ({ data: [], isPending: false }),
+}));
+
+vi.mock("../lib/mutations/agents", () => ({
+  useCreateAgentSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteAgentSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  usePatchAgentRuntimeConfig: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useResolveApproval: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useSendAgentMessage: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({ response: "http answer" }),
+    isPending: false,
+  }),
+  useStopAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUploadAgentFile: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../lib/queries/agents", () => ({
+  agentQueries: {
+    session: (agentId: string, sessionId: string | null) => ({
+      queryKey: ["agent-session", agentId, sessionId],
+      queryFn: () => Promise.resolve({ messages: [] }),
+    }),
+    sessionContext: () => ({ queryKey: ["ctx"], queryFn: () => Promise.resolve({}) }),
+  },
+  useAgents: () => ({ data: [] }),
+  useAgentSessions: () => ({ data: [] }),
+}));
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    buildAuthenticatedWebSocket: (path: string) => ({
+      url: `ws://test${path}`,
+      protocols: [] as string[],
+    }),
+  };
+});
+
+vi.mock("../lib/store", () => ({
+  useUIStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      addSkillOutput: vi.fn(),
+      addToast: vi.fn(),
+      deepThinking: false,
+      showThinkingProcess: false,
+    }),
+}));
+
+type Listener = (event: unknown) => void;
+
+/**
+ * A socket that has gone half-open: still `OPEN`, still accepting writes that go
+ * nowhere, and — the defining trait — it never fires `onclose` on its own.
+ *
+ * That last part is the whole point. `close()` fires `onclose` because a browser
+ * does when *you* close a socket; nothing in this double ever fires it
+ * spontaneously, because a dead link never tells the browser it died.
+ */
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    // Fail fast instead of exhausting the heap: a reconnect storm shows up here
+    // first, and an OOM'd worker reports no test results at all — it looks like
+    // the suite never ran rather than like a bug.
+    if (MockWebSocket.instances.length > 50) {
+      throw new Error("runaway WebSocket construction — the hook is reconnecting in a loop");
+    }
+  }
+
+  addEventListener(type: string, fn: Listener) {
+    const set = this.listeners.get(type) ?? new Set<Listener>();
+    set.add(fn);
+    this.listeners.set(type, set);
+  }
+
+  removeEventListener(type: string, fn: Listener) {
+    this.listeners.get(type)?.delete(fn);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1000 });
+  }
+
+  emitOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Deliver a server frame to every `message` listener the hook has attached. */
+  emitMessage(data: unknown) {
+    const event = { data: JSON.stringify(data) };
+    for (const fn of this.listeners.get("message") ?? []) fn(event);
+  }
+
+  /** Every frame this socket was asked to write, as parsed message types. */
+  sentTypes(): string[] {
+    return this.sent.map((frame) => {
+      try {
+        return String((JSON.parse(frame) as { type?: unknown }).type ?? "");
+      } catch {
+        return "";
+      }
+    });
+  }
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const AGENTS = [{ id: "agent-a", name: "Agent A" }] as AgentItem[];
+
+/** Longer than any probe deadline the hook could reasonably use. */
+const PAST_ANY_PROBE_DEADLINE = 30_000;
+
+function setVisibility(state: "hidden" | "visible") {
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: state });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+/** Render the hook on `agent-a` and bring its socket up, as a real upgrade would. */
+async function connected() {
+  const view = renderHook(({ agent }: { agent: string }) => useChatMessages(agent, AGENTS), {
+    wrapper,
+    initialProps: { agent: AGENTS[0].id },
+  });
+
+  const socket = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  if (!socket) throw new Error("hook did not open a socket");
+  await act(async () => {
+    socket.emitOpen();
+  });
+  await waitFor(() => expect(view.result.current.wsConnected).toBe(true));
+  return { ...view, socket };
+}
+
+/** Leave the tab and come back, with the link having died silently in between. */
+async function leaveAndReturn() {
+  await act(async () => {
+    setVisibility("hidden");
+  });
+  await act(async () => {
+    setVisibility("visible");
+  });
+}
+
+describe("chat socket liveness when the tab comes back", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The control. If the harness could not open a socket or drive it to OPEN,
+  // every assertion below would fail for that reason and read exactly like a
+  // missing probe.
+  it("opens a socket that reports itself connected", async () => {
+    const { result, socket } = await connected();
+    expect(result.current.wsConnected).toBe(true);
+    expect(socket.readyState).toBe(MockWebSocket.OPEN);
+  });
+
+  // The defect. `wakeUp` returns early unless `gaveUpRef` is set, and that flag is
+  // only ever set inside `ws.onclose` after the retries run out — an event a
+  // half-open socket never fires. So the one case the listener exists for is the
+  // one case it cannot act on, and `readyState` keeps saying OPEN.
+  it("probes the socket when the tab becomes visible again", async () => {
+    const { socket } = await connected();
+
+    await leaveAndReturn();
+
+    expect(socket.sentTypes()).toContain("ping");
+  });
+
+  // Sending the probe is only useful if an unanswered one ends the connection:
+  // closing it is what hands the turn to the reconnect path that already exists.
+  it("closes a socket that never answers the probe", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { socket } = await connected();
+
+    await leaveAndReturn();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_ANY_PROBE_DEADLINE);
+    });
+
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED);
+  });
+
+  // Closing is only the handover, not the outcome the user cares about. Assert the
+  // rest of the chain actually runs: `onclose` feeds the existing backoff
+  // reconnect, so the tab ends up on a working socket rather than merely a
+  // truthfully-closed one.
+  it("reconnects after discarding a socket that failed the probe", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await connected();
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    await leaveAndReturn();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_ANY_PROBE_DEADLINE);
+    });
+
+    expect(MockWebSocket.instances.length).toBeGreaterThan(1);
+  });
+
+  // The discriminator against a fix that just drops sockets on every tab switch.
+  // This must pass both before and after the change, so the two tests above
+  // cannot be made green by closing the connection unconditionally.
+  it("keeps a socket that answers the probe", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { socket } = await connected();
+
+    await leaveAndReturn();
+    await act(async () => {
+      socket.emitMessage({ type: "pong" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_ANY_PROBE_DEADLINE);
+    });
+
+    expect(socket.readyState).toBe(MockWebSocket.OPEN);
+  });
+
+  // The guard reads `onDropRef`, which is the turn-in-flight marker rather than a
+  // flag of its own. If a normally-completed turn ever left it set, the guard
+  // would latch on and no socket would be probed again for the life of the page —
+  // the fix would be inert and the symptom identical. This is the user's actual
+  // sequence: ask, get answered, leave the window, come back.
+  it("probes again after a turn has completed normally", async () => {
+    const { result, socket } = await connected();
+    await act(async () => {
+      result.current.sendMessage("what is the status");
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    await act(async () => {
+      socket.emitMessage({ type: "response", content: "all good" });
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await leaveAndReturn();
+
+    expect(socket.sentTypes()).toContain("ping");
+  });
+
+  // `ws.rs:1492` awaits the whole agent turn inside the main loop, so while a turn
+  // runs the daemon is not reading the socket and cannot answer a probe. Probing
+  // there would time out on a healthy connection and close a live chat, so the
+  // turn's own 180 s watchdog owns that window instead.
+  it("does not probe while a turn is in flight", async () => {
+    const { result, socket } = await connected();
+    await act(async () => {
+      result.current.sendMessage("run the long job");
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    const beforeReturn = socket.sentTypes().filter((type) => type === "ping").length;
+
+    await leaveAndReturn();
+
+    expect(socket.sentTypes().filter((type) => type === "ping").length).toBe(beforeReturn);
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -126,6 +126,11 @@ function makeMessageId(prefix: string): string {
 const WS_MAX_RETRIES = 10;
 // Auth-failure close codes — do not reconnect on these
 const WS_AUTH_ERROR_CODES = new Set([4401, 4403]);
+// How long a liveness probe waits for the daemon to say anything at all.
+// Generous for a round trip on any link worth keeping, and far below the 180s
+// turn watchdog, so a socket found dead here is replaced long before that
+// watchdog would re-send the message over HTTP.
+const WS_PROBE_TIMEOUT_MS = 5_000;
 
 function useWebSocket(
   agentId: string | null,
@@ -178,6 +183,9 @@ function useWebSocket(
   // visibilitychange / online listeners below recover the socket
   // when the user comes back or the network reappears.
   const gaveUpRef = useRef(false);
+  // Armed while a liveness probe is outstanding, so a burst of visibilitychange
+  // events cannot stack probes on one socket.
+  const probeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Keep onAuthError in a ref to avoid triggering the effect when the caller
   // passes a fresh inline lambda on every render.
   const onAuthErrorRef = useRef(onAuthError);
@@ -299,13 +307,61 @@ function useWebSocket(
     // dead socket until they refresh the page (audit of #3930
     // 'silent giveup' finding).  Auth-error termination is left
     // alone — that genuinely needs a refresh to pick up new auth.
+    // Ask the daemon to prove the link is alive, because `readyState` cannot.
+    // `ws.rs` has answered {"type":"ping"} with {"type":"pong"} since the socket
+    // was written and nothing had ever called it; this is that caller, not a new
+    // protocol.
+    const probeLiveness = () => {
+      const socket = wsRef.current;
+      // CONNECTING / CLOSING / CLOSED already have their own paths; only a socket
+      // claiming OPEN can be lying.
+      if (!socket || socket.readyState !== WebSocket.OPEN) return;
+      // One probe per socket: visibilitychange and online can both fire on the
+      // same wake-up.
+      if (probeTimer.current) return;
+      // A turn in flight owns this window instead. `ws.rs` awaits the whole agent
+      // turn inside its main loop, so while one runs the daemon is not reading
+      // the socket and cannot answer a probe — timing out here would close a
+      // healthy chat mid-answer. `onDropRef` is non-null exactly while this
+      // socket is awaiting a response, and that turn's own 180s watchdog already
+      // covers it. Do not remove this guard without moving the daemon's turn off
+      // the socket's read loop first.
+      if (onDropRef.current) return;
+
+      const settle = () => {
+        if (probeTimer.current) clearTimeout(probeTimer.current);
+        probeTimer.current = null;
+        socket.removeEventListener("message", onAnyFrame);
+      };
+      // Any frame answers the probe, not just the pong — a stream delta is the
+      // same proof that the link carries traffic.
+      const onAnyFrame = () => settle();
+      socket.addEventListener("message", onAnyFrame);
+      probeTimer.current = setTimeout(() => {
+        settle();
+        // Hand off to the machinery that already exists: close() fires onclose,
+        // which runs the pending-turn recovery and the backoff reconnect.
+        socket.close();
+      }, WS_PROBE_TIMEOUT_MS);
+      socket.send(JSON.stringify({ type: "ping" }));
+    };
+
     const wakeUp = () => {
       if (authErrorRef.current) return;
-      if (!gaveUpRef.current) return;
-      gaveUpRef.current = false;
-      retriesRef.current = 0;
-      setAriaAnnouncement("Reconnecting…");
-      connect();
+      if (gaveUpRef.current) {
+        gaveUpRef.current = false;
+        retriesRef.current = 0;
+        setAriaAnnouncement("Reconnecting…");
+        connect();
+        return;
+      }
+      // Not having given up is not the same as being alive. A link that dies
+      // while the tab is hidden — suspend, wifi roam, a NAT drop — never fires
+      // `onclose`, so no retry is ever attempted, `gaveUpRef` stays false and
+      // this listener used to return here having done nothing. That silent case
+      // is the one it exists for; the retries-exhausted case above is the one
+      // where the browser already noticed (#3854, #3930, #4063).
+      probeLiveness();
     };
     const onVisibility = () => {
       if (document.visibilityState === "visible") wakeUp();
@@ -317,6 +373,12 @@ function useWebSocket(
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("online", wakeUp);
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      if (probeTimer.current) {
+        // An outstanding probe would otherwise fire against the socket this
+        // teardown is replacing and close the new one's predecessor by surprise.
+        clearTimeout(probeTimer.current);
+        probeTimer.current = null;
+      }
       retriesRef.current = 0;
       authErrorRef.current = false;
       gaveUpRef.current = false;


### PR DESCRIPTION
Closes #8273.

## The defect

A chat WebSocket that dies while the tab is hidden is never noticed, so the next message the user sends is written into a connection whose bytes go nowhere.

`wakeUp` (`ChatPage.tsx`) returns early unless `gaveUpRef` is set, and that flag is assigned in exactly one place: inside `ws.onclose`, after `retriesRef.current >= WS_MAX_RETRIES`.
A half-open socket never fires `onclose` — that is its defining property — so a link that dies to a suspend, a wifi roam or a NAT drop produces no close event, no retries, and therefore no `gaveUpRef`.
The `visibilitychange` / `online` listener added in #4063 then returns having done nothing, in the one case it exists for.

`readyState` still reports `OPEN`, which is what the send path branches on, so the frame is written and lost.
Nothing is persisted because nothing arrived, which is why reloading shows neither the question nor an answer.

The intent of #4063 was right; the guard is what leaves it short. It covers the case where the browser noticed the disconnect, and not the case where it could not.

## The change

Returning to the tab now probes the link instead of trusting `readyState`.

**No protocol was added.** `crates/librefang-api/src/ws.rs:1706` has answered `{"type":"ping"}` with `{"type":"pong"}` since the socket was first written, and no client had ever sent it — zero occurrences across `dashboard/src`, and in Rust only the definition itself. This PR is that caller.

- Any inbound frame answers the probe, not only the pong: a stream delta is the same proof that the link carries traffic.
- A socket that stays silent for `WS_PROBE_TIMEOUT_MS` (5 s, far below the 180 s turn watchdog) is closed, which hands it to the pending-turn recovery and backoff reconnect that already exist.
- One probe per socket, so `visibilitychange` and `online` firing together cannot stack them.
- An outstanding probe is cleared on effect teardown, so it cannot fire against a socket an agent switch has already replaced.

### The turn-in-flight guard

The probe is skipped while a turn is in flight, and this is not an optimisation.
`crates/librefang-api/src/ws.rs:1492` awaits the whole agent turn inside the socket's read loop, so during a turn the daemon is not reading the socket and cannot answer a probe.
Probing there would time out on a healthy connection and close a live chat mid-answer; that window is already owned by the turn's own 180 s watchdog.
`onDropRef` is reused as the marker rather than adding a parameter, because it is already non-null exactly while this socket awaits a response, and it already lives in the hook that owns the socket.

## Verification

`vitest` — the dashboard lane; these are not covered by `Test / Unit (lib+bin)` or the `Test / Ubuntu (shard N/4)` lanes.

- New file `ChatPage.liveness.test.tsx`, **7 passing**.
- Full dashboard suite: **1856 pass, 1 fail**. The failure is `PromptsExperimentsModal > stops selection when every variant has a traffic bucket`, which is pre-existing and unrelated — measured, not assumed: with every change stashed (`git stash -u`) the clean tree gives **1851 pass, 1 fail**, the same test. In isolation it passes in 5.37 s with the test itself at 3.81 s against a 5 s cap, and it imports nothing from `ChatPage`.
- `tsc --noEmit` and `eslint .` clean.
- Run with `LANG=en_US.UTF-8`; `AnalyticsPage` asserts `en_US` number formatting and gives false failures under other locales.

### How to reproduce the red

The pre-fix tree is `git show origin/main:crates/librefang-api/dashboard/src/pages/ChatPage.tsx` plus the one-word `export` on `useChatMessages` and nothing else — verified with `probeLiveness` at 0 occurrences and the original `if (!gaveUpRef.current) return;` at 1. Against that:

```
× probes the socket when the tab becomes visible again        expected [] to include 'ping'
× closes a socket that never answers the probe                expected 1 to be 3
× reconnects after discarding a socket that failed the probe  expected 1 to be greater than 1
× probes again after a turn has completed normally            (passes pre-fix; see below)
  Tests  3 failed | 4 passed (7)
```

`[]` is the socket having written nothing at all, and `1` is `WebSocket.OPEN`.

Stashing the whole file instead is **not** a valid red: it also reverts the `export`, the test module fails to load, and all seven fail — including the control, which is the tell that a red is a broken harness rather than a finding.

### Tests that pass before the change, and why each is still load-bearing

- `opens a socket that reports itself connected` — the control. If the harness could not open a socket, every other assertion would time out for that reason and read exactly like a missing probe.
- `keeps a socket that answers the probe` — the discriminator against a fix that simply drops sockets on every tab switch.
- `does not probe while a turn is in flight` — passes trivially pre-fix, so it was checked separately: removing the guard from the source makes it fail.
- `probes again after a turn has completed normally` — guards the failure mode the `onDropRef` reuse creates. If a normally-completed turn ever left the marker set, the guard would latch on and nothing would be probed again for the life of the page, leaving the fix inert with an identical symptom. Verified discriminating by suppressing the `onDropRef.current = null` inside `cleanup()`, which fails this test alone with `expected [ 'message' ] to include 'ping'`.

## Notes for the reviewer

- Benign overlap with #8258: both add `export` to `useChatMessages` — the same one-word change, which resolves either way — and both add a ChatPage test file, under different names. No functional overlap; #8258 fixes the agent-switch teardown path (#8257) and touches neither `gaveUpRef` nor the visibility listeners.
- The daemon side of the same defect — neither end sends a periodic ping, so a dead peer is undetectable from the server too — is deliberately not in this PR. It shares no code or config with this change and is worth reviewing on its own.

## Related

- #3854 — the reconnect policy this listener belongs to.
- #3930 — implemented it.
- #4063 — added the `visibilitychange` / `online` wake-up whose guard is the subject here.
