### PR TITLE
fix(kernel): reject a zero tool-exec timeout on save, not at the next boot

### DIFF
--- a/changelog.d/fixed/8285-config-set-rejects-zero-tool-exec-timeout.md
+++ b/changelog.d/fixed/8285-config-set-rejects-zero-tool-exec-timeout.md
@@ -1,0 +1,4 @@
+`POST /api/config/set` now refuses `tool_exec.default_timeout_secs = 0` instead of answering 200 OK and persisting it.
+  The value has been rejected since the field was introduced, but only by the check kernel boot runs, and that section takes effect on restart — so saving a zero from the dashboard looked like it worked and the daemon then refused to start, with `Invalid [tool_exec] config` arriving long afterwards and nothing connecting it to the save that caused it.
+  Recovering meant editing `~/.librefang/config.toml` by hand on the host, because the API that would undo the write was exactly what no longer came up.
+  The check now lives in the validator every config write already funnels through, so the reload endpoint and the user and budget writers are covered by the same guard rather than each growing its own copy (#8285) (@DaBlitzStein)

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -775,6 +775,95 @@ async fn config_set_rejects_path_traversal() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
+/// `tool_exec.default_timeout_secs = 0` is rejected by `ToolExecConfig::validate`,
+/// but that ran only at kernel boot — so this write was answered 200 OK and
+/// persisted, and the *next* daemon start aborted with `Invalid [tool_exec] config`.
+/// Recovering from that needs a hand-edit of `config.toml` on the host, because the
+/// API that would undo it is exactly what no longer comes up.
+/// The value must therefore be refused before it reaches disk.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_rejects_a_zero_local_backend_timeout() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    let (status, body) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({"path": "tool_exec.default_timeout_secs", "value": 0}),
+        ),
+    )
+    .await;
+    let text = String::from_utf8_lossy(&body).to_string();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a zero local-backend timeout bricks the next boot and must not persist, got {status}: {text}"
+    );
+    // The body is asserted too, not just the status: a 400 that named some other
+    // field would satisfy the status check while leaving this value writable.
+    assert!(
+        text.contains("tool_exec") && text.contains("default_timeout_secs"),
+        "the rejection must name the field it refused, got: {text}"
+    );
+
+    // And nothing landed: the rejection happens before the file is written, so
+    // the operator's config is exactly as it was.
+    // `unwrap_or_default` and not `expect`: the refusal is what keeps this
+    // harness from ever creating `config.toml`, so its absence is the strongest
+    // form of the assertion below rather than a reason to panic.
+    let written = std::fs::read_to_string(h.home.join("config.toml")).unwrap_or_default();
+    let parsed: toml::Value = toml::from_str(&written).expect("valid toml");
+    let persisted = parsed
+        .get("tool_exec")
+        .and_then(|t| t.get("default_timeout_secs"));
+    assert!(
+        persisted.is_none(),
+        "the rejected value must not reach config.toml, wrote: {written}"
+    );
+    assert_eq!(
+        h.state.kernel.config_ref().tool_exec.default_timeout_secs,
+        None,
+        "nor the live config"
+    );
+}
+
+/// The other half of the guard above: the field is still writable, so a rejection
+/// that covered every value would be indistinguishable from the fix here and would
+/// silently close a knob #8171 opened on purpose.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_set_accepts_a_nonzero_local_backend_timeout() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    let (status, body) = send(
+        h.app.clone(),
+        auth_post_json(
+            "/api/config/set",
+            serde_json::json!({"path": "tool_exec.default_timeout_secs", "value": 45}),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "expected 200 for a sane timeout, got {status}: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let written = std::fs::read_to_string(h.home.join("config.toml")).expect("toml exists");
+    let parsed: toml::Value = toml::from_str(&written).expect("valid toml");
+    assert_eq!(
+        parsed
+            .get("tool_exec")
+            .and_then(|t| t.get("default_timeout_secs"))
+            .and_then(|v| v.as_integer()),
+        Some(45),
+        "wrote: {written}"
+    );
+    assert_eq!(
+        h.state.kernel.config_ref().tool_exec.default_timeout_secs,
+        Some(45),
+        "and the live config picked it up on the post-write reload"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn config_set_rejects_empty_path() {
     let h = boot_router_with_api_key(API_KEY).await;

--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -1190,6 +1190,22 @@ pub fn validate_config_for_reload(config: &KernelConfig) -> Result<(), Vec<Strin
         errors.push(format!("approval policy: {e}"));
     }
 
+    // The same check kernel boot runs, which is exactly why it belongs here: a
+    // config the API accepts has to be one the daemon can still start on.
+    // `[tool_exec]` is restart-classified, so validating only at boot meant
+    // `default_timeout_secs = 0` was answered 200 OK and written to
+    // `config.toml`, and the failure surfaced at the next start as
+    // `Invalid [tool_exec] config` — decoupled from the save that caused it, and
+    // unrecoverable over the API, since the API is what no longer comes up.
+    // Hand-editing `config.toml` on the host was the only way back.
+    // Validated in this function rather than in the route handler because it is
+    // the one place every config write already funnels through: the config
+    // editor, `POST /api/config/reload`, and the budget and user/group writers
+    // are covered without each growing its own copy of the check (#8175).
+    if let Err(e) = config.tool_exec.validate() {
+        errors.push(format!("tool_exec: {e}"));
+    }
+
     // Network config: if network is enabled, shared_secret must be set
     if config.network_enabled && config.network.shared_secret.is_empty() {
         errors.push("network_enabled is true but network.shared_secret is empty".to_string());

--- a/crates/librefang-types/src/tool_exec.rs
+++ b/crates/librefang-types/src/tool_exec.rs
@@ -141,11 +141,14 @@ impl ToolExecConfig {
     /// Validate that the active backend kind has the matching sub-table
     /// populated. Called from kernel boot so misconfigurations fail
     /// loudly at startup instead of silently downgrading at the first
-    /// tool call.
+    /// tool call, and from `validate_config_for_reload` so a write that
+    /// would produce one is refused at the point it is made rather than
+    /// at the next restart (#8175).
     ///
-    /// Currently only enforces presence of the sub-table; detailed
-    /// per-field checks (host non-empty, api_url scheme, etc.) live in
-    /// the per-backend constructor where the error context is richest.
+    /// Enforces presence of the sub-table, the fields that sub-table
+    /// cannot work without, and the zero timeout below; the remaining
+    /// per-field checks (api_url scheme, credential reachability) live
+    /// in the per-backend constructor where the error context is richest.
     pub fn validate(&self) -> Result<(), String> {
         // `0` builds a `Duration::from_secs(0)`, which makes every local exec
         // return `ExecError::Timeout("after 0s")` — a daemon that boots clean


### PR DESCRIPTION
## What

`ToolExecConfig::validate` has rejected `tool_exec.default_timeout_secs = 0` since the field was introduced (#8171, #8175), but only kernel boot ever called it.

`[tool_exec]` is restart-classified, so `POST /api/config/set` answered **200 OK**, wrote the value to `config.toml`, and the daemon then refused to start with `Invalid [tool_exec] config`.
That error arrives long after the save, with nothing connecting the two — and the API that would undo the write is exactly what no longer comes up, so the only way back is hand-editing `~/.librefang/config.toml` on the host.

## Changes

- `crates/librefang-kernel/src/config_reload.rs` — call `config.tool_exec.validate()` from `validate_config_for_reload`, next to the sibling `approval.validate()` call.
  This is the one function every config write already funnels through, so the config editor, `POST /api/config/reload`, and the budget and user/group writers are covered by a single guard instead of each growing its own copy.
  Putting it in the route handler would have fixed one caller and left the others.
- `crates/librefang-api/tests/config_routes_integration.rs` — two integration tests: the zero is refused with 400 and never reaches `config.toml` or the live config, and a non-zero value is still written and read back.
- `crates/librefang-types/src/tool_exec.rs` — doc only. The comment said `validate` "only enforces presence of the sub-table", which stopped being true once it grew the zero check and the ssh/daytona field checks; it also now names its second caller.

## The failing test first

Both tests were run against `origin/main` **without** the fix. The rejection test failed exactly as the bug describes:

```
assertion `left == right` failed: a zero local-backend timeout bricks the next boot and must not persist,
got 200 OK: {"status":"applied_partial","path":"tool_exec.default_timeout_secs"}
  left: 200
 right: 400
```

`"applied_partial"` is the daemon confirming it had accepted and applied the value.
The positive-control test passed on the unfixed code, which is what makes the pair meaningful: the guard rejects the broken value and nothing else.

Both assert the **body** as well as the status — a 400 naming some other field would satisfy a status-only check while leaving this value writable.

## Verification

- `cargo test -p librefang-api --test config_routes_integration` — **57 passed, 0 failed** (`TESTS_EXIT=0`), including both new tests.
- `cargo check --workspace --all-targets --exclude librefang-desktop` — `CHECK_EXIT=0`.
- `cargo clippy --workspace --all-targets --exclude librefang-desktop -- -D warnings` — `CLIPPY_EXIT=0`.
- `librefang-desktop` is excluded because this host lacks the GTK headers, not to hide anything: the diff does not touch that crate.

## Prior art searched

Searched issues and PRs, open and closed, for `default_timeout_secs`, `tool_exec validate`, `validate_config_for_reload` and `config/set rejects`.
The only related item is #8175 (closed), which added the boot-time rejection and the `GET /api/config` round-trip but not the save-time one; its issue is #8171.
Also checked every open PR that touches `config_reload.rs` or `tool_exec.rs` (#8217, #8194, #8185, #7989, #7789, #7781) — none of them adds a `tool_exec.validate()` call, so this does not overlap or compete with work in flight.

## Scope

No behaviour change for any value other than `0`, which was already unusable: it builds a `Duration::from_secs(0)` and fails every local exec immediately.
Rejected rather than clamped, because unlike `max_history_messages` there is no sensible timeout an operator meant by zero.
