### PR TITLE
test(cli): discover shipped locales from disk instead of listing them

### DIFF
--- a/changelog.d/fixed/8307-i18n-locales-discovered-from-disk.md
+++ b/changelog.d/fixed/8307-i18n-locales-discovered-from-disk.md
@@ -1,0 +1,3 @@
+The CLI locale coverage test now discovers the locales it checks by reading `crates/librefang-cli/locales/`, instead of running against a hand-written list.
+The list was how `ko` went uncovered while shipping a complete 2510-line locale, and a hand-written list re-arms that for whichever locale is added next — the test cannot fail for a locale nobody remembered to add to it.
+Its failure message now names the file (`locales/<code>/main.ftl`) and the count, so a locale added without translations says which one it is. (#8307) (@houko)

--- a/crates/librefang-cli/tests/i18n_checks.rs
+++ b/crates/librefang-cli/tests/i18n_checks.rs
@@ -970,10 +970,42 @@ fn collect_required_i18n_keys(
     required_keys
 }
 
+/// Every locale directory under `locales/` that ships a `main.ftl`, sorted.
+///
+/// Read from disk so a locale added later is covered without anyone editing a
+/// list — the hole in #8151 was `ko` being absent from a hand-written one, and
+/// the same hole reopens for the next locale added if the list stays manual.
+///
+/// A directory without `main.ftl` is skipped rather than failing: the loader
+/// resolves that file specifically, so a directory that does not have one is
+/// not a locale the binary can serve.
+fn shipped_locales(manifest_dir: &Path) -> Vec<String> {
+    let locales_dir = manifest_dir.join("locales");
+    let mut locales: Vec<String> = std::fs::read_dir(&locales_dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", locales_dir.display()))
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            if !entry.file_type().ok()?.is_dir() {
+                return None;
+            }
+            if !entry.path().join("main.ftl").is_file() {
+                return None;
+            }
+            entry.file_name().into_string().ok()
+        })
+        .collect();
+    locales.sort();
+    assert!(
+        locales.iter().any(|l| l == "en"),
+        "locales/en/main.ftl is the reference every other locale is checked against — \
+         finding no `en` means this scan is looking in the wrong place, not that English was dropped"
+    );
+    locales
+}
+
 fn assert_locale_covers_required_i18n_keys(
     manifest_dir: &Path,
     locale: &str,
-    display_name: &str,
     required_keys: &std::collections::BTreeSet<String>,
 ) {
     let locale_keys: std::collections::BTreeSet<String> =
@@ -989,7 +1021,8 @@ fn assert_locale_covers_required_i18n_keys(
 
     if !missing_keys.is_empty() {
         panic!(
-            "{display_name} locale is missing keys referenced by CLI Rust code:\n{}",
+            "locales/{locale}/main.ftl is missing {} key(s) referenced by CLI Rust code:\n{}",
+            missing_keys.len(),
             missing_keys.join("\n")
         );
     }
@@ -1094,10 +1127,16 @@ fn test_locales_cover_used_i18n_keys() {
     let known_prefixes = locale_key_prefixes(&english_keys.iter().cloned().collect::<Vec<_>>());
     let required_keys = collect_required_i18n_keys(manifest_dir, &known_prefixes);
 
-    assert_locale_covers_required_i18n_keys(manifest_dir, "en", "English", &required_keys);
-    assert_locale_covers_required_i18n_keys(manifest_dir, "uk", "Ukrainian", &required_keys);
-    assert_locale_covers_required_i18n_keys(manifest_dir, "zh-CN", "Chinese", &required_keys);
-    // ko was the one shipped locale this assertion did not cover, which is why the
-    // eight Auxiliary-tab keys reached a branch without anything failing.
-    assert_locale_covers_required_i18n_keys(manifest_dir, "ko", "Korean", &required_keys);
+    // Every locale that ships, discovered from disk rather than listed here.
+    //
+    // The list used to be hand-written, and `ko` was missing from it while
+    // `locales/ko/main.ftl` was a complete 2510-line locale — so eight
+    // Auxiliary-tab keys reached a branch with no Korean translation and
+    // nothing failed (#8151). Adding the missing line fixes that one locale;
+    // reading the directory fixes the shape, because the failure mode was a
+    // locale nobody remembered to list, and a hand-written list re-arms it for
+    // the next one added.
+    for locale in shipped_locales(manifest_dir) {
+        assert_locale_covers_required_i18n_keys(manifest_dir, &locale, &required_keys);
+    }
 }

--- a/crates/librefang-cli/tests/i18n_checks.rs
+++ b/crates/librefang-cli/tests/i18n_checks.rs
@@ -972,13 +972,9 @@ fn collect_required_i18n_keys(
 
 /// Every locale directory under `locales/` that ships a `main.ftl`, sorted.
 ///
-/// Read from disk so a locale added later is covered without anyone editing a
-/// list — the hole in #8151 was `ko` being absent from a hand-written one, and
-/// the same hole reopens for the next locale added if the list stays manual.
+/// Read from disk so a locale added later is covered without anyone editing a list — the hole in #8151 was `ko` being absent from a hand-written one, and the same hole reopens for the next locale added if the list stays manual.
 ///
-/// A directory without `main.ftl` is skipped rather than failing: the loader
-/// resolves that file specifically, so a directory that does not have one is
-/// not a locale the binary can serve.
+/// A directory without `main.ftl` is skipped rather than failing: the loader resolves that file specifically, so a directory that does not have one is not a locale the binary can serve.
 fn shipped_locales(manifest_dir: &Path) -> Vec<String> {
     let locales_dir = manifest_dir.join("locales");
     let mut locales: Vec<String> = std::fs::read_dir(&locales_dir)
@@ -1129,13 +1125,8 @@ fn test_locales_cover_used_i18n_keys() {
 
     // Every locale that ships, discovered from disk rather than listed here.
     //
-    // The list used to be hand-written, and `ko` was missing from it while
-    // `locales/ko/main.ftl` was a complete 2510-line locale — so eight
-    // Auxiliary-tab keys reached a branch with no Korean translation and
-    // nothing failed (#8151). Adding the missing line fixes that one locale;
-    // reading the directory fixes the shape, because the failure mode was a
-    // locale nobody remembered to list, and a hand-written list re-arms it for
-    // the next one added.
+    // The list used to be hand-written, and `ko` was missing from it while `locales/ko/main.ftl` was a complete 2510-line locale — so eight Auxiliary-tab keys reached a branch with no Korean translation and nothing failed (#8151).
+    // Adding the missing line fixes that one locale; reading the directory fixes the shape, because the failure mode was a locale nobody remembered to list, and a hand-written list re-arms it for the next one added.
     for locale in shipped_locales(manifest_dir) {
         assert_locale_covers_required_i18n_keys(manifest_dir, &locale, &required_keys);
     }


### PR DESCRIPTION
Addresses the second of the two things #8151 asks to decide together.

## Where the issue stands

The first half is already on `main`: `ko` was added to the required list, with a comment recording that its absence is why eight Auxiliary-tab keys shipped without Korean and nothing failed. Korean is covered now, and the backfill the issue anticipated turned out not to be needed — `ko` already carries every required key.

The second half is untouched, and it is the part that outlives this locale:

> Whether the required set should be derived from the directories present under `locales/` rather than hand-maintained. As written, a locale added in the future inherits the same silence by default — the test cannot fail for a locale nobody remembered to list.

## What changed

`shipped_locales()` reads `crates/librefang-cli/locales/` and returns every directory that carries a `main.ftl`, sorted. The test loops over that instead of four hardcoded calls.

Two deliberate details:

- **A directory without `main.ftl` is skipped, not failed.** That is the file the loader resolves, so a directory lacking one is not a locale the binary can serve.
- **A scan that finds no `en` panics.** `en` is the reference every other locale is compared against, so its absence means the scan is pointed at the wrong directory — failing loudly beats silently checking nothing, which is the failure mode this PR exists to remove.

The per-locale display name went with the list. It only fed the panic message, and naming the file is more useful than naming the language:

```
locales/xx-TEST/main.ftl is missing 2368 key(s) referenced by CLI Rust code:
```

## Verification

- `cargo test -p librefang-cli --test i18n_checks` — 3 passed, 0 failed.
- Confirmed a newly added locale is picked up without touching the test: creating `locales/xx-TEST/main.ftl` with a single key fails the run with the message above, naming the file and the count. Removed again afterwards; `locales/` is back to `en ko uk zh-CN`.
- `cargo fmt --all` applied.

## Not in scope

#8178 is the neighbouring hole — a value copied over with its English text passes this guard exactly as well as a real translation. That one needs an exception list (env var names, `provider:model`, `[Enter]`-style key hints) and the issue is explicit that choosing it is a maintainer call, so it is not folded in here.
