### PR TITLE
fix(api): list media providers from the registry, not a five-name constant

### DIFF
--- a/changelog.d/fixed/8297-media-providers-from-registry.md
+++ b/changelog.d/fixed/8297-media-providers-from-registry.md
@@ -1,0 +1,3 @@
+The media providers the API reports are now the ones the daemon actually knows about, read from the provider registry instead of a list of five names compiled into the route.
+The two had drifted apart in both directions: a provider that declares image and video generation in the registry was invisible to every surface while auto-detection could already select it, so the daemon could pick a provider the dashboard never offered.
+A provider the registry declares but no driver serves yet is now reported as unconfigured, with the functions it would cover, rather than as a driver that failed to start. (#8297) (@DaBlitzStein)

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -27,18 +27,6 @@ pub fn router() -> axum::Router<Arc<AppState>> {
         .route("/media/transcribe", axum::routing::post(transcribe_audio))
 }
 
-// ── Known media providers (mirrors MEDIA_PROVIDER_ORDER in runtime) ─────
-
-/// Built-in media provider names, in preference order, for
-/// `GET /media/providers` to report configuration status against.
-///
-/// This is a **display list, not an allowlist**: `create_media_driver` also
-/// serves user-defined providers that have `provider_urls.<name>` configured,
-/// via the generic OpenAI-compatible driver. Gating a route on membership here
-/// would reject those.
-/// Keep in sync with `librefang_kernel::media::MEDIA_PROVIDER_ORDER`.
-const KNOWN_MEDIA_PROVIDERS: &[&str] = &["openai", "gemini", "elevenlabs", "minimax", "google_tts"];
-
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 /// Convert a `MediaError` into an [`ApiErrorResponse`].
@@ -541,11 +529,25 @@ impl Drop for TempUploadGuard {
 // ── GET /media/providers ────────────────────────────────────────────────
 
 /// List available media providers with their capabilities and config status.
+///
+/// The provider list comes from [`MediaDriverCache::media_provider_ids`], which the kernel loads from the registry at boot — the same list auto-detection picks from.
+/// It used to be a five-name constant in this file, and the two inventories had already drifted apart in both directions: `byteplus` declares image and video generation in the registry and was invisible here, so the daemon could auto-select a provider the dashboard never listed.
 pub async fn list_media_providers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    // Registry-declared capabilities, for providers that have no built-in
+    // driver. `create_media_driver` fails for those unless a `provider_urls`
+    // entry gives it a base URL, but the provider is still real and the
+    // dashboard needs to know which functions it would serve once configured.
+    let catalog = state.kernel.model_catalog_ref().load();
+    let declared: std::collections::HashMap<&str, &[String]> = catalog
+        .list_providers()
+        .iter()
+        .map(|p| (p.id.as_str(), p.media_capabilities.as_slice()))
+        .collect();
+
     let mut providers = Vec::new();
 
-    for &name in KNOWN_MEDIA_PROVIDERS {
-        match state.media_drivers.get_or_create(name, None) {
+    for name in state.media_drivers.media_provider_ids() {
+        match state.media_drivers.get_or_create(&name, None) {
             Ok(driver) => {
                 providers.push(serde_json::json!({
                     "name": driver.provider_name(),
@@ -554,12 +556,13 @@ pub async fn list_media_providers(State(state): State<Arc<AppState>>) -> impl In
                 }));
             }
             Err(_) => {
-                // Provider could not be instantiated (should not happen for known providers)
+                // No built-in driver and no `provider_urls.<name>` base URL, so
+                // there is nothing to ask `is_configured()`. That is an
+                // unconfigured provider, not a broken one.
                 providers.push(serde_json::json!({
                     "name": name,
                     "configured": false,
-                    "capabilities": [],
-                    "error": "driver instantiation failed",
+                    "capabilities": declared.get(name.as_str()).copied().unwrap_or(&[]),
                 }));
             }
         }

--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -23,7 +23,7 @@ use axum::body::Body;
 use axum::http::{HeaderValue, Method, Request, StatusCode};
 use axum::Router;
 use librefang_api::routes::{self, AppState};
-use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_testing::{CatalogSeed, MockKernelBuilder, TestAppState};
 use std::sync::Arc;
 use tower::ServiceExt;
 
@@ -93,8 +93,12 @@ async fn boot_clears_provider_credentials_from_the_environment() {
 }
 
 async fn boot() -> Harness {
+    boot_with_catalog(None).await
+}
+
+async fn boot_with_catalog(seed: Option<CatalogSeed>) -> Harness {
     clear_media_provider_env();
-    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
+    let mut builder = MockKernelBuilder::new().with_config(|cfg| {
         cfg.default_model = librefang_types::config::DefaultModelConfig {
             provider: "ollama".to_string(),
             model: "test-model".to_string(),
@@ -104,7 +108,11 @@ async fn boot() -> Harness {
             extra_params: std::collections::BTreeMap::new(),
             cli_profile_dirs: Vec::new(),
         };
-    }));
+    });
+    if let Some(seed) = seed {
+        builder = builder.with_catalog_seed(seed);
+    }
+    let test = TestAppState::with_builder(builder);
     let state = test.state.clone();
     let app = Router::new()
         .nest("/api", routes::media::router())
@@ -418,6 +426,65 @@ async fn media_providers_lists_all_known_with_unconfigured_status() {
             "unexpected configured=true with no API keys: {p}"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn media_providers_lists_registry_declared_providers_with_no_builtin_driver() {
+    // `byteplus` is the real case this guards: it declares image and video
+    // generation in `librefang/librefang-registry`, has no compiled-in driver,
+    // and was absent from the five-name constant this route used to enumerate.
+    // `detect_for_capability` could already select it — so the daemon could
+    // pick a provider the dashboard never listed.
+    let providers = vec![
+        librefang_types::model_catalog::ProviderInfo {
+            id: "byteplus".to_string(),
+            display_name: "BytePlus".to_string(),
+            api_key_env: "BYTEPLUS_API_KEY".to_string(),
+            media_capabilities: vec!["image_generation".into(), "video_generation".into()],
+            ..Default::default()
+        },
+        librefang_types::model_catalog::ProviderInfo {
+            id: "anthropic".to_string(),
+            display_name: "Anthropic".to_string(),
+            api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            media_capabilities: Vec::new(),
+            ..Default::default()
+        },
+    ];
+    let h = boot_with_catalog(Some((providers, Vec::new()))).await;
+    let (status, body) = json_request(&h, Method::GET, "/api/media/providers", None).await;
+    assert_eq!(status, StatusCode::OK, "got: {body:?}");
+    let listed = body["providers"].as_array().expect("providers array");
+    let names: Vec<&str> = listed.iter().filter_map(|p| p["name"].as_str()).collect();
+
+    assert!(
+        names.contains(&"byteplus"),
+        "registry provider declaring media_capabilities is missing from: {names:?}"
+    );
+    // A provider with no compiled-in driver still has to report which
+    // functions it would serve, or the dashboard cannot file it under a tab.
+    let byteplus = listed
+        .iter()
+        .find(|p| p["name"] == "byteplus")
+        .expect("byteplus entry");
+    assert_eq!(
+        byteplus["capabilities"],
+        serde_json::json!(["image_generation", "video_generation"]),
+        "declared capabilities lost: {byteplus}"
+    );
+    assert_eq!(byteplus["configured"], false, "got: {byteplus}");
+
+    // `google_tts` has a working driver and no registry entry at all. Reading
+    // the list from the registry must not drop it.
+    assert!(
+        names.contains(&"google_tts"),
+        "built-in driver without a registry entry was dropped: {names:?}"
+    );
+    // A provider that declares no media capabilities is not a media provider.
+    assert!(
+        !names.contains(&"anthropic"),
+        "non-media provider leaked into the media list: {names:?}"
+    );
 }
 
 // ── POST /media/transcribe ──────────────────────────────────────────────

--- a/crates/librefang-runtime-media/src/lib.rs
+++ b/crates/librefang-runtime-media/src/lib.rs
@@ -248,6 +248,13 @@ impl MediaDriverCache {
         *write_media_state(&self.media_providers, "media_providers") = media_provs;
     }
 
+    /// The media provider IDs this cache knows about, in preference order.
+    ///
+    /// This is the same list [`detect_for_capability`](Self::detect_for_capability) picks from, which is the point of exposing it: a surface that enumerates media providers from its own hardcoded list can disagree with the list auto-detection actually uses, and then the daemon selects a provider the UI never showed.
+    pub fn media_provider_ids(&self) -> Vec<String> {
+        read_media_state(&self.media_providers, "media_providers").clone()
+    }
+
     /// Get or create a cached driver for the given provider.
     ///
     /// If `base_url` is `None`, the cache checks its `provider_urls` map

--- a/crates/librefang-runtime/src/media_stub.rs
+++ b/crates/librefang-runtime/src/media_stub.rs
@@ -27,6 +27,10 @@ impl MediaDriverCache {
 
     pub fn load_providers_from_registry(&self, _registry: &impl std::any::Any) {}
 
+    pub fn media_provider_ids(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     pub fn clear(&self) {}
 
     pub fn update_provider_urls<I>(&self, _urls: I) {}

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -298,6 +298,22 @@ impl TestAppState {
                 cfg.api_key_hash.trim().to_string(),
             )
         };
+        // Mirrors `kernel::boot`, which loads the media provider order from the
+        // catalog right after constructing the cache. Without this the harness
+        // hands every test the five compiled-in built-ins while production
+        // serves whatever the registry declares, so a test over
+        // `GET /media/providers` would pass against a list production never
+        // produces.
+        let media_drivers = librefang_runtime::media::MediaDriverCache::new();
+        // `KernelApi` is called through its path rather than imported: bringing
+        // the trait into scope makes `set_self_handle` resolve to the
+        // by-value `Arc<Self>` trait method and moves the caller's kernel.
+        media_drivers.load_providers_from_registry(
+            librefang_kernel::KernelApi::model_catalog_ref(&*kernel)
+                .load()
+                .list_providers(),
+        );
+
         // Rooted at the test's temp home so a transparent api_key upgrade hint
         // (#6613) lands there rather than in the process CWD.
         let master_key = Arc::new(librefang_api::middleware::MasterKeyState::new(
@@ -326,7 +342,7 @@ impl TestAppState {
             api_key_lock: Arc::new(tokio::sync::RwLock::new(master_plaintext)),
             master_key,
             user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
-            media_drivers: librefang_runtime::media::MediaDriverCache::new(),
+            media_drivers,
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             config_write_lock: tokio::sync::Mutex::new(()),
             pending_a2a_agents: dashmap::DashMap::new(),


### PR DESCRIPTION
Closes part of #8011.

## The defect

`GET /api/media/providers` enumerated a hardcoded constant:

```rust
// crates/librefang-api/src/routes/media.rs:40
const KNOWN_MEDIA_PROVIDERS: &[&str] = &["openai", "gemini", "elevenlabs", "minimax", "google_tts"];
```

`MediaDriverCache` already holds a registry-loaded list — `load_providers_from_registry` is called at `crates/librefang-kernel/src/kernel/boot.rs:1635` — and `detect_for_capability` picks from it. The two inventories had drifted apart in both directions:

- `byteplus` declares `media_capabilities = ["image_generation", "video_generation"]` in `librefang/librefang-registry` and was absent from the constant, so **the daemon could auto-select a provider the dashboard never listed**.
- `google_tts` is the reverse: a working compiled-in driver (`google_tts.rs:56`) with no registry entry, which reading the list from the registry must not drop.

The constant's doc comment also told you to keep it in sync with `librefang_kernel::media::MEDIA_PROVIDER_ORDER`, a symbol that does not exist anywhere in the tree.

## Changes

- `MediaDriverCache::media_provider_ids()` exposes the list `detect_for_capability` already uses; the route enumerates from it. `load_providers_from_registry` appends the built-ins unconditionally, so `google_tts` survives.
- A provider with no compiled-in driver and no `provider_urls.<name>` base URL now reports `configured: false` with the capabilities the registry declared, rather than `"error": "driver instantiation failed"`. `create_media_driver` fails on exactly one path — an unknown provider without a base URL — which is an unconfigured provider, not a broken one.
- `librefang-testing`'s `TestAppState::build_state` built the cache without `load_providers_from_registry`, unlike `kernel::boot`. The harness therefore served the five compiled-in built-ins while production served the registry, and no integration test over this route could discriminate until both agree.
- Matching stub method in `media_stub.rs` for `--no-default-features` builds.

## Verification

- `cargo check -p librefang-api -p librefang-testing -p librefang-runtime-media --all-targets` — clean.
- `cargo clippy -p librefang-api -p librefang-testing -p librefang-runtime-media --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-api --test media_routes_integration` — 20/20.
- New integration test `media_providers_lists_registry_declared_providers_with_no_builtin_driver`: seeds a catalog with a media-capable provider that has no built-in driver, asserts it appears with its declared capabilities and `configured: false`, that `google_tts` is still listed, and that a provider declaring no media capabilities is not.
- **Shown to discriminate**: with only `routes/media.rs` reverted, the new test fails and the pre-existing `media_providers_lists_all_known_with_unconfigured_status` still passes.

## Not in this PR

The registry data itself. `replicate`, `together`, `fireworks`, `siliconflow` and `groq` are in the registry and do media without declaring `media_capabilities`, so they still will not appear; and `fal`, `runway`, `luma`, `stability`, `deepgram` and the other major providers are absent from it entirely. Those are `librefang/librefang-registry` changes, not this repository's, and this PR is what makes them take effect once made.