### PR TITLE
fix(api): compare the include-conflict path in its canonical form

### DIFF
--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -2859,10 +2859,17 @@ mod sidecar_configuration_write_tests {
             None,
         );
 
+        // `walk` canonicalizes before recording a hit, so compare against the
+        // canonical form rather than the path this test happened to build.
+        // On macOS `tempfile::tempdir()` lands under `/var/folders/…`, which is
+        // a symlink to `/private/var/folders/…`, so the two spellings differ
+        // there and are identical on Linux — which is why this only ever failed
+        // on the macOS runner.
+        let expected_included = std::fs::canonicalize(&included_path).unwrap();
         assert!(matches!(
             result,
             Err(ConfigureSidecarWriteError::IncludedSidecars(paths))
-                if paths == vec![included_path]
+                if paths == vec![expected_included]
         ));
         assert!(!secrets_path.exists());
         assert_eq!(

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -2859,12 +2859,8 @@ mod sidecar_configuration_write_tests {
             None,
         );
 
-        // `walk` canonicalizes before recording a hit, so compare against the
-        // canonical form rather than the path this test happened to build.
-        // On macOS `tempfile::tempdir()` lands under `/var/folders/…`, which is
-        // a symlink to `/private/var/folders/…`, so the two spellings differ
-        // there and are identical on Linux — which is why this only ever failed
-        // on the macOS runner.
+        // `walk` canonicalizes before recording a hit, so compare against the canonical form rather than the path this test happened to build.
+        // On macOS `tempfile::tempdir()` lands under `/var/folders/…`, which is a symlink to `/private/var/folders/…`, so the two spellings differ there and are identical on Linux — which is why this only ever failed on the macOS runner.
         let expected_included = std::fs::canonicalize(&included_path).unwrap();
         assert!(matches!(
             result,


### PR DESCRIPTION
`main` is red on `Test / macOS` and green on every other job. One assertion, one platform.

## What fails

```
routes::channels::sidecar_configuration_write_tests::included_sidecar_conflict_prevents_all_writes
panicked at crates/librefang-api/src/routes/channels.rs:2862:9:
assertion failed: matches!(result, Err(ConfigureSidecarWriteError::IncludedSidecars(paths)) if
```

Introduced by #7971, which rewrote the include scan as `included_files_with_sidecars_blocking`. Its `walk` canonicalizes each path before recording a hit — that is what makes the diamond-include and cycle detection work, so it is correct and not what should change:

```rust
let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
if !seen.insert(canonical.clone()) { return Ok(()); }
…
hits.push(canonical.clone());
```

The test compares against the `PathBuf` it built from `tempfile::tempdir()`. On Linux that path is already canonical and the two agree. On macOS `tempdir()` lands under `/var/folders/…`, which is a symlink to `/private/var/folders/…`, so they differ and the match arm never binds.

## The fix

Canonicalize in the assertion, which is what every sibling test in the same module already does — `included_files_with_sidecars_blocking(&root, false)` is asserted against `vec![std::fs::canonicalize(&included).unwrap()]` two tests up, and against `vec![std::fs::canonicalize(&leaf).unwrap()]` in the two-level include case. This one was the exception rather than the rule.

Test-only; no production behaviour changes.

## Verification

- `cargo test -p librefang-api --lib routes::channels::sidecar_configuration_write_tests` on macOS: 10 passed, 0 failed (was 9 passed, 1 failed).
- Confirmed the same assertion is the failure on the CI runner, at the same line, in run 34676018677's `Test / macOS` job.
- Confirmed `69a96a55f` — the commit before #7971 — passes it, so this is the change that introduced it rather than something older surfacing.
- Grepped the rest of the module for the same shape: the other five call sites already canonicalize.
