### PR TITLE
perf(api): count task statuses in SQL instead of listing every row

### DIFF
--- a/changelog.d/fixed/8309-task-status-counts-aggregate.md
+++ b/changelog.d/fixed/8309-task-status-counts-aggregate.md
@@ -1,0 +1,4 @@
+`GET /api/tasks/status` now counts tasks in SQL instead of listing every row to tally four integers.
+It called `task_list` with no filter, which has no `LIMIT`, and `task_prune_finished` only ever deletes completed / failed / cancelled rows — so the pending set grows for the life of the install and each poll allocated one `serde_json::Value` per task in the table before answering.
+This is the endpoint the dashboard polls, which is what turned unbounded table growth into unbounded per-request heap.
+The response is unchanged, including the warning logged for a status the summary does not recognise — now once per status with its count, rather than once per row. (#8309) (@houko)

--- a/crates/librefang-api/src/routes/task_queue.rs
+++ b/crates/librefang-api/src/routes/task_queue.rs
@@ -88,22 +88,32 @@ pub async fn task_queue_status(
     State(state): State<Arc<AppState>>,
     _lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    match state.kernel.task_list(None).await {
-        Ok(tasks) => {
+    // Counted in SQL rather than by listing every task: `task_list` has no
+    // `LIMIT` and only terminal rows are ever pruned, so deriving four integers
+    // from it allocated one `serde_json::Value` per row in the table on every
+    // poll — and this is the endpoint the dashboard polls (#8219).
+    match state.kernel.task_status_counts().await {
+        Ok(counts) => {
             let mut pending = 0u64;
             let mut in_progress = 0u64;
             let mut completed = 0u64;
             let mut failed = 0u64;
-            for t in &tasks {
-                match t["status"].as_str().unwrap_or("") {
-                    "pending" => pending += 1,
-                    "in_progress" => in_progress += 1,
-                    "completed" => completed += 1,
-                    "failed" => failed += 1,
+            let mut total = 0u64;
+            for (status, count) in &counts {
+                total += count;
+                match status.as_str() {
+                    "pending" => pending += count,
+                    "in_progress" => in_progress += count,
+                    "completed" => completed += count,
+                    "failed" => failed += count,
                     unknown => {
+                        // Still reported, but once per status rather than once
+                        // per row — the old warning named the offending task id,
+                        // which a `GROUP BY` cannot carry. The count is the more
+                        // useful half: it says how far the drift has spread.
                         tracing::warn!(
                             status = unknown,
-                            task_id = t["id"].as_str().unwrap_or(""),
+                            count,
                             "task queue status summary encountered an unknown status"
                         );
                     }
@@ -112,7 +122,7 @@ pub async fn task_queue_status(
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
-                    "total": tasks.len(),
+                    "total": total,
                     "pending": pending,
                     "in_progress": in_progress,
                     "completed": completed,

--- a/crates/librefang-api/src/routes/task_queue.rs
+++ b/crates/librefang-api/src/routes/task_queue.rs
@@ -88,10 +88,7 @@ pub async fn task_queue_status(
     State(state): State<Arc<AppState>>,
     _lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    // Counted in SQL rather than by listing every task: `task_list` has no
-    // `LIMIT` and only terminal rows are ever pruned, so deriving four integers
-    // from it allocated one `serde_json::Value` per row in the table on every
-    // poll — and this is the endpoint the dashboard polls (#8219).
+    // Counted in SQL rather than by listing every task: `task_list` has no `LIMIT` and only terminal rows are ever pruned, so deriving four integers from it allocated one `serde_json::Value` per row in the table on every poll — and this is the endpoint the dashboard polls (#8219).
     match state.kernel.task_status_counts().await {
         Ok(counts) => {
             let mut pending = 0u64;
@@ -107,10 +104,8 @@ pub async fn task_queue_status(
                     "completed" => completed += count,
                     "failed" => failed += count,
                     unknown => {
-                        // Still reported, but once per status rather than once
-                        // per row — the old warning named the offending task id,
-                        // which a `GROUP BY` cannot carry. The count is the more
-                        // useful half: it says how far the drift has spread.
+                        // Still reported, but once per status rather than once per row — the old warning named the offending task id, which a `GROUP BY` cannot carry.
+                        // The count is the more useful half: it says how far the drift has spread.
                         tracing::warn!(
                             status = unknown,
                             count,

--- a/crates/librefang-kernel-handle/src/task_queue.rs
+++ b/crates/librefang-kernel-handle/src/task_queue.rs
@@ -34,6 +34,21 @@ pub trait TaskQueue: Send + Sync {
         status: Option<&str>,
     ) -> Result<Vec<serde_json::Value>, KernelOpError>;
 
+    /// Count of tasks per status, as `(status, count)` pairs.
+    ///
+    /// Separate from [`Self::task_list`] because the summary a caller wants four integers for should not cost one materialised row per task: `task_list` has no `LIMIT`, `task_prune_finished` only deletes terminal rows, and `GET /api/tasks/status` — which the dashboard polls — was deriving its counts that way (#8219).
+    ///
+    /// The default implementation does exactly that, so a stub implementing this trait keeps working unchanged. The kernel overrides it with a `GROUP BY`.
+    async fn task_status_counts(&self) -> Result<Vec<(String, u64)>, KernelOpError> {
+        let tasks = self.task_list(None).await?;
+        let mut counts: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+        for task in &tasks {
+            let status = task["status"].as_str().unwrap_or("").to_string();
+            *counts.entry(status).or_insert(0) += 1;
+        }
+        Ok(counts.into_iter().collect())
+    }
+
     /// Delete a task by ID. Returns true if deleted.
     async fn task_delete(&self, task_id: &str) -> Result<bool, KernelOpError>;
 

--- a/crates/librefang-kernel-handle/src/task_queue.rs
+++ b/crates/librefang-kernel-handle/src/task_queue.rs
@@ -38,7 +38,8 @@ pub trait TaskQueue: Send + Sync {
     ///
     /// Separate from [`Self::task_list`] because the summary a caller wants four integers for should not cost one materialised row per task: `task_list` has no `LIMIT`, `task_prune_finished` only deletes terminal rows, and `GET /api/tasks/status` — which the dashboard polls — was deriving its counts that way (#8219).
     ///
-    /// The default implementation does exactly that, so a stub implementing this trait keeps working unchanged. The kernel overrides it with a `GROUP BY`.
+    /// The default implementation does exactly that, so a stub implementing this trait keeps working unchanged.
+    /// The kernel overrides it with a `GROUP BY`.
     async fn task_status_counts(&self) -> Result<Vec<(String, u64)>, KernelOpError> {
         let tasks = self.task_list(None).await?;
         let mut counts: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();

--- a/crates/librefang-kernel/src/kernel/handles/task_queue.rs
+++ b/crates/librefang-kernel/src/kernel/handles/task_queue.rs
@@ -168,6 +168,18 @@ impl kernel_handle::TaskQueue for LibreFangKernel {
             .map_err(|e| kernel_handle::KernelOpError::Internal(format!("Task list failed: {e}")))
     }
 
+    /// Overrides the trait's list-and-count default with a `GROUP BY`, so the
+    /// summary costs one row per distinct status instead of one per task.
+    async fn task_status_counts(&self) -> Result<Vec<(String, u64)>, kernel_handle::KernelOpError> {
+        self.memory
+            .substrate
+            .task_status_counts()
+            .await
+            .map_err(|e| {
+                kernel_handle::KernelOpError::Internal(format!("Task status counts failed: {e}"))
+            })
+    }
+
     async fn task_delete(&self, task_id: &str) -> Result<bool, kernel_handle::KernelOpError> {
         self.memory
             .substrate

--- a/crates/librefang-kernel/src/kernel/handles/task_queue.rs
+++ b/crates/librefang-kernel/src/kernel/handles/task_queue.rs
@@ -168,8 +168,7 @@ impl kernel_handle::TaskQueue for LibreFangKernel {
             .map_err(|e| kernel_handle::KernelOpError::Internal(format!("Task list failed: {e}")))
     }
 
-    /// Overrides the trait's list-and-count default with a `GROUP BY`, so the
-    /// summary costs one row per distinct status instead of one per task.
+    /// Overrides the trait's list-and-count default with a `GROUP BY`, so the summary costs one row per distinct status instead of one per task.
     async fn task_status_counts(&self) -> Result<Vec<(String, u64)>, kernel_handle::KernelOpError> {
         self.memory
             .substrate

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1287,6 +1287,34 @@ impl MemorySubstrate {
         .map_err(|e| LibreFangError::Internal(e.to_string()))?
     }
 
+    /// Count of `task_queue` rows per status, as `(status, count)` pairs.
+    ///
+    /// The summary endpoint used to derive these from [`Self::task_list`] with no filter, which materialises every row in the table and builds one `serde_json::Value` per row in order to answer with four integers.
+    /// `task_list` has no `LIMIT` and `task_prune_finished` only deletes terminal rows, so that cost grows with the table for the life of the install (#8219) — and `GET /api/tasks/status`, the endpoint that paid it, is what the dashboard polls.
+    ///
+    /// Returns the raw pairs rather than a struct with four named fields so a status the caller does not recognise still reaches it: the previous code logged a WARN naming the unknown status and the task it came from, and a fixed shape would have silently dropped that.
+    pub async fn task_status_counts(&self) -> LibreFangResult<Vec<(String, u64)>> {
+        let conn = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let db = conn.get().map_err(LibreFangError::memory)?;
+            let mut stmt = db
+                .prepare("SELECT status, COUNT(*) FROM task_queue GROUP BY status")
+                .map_err(LibreFangError::memory)?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+                })
+                .map_err(LibreFangError::memory)?;
+            let mut counts = Vec::new();
+            for row in rows {
+                counts.push(row.map_err(LibreFangError::memory)?);
+            }
+            Ok(counts)
+        })
+        .await
+        .map_err(|e| LibreFangError::Internal(e.to_string()))?
+    }
+
     /// List tasks, optionally filtered by status.
     pub async fn task_list(&self, status: Option<&str>) -> LibreFangResult<Vec<serde_json::Value>> {
         let conn = self.pool.clone();
@@ -1854,6 +1882,69 @@ impl Memory for MemorySubstrate {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #8219: the aggregate must agree with what listing every row would have counted.
+    ///
+    /// The endpoint's four integers are the contract, not the query that produces
+    /// them, so this compares the new `GROUP BY` against the old list-and-tally on
+    /// the same store — including a status the summary handler does not recognise,
+    /// which has to survive as its own bucket rather than being folded away.
+    #[tokio::test]
+    async fn task_status_counts_agrees_with_listing_every_row() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+
+        for (title, assignee) in [("a", "agent-1"), ("b", "agent-1"), ("c", "agent-2")] {
+            substrate
+                .task_post(title, "body", Some(assignee), Some("boss"))
+                .await
+                .expect("post");
+        }
+        // Drive one row out of `pending` through the normal path, and put another
+        // into a status the handler has no arm for.
+        let claimed = substrate
+            .task_claim("agent-1", None)
+            .await
+            .expect("claim")
+            .expect("a pending task to claim");
+        substrate
+            .task_complete(claimed["id"].as_str().unwrap(), "done")
+            .await
+            .expect("complete");
+        {
+            let db = substrate.pool.get().unwrap();
+            db.execute(
+                "UPDATE task_queue SET status = 'wedged' WHERE title = 'c'",
+                [],
+            )
+            .unwrap();
+        }
+
+        let mut from_aggregate = substrate.task_status_counts().await.expect("counts");
+        from_aggregate.sort();
+
+        let mut from_listing: Vec<(String, u64)> = {
+            let mut tally: std::collections::BTreeMap<String, u64> = Default::default();
+            for task in substrate.task_list(None).await.expect("list") {
+                *tally
+                    .entry(task["status"].as_str().unwrap_or("").to_string())
+                    .or_insert(0) += 1;
+            }
+            tally.into_iter().collect()
+        };
+        from_listing.sort();
+
+        assert_eq!(from_aggregate, from_listing);
+        assert_eq!(
+            from_aggregate,
+            vec![
+                ("completed".to_string(), 1),
+                ("pending".to_string(), 1),
+                ("wedged".to_string(), 1),
+            ],
+            "an unrecognised status must arrive as its own bucket — the handler warns on it, \
+             and a shape that dropped it would lose both the warning and the total"
+        );
+    }
 
     /// #7911: the cap the runtime reads and the cap an operator configures must be the same number.
     /// They live in different crates — the substrate's fallback exists for test stores and for any embedder that never calls the setter — so nothing but this assertion stops them drifting apart, and a drift would silently give the daemon a different budget than the one in `config.toml`'s documented default.

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1885,10 +1885,7 @@ mod tests {
 
     /// #8219: the aggregate must agree with what listing every row would have counted.
     ///
-    /// The endpoint's four integers are the contract, not the query that produces
-    /// them, so this compares the new `GROUP BY` against the old list-and-tally on
-    /// the same store — including a status the summary handler does not recognise,
-    /// which has to survive as its own bucket rather than being folded away.
+    /// The endpoint's four integers are the contract, not the query that produces them, so this compares the new `GROUP BY` against the old list-and-tally on the same store — including a status the summary handler does not recognise, which has to survive as its own bucket rather than being folded away.
     #[tokio::test]
     async fn task_status_counts_agrees_with_listing_every_row() {
         let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();


### PR DESCRIPTION
Addresses the allocation half of #8219. The enforcement half is not in here — see the bottom.

## What this fixes

`GET /api/tasks/status` returns four integers. It got them by calling `task_list(None)`, which has no `LIMIT`, and counting the results in Rust. So every poll:

- selected every row in `task_queue`, and
- built one `serde_json::Value` per row, with ten fields each, to produce four numbers.

`task_prune_finished` only deletes `completed` / `failed` / `cancelled`, so the pending set grows for the life of the install. And this is the endpoint the dashboard polls, which is what turns "the table grows" into "per-request heap grows, on a timer".

`task_status_counts()` runs `SELECT status, COUNT(*) FROM task_queue GROUP BY status` instead. The response is byte-identical.

## Two decisions worth naming

**It returns `(status, count)` pairs, not a struct with four fields.** The handler warns when it meets a status it has no arm for, and names it. A fixed four-field shape would have dropped both that warning and the row's contribution to `total`. The warning survives, now emitted once per unrecognised status with its count rather than once per row — the count is the more useful half, since it says how far the drift has spread.

**The trait method has a default implementation** that does the old list-and-tally. Several test stubs implement `TaskQueue`, and none of them needs to change; the kernel overrides the default with the aggregate. A stub that never gets around to it keeps working, just as slowly as before.

## Verification

- `cargo test -p librefang-memory --lib` — 463 passed, 0 failed.
- `cargo test -p librefang-api --lib` — 1179 passed, 0 failed.
- New `task_status_counts_agrees_with_listing_every_row` compares the aggregate against the old list-and-tally over the same store, and includes a status the handler has no arm for (`wedged`) to pin that it arrives as its own bucket rather than being folded away. Also drives a row out of `pending` through `task_claim` → `task_complete` rather than by writing the status directly, so the test exercises the real transition.
- `cargo clippy -p librefang-api -p librefang-memory -p librefang-kernel-handle --lib -- -D warnings` — clean.

## What is left in #8219

The three knobs are still inert: `max_depth_per_agent`, `max_depth_global` and `task_ttl_secs` are read in two places and both of them only echo the value back as JSON. Nothing consults them on the enqueue path.

I stopped short of that deliberately, because closing it needs decisions this PR should not make quietly:

- **`max_depth_per_agent` counts what?** `task_claim` matches `assigned_to = <agent> OR assigned_to = ''`, so an agent's queue is its directed tasks plus a shared pool. Counting by `assigned_to` protects a backed-up consumer; counting by `created_by` protects against a runaway producer. The issue names both symptoms and the field name settles neither.
- **Where the check lives.** Counting then inserting has to happen in one transaction or the limit is advisory under concurrency, and `task_post` is `spawn_blocking` per call today.
- **What rejection looks like.** There is no error variant that maps cleanly to a 429/503; `Conflict` is the closest and reads wrong.
- **Signature reach.** `task_post` has 39 call sites. Threading limits through it is mechanical but wide, and the limits must be read live — the queue keys are classified `N` in `docs/operations/config-reload.md`, so a boot snapshot would contradict the doc.

Happy to take it as a follow-up once the first two are settled.
