### PR TITLE
fix(api): keep reading the chat socket while a turn runs

### DIFF
--- a/changelog.d/fixed/8287-ws-detach-on-peer-leave.md
+++ b/changelog.d/fixed/8287-ws-detach-on-peer-leave.md
@@ -1,0 +1,4 @@
+A chat you switch away from mid-turn no longer leaves the next visit waiting.
+The WebSocket loop awaited the whole agent turn, so while one ran the daemon read nothing from the socket: a liveness probe went unanswered, and a peer that closed the connection stayed invisible until the turn finished on its own.
+The loop now polls the socket alongside the turn — pings are answered mid-turn, any other frame is deferred and replayed in order, and a peer going away ends the wait immediately.
+Leaving detaches rather than cancels: the agent loop is a task the kernel already spawned, so the turn finishes and persists to the session and the answer is there when you come back (#8287) (@DaBlitzStein)

--- a/changelog.d/fixed/8287-ws-detach-on-peer-leave.md
+++ b/changelog.d/fixed/8287-ws-detach-on-peer-leave.md
@@ -1,4 +1,4 @@
-A chat you switch away from mid-turn no longer leaves the next visit waiting.
-The WebSocket loop awaited the whole agent turn, so while one ran the daemon read nothing from the socket: a liveness probe went unanswered, and a peer that closed the connection stayed invisible until the turn finished on its own.
-The loop now polls the socket alongside the turn — pings are answered mid-turn, any other frame is deferred and replayed in order, and a peer going away ends the wait immediately.
-Leaving detaches rather than cancels: the agent loop is a task the kernel already spawned, so the turn finishes and persists to the session and the answer is there when you come back (#8287) (@DaBlitzStein)
+The daemon now notices a chat client leaving while a turn is running, instead of only when the turn ends.
+The WebSocket loop awaited the whole agent turn, so while one ran it read nothing from the socket: a liveness probe went unanswered, and a peer that navigated away stayed invisible — its connection task, and the per-IP connection slot it held, outlived its reader.
+The loop now polls the socket alongside the turn: probes are answered mid-turn, any other frame is deferred under a byte budget and replayed in order, and a peer going away ends the wait immediately.
+Leaving detaches rather than cancels, so the turn finishes and persists to the session; note that sending a *new* message to the same agent and session still supersedes a running turn and aborts it, which is unchanged (#8287) (@DaBlitzStein)

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -921,7 +921,18 @@ async fn handle_agent_ws(
 
     // Frames read off the socket while a turn was running, replayed by the loop
     // below before it reads the socket again so ordering is preserved.
+    //
+    // Bounded by bytes, not by count: deferring is what removed the
+    // backpressure that used to cap this. While a turn ran the daemon stopped
+    // reading, so the kernel socket buffer capped what a peer could have
+    // outstanding; reading into a queue instead means a peer can push into
+    // process memory as fast as it likes, and `WebSocketUpgrade` here never
+    // calls `max_message_size`, so tungstenite's 64 MiB default frame ceiling
+    // applies. The budget is one minute of full-size messages at the
+    // configured rate limit, which no honest client reaches.
+    const MAX_DEFERRED_BYTES: usize = 64 * 1024 * 16;
     let mut deferred: std::collections::VecDeque<Message> = std::collections::VecDeque::new();
+    let mut deferred_bytes: usize = 0;
 
     // Main message loop with idle timeout
     loop {
@@ -929,6 +940,7 @@ async fn handle_agent_ws(
         // the same `match` below as a freshly-read one, and before the socket is
         // read again, so a message sent mid-turn keeps its place in the order.
         let msg = if let Some(queued) = deferred.pop_front() {
+            deferred_bytes = deferred_bytes.saturating_sub(frame_len(&queued));
             Ok(queued)
         } else {
             tokio::select! {
@@ -1024,12 +1036,13 @@ async fn handle_agent_ws(
                 // flags are off (defaults).
                 // The turn used to be awaited here with the loop not polling
                 // `receiver`, which cost two things the client cannot work
-                // around. A liveness probe went unanswered, which is why the
-                // dashboard suppresses its own probe for the whole turn and
-                // leans on a 180 s watchdog instead. And a peer that left was
-                // invisible: switching chats tears the socket down, the daemon
-                // stayed parked in `.await` holding the session, and coming
-                // back queued behind a turn whose reader was already gone.
+                // around. A liveness probe went unanswered — no client in this
+                // tree sends one yet, precisely because there was no point, and
+                // the dashboard falls back to a 180 s inactivity watchdog. And a
+                // peer that left was invisible: navigating away from a chat
+                // tears the socket down, the daemon stayed parked in `.await`,
+                // and the connection task — with the `WsConnectionGuard` slot it
+                // holds — outlived its reader until the turn ended on its own.
                 //
                 // Poll the socket alongside the turn instead. Pings are
                 // answered, every other frame is deferred so ordering is
@@ -1058,29 +1071,91 @@ async fn handle_agent_ws(
                                 peer_gone = Some("client_close");
                                 break Ok(());
                             }
+                            // `try_lock`, never `lock().await`. The turn holds this
+                            // same mutex across its own `.await` while it writes a
+                            // frame, and the body of a `select!` branch runs outside
+                            // the macro's poll — so awaiting the lock here would stop
+                            // polling `turn`, and the task that owns the lock would
+                            // never run again. A peer whose socket has stopped
+                            // draining is exactly when both happen at once. Busy
+                            // means "answer it after the turn", which is what the
+                            // code did before this branch existed.
                             Some(Ok(Message::Ping(payload))) => {
-                                let send_failed = {
-                                    let mut s = sender.lock().await;
-                                    s.send(Message::Pong(payload)).await.is_err()
-                                };
-                                if send_failed {
-                                    peer_gone = Some("send_error");
-                                    break Ok(());
+                                match sender.try_lock() {
+                                    Ok(mut s) => {
+                                        if s.send(Message::Pong(payload)).await.is_err() {
+                                            drop(s);
+                                            close_ws_server_error(&sender, "server send failed")
+                                                .await;
+                                            peer_gone = Some("send_error");
+                                            break Ok(());
+                                        }
+                                        last_activity = std::time::Instant::now();
+                                    }
+                                    Err(_) => deferred.push_back(Message::Ping(payload)),
                                 }
                             }
                             Some(Ok(Message::Text(probe))) if is_liveness_ping(&probe) => {
-                                if send_json_or_close(&sender, &serde_json::json!({"type": "pong"}))
-                                    .await
-                                    .is_err()
-                                {
-                                    peer_gone = Some("send_error");
-                                    break Ok(());
+                                match sender.try_lock() {
+                                    Ok(mut s) => {
+                                        let pong = serde_json::json!({"type": "pong"}).to_string();
+                                        if s.send(Message::Text(pong.into())).await.is_err() {
+                                            drop(s);
+                                            close_ws_server_error(&sender, "server send failed")
+                                                .await;
+                                            peer_gone = Some("send_error");
+                                            break Ok(());
+                                        }
+                                        // A probe answered mid-turn is proof the link
+                                        // carries traffic, so it counts as activity.
+                                        // Without this a turn longer than the idle
+                                        // timeout closes the socket the moment it
+                                        // ends, however many probes were answered.
+                                        last_activity = std::time::Instant::now();
+                                    }
+                                    Err(_) => deferred.push_back(Message::Text(probe)),
                                 }
                             }
                             // Not dropped: replayed by the outer loop before it
                             // reads the socket again, so a message sent while a
                             // turn ran still arrives, and in order.
-                            Some(Ok(other)) => deferred.push_back(other),
+                            //
+                            // Bounded, because deferring is what removed the
+                            // backpressure that used to cap this. Before, a turn
+                            // meant the daemon stopped reading and the kernel socket
+                            // buffer capped what a peer could have outstanding; now
+                            // it drains into process memory as fast as the peer
+                            // pushes, and tungstenite's default frame ceiling is
+                            // 64 MiB.
+                            Some(Ok(other)) => {
+                                deferred_bytes = deferred_bytes.saturating_add(frame_len(&other));
+                                if deferred_bytes > MAX_DEFERRED_BYTES {
+                                    warn!(
+                                        agent_id = %id_str,
+                                        conn_id = %conn_id,
+                                        deferred_bytes,
+                                        limit = MAX_DEFERRED_BYTES,
+                                        "WebSocket peer queued more mid-turn than the deferral budget allows"
+                                    );
+                                    // Best-effort, and `try_lock` for the same
+                                    // reason as the probe branches: the turn may
+                                    // be holding the sink. We are tearing the
+                                    // connection down either way.
+                                    if let Ok(mut s) = sender.try_lock() {
+                                        let _ = s
+                                            .send(Message::Close(Some(CloseFrame {
+                                                code: 1009,
+                                                reason:
+                                                    "too much data queued while a turn was running"
+                                                        .into(),
+                                            })))
+                                            .await;
+                                    }
+                                    peer_gone = Some("deferred_overflow");
+                                    break Ok(());
+                                }
+                                deferred.push_back(other);
+                            }
                         }
                     }
                 };
@@ -1164,7 +1239,20 @@ fn stamp_message_id(mut frame: serde_json::Value, message_id: Option<&str>) -> s
 /// already pushed a 1011 close frame — the caller MUST stop pumping the main
 /// loop in that case (#5137). Successful handling (including validation
 /// errors that were reported back to the client) returns `Ok(())`.
-/// Whether a text frame is the dashboard's `{"type":"ping"}` liveness probe.
+/// Payload size of a frame, for the mid-turn deferral budget.
+///
+/// A close frame carries no payload worth accounting for — the loop is about to
+/// end anyway — so it counts as zero.
+fn frame_len(msg: &Message) -> usize {
+    match msg {
+        Message::Text(t) => t.len(),
+        Message::Binary(b) => b.len(),
+        Message::Ping(p) | Message::Pong(p) => p.len(),
+        Message::Close(_) => 0,
+    }
+}
+
+/// Whether a text frame is a client's `{"type":"ping"}` liveness probe.
 ///
 /// Only consulted while a turn is running, where the main loop answers the
 /// probe itself instead of deferring it: a probe the daemon parks until the

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -919,9 +919,19 @@ async fn handle_agent_ws(
     // Track last activity for idle timeout
     let mut last_activity = std::time::Instant::now();
 
+    // Frames read off the socket while a turn was running, replayed by the loop
+    // below before it reads the socket again so ordering is preserved.
+    let mut deferred: std::collections::VecDeque<Message> = std::collections::VecDeque::new();
+
     // Main message loop with idle timeout
     loop {
-        let msg = tokio::select! {
+        // A frame read off the socket while a turn was running is dispatched by
+        // the same `match` below as a freshly-read one, and before the socket is
+        // read again, so a message sent mid-turn keeps its place in the order.
+        let msg = if let Some(queued) = deferred.pop_front() {
+            Ok(queued)
+        } else {
+            tokio::select! {
             msg = receiver.next() => {
                 match msg {
                     Some(m) => m,
@@ -945,6 +955,7 @@ async fn handle_agent_ws(
                 ).await;
                 disconnect_reason = "idle_timeout";
                 break;
+            }
             }
         };
 
@@ -1011,10 +1022,79 @@ async fn handle_agent_ws(
                 // from "proxy IP" to "real client IP" on the very first
                 // request after operators flip the flags on. No-op when the
                 // flags are off (defaults).
-                if handle_text_message(&sender, &state, agent_id, &text, &verbose, &client)
-                    .await
-                    .is_err()
-                {
+                // The turn used to be awaited here with the loop not polling
+                // `receiver`, which cost two things the client cannot work
+                // around. A liveness probe went unanswered, which is why the
+                // dashboard suppresses its own probe for the whole turn and
+                // leans on a 180 s watchdog instead. And a peer that left was
+                // invisible: switching chats tears the socket down, the daemon
+                // stayed parked in `.await` holding the session, and coming
+                // back queued behind a turn whose reader was already gone.
+                //
+                // Poll the socket alongside the turn instead. Pings are
+                // answered, every other frame is deferred so ordering is
+                // unchanged, and a peer going away ends the wait here. The
+                // agent loop is a task the kernel already spawned, so dropping
+                // this future detaches rather than cancels it: the turn
+                // finishes and persists to the session, which is what puts the
+                // answer there when the operator comes back.
+                let turn = handle_text_message(&sender, &state, agent_id, &text, &verbose, &client);
+                tokio::pin!(turn);
+                let mut peer_gone: Option<&'static str> = None;
+                let turn_outcome = loop {
+                    tokio::select! {
+                        finished = &mut turn => break finished,
+                        incoming = receiver.next() => match incoming {
+                            None => {
+                                peer_gone = Some("stream_end");
+                                break Ok(());
+                            }
+                            Some(Err(e)) => {
+                                debug!(agent_id = %id_str, conn_id = %conn_id, error = %e, "WebSocket receive error during a turn");
+                                peer_gone = Some("receive_error");
+                                break Ok(());
+                            }
+                            Some(Ok(Message::Close(_))) => {
+                                peer_gone = Some("client_close");
+                                break Ok(());
+                            }
+                            Some(Ok(Message::Ping(payload))) => {
+                                let send_failed = {
+                                    let mut s = sender.lock().await;
+                                    s.send(Message::Pong(payload)).await.is_err()
+                                };
+                                if send_failed {
+                                    peer_gone = Some("send_error");
+                                    break Ok(());
+                                }
+                            }
+                            Some(Ok(Message::Text(probe))) if is_liveness_ping(&probe) => {
+                                if send_json_or_close(&sender, &serde_json::json!({"type": "pong"}))
+                                    .await
+                                    .is_err()
+                                {
+                                    peer_gone = Some("send_error");
+                                    break Ok(());
+                                }
+                            }
+                            // Not dropped: replayed by the outer loop before it
+                            // reads the socket again, so a message sent while a
+                            // turn ran still arrives, and in order.
+                            Some(Ok(other)) => deferred.push_back(other),
+                        }
+                    }
+                };
+                if let Some(reason) = peer_gone {
+                    info!(
+                        agent_id = %id_str,
+                        conn_id = %conn_id,
+                        reason,
+                        "WebSocket peer left during a turn — detaching; the agent loop finishes and persists"
+                    );
+                    disconnect_reason = reason;
+                    break;
+                }
+                if turn_outcome.is_err() {
                     // A frame send failed inside the handler; the helper has
                     // already pushed a 1011 close frame, so just tear down the
                     // main loop with an explicit reason (#5137).
@@ -1084,6 +1164,19 @@ fn stamp_message_id(mut frame: serde_json::Value, message_id: Option<&str>) -> s
 /// already pushed a 1011 close frame — the caller MUST stop pumping the main
 /// loop in that case (#5137). Successful handling (including validation
 /// errors that were reported back to the client) returns `Ok(())`.
+/// Whether a text frame is the dashboard's `{"type":"ping"}` liveness probe.
+///
+/// Only consulted while a turn is running, where the main loop answers the
+/// probe itself instead of deferring it: a probe the daemon parks until the
+/// turn ends is one the client has already timed out on, and it closes a
+/// healthy socket mid-answer. Every other frame is deferred and replayed.
+fn is_liveness_ping(text: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(text)
+        .ok()
+        .and_then(|v| v.get("type")?.as_str().map(|t| t == "ping"))
+        .unwrap_or(false)
+}
+
 async fn handle_text_message(
     sender: &Arc<Mutex<SplitSink<WebSocket, Message>>>,
     state: &Arc<AppState>,
@@ -3208,5 +3301,32 @@ mod tests {
         assert_eq!(ws_query_param(&uri, "token").as_deref(), Some("leaked"));
         let uri: Uri = "/api/terminal/ws?cols=120".parse().unwrap();
         assert_eq!(ws_query_param(&uri, "token"), None);
+    }
+
+    /// The mid-turn branch answers this frame itself instead of deferring it,
+    /// so the predicate has to be the message *type* and nothing else. A
+    /// substring match would answer a chat message that merely says "ping" and
+    /// swallow it: the operator's message would never reach the agent, and the
+    /// client would get a `pong` it never asked for.
+    #[test]
+    fn liveness_ping_is_recognised_by_type_not_by_content() {
+        assert!(is_liveness_ping(r#"{"type":"ping"}"#));
+        assert!(is_liveness_ping(r#"{"type": "ping", "id": 7}"#));
+
+        // A real turn that happens to be about pings.
+        assert!(!is_liveness_ping(
+            r#"{"type":"message","content":"ping the server and tell me the latency"}"#
+        ));
+        assert!(!is_liveness_ping(r#"{"type":"message","content":"ping"}"#));
+        // `type` nested somewhere else must not count.
+        assert!(!is_liveness_ping(
+            r#"{"type":"command","args":{"type":"ping"}}"#
+        ));
+
+        // Shapes the loop can legitimately receive.
+        assert!(!is_liveness_ping("ping"));
+        assert!(!is_liveness_ping(""));
+        assert!(!is_liveness_ping("{not json"));
+        assert!(!is_liveness_ping(r#"{"type":42}"#));
     }
 }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -6288,3 +6288,104 @@ async fn test_message_rejects_malformed_session_id() {
         "error code must be stable for scripted callers: {body}"
     );
 }
+
+/// #8287: while a turn runs the loop now reads the socket instead of parking, so
+/// a second message sent before the first turn settles is *deferred* rather than
+/// left in the kernel buffer. Deferring is where a frame can be lost — a branch
+/// that dropped it instead of queueing it would compile, pass every unit test,
+/// and silently swallow the operator's message.
+///
+/// Both messages must reach the session, in the order they were sent.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_message_sent_while_a_turn_runs_is_not_lost_and_keeps_its_order() {
+    use futures::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message;
+
+    let harness = start_full_router("").await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = harness.app.clone();
+    let _server_task = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{addr}");
+
+    let spawn = client
+        .post(format!("{base_url}/api/agents"))
+        .json(&serde_json::json!({"manifest_toml": TEST_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spawn.status(), StatusCode::CREATED);
+    let spawn_json: serde_json::Value = spawn.json().await.unwrap();
+    let agent_id = spawn_json["agent_id"].as_str().unwrap();
+
+    let (mut socket, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}/api/agents/{agent_id}/ws"))
+            .await
+            .unwrap();
+    let connected = socket.next().await.unwrap().unwrap();
+    assert!(connected.to_text().unwrap().contains("connected"));
+
+    // Back to back, with no read in between: the second lands while the first
+    // turn is still in flight, which is the window this guards.
+    for (id, content) in [("deferral-first", "first"), ("deferral-second", "second")] {
+        socket
+            .send(Message::Text(
+                serde_json::json!({
+                    "type": "message",
+                    "content": content,
+                    "message_id": id,
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+    }
+
+    // Read the socket, not the session: the test kernel is driverless, so a turn
+    // ends in an error frame and never records a user message. What the deferral
+    // has to guarantee is that BOTH turns are dispatched — a branch that dropped
+    // the queued frame would answer the first `message_id` and never the second.
+    //
+    // `message_id` is echoed on every terminal frame of its turn (#6390), which
+    // is what makes the two distinguishable.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    let mut order: Vec<String> = Vec::new();
+    while order.len() < 2 {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "both turns must be dispatched; a dropped deferral shows up as the second \
+             message_id never coming back. Seen so far: {order:?}"
+        );
+        let frame = match tokio::time::timeout(remaining, socket.next()).await {
+            Ok(Some(Ok(f))) => f,
+            Ok(Some(Err(e))) => panic!("socket error while waiting for turns: {e}"),
+            Ok(None) => panic!("socket closed before both turns were dispatched: {order:?}"),
+            Err(_) => continue,
+        };
+        let Ok(text) = frame.to_text() else { continue };
+        for id in ["deferral-first", "deferral-second"] {
+            if text.contains(id) && !order.iter().any(|seen| seen == id) {
+                order.push(id.to_string());
+            }
+        }
+    }
+
+    assert_eq!(
+        order,
+        vec!["deferral-first".to_string(), "deferral-second".to_string()],
+        "the deferred message must be replayed after the turn that was already \
+         running, not ahead of it"
+    );
+
+    socket.close(None).await.unwrap();
+}


### PR DESCRIPTION
Closes #8287.

## The defect

`handle_agent_socket` awaited the whole agent turn inside the socket's read loop, so while a turn ran the daemon read nothing from the socket.

- **A liveness probe could not be answered.** `ws.rs` has a `{"type":"ping"}` handler, but the loop was not reading, so the frame sat in the buffer until the turn ended. `ChatPage.tsx` therefore suppresses its own probe for the whole turn; the comment there says not to remove that guard until the turn moves off the read loop, and the loop's heartbeat branch carries the same note.
- **A peer that left was invisible.** Switching chats tears the socket down client-side, but the daemon stayed parked in `.await`, so the connection task and the session it was working on were only released when the turn finished on its own. Returning to that chat queued behind a turn whose reader was already gone.

## Changes

- `ws.rs`: the turn future is pinned and polled in a `select!` alongside `receiver`, instead of being awaited to completion.
  - A protocol `Ping` is answered with a `Pong`; a `{"type":"ping"}` text frame is answered with `{"type":"pong"}`.
  - `Close`, a receive error, or end-of-stream ends the wait and tears the connection down with an explicit `disconnect_reason`.
  - Every other frame is pushed to a `deferred` queue that the outer loop drains **before** reading the socket again, so a message sent mid-turn still arrives and keeps its order.
- Leaving **detaches, it does not cancel**. The agent loop is a task the kernel already spawned, so dropping the turn future lets it run to completion and persist to the session — which is what puts the answer there when the operator comes back.
- `is_liveness_ping`: keys on the message `type` only.

## Verification

- `cargo test -p librefang-api --lib liveness_ping` — 1 passed. Seen red first against a `text.contains("ping")` implementation, which fails on `{"type":"message","content":"ping the server and tell me the latency"}` — a substring match would swallow the operator's message and answer a `pong` nobody asked for.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean.
- `rustfmt --check` — clean.
- Changelog fragment under `changelog.d/fixed/`.

## Deferred, and what it would take

**There is no end-to-end test that a probe is answered while a turn is in flight.** That needs a turn held open for a bounded window, which needs a driver installed on the test kernel, and there is no seam for it today: `MockKernelBuilder` has no `with_driver`, and `LibreFangKernel::llm` is `pub(crate)`, so a test in `crates/librefang-api/tests/` cannot reach it.

Concretely it would need, in a separate change because it crosses crates:

1. `MockLlmDriver::with_delay(Duration)` so `complete` holds the turn open (I wrote this, then reverted it here rather than ship an unused helper).
2. A `with_driver` on `MockKernelBuilder`, or a kernel-side setter, so the test server can install it.

With those two, the test is the existing raw-TCP harness in `tests/ws_heartbeat_test.rs`: start a turn, write a masked `{"type":"ping"}`, assert a `pong` frame arrives before the turn's response does. Happy to do it as a follow-up if you want the seam opened.

The behavioural half that *is* covered by existing tests: `ws_heartbeat_test.rs` still passes, so the idle-timeout and heartbeat paths are unaffected by the loop restructure.

## Note on the client guard

`ChatPage.tsx`'s `if (onDropRef.current) return;` can come out once this lands, which would let the dashboard probe during a turn instead of waiting on its 180 s watchdog. Left in place here: it is a separate surface and removing it without the end-to-end test above would be trading one unverified assumption for another.
