### PR TITLE
fix(dashboard): pin number formatting to one locale

### DIFF
--- a/changelog.d/fixed/8310-dashboard-number-locale.md
+++ b/changelog.d/fixed/8310-dashboard-number-locale.md
@@ -1,0 +1,4 @@
+Dashboard number formatting is pinned to one locale, so the same figure reads the same for every operator.
+Counts went through a bare `toLocaleString()`, which resolves against the browser's language — a token total rendered `2,000` for one operator and `2000` for another (Spanish does not group four-digit numbers) looking at the same daemon, in a column meant to be compared row against row.
+Timestamps are unchanged and still follow the viewer's locale, which is what a reader wants from a time and not from a count.
+This also fixes `AnalyticsPage.test.tsx` failing on `main` itself wherever the environment locale was not English (#8156), and the `format.ts` tests that built their expected values from the same ambient locale the implementation used — agreeing with themselves whatever it was. (#8310) (@houko)

--- a/crates/librefang-api/dashboard/src/lib/format.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/format.test.ts
@@ -1,21 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { NUMBER_LOCALE, formatBytes, formatCompact, formatCost, formatNumber } from "./format";
 
-// Built against the same pinned locale the formatters use. This used to pass
-// `undefined`, which made both sides follow the environment: the assertion and
-// the implementation drifted together, so the test agreed with itself no matter
-// what and asserted nothing about the output an operator sees (#8156).
+// Built against the same pinned locale the formatters use.
+// This used to pass `undefined`, which made both sides follow the environment: the assertion and the implementation drifted together, so the test agreed with itself no matter what and asserted nothing about the output an operator sees (#8156).
 const oneDecimal = new Intl.NumberFormat(NUMBER_LOCALE, {
   minimumFractionDigits: 1,
   maximumFractionDigits: 1,
 });
 
 describe("numeric formatters", () => {
-  // Literal expectations, not `Intl`-derived ones. Everything else in this file
-  // builds its expected value from the same API the implementation uses, which
-  // catches a wrong tier or a dropped sign but cannot catch the whole output
-  // shifting with the environment — the failure #8156 was about. These are the
-  // assertions that fail if the pinned locale is removed.
+  // Literal expectations, not `Intl`-derived ones.
+  // Everything else in this file builds its expected value from the same API the implementation uses, which catches a wrong tier or a dropped sign but cannot catch the whole output shifting with the environment — the failure #8156 was about.
+  // These are the assertions that fail if the pinned locale is removed.
   it("groups thousands the same way regardless of the environment locale", () => {
     expect(formatNumber(2_000)).toBe("2,000");
     expect(formatNumber(1_234_567)).toBe("1,234,567");

--- a/crates/librefang-api/dashboard/src/lib/format.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/format.test.ts
@@ -1,12 +1,34 @@
 import { describe, expect, it } from "vitest";
-import { formatBytes, formatCompact, formatCost } from "./format";
+import { NUMBER_LOCALE, formatBytes, formatCompact, formatCost, formatNumber } from "./format";
 
-const oneDecimal = new Intl.NumberFormat(undefined, {
+// Built against the same pinned locale the formatters use. This used to pass
+// `undefined`, which made both sides follow the environment: the assertion and
+// the implementation drifted together, so the test agreed with itself no matter
+// what and asserted nothing about the output an operator sees (#8156).
+const oneDecimal = new Intl.NumberFormat(NUMBER_LOCALE, {
   minimumFractionDigits: 1,
   maximumFractionDigits: 1,
 });
 
 describe("numeric formatters", () => {
+  // Literal expectations, not `Intl`-derived ones. Everything else in this file
+  // builds its expected value from the same API the implementation uses, which
+  // catches a wrong tier or a dropped sign but cannot catch the whole output
+  // shifting with the environment — the failure #8156 was about. These are the
+  // assertions that fail if the pinned locale is removed.
+  it("groups thousands the same way regardless of the environment locale", () => {
+    expect(formatNumber(2_000)).toBe("2,000");
+    expect(formatNumber(1_234_567)).toBe("1,234,567");
+    expect(formatCompact(1_500)).toBe("1.5K");
+    expect(formatCompact(2_000_000)).toBe("2.0M");
+  });
+
+  it("treats a nullish count as zero", () => {
+    expect(formatNumber(null)).toBe("0");
+    expect(formatNumber(undefined)).toBe("0");
+    expect(formatNumber(0)).toBe("0");
+  });
+
   it("compacts positive and negative values with locale decimals", () => {
     expect(formatCompact(1_500)).toBe(`${oneDecimal.format(1.5)}K`);
     expect(formatCompact(-1_500)).toBe(`${oneDecimal.format(-1.5)}K`);

--- a/crates/librefang-api/dashboard/src/lib/format.ts
+++ b/crates/librefang-api/dashboard/src/lib/format.ts
@@ -1,8 +1,40 @@
 /**
+ * The locale every number on the dashboard is formatted in.
+ *
+ * Pinned rather than left to resolve from the environment. `toLocaleString()`
+ * with no argument, and `Intl.NumberFormat(undefined, …)`, follow the host's
+ * `LC_ALL` / `LANG` under Node and the browser's language on a page — so the
+ * same figure renders as `2,000` for one operator and `2000` for another
+ * (Spanish does not group four-digit numbers) against the same daemon.
+ *
+ * It also made `AnalyticsPage.test.tsx` fail on `main` itself wherever the
+ * environment locale was not English, because the component and the assertion
+ * disagreed about which locale was in force (#8156).
+ *
+ * Dates deliberately keep the ambient locale — see `lib/datetime.ts`. A
+ * timestamp is read as "when, for me"; a token count is read against the row
+ * above it.
+ */
+export const NUMBER_LOCALE = "en-US";
+
+/**
+ * Format an integer with thousands separators: `2000` → `2,000`.
+ *
+ * Use in place of calling `toLocaleString` on the value directly. A nullish
+ * value renders as `0`, which is what the call sites' inline `?? 0` was
+ * already doing.
+ */
+const GROUPED = new Intl.NumberFormat(NUMBER_LOCALE);
+
+export function formatNumber(value: number | null | undefined): string {
+  return GROUPED.format(value ?? 0);
+}
+
+/**
  * Format a number with compact units (K / M / B).
  * Hover-friendly: callers can use the raw number as a `title` attribute.
  */
-const COMPACT_DECIMAL = new Intl.NumberFormat(undefined, {
+const COMPACT_DECIMAL = new Intl.NumberFormat(NUMBER_LOCALE, {
   minimumFractionDigits: 1,
   maximumFractionDigits: 1,
 });
@@ -13,7 +45,7 @@ export function formatCompact(n: number): string {
   if (abs >= 999_950_000) return `${COMPACT_DECIMAL.format(n / 1_000_000_000)}B`;
   if (abs >= 999_950) return `${COMPACT_DECIMAL.format(n / 1_000_000)}M`;
   if (abs >= 1_000) return `${COMPACT_DECIMAL.format(n / 1_000)}K`;
-  return n.toLocaleString();
+  return formatNumber(n);
 }
 
 /**

--- a/crates/librefang-api/dashboard/src/lib/format.ts
+++ b/crates/librefang-api/dashboard/src/lib/format.ts
@@ -1,19 +1,13 @@
 /**
  * The locale every number on the dashboard is formatted in.
  *
- * Pinned rather than left to resolve from the environment. `toLocaleString()`
- * with no argument, and `Intl.NumberFormat(undefined, …)`, follow the host's
- * `LC_ALL` / `LANG` under Node and the browser's language on a page — so the
- * same figure renders as `2,000` for one operator and `2000` for another
- * (Spanish does not group four-digit numbers) against the same daemon.
+ * Pinned rather than left to resolve from the environment.
+ * `toLocaleString()` with no argument, and `Intl.NumberFormat(undefined, …)`, follow the host's `LC_ALL` / `LANG` under Node and the browser's language on a page — so the same figure renders as `2,000` for one operator and `2000` for another (Spanish does not group four-digit numbers) against the same daemon.
  *
- * It also made `AnalyticsPage.test.tsx` fail on `main` itself wherever the
- * environment locale was not English, because the component and the assertion
- * disagreed about which locale was in force (#8156).
+ * It also made `AnalyticsPage.test.tsx` fail on `main` itself wherever the environment locale was not English, because the component and the assertion disagreed about which locale was in force (#8156).
  *
- * Dates deliberately keep the ambient locale — see `lib/datetime.ts`. A
- * timestamp is read as "when, for me"; a token count is read against the row
- * above it.
+ * Dates deliberately keep the ambient locale — see `lib/datetime.ts`.
+ * A timestamp is read as "when, for me"; a token count is read against the row above it.
  */
 export const NUMBER_LOCALE = "en-US";
 

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -3029,7 +3029,7 @@ export function AgentsPage() {
                       </Badge>
                     </DetailRow>
                     <DetailRow label={t("agents.budget_tokens")}>
-                      <span className="font-mono">{detailAgent.thinking.budget_tokens?.toLocaleString() ?? 0}</span>
+                      <span className="font-mono">{formatNumber(detailAgent.thinking.budget_tokens)}</span>
                     </DetailRow>
                     <DetailRow label={t("agents.stream_thinking")}>
                       <Badge variant={detailAgent.thinking.stream_thinking ? "brand" : "default"}>

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -91,6 +91,7 @@ import {
   useSetAgentSkills,
 } from "../lib/mutations/agents";
 import { useBindPromptVersionToAgent } from "../lib/mutations/prompts";
+import { formatNumber } from "../lib/format";
 
 /**
  * Local view type that pairs the strict `AgentDetail` shape from `api.ts`
@@ -2802,7 +2803,7 @@ export function AgentsPage() {
                           <span className="font-mono">
                             {detailAgent.model.max_tokens == null
                               ? t("agents.form.inherit_default")
-                              : detailAgent.model.max_tokens.toLocaleString()}
+                              : formatNumber(detailAgent.model.max_tokens)}
                           </span>
                         </DetailRow>
                         <DetailRow label={t("agents.temperature")}>
@@ -3156,7 +3157,7 @@ export function AgentsPage() {
                       {t("agents.token_injected_total", { defaultValue: "Injected per request" })}
                     </span>
                     <span className="font-mono font-bold">
-                      {detailAgent.injected_footprint_tokens.toLocaleString()}
+                      {formatNumber(detailAgent.injected_footprint_tokens)}
                     </span>
                   </div>
                   {(agentEventsQuery.data ?? []).length > 0 && (

--- a/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import { formatCompact, formatCost } from "../lib/format";
+import { formatCompact, formatCost, formatNumber } from "../lib/format";
 import { useMemo, useState, useCallback, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type { UsageByAgentItem, UsageByModelItem, UsageDailyItem } from "../api";
@@ -319,10 +319,10 @@ function ProviderBudgetsCard({
                     <td className="py-2 px-2 text-right font-mono">
                       <div className="flex flex-col items-end gap-1">
                         <span>
-                          {row.tokens_this_hour.toLocaleString()}
+                          {formatNumber(row.tokens_this_hour)}
                           <span className="text-text-dim/60">
                             {" / "}
-                            {row.cap_tokens_per_hour > 0 ? row.cap_tokens_per_hour.toLocaleString() : "∞"}
+                            {row.cap_tokens_per_hour > 0 ? formatNumber(row.cap_tokens_per_hour) : "∞"}
                           </span>
                         </span>
                         <ProviderCapBar
@@ -962,9 +962,9 @@ export function AnalyticsPage() {
                         </td>
                         <td className="px-3 py-2 text-right">{a.call_count ?? a.calls ?? 0}</td>
                         <td className="px-3 py-2 text-right">{a.tool_calls ?? 0}</td>
-                        <td className="px-3 py-2 text-right font-mono text-text-dim">{(a.input_tokens ?? 0).toLocaleString()}</td>
-                        <td className="px-3 py-2 text-right font-mono text-text-dim">{(a.output_tokens ?? 0).toLocaleString()}</td>
-                        <td className="px-3 py-2 text-right font-mono">{(a.total_tokens ?? 0).toLocaleString()}</td>
+                        <td className="px-3 py-2 text-right font-mono text-text-dim">{formatNumber(a.input_tokens ?? 0)}</td>
+                        <td className="px-3 py-2 text-right font-mono text-text-dim">{formatNumber(a.output_tokens ?? 0)}</td>
+                        <td className="px-3 py-2 text-right font-mono">{formatNumber(a.total_tokens ?? 0)}</td>
                         <td className="px-3 py-2 text-right font-mono">{formatCost(a.total_cost_usd ?? a.cost ?? 0)}</td>
                       </tr>
                     ))}
@@ -1071,9 +1071,9 @@ export function AnalyticsPage() {
                           <td className="py-2 px-3 text-right font-mono">{(m.avg_latency_ms ?? 0).toFixed(0)}ms</td>
                           <td className="py-2 px-3 text-right font-mono">{m.p95_latency_ms ?? 0}ms</td>
                           <td className="py-2 px-3 text-right font-mono text-text-dim">{(m.min_latency_ms ?? 0)}/{(m.max_latency_ms ?? 0)}ms</td>
-                          <td className="py-2 px-3 text-right font-mono text-text-dim">{(m.total_input_tokens ?? 0).toLocaleString()}</td>
-                          <td className="py-2 px-3 text-right font-mono text-text-dim">{(m.total_output_tokens ?? 0).toLocaleString()}</td>
-                          <td className="py-2 px-3 text-right font-mono">{((m.total_input_tokens ?? 0) + (m.total_output_tokens ?? 0)).toLocaleString()}</td>
+                          <td className="py-2 px-3 text-right font-mono text-text-dim">{formatNumber(m.total_input_tokens ?? 0)}</td>
+                          <td className="py-2 px-3 text-right font-mono text-text-dim">{formatNumber(m.total_output_tokens ?? 0)}</td>
+                          <td className="py-2 px-3 text-right font-mono">{formatNumber((m.total_input_tokens ?? 0) + (m.total_output_tokens ?? 0))}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { formatBytes, formatCost } from "../lib/format";
+import { formatBytes, formatCost, formatNumber } from "../lib/format";
 import { safeStorageGet, safeStorageSet } from "../lib/safeStorage";
 import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -2382,8 +2382,8 @@ function ContextUsageIndicator({ agentId, sessionId }: { agentId: string; sessio
 
   const clampedPct = Math.max(0, Math.min(100, pct));
   const label = t("chat.context_usage", {
-    used: used.toLocaleString(),
-    max: max.toLocaleString(),
+    used: formatNumber(used),
+    max: formatNumber(max),
     pct: clampedPct.toFixed(1),
   });
   const ariaLabel = t("chat.context_usage_aria", { pct: clampedPct.toFixed(1) });
@@ -2395,7 +2395,7 @@ function ContextUsageIndicator({ agentId, sessionId }: { agentId: string; sessio
   // the operator cannot explain. Refs #7774.
   const assumedLabel = assumed ? t("chat.context_usage_assumed") : "";
   const assumedDetail = assumed
-    ? t("chat.context_usage_assumed_detail", { max: max.toLocaleString() })
+    ? t("chat.context_usage_assumed_detail", { max: formatNumber(max) })
     : "";
 
   return (

--- a/crates/librefang-api/dashboard/src/pages/Memory/components/AutoDreamAgentRow.tsx
+++ b/crates/librefang-api/dashboard/src/pages/Memory/components/AutoDreamAgentRow.tsx
@@ -10,6 +10,7 @@ import type {
   AutoDreamUsage,
 } from "../../../api";
 import { formatRelativeMs, formatHours } from "../formatters";
+import { formatNumber } from "../../../lib/format";
 
 export function autoDreamStatusVariant(status: AutoDreamStatusName): BadgeVariant {
   switch (status) {
@@ -269,7 +270,7 @@ export function AutoDreamAgentRow({
                 )}
               >
                 <span className="font-mono">{cacheStats.hitPct}%</span>{" "}
-                ({usage.cache_read_input_tokens.toLocaleString()}/{cacheStats.totalInputTokens.toLocaleString()} tok)
+                ({formatNumber(usage.cache_read_input_tokens)}/{formatNumber(cacheStats.totalInputTokens)} tok)
               </span>
               {typeof usage.cost_usd === "number" && (
                 <>

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import { formatCost as formatCostUtil } from "../lib/format";
+import { formatCost as formatCostUtil, formatNumber } from "../lib/format";
 import type {
   MediaModelEndpoint,
   MediaModelEndpointDraft,
@@ -1433,7 +1433,7 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
   const catalogHint = useCallback(
     (declared?: number): string | undefined =>
       declared && declared > 0
-        ? t("models.catalog_value", { value: declared.toLocaleString() })
+        ? t("models.catalog_value", { value: formatNumber(declared) })
         : undefined,
     [t],
   );

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { formatTime, formatDateTime } from "../lib/datetime";
-import { formatCompact } from "../lib/format";
+import { formatCompact, formatNumber } from "../lib/format";
 import { memo, useId, useMemo, useRef, useState, useCallback, useEffect, useReducer } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -358,7 +358,7 @@ function ProviderModelLimitsSection({ providerId, addToast }: {
             label={t("providers.context_window")}
             savedMessage={t("providers.context_window_saved")}
             hintDefault={t("providers.context_window_hint_default")}
-            hintOverride={t("providers.context_window_hint_override", { value: catalogWindow != null ? catalogWindow.toLocaleString() : "-" })}
+            hintOverride={t("providers.context_window_hint_override", { value: catalogWindow != null ? formatNumber(catalogWindow) : "-" })}
             addToast={addToast}
           />
           <ModelLimitEditor
@@ -371,7 +371,7 @@ function ProviderModelLimitsSection({ providerId, addToast }: {
             label={t("providers.max_tokens")}
             savedMessage={t("providers.max_tokens_saved")}
             hintDefault={t("providers.max_tokens_hint_default")}
-            hintOverride={t("providers.max_tokens_hint_override", { value: catalogMaxOut != null ? catalogMaxOut.toLocaleString() : "-" })}
+            hintOverride={t("providers.max_tokens_hint_override", { value: catalogMaxOut != null ? formatNumber(catalogMaxOut) : "-" })}
             addToast={addToast}
           />
         </>
@@ -635,7 +635,7 @@ const ProviderCard = memo(function ProviderCard({ provider: p, isSelected, isDef
             <p className={`text-xs font-black ${getLatencyColor(p.latency_ms)}`}>{p.latency_ms != null ? `${p.latency_ms}ms` : "-"}</p>
             <p className="text-[8px] uppercase text-text-dim">{t("providers.latency")}</p>
           </div>
-          <div className="text-center" title={p.max_output_tokens != null ? p.max_output_tokens.toLocaleString() : undefined}>
+          <div className="text-center" title={p.max_output_tokens != null ? formatNumber(p.max_output_tokens) : undefined}>
             <p className="text-xs font-black">{p.max_output_tokens != null ? formatCompact(p.max_output_tokens) : "-"}</p>
             <p className="text-[8px] uppercase text-text-dim">{t("providers.max_tokens")}</p>
           </div>
@@ -760,7 +760,7 @@ const ProviderCard = memo(function ProviderCard({ provider: p, isSelected, isDef
           </div>
           <div
             className="p-3 rounded-xl bg-linear-to-br from-main/60 to-main/30 border border-border-subtle/50"
-            title={p.max_output_tokens != null ? p.max_output_tokens.toLocaleString() : undefined}
+            title={p.max_output_tokens != null ? formatNumber(p.max_output_tokens) : undefined}
           >
             <div className="flex items-center gap-1.5 mb-1">
               <Gauge className="w-3 h-3 text-brand" />
@@ -1610,7 +1610,7 @@ function CredentialKeyRow({ cred }: { cred: CredentialPoolKeySnapshot }) {
         <span className="text-text-dim">priority {cred.priority}</span>
       </div>
       <div className="flex items-center gap-3 shrink-0">
-        <span className="text-text-dim">{cred.request_count.toLocaleString()} reqs</span>
+        <span className="text-text-dim">{formatNumber(cred.request_count)} reqs</span>
         {statusBadge}
       </div>
     </div>

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -93,6 +93,7 @@ import {
   CloudOff,
   ExternalLink,
 } from "lucide-react";
+import { formatNumber } from "../lib/format";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -431,7 +432,7 @@ const SkillCard = React.memo(function SkillCard({
           {downloads !== undefined && (
             <span className="flex items-center gap-1 text-[10.5px] font-mono text-text-dim/80">
               <Download className="w-3 h-3" />
-              {downloads.toLocaleString()}
+              {formatNumber(downloads)}
             </span>
           )}
           {variant === "installed" && toolsCount !== undefined && (
@@ -805,7 +806,7 @@ function CreateSkillModal({
             })}
           />
           <p className="text-[10px] text-text-dim mt-1">
-            {promptContext.length.toLocaleString()} / 160,000
+            {formatNumber(promptContext.length)} / 160,000
           </p>
         </div>
         <div>
@@ -878,7 +879,7 @@ function EvolveUpdatePane({
         className="w-full h-64 px-3 py-2 text-sm rounded-lg bg-surface-2 border border-border text-text-main resize-y font-mono"
       />
       <p className="text-[10px] text-text-dim">
-        {content.length.toLocaleString()} / 160,000
+        {formatNumber(content.length)} / 160,000
       </p>
       <Input
         value={changelog}
@@ -1108,7 +1109,7 @@ function EvolveUploadPane({
             {t("skills.evo_load_from_disk", { defaultValue: "Load from disk" })}
           </Button>
           <span className="text-[10px] text-text-dim">
-            {content.length.toLocaleString()} chars
+            {formatNumber(content.length)} chars
           </span>
         </div>
       </div>
@@ -1641,7 +1642,7 @@ function SkillDetailModal({
             </p>
             <p>
               {t("skills.evo_prompt_size", { defaultValue: "Prompt context" })}:{" "}
-              {detail.prompt_context_length.toLocaleString()} chars
+              {formatNumber(detail.prompt_context_length)} chars
             </p>
             <p className="font-mono truncate">{detail.path}</p>
           </div>

--- a/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TelemetryPage.tsx
@@ -1,4 +1,4 @@
-import { formatCompact } from "../lib/format";
+import { formatCompact, formatNumber } from "../lib/format";
 import { formatUptime } from "../lib/datetime";
 import { useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -296,13 +296,13 @@ export function TelemetryPage() {
             <MetricCard
               label={t("telemetry.total_requests")}
               icon={<BarChart3 className="w-3.5 h-3.5 text-brand" />}
-              value={<p className="text-xl font-black tracking-tight" title={totalRequests.toLocaleString()}>{formatCompact(totalRequests)}</p>}
+              value={<p className="text-xl font-black tracking-tight" title={formatNumber(totalRequests)}>{formatCompact(totalRequests)}</p>}
               variant="brand"
             />
             <MetricCard
               label={t("telemetry.total_tokens")}
               icon={<BarChart3 className="w-3.5 h-3.5 text-brand" />}
-              value={<p className="text-xl font-black tracking-tight text-brand" title={totalTokens.toLocaleString()}>{formatCompact(totalTokens)}</p>}
+              value={<p className="text-xl font-black tracking-tight text-brand" title={formatNumber(totalTokens)}>{formatCompact(totalTokens)}</p>}
               variant="brand"
               sub={
                 <span className="font-mono">
@@ -316,7 +316,7 @@ export function TelemetryPage() {
             <MetricCard
               label={t("telemetry.llm_calls")}
               icon={<MessageSquare className="w-3.5 h-3.5 text-accent" />}
-              value={<p className="text-xl font-black tracking-tight" title={totalLlmCalls.toLocaleString()}>{formatCompact(totalLlmCalls)}</p>}
+              value={<p className="text-xl font-black tracking-tight" title={formatNumber(totalLlmCalls)}>{formatCompact(totalLlmCalls)}</p>}
               variant="accent"
               sub={
                 <span className="font-mono">
@@ -362,7 +362,7 @@ export function TelemetryPage() {
                 </p>
               }
               variant={errorRateVariant}
-              sub={totalRequests > 0 ? `${errorCount.toLocaleString()} / ${totalRequests.toLocaleString()}` : undefined}
+              sub={totalRequests > 0 ? `${formatNumber(errorCount)} / ${formatNumber(totalRequests)}` : undefined}
             />
           </StaggerList>
 
@@ -391,7 +391,7 @@ export function TelemetryPage() {
                           {(a.provider || a.model) && (
                             <Badge variant="default" className="font-mono text-[10px]">{a.provider}/{a.model}</Badge>
                           )}
-                          <span className="text-sm font-black text-brand text-right tabular-nums" title={a.tokens.toLocaleString()}>
+                          <span className="text-sm font-black text-brand text-right tabular-nums" title={formatNumber(a.tokens)}>
                             {formatCompact(a.tokens)}
                             <span className="text-[10px] font-normal text-text-dim ml-0.5">{t("telemetry.unit_tokens")}</span>
                           </span>
@@ -400,7 +400,7 @@ export function TelemetryPage() {
                         {inOut > 0 && (
                           <div
                             className="flex h-1 w-full rounded-full overflow-hidden bg-border-subtle/30"
-                            title={`${a.inputTokens.toLocaleString()} in · ${a.outputTokens.toLocaleString()} out`}
+                            title={`${formatNumber(a.inputTokens)} in · ${formatNumber(a.outputTokens)} out`}
                           >
                             <div style={{ width: `${inputPct}%` }} className="bg-success/60" />
                             <div style={{ width: `${100 - inputPct}%` }} className="bg-warning/60" />
@@ -443,7 +443,7 @@ export function TelemetryPage() {
                         <Badge variant="default" className="font-mono text-[10px] w-14 justify-center shrink-0">{r.method}</Badge>
                         <span className="text-xs font-mono flex-1 truncate" title={r.path}>{r.path}</span>
                         <StatusBar ok={r.ok} redirect={r.redirect} client={r.client} server={r.server} total={r.total} maxTotal={maxTotal} />
-                        <span className="text-sm font-black text-brand text-right tabular-nums w-14" title={r.total.toLocaleString()}>{formatCompact(r.total)}</span>
+                        <span className="text-sm font-black text-brand text-right tabular-nums w-14" title={formatNumber(r.total)}>{formatCompact(r.total)}</span>
                       </div>
                     ));
                   })()}


### PR DESCRIPTION
Closes #8156.

## Why the component and not the environment

`LC_ALL=en_US.UTF-8` in CI would turn the test green. It would not change the fact that two operators looking at the same daemon see different numbers, which is the part worth fixing:

| locale | `(2000).toLocaleString()` |
|---|---|
| `en-US` | `2,000` |
| `es-ES` | `2000` |
| `fr-FR` | `2 000` |
| `C` | `2000` |

These are counts read against each other down a column — tokens, requests, chars. One grouping convention is the point, and pinning it is also what makes the output assertable.

## The change

`formatNumber` goes into `lib/format.ts` next to `formatCompact`, both on a shared `NUMBER_LOCALE`. `formatCompact` had the same defect in a quieter form — `Intl.NumberFormat(undefined, …)` — and now shares the pin.

36 call sites across 9 files move from `x.toLocaleString()` to `formatNumber(x)`.

**Five calls stay as they are**, all on `Date` values:

```
components/OperatorActionBar.tsx:137   pages/SchedulerPage.tsx:321
pages/AgentTypesPage.tsx:555          pages/SkillsPage.tsx:1625
pages/PromptsPage.tsx:393
```

`lib/datetime.ts` keeps the ambient locale deliberately, and that is right: a timestamp is read as "when, for me", where a token count is read against the row above it. Two earlier passes of this migration mangled those into `new DateformatNumber(...)` by matching `toLocaleDateString` with a sloppy pattern — caught by typecheck, but the reason the final pass excludes date lines explicitly rather than relying on a lookbehind.

## The test file was asserting nothing

`format.test.ts` built its expected values with `Intl.NumberFormat(undefined, …)` — the same ambient locale the implementation resolved. Both sides moved together, so it passed under every locale and could not have caught this. It now uses `NUMBER_LOCALE`, and gains literal expectations:

```ts
expect(formatNumber(2_000)).toBe("2,000");
expect(formatCompact(1_500)).toBe("1.5K");
```

Confirmed those fail without the pin: replacing `NUMBER_LOCALE` with `undefined` under `es-ES` gives `expected '2000' to be '2,000'`. The `Intl`-derived assertions stayed green through that, which is the demonstration that they were never guarding this.

## Verification

- `AnalyticsPage.test.tsx` under `es_ES`, `fr_FR`, `de_DE`, `C` and `en_US` — 30 passed in each. It fails on `main` under the first four.
- Full dashboard suite under `LC_ALL=es_ES.UTF-8` — 209 files, 1915 tests, 0 failures.
- `npx tsc --noEmit` clean; `npx vite build` succeeds.
