### PR TITLE
fix(kernel): warn when a configured tool_exec backend never reaches tool dispatch

### DIFF
--- a/changelog.d/fixed/8221-tool-exec-backend-unwired-warning.md
+++ b/changelog.d/fixed/8221-tool-exec-backend-unwired-warning.md
@@ -1,0 +1,4 @@
+The daemon now warns when `[tool_exec] kind` or an agent's `tool_exec_backend` names a backend that tool calls never actually reach.
+`docs/architecture/tool-exec-backends.md` has said since #3332 that the kernel emits this warning at boot, and it was never implemented — `librefang_runtime::tool_exec_backend::build_backend` still has no caller outside the test suite, so the resolved backend is discarded and every tool runs as a subprocess on the daemon host.
+An operator who pointed `kind` at an SSH host to keep shell commands off that machine therefore got a clean boot, a passing config validation, and the exact opposite of what they configured, with nothing in the log to say so.
+The setting is still accepted rather than rejected — deployments carrying it in anticipation should keep starting — but boot and every affected spawn now say plainly that it is ignored and is not a sandbox. (@houko)

--- a/crates/librefang-kernel/src/kernel/boot.rs
+++ b/crates/librefang-kernel/src/kernel/boot.rs
@@ -318,6 +318,22 @@ impl LibreFangKernel {
             );
         }
 
+        // A configured non-local backend does not route tool calls yet, and the operator has no other way to find that out (#8221).
+        //
+        // `docs/architecture/tool-exec-backends.md` states that the kernel warns here, and that warning was the one thing making the deferral visible — it was never implemented.
+        // So an operator who pointed `kind` at an SSH host to keep shell commands off this machine got the exact opposite of what they configured, silently.
+        // `validate()` above only rejects a malformed sub-table, so a well-formed `[tool_exec.ssh]` boots clean and every `shell_exec` still runs locally.
+        //
+        // Deliberately a `warn!` and not a boot failure: refusing to start would break deployments carrying the setting in anticipation, and this is a missing feature rather than a broken config.
+        if !config.tool_exec.kind.is_wired_into_dispatch() {
+            warn!(
+                configured_backend = config.tool_exec.kind.as_str(),
+                "[tool_exec] kind is set to a non-local backend, but tool calls still execute on the daemon host — \
+                 backend routing is not wired into tool dispatch yet (#8221). Shell and process tools ignore this \
+                 setting; it is not a sandbox."
+            );
+        }
+
         // Check TOTP configuration consistency
         if config.approval.second_factor == librefang_types::approval::SecondFactor::Totp {
             let vault_path = config.home_dir.join("vault.enc");

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -86,6 +86,19 @@ impl LibreFangKernel {
                     ),
                 )));
             }
+            // The check above only rejects an override the config cannot satisfy.
+            // A well-formed one is accepted and then ignored, because backend routing does not reach tool dispatch yet — the same gap the boot warning covers for the global `[tool_exec] kind` (#8221), reached through `agent.toml` instead.
+            //
+            // Warned per spawn rather than once at boot: a manifest can be added or edited long after startup, so a boot-time warning would never have been printed for it.
+            if !override_kind.is_wired_into_dispatch() {
+                warn!(
+                    agent = %name,
+                    configured_backend = override_kind.as_str(),
+                    "agent sets tool_exec_backend to a non-local backend, but its tool calls still execute on the \
+                     daemon host — backend routing is not wired into tool dispatch yet (#8221). This setting is \
+                     not a sandbox."
+                );
+            }
         }
 
         Ok(())

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -18577,3 +18577,182 @@ fn a_requested_iteration_cap_is_clamped_to_the_operator_ceiling() {
         "zero is not a request for a worker that does nothing before answering"
     );
 }
+
+/// Buffered `tracing` writer for the #8221 warning tests.
+///
+/// Kept local to this pair of tests rather than promoted to a shared helper: `config.rs` and `cron.rs` each carry their own copy, and factoring the three together is a change to two files this PR has no other reason to touch.
+#[derive(Clone)]
+struct CapturedLogs(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CapturedLogs {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = CapturedLogs;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+impl CapturedLogs {
+    fn new() -> Self {
+        Self(Arc::new(std::sync::Mutex::new(Vec::new())))
+    }
+
+    /// Install this buffer as the calling thread's subscriber for the duration of the returned guard.
+    fn install(&self) -> tracing::subscriber::DefaultGuard {
+        use tracing_subscriber::layer::SubscriberExt;
+        let layer = tracing_subscriber::fmt::layer()
+            .with_writer(self.clone())
+            .with_ansi(false)
+            .with_target(false);
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(layer))
+    }
+
+    fn text(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).expect("utf8")
+    }
+}
+
+/// A `KernelConfig` rooted in `dir` with `[tool_exec]` pointed at a well-formed SSH backend.
+///
+/// Well-formed matters: `ToolExecConfig::validate` rejects `kind = "ssh"` without a populated sub-table, and boot turns that rejection into a `BootFailed`. The configuration under test is the one that passes every existing check and still does nothing.
+fn ssh_tool_exec_config(dir: &std::path::Path) -> KernelConfig {
+    let home_dir = dir.join("librefang-tool-exec-warning-test");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        tool_exec: librefang_types::tool_exec::ToolExecConfig {
+            kind: librefang_types::tool_exec::BackendKind::Ssh,
+            ssh: Some(librefang_types::tool_exec::SshBackendConfig {
+                host: "build.example.com".to_string(),
+                user: "agent".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..KernelConfig::default()
+    }
+}
+
+/// #8221: booting with `[tool_exec] kind = "ssh"` must say out loud that tool calls still run on the daemon host.
+///
+/// `docs/architecture/tool-exec-backends.md` has promised this warning since #3332 and it was never implemented, which left the deferral invisible: `librefang_runtime::tool_exec_backend::build_backend` has no production caller, so the resolved kind reaches nothing.
+/// An operator who set this to keep shell commands off the daemon machine got the opposite of what they configured, with a clean boot and no log line anywhere.
+///
+/// Asserting on the rendered text rather than on a predicate, because the text is the entire deliverable — a warning nobody can act on is the same defect one level up.
+#[test]
+fn boot_warns_that_a_non_local_tool_exec_backend_does_not_route_tool_calls_8221() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = ssh_tool_exec_config(tmp.path());
+
+    let logs = CapturedLogs::new();
+    let kernel = {
+        let _g = logs.install();
+        LibreFangKernel::boot_with_config(config).expect(
+            "a well-formed non-local backend is a missing feature, not a broken config; boot must succeed",
+        )
+    };
+
+    let captured = logs.text();
+    assert!(
+        captured.contains("#8221"),
+        "warning must cite the tracking issue so the operator can find the status; captured: {captured:?}"
+    );
+    assert!(
+        captured.contains("ssh"),
+        "warning must name the backend that was configured and ignored; captured: {captured:?}"
+    );
+    assert!(
+        captured.contains("not a sandbox"),
+        "warning must deny the security property an operator most plausibly assumed; captured: {captured:?}"
+    );
+
+    kernel.shutdown();
+}
+
+/// #8221, per-agent half: the same gap reached through `agent.toml`'s `tool_exec_backend`.
+///
+/// Warned per spawn rather than at boot because a manifest can be written long after the daemon started, so a boot-time sweep would never see it.
+/// The kernel here boots on the default (local) config, which also proves the two warnings are independent — this one fires with nothing wrong in `config.toml`.
+#[test]
+fn spawn_warns_that_a_per_agent_tool_exec_backend_does_not_route_tool_calls_8221() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp
+        .path()
+        .join("librefang-per-agent-tool-exec-warning-test");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let mut config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    // `validate_override` rejects an override whose sub-table is absent, so the manifest needs a config that can satisfy it. `kind` stays `local`: only the per-agent override is under test.
+    config.tool_exec.ssh = Some(librefang_types::tool_exec::SshBackendConfig {
+        host: "build.example.com".to_string(),
+        user: "agent".to_string(),
+        ..Default::default()
+    });
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    let manifest = AgentManifest {
+        name: "remote-runner".to_string(),
+        description: "asks for a backend that does not exist yet".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        tool_exec_backend: Some(librefang_types::tool_exec::BackendKind::Ssh),
+        ..Default::default()
+    };
+
+    let logs = CapturedLogs::new();
+    {
+        let _g = logs.install();
+        kernel
+            .validate_spawnable(&manifest, "remote-runner")
+            .expect("an unimplemented backend must not make an agent unspawnable");
+    }
+
+    let captured = logs.text();
+    assert!(
+        captured.contains("#8221"),
+        "warning must cite the tracking issue; captured: {captured:?}"
+    );
+    assert!(
+        captured.contains("remote-runner"),
+        "warning must name the agent, since one manifest among many is the thing to fix; captured: {captured:?}"
+    );
+    assert!(
+        captured.contains("not a sandbox"),
+        "warning must deny the security property an operator most plausibly assumed; captured: {captured:?}"
+    );
+
+    // A local override is the configured default and must stay silent, or the warning becomes noise on every spawn.
+    let local = AgentManifest {
+        name: "local-runner".to_string(),
+        module: "builtin:chat".to_string(),
+        tool_exec_backend: Some(librefang_types::tool_exec::BackendKind::Local),
+        ..Default::default()
+    };
+    let quiet = CapturedLogs::new();
+    {
+        let _g = quiet.install();
+        kernel
+            .validate_spawnable(&local, "local-runner")
+            .expect("local override is always valid");
+    }
+    assert!(
+        !quiet.text().contains("#8221"),
+        "an explicit local override must not warn; captured: {:?}",
+        quiet.text()
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-types/src/tool_exec.rs
+++ b/crates/librefang-types/src/tool_exec.rs
@@ -55,6 +55,19 @@ impl BackendKind {
             BackendKind::Daytona => "daytona",
         }
     }
+
+    /// Whether selecting this kind actually changes where a tool call runs.
+    ///
+    /// Only `Local` does today: the resolver in this module picks a kind, but nothing downstream reads that choice, so every tool still executes as a subprocess on the daemon host (#8221).
+    /// Callers use this to warn an operator whose configuration is being silently ignored — the boot warning in `librefang-kernel`'s `boot.rs` for the global kind, and the per-agent one in `spawn.rs`.
+    ///
+    /// Written as an exhaustive match rather than a comparison against `Local` so that adding a variant, or wiring an existing one into dispatch, forces this answer to be revisited instead of inheriting a default.
+    pub fn is_wired_into_dispatch(self) -> bool {
+        match self {
+            BackendKind::Local => true,
+            BackendKind::Docker | BackendKind::Ssh | BackendKind::Daytona => false,
+        }
+    }
 }
 
 impl FromStr for BackendKind {
@@ -611,5 +624,24 @@ mod tests {
         ToolExecConfig::default()
             .validate_override(BackendKind::Local)
             .expect("local always ok");
+    }
+
+    /// Pins the set of backends that actually route tool calls (#8221).
+    ///
+    /// The two operator-facing warnings — at boot for `[tool_exec] kind`, at spawn for a manifest's `tool_exec_backend` — fire on exactly the complement of this set, so an entry silently flipping to `true` would take the warning away from a backend that still does nothing.
+    /// Whoever wires a backend into dispatch updates this test in the same change.
+    #[test]
+    fn only_the_local_backend_is_wired_into_dispatch_8221() {
+        assert!(
+            BackendKind::Local.is_wired_into_dispatch(),
+            "local is the backend every tool call has always used"
+        );
+        for kind in [BackendKind::Docker, BackendKind::Ssh, BackendKind::Daytona] {
+            assert!(
+                !kind.is_wired_into_dispatch(),
+                "{} is selectable but never reaches tool dispatch; if that changed, drop it from this list and from the warnings in boot.rs / spawn.rs",
+                kind.as_str()
+            );
+        }
     }
 }

--- a/docs/architecture/tool-exec-backends.md
+++ b/docs/architecture/tool-exec-backends.md
@@ -6,21 +6,22 @@ managed sandbox like Daytona. Issue #3332.
 
 ## Status
 
-This PR (#3332) lands the **trait + concrete backend implementations
-+ config plumbing**. It does **NOT** yet route the existing
-`tool_runner.rs` shell / `docker_exec` / process-spawn call sites
-through the trait — that migration is a deliberate follow-up because
-the call-site refactor is large enough to deserve its own review.
+This PR (#3332) lands the **trait + concrete backend implementations + config plumbing**.
+It does **NOT** yet route the existing `tool_runner.rs` shell / `docker_exec` / process-spawn call sites through the trait — that migration is a deliberate follow-up because the call-site refactor is large enough to deserve its own review.
 
-Concretely: configuring `tool_exec.kind = "ssh"` (or `"daytona"`) in
-`config.toml` resolves correctly through `resolve_backend_kind` and
-materialises the corresponding `ToolExecBackend` impl, but tool calls
-emitted by an LLM still flow through the legacy local / docker
-helpers. **The kernel emits a `WARN` at boot when `kind != "local"`**
-to make this visible. Operators experimenting with the SSH or Daytona
-backend should expect the override to take effect only after the
-follow-up PR migrates the call sites; until then, set `kind` to
-preview the resolver and feature-flag plumbing.
+Concretely: configuring `tool_exec.kind = "ssh"` (or `"daytona"`) in `config.toml` resolves correctly through `resolve_backend_kind` and materialises the corresponding `ToolExecBackend` impl, but tool calls emitted by an LLM still flow through the legacy local / docker helpers.
+`build_backend` has no caller outside the test suite, so the backend a deployment selects is built nowhere and discarded.
+
+**The kernel says so at both points where a backend can be selected**, since a silently ignored setting here reads as a security boundary that does not exist:
+
+- **Boot**, for the global `[tool_exec] kind`, whenever it is not `local` — `LibreFangKernel::boot_with_config` in `crates/librefang-kernel/src/kernel/boot.rs`.
+- **Every spawn**, for an agent's `tool_exec_backend` in `agent.toml` — `validate_spawnable` in `crates/librefang-kernel/src/kernel/spawn.rs`.
+  Per spawn rather than once at boot, because a manifest can be written or edited long after the daemon started.
+
+Both are `warn!` and neither rejects: the configuration is a missing feature, not a broken config, and deployments carrying the setting in anticipation should keep starting.
+The single source of truth for which backends are still unwired is `BackendKind::is_wired_into_dispatch`; whoever migrates the call sites updates that method, and `only_the_local_backend_is_wired_into_dispatch_8221` fails until they do.
+
+Operators experimenting with the SSH or Daytona backend should expect the override to take effect only after the follow-up PR migrates the call sites; until then, set `kind` to preview the resolver and feature-flag plumbing.
 
 ## Why a trait
 


### PR DESCRIPTION
Closes #8221 for the operator-visibility half.

## The problem

`docs/architecture/tool-exec-backends.md` has said since #3332 that **the kernel emits a `WARN` at boot when `kind != "local"`**. It never did — `boot.rs` called `config.tool_exec.validate()` and nothing else.

That matters more than a missing log line, because the thing it was supposed to make visible is still true: `librefang_runtime::tool_exec_backend::build_backend` has **no caller outside the test suite**. Every occurrence in the repo is a test or a doc reference. The resolver picks a `BackendKind`, `build_backend` would materialise it, and nothing calls it, so every tool call still runs as a subprocess on the daemon host.

So an operator who set `kind = "ssh"` to keep shell commands off the daemon machine got:

- a clean boot
- a passing `ToolExecConfig::validate` (it only checks that the sub-table exists and is populated)
- `shell_exec` still running locally
- nothing anywhere saying so

A security boundary that does not exist, presenting as one that does.

## Changes

- **`BackendKind::is_wired_into_dispatch`** (`librefang-types/src/tool_exec.rs`) — the single source of truth for which kinds actually route a tool call. Written as an exhaustive match rather than a comparison against `Local`, so adding a variant or wiring an existing one forces the question to be answered instead of inheriting a default.
- **Boot warning** (`librefang-kernel/src/kernel/boot.rs`) — fires for the global `[tool_exec] kind`, immediately after the existing `validate()` call that this sits alongside in the docs.
- **Per-spawn warning** (`librefang-kernel/src/kernel/spawn.rs`, `validate_spawnable`) — fires for a manifest's `tool_exec_backend`. Per spawn rather than once at boot: a manifest can be written or edited long after the daemon started, so a boot-time sweep would never see it.
- **Docs** — the Status section now describes both warning sites and names `is_wired_into_dispatch` as the thing to update when the call-site migration lands. Section reflowed to sentence-per-line per CLAUDE.md, since it was being edited.
- Changelog fragment under `changelog.d/fixed/`.

Both are `warn!` and neither rejects. This is a missing feature, not a broken config, and failing the boot would break deployments carrying the setting in anticipation of the follow-up PR.

## What this does not do

It does not route tool calls through `ToolExecBackend`. That is the call-site migration #3332 deferred, it spans `tool_runner.rs` and both sandbox modules, and it belongs in its own review. #8221 stays open for it.

## Verification

- `cargo test -p librefang-kernel --lib 8221` — 2 passed.
  - `boot_warns_that_a_non_local_tool_exec_backend_does_not_route_tool_calls_8221` — boots a real kernel on a well-formed `[tool_exec.ssh]` config with `tracing` captured, asserts the boot succeeds and the rendered warning names the backend, cites the issue, and denies the sandbox property.
  - `spawn_warns_that_a_per_agent_tool_exec_backend_does_not_route_tool_calls_8221` — same for a manifest override against a kernel whose global `kind` is `local`, proving the two paths are independent; also asserts an explicit `Local` override stays silent, so the warning does not become per-spawn noise.
- **Red before green**: with both `if` conditions replaced by `if false`, the two tests fail (`0 passed; 2 failed`); restored from the commit and they pass again.
- `cargo test -p librefang-types --lib only_the_local_backend` — 1 passed. Pins the wired set so flipping an entry to `true` without removing the corresponding warning fails here.
- `cargo clippy -p librefang-types -p librefang-kernel --all-targets -- -D warnings` — exit 0.
- `cargo check --workspace --lib` — exit 0.
