### PR TITLE
fix(dashboard): stop a negative penalty losing its sign as it is typed

### DIFF
--- a/changelog.d/fixed/8319-penalty-negative-sign.md
+++ b/changelog.d/fixed/8319-penalty-negative-sign.md
@@ -1,0 +1,3 @@
+Typing a negative penalty into a model's settings no longer saves it positive.
+Entering `-0.25` by hand stored `+0.25`: the drawer keeps the parsed number, and `-0` — a legitimate value on the way to `-0.25` — reads back as `0`, which rewrote the field and erased the minus sign mid-keystroke.
+Every negative fraction between -1 and 0 was affected except the `-0.5` preset, and nothing about the interface suggested the value had changed. (#8319) (@DaBlitzStein)

--- a/crates/librefang-api/dashboard/src/components/ui/StepLadderInput.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/StepLadderInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it } from "vitest";
@@ -190,5 +190,34 @@ describe("StepLadderInput — custom entry against a value-parsing call site", (
     expect(field).toHaveAttribute("min", "-2");
     await userEvent.type(field, "0");
     expect(field).toBeValid();
+  });
+});
+
+describe("StepLadderInput — a value that passes through negative zero", () => {
+  /**
+   * `userEvent.type` cannot show this one. A real `<input type="number">`
+   * sanitizes its `value` to `""` for anything that is not yet a valid float,
+   * so typing `-0.25` reaches the handler as `"-0"`, `""`, `"-0.2"`, `"-0.25"`;
+   * jsdom does not implement that sanitization and hands the raw buffer over,
+   * so the round trip that breaks in a browser never happens in the test.
+   *
+   * `fireEvent.change` with the exact strings a browser reports is what makes
+   * it visible. The defect: a parent that stores the parsed number takes
+   * `Number("-0")` — a legitimate penalty — and hands back `String(-0)`, which
+   * is `"0"`. The field is controlled, so the minus sign is erased from under
+   * the operator mid-keystroke, and the rest of what they type lands on a
+   * positive number. They save `+0.25` having typed `-0.25`, with no error.
+   */
+  it("does not erase the minus sign when the parent normalises -0 to \"0\"", () => {
+    render(<NumericHarness ladder={PENALTY_LADDER} />);
+    fireEvent.click(screen.getByRole("button", { name: "custom" }));
+
+    const field = screen.getByRole("spinbutton", {
+      name: "Temperature — custom",
+    }) as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "-0" } });
+
+    // What the operator can still see and keep typing into.
+    expect(field.value).toBe("-0");
   });
 });

--- a/crates/librefang-api/dashboard/src/components/ui/StepLadderInput.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/StepLadderInput.tsx
@@ -76,8 +76,25 @@ export function StepLadderInput({
   const offLadder = value.trim() !== "" && !isOnLadder(rungs, numeric);
   const isCustom = customMode || offLadder;
 
+  // What the operator typed, kept as they typed it.
+  //
+  // The field is controlled by `value`, and a call site that stores the parsed
+  // number rather than the text hands back a different string for the same
+  // number: the model settings drawer keeps `temperature: number`, so `-0` —
+  // a legitimate penalty — comes back as `String(-0)`, which is `"0"`. React
+  // then rewrites the DOM and the minus sign vanishes from under the operator
+  // mid-keystroke; the rest of `-0.25` lands on `0.25` and a positive value is
+  // saved with no error shown.
+  //
+  // The draft is only what is displayed. Every keystroke still reaches the
+  // parent, so nothing about what gets stored changes — this only stops the
+  // parent's rounding of the *representation* from editing the input.
+  const [draft, setDraft] = useState<string | null>(null);
+  const shownValue = isCustom && draft !== null ? draft : value;
+
   const pick = (next: string): void => {
     setCustomMode(false);
+    setDraft(null);
     onChange(next);
   };
 
@@ -129,6 +146,7 @@ export function StepLadderInput({
           // nobody chose and arms their Save button.
           onClick={() => {
             setCustomMode(true);
+            setDraft(null);
             if (numeric !== null) onChange(String(numeric));
           }}
         >
@@ -141,11 +159,14 @@ export function StepLadderInput({
           min={min}
           max={max}
           step={step}
-          value={value}
+          value={shownValue}
           aria-label={`${label} — ${customLabel}`}
           aria-invalid={warning ? true : undefined}
           aria-describedby={warning ? `${id}-warning` : undefined}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            onChange(e.target.value);
+          }}
           placeholder={customPlaceholder}
           className="w-full rounded-lg border border-border-subtle bg-main px-2 py-1 text-xs font-mono outline-none focus:border-brand"
         />


### PR DESCRIPTION
Follow-up to #8295, found by review after it merged.

## The bug

Type `-0.25` into a frequency- or presence-penalty custom field in the model settings drawer. **`+0.25` is saved.** No error, no warning, and the field looks like it accepted what you typed until you read it back.

The chain:

1. The drawer's reducer stores the parsed number (`temperature: number`, `freqPenalty: number`, …), and the field's value comes back as `String(state.freqPenalty)`.
2. `Number("-0")` is `-0`, a perfectly legitimate penalty, so `isValidParamValue` accepts it and the reducer stores it.
3. `String(-0)` is `"0"`.
4. The field is controlled, so React rewrites the DOM value from `-0` to `0` — the minus sign is erased from under the operator, mid-keystroke.
5. The remaining `.25` lands on `0.25`.

Every negative fraction in (-1, 0) goes in with the wrong sign, except `-0.5`, which is a rung and never reaches the custom field.

## The fix

`StepLadderInput` keeps what was typed and displays that while the custom field is open. Every keystroke still reaches the parent unchanged, so **nothing about what gets stored changes** — this only stops the parent's choice of *representation* from editing the input.

## Why the test uses `fireEvent.change` and not `userEvent.type`

This matters, because I got it wrong once already.

A real `<input type="number">` sanitizes its `value` to `""` for anything that is not yet a valid floating-point number, so typing `-0.25` reaches the handler as `"-0"`, `""`, `"-0.2"`, `"-0.25"`. **jsdom does not implement that sanitization** and hands over the raw buffer, so the round trip that breaks in a browser never happens under `userEvent.type`.

I wrote this fix during #8295, watched a `userEvent`-based test pass against the *unfixed* code, concluded the bug was unreproduced, and reverted it. The fix was right; the test was not. Driving the handler with the strings a browser actually reports makes the defect visible in one line: `expected '0' to be '-0'`.

## Verification

- New test fails against the unfixed component with `AssertionError: expected '0' to be '-0'`, passes with it. Checked both ways.
- `vitest run` — 209/209 files, 1914/1914 tests.
- `tsc --noEmit`, `eslint .` and **`pnpm build`** all clean. The build is in the list deliberately: on #8299 `tsc`, `vitest` and `eslint` were all green while `vite build` failed, because the production build aliases `lucide-react` to a curated barrel that the other three never consult.