### PR TITLE
fix(channels): carry the approval fan-out remedy as a field, not in the message

### DIFF
--- a/changelog.d/fixed/8283-approval-remedy-as-structured-field.md
+++ b/changelog.d/fixed/8283-approval-remedy-as-structured-field.md
@@ -1,0 +1,4 @@
+The warning raised when an approval reaches no channel now carries its remedy as a `remedy=` field instead of splicing it into the event message.
+The remedy is worded off what the adapters actually reported and takes four different forms, so interpolating it meant one operational condition arrived as four distinct message strings: any log backend that groups or counts by message saw four rare events rather than one recurring one, and an operator asking "how often are approvals going undelivered on this host" could not get an answer out of it.
+The four values already beside it on that same `warn!` — the request id, the requesting agent, the adapter count and the skipped-adapter list — were structured fields all along; the remedy was the one exception, so this aligns it with the convention rather than inventing one.
+Nothing is lost from the log: the same sentence still reaches the operator, one field to the right (#8283) (@DaBlitzStein)

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2295,12 +2295,24 @@ impl BridgeManager {
                                             .map(|s| s.to_string())
                                             .collect::<Vec<_>>()
                                             .join("; ");
+                                        // `remedy` is a field, not part of the
+                                        // message: it takes four different
+                                        // values above, and interpolating a
+                                        // varying value into the event
+                                        // *message* splits one condition into
+                                        // four distinct strings, so every log
+                                        // backend that groups by message stops
+                                        // being able to count how often this
+                                        // fires. The four fields below are
+                                        // already structured for that reason;
+                                        // `remedy` was the exception.
                                         warn!(
                                             request_id = %approval.request_id,
                                             requesting_agent = %requesting_agent,
                                             adapters = adapters.len(),
                                             skipped = %considered,
-                                            "Approval reached no channel: {remedy}"
+                                            remedy = %remedy,
+                                            "Approval reached no channel"
                                         );
                                     }
                                 }

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -3602,6 +3602,18 @@ async fn test_approval_direct_route_failure_does_not_claim_coverage() {
         !aggregate.contains("no adapter has a channel_default"),
         "routing is configured here — the operator must not be sent to channel_default, got: {aggregate}"
     );
+    // The remedy varies per occurrence, so it belongs in a field: interpolated
+    // into the message it splits one condition into four strings and every
+    // backend that aggregates by message loses the count (#8228 review).
+    assert!(
+        aggregate.contains("message=Approval reached no channel "),
+        "the event message must stay a constant; the varying remedy belongs in its \
+         own field, got: {aggregate}"
+    );
+    assert!(
+        aggregate.contains("remedy="),
+        "the remedy must still reach the operator, as a field, got: {aggregate}"
+    );
 
     manager.stop().await;
 }


### PR DESCRIPTION
Follow-up to #8228 (merged), which fixed #8227 by evaluating the "approval reached no channel" warning once per approval instead of once per adapter.
That PR left one thing in the shape it inherited.

## The change

`crates/librefang-channels/src/bridge.rs` raised the aggregate warning as:

```rust
warn!(
    request_id = %approval.request_id,
    requesting_agent = %requesting_agent,
    adapters = adapters.len(),
    skipped = %considered,
    "Approval reached no channel: {remedy}"
);
```

`remedy` is computed immediately above and takes **four** different values, depending on what the adapters reported:

- `no adapter produced a delivery target`
- `every adapter routing to this agent has an empty notification_recipients list — …`
- `delivery was attempted and every send failed — …`
- `no adapter has a channel_default or AgentBinding peer_id covering the requesting agent`

Interpolated into the event *message*, one operational condition is emitted as four distinct message strings.
Any log backend that groups or counts by message sees four rare events instead of one recurring one, so "how often are approvals going undelivered on this host" has no answer.

The argument is not a general preference for structured logging.
It is that the other four values on this exact `warn!` — `request_id`, `requesting_agent`, `adapters`, `skipped` — are already fields.
`remedy` was the single exception, so this aligns one call with the convention it already follows rather than introducing one.

The remedy still reaches the operator; it moves from the message body into `remedy=`.

## Substantive changes

- `crates/librefang-channels/src/bridge.rs`: `remedy` becomes a `remedy = %remedy` field; the message becomes the constant `"Approval reached no channel"`.
- `crates/librefang-channels/tests/bridge_integration_test.rs`: two asserts added to the existing `test_approval_direct_route_failure_does_not_claim_coverage` — the message must stay constant, and `remedy=` must still be present.

## Verification

The two new asserts were run against unmodified `bridge.rs` first, and fail there:

```
thread 'test_approval_direct_route_failure_does_not_claim_coverage' panicked at
crates/librefang-channels/tests/bridge_integration_test.rs:3608:5:
the event message must stay a constant; the varying remedy belongs in its own field, got:
[WARN] message=Approval reached no channel: delivery was attempted and every send failed — see the per-adapter errors above request_id=8228dddd66667777 requesting_agent=… adapters=1 skipped=telegram-a/bot-a (telegram, delivery failed)
```

After the change the same test passes.
The asserts are matched against the real `WarnVisitor` output, which records via `record_debug` on `format_args!` and therefore renders values **unquoted** — an assert written against a quoted `message="…"` would be red both before and after the fix and would guard nothing.

- `cargo test -p librefang-channels --no-fail-fast --test bridge_integration_test` — 38 passed, 0 failed (exit 0)
- `cargo test -p librefang-channels --no-fail-fast` — whole crate green, including doc-tests (exit 0)
- `cargo check --workspace --all-targets --exclude librefang-desktop` — green, exit 0 (18m 54s, cold; 27 crates checked)
- `cargo clippy --workspace --all-targets --exclude librefang-desktop -- -D warnings` — green, exit 0 (7m 33s; zero warnings, `librefang-channels` among the 27 crates linted)

`librefang-desktop` is excluded because this host has no GTK development headers; it is unrelated to this diff and is covered by CI.

## Prior art searched

Searched the repository's issues and PRs, open and closed, for `Approval reached no channel`, `structured logging`, `tracing field`, `remedy`, and `approval fan-out warning`.
Nothing proposes moving this remedy — or any other interpolated value — out of a message and into a field.
The only hits on the exact warning text are #8228 and its issue #8227, both of which concern *how often* the warning fires, not how it is shaped.
Related but distinct, and deliberately not touched here: #8270 (the dashboard "Logs" page shows the audit trail rather than the daemon log).

## Deferred

None.