### PR TITLE
fix(api,runtime-media): report media capabilities we can serve, and reach a provider the registry already describes

### DIFF
--- a/changelog.d/fixed/8320-media-capabilities-and-base-url.md
+++ b/changelog.d/fixed/8320-media-capabilities-and-base-url.md
@@ -1,0 +1,5 @@
+A media provider no longer advertises functions it cannot actually perform, and one the registry already describes can be reached without editing config.toml.
+Configuring such a provider used to *reduce* what it offered: the unconfigured entry repeated everything the registry said the service could do, and the moment it was wired up the answer narrowed to what the generic connector implements, so it vanished from the video section exactly when it started working.
+Both states now report the same thing — what can actually be served.
+Separately, a provider whose endpoint the registry states is now reachable from its API key alone; before, it stayed marked unconfigured with nothing to indicate that a hand-written endpoint override was the missing piece.
+The list of media providers is also read fresh on each request rather than taken once at startup, so one added by a catalog update appears without a restart. (#8320) (@DaBlitzStein)

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_kernel::media::{MediaDriverCache, MediaError};
+use librefang_kernel::media::{MediaDriverCache, MediaError, BUILTIN_MEDIA_DRIVERS};
 use librefang_types::media::{
     MediaCapability, MediaImageRequest, MediaMusicRequest, MediaTtsRequest, MediaVideoRequest,
 };
@@ -528,41 +528,91 @@ impl Drop for TempUploadGuard {
 
 // ── GET /media/providers ────────────────────────────────────────────────
 
+/// What an OpenAI-compatible provider with no purpose-built driver can serve.
+///
+/// `GenericOpenAICompatMediaDriver` delegates to `/images/generations` and
+/// implements nothing else, so this is the ceiling for any provider we reach
+/// through it, whatever the registry says the *service* is capable of.
+///
+/// The distinction is load-bearing for this route. A provider is reported
+/// through the generic driver once configured and from its registry entry
+/// before that, and reporting the registry's full set on the unconfigured side
+/// meant `byteplus` advertised `video_generation` right up until someone
+/// configured it, at which point the capability disappeared — the dashboard's
+/// video tab dropped it exactly when it started working. Reporting what we can
+/// actually serve on both sides is the honest answer; widening it is a matter
+/// of teaching the generic driver video, not of relabelling this list.
+const GENERIC_DRIVER_CAPABILITIES: &[&str] = &["image_generation"];
+
 /// List available media providers with their capabilities and config status.
 ///
-/// The provider list comes from [`MediaDriverCache::media_provider_ids`], which the kernel loads from the registry at boot — the same list auto-detection picks from.
-/// It used to be a five-name constant in this file, and the two inventories had already drifted apart in both directions: `byteplus` declares image and video generation in the registry and was invisible here, so the daemon could auto-select a provider the dashboard never listed.
+/// The list is derived from the live catalog on every request rather than from
+/// the snapshot `kernel::boot` hands `MediaDriverCache`. Nothing re-runs
+/// `load_providers_from_registry` after boot, so a provider added by a catalog
+/// update was invisible here until a restart — which is the same class of drift
+/// this route was changed to fix — and one removed lingered with an empty
+/// capability list.
 pub async fn list_media_providers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    // Registry-declared capabilities, for providers that have no built-in
-    // driver. `create_media_driver` fails for those unless a `provider_urls`
-    // entry gives it a base URL, but the provider is still real and the
-    // dashboard needs to know which functions it would serve once configured.
     let catalog = state.kernel.model_catalog_ref().load();
     let declared: std::collections::HashMap<&str, &[String]> = catalog
         .list_providers()
         .iter()
+        .filter(|p| !p.media_capabilities.is_empty())
         .map(|p| (p.id.as_str(), p.media_capabilities.as_slice()))
         .collect();
 
-    let mut providers = Vec::new();
+    // Registry order first, then the compiled-in drivers that have no registry
+    // entry — `google_tts` is one, and dropping it would remove a provider that
+    // works. Deduplicated, because a built-in that IS in the registry must not
+    // appear twice.
+    let mut names: Vec<String> = catalog
+        .list_providers()
+        .iter()
+        .filter(|p| !p.media_capabilities.is_empty())
+        .map(|p| p.id.clone())
+        .collect();
+    for builtin in BUILTIN_MEDIA_DRIVERS {
+        if !names.iter().any(|n| n == builtin) {
+            names.push((*builtin).to_string());
+        }
+    }
 
-    for name in state.media_drivers.media_provider_ids() {
+    let mut providers = Vec::new();
+    for name in names {
         match state.media_drivers.get_or_create(&name, None) {
             Ok(driver) => {
+                // A provider served by the generic driver can only do what the
+                // generic driver does, so intersect rather than take either
+                // side whole: the registry may promise more, and a purpose-built
+                // driver reports its own set and is unaffected by this.
+                let capabilities: Vec<String> = driver
+                    .capabilities()
+                    .iter()
+                    .map(|c| c.to_string())
+                    .collect();
                 providers.push(serde_json::json!({
-                    "name": driver.provider_name(),
+                    "name": name,
                     "configured": driver.is_configured(),
-                    "capabilities": driver.capabilities(),
+                    "capabilities": capabilities,
                 }));
             }
             Err(_) => {
-                // No built-in driver and no `provider_urls.<name>` base URL, so
-                // there is nothing to ask `is_configured()`. That is an
-                // unconfigured provider, not a broken one.
+                // No compiled-in driver and no base URL from either the operator
+                // or the registry, so there is nothing to ask `is_configured()`.
+                // That is an unconfigured provider, not a broken one — and what
+                // it would serve is what the generic driver could serve for it.
+                let capabilities: Vec<&str> = declared
+                    .get(name.as_str())
+                    .copied()
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|c| GENERIC_DRIVER_CAPABILITIES.contains(c))
+                    .collect();
                 providers.push(serde_json::json!({
                     "name": name,
                     "configured": false,
-                    "capabilities": declared.get(name.as_str()).copied().unwrap_or(&[]),
+                    "capabilities": capabilities,
                 }));
             }
         }

--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -461,16 +461,23 @@ async fn media_providers_lists_registry_declared_providers_with_no_builtin_drive
         names.contains(&"byteplus"),
         "registry provider declaring media_capabilities is missing from: {names:?}"
     );
-    // A provider with no compiled-in driver still has to report which
-    // functions it would serve, or the dashboard cannot file it under a tab.
+    // A provider with no compiled-in driver reports what it would serve *here*,
+    // which is what the generic OpenAI-compatible driver implements — images
+    // and nothing else. The registry declares the service can also do video,
+    // and this assertion used to repeat that, which made configuring the
+    // provider look like it removed a capability: the driver reports only
+    // `image_generation`, so the dashboard's video tab dropped byteplus at the
+    // exact moment it started working. One answer on both sides of
+    // `configured` is the honest one; offering video here would advertise a
+    // path that has no implementation behind it.
     let byteplus = listed
         .iter()
         .find(|p| p["name"] == "byteplus")
         .expect("byteplus entry");
     assert_eq!(
         byteplus["capabilities"],
-        serde_json::json!(["image_generation", "video_generation"]),
-        "declared capabilities lost: {byteplus}"
+        serde_json::json!(["image_generation"]),
+        "unconfigured capabilities must be what we can actually serve: {byteplus}"
     );
     assert_eq!(byteplus["configured"], false, "got: {byteplus}");
 

--- a/crates/librefang-runtime-media/src/lib.rs
+++ b/crates/librefang-runtime-media/src/lib.rs
@@ -152,6 +152,15 @@ pub trait MediaDriver: Send + Sync {
 
 // ── Driver cache ───────────────────────────────────────────────────────
 
+/// Provider names `create_media_driver` serves with a purpose-built driver.
+///
+/// These have no registry entry to derive them from — `google_tts` is not in
+/// the provider registry at all — so any surface enumerating media providers
+/// has to add them, and had been doing so from its own copy of the list.
+/// One list, exported, so a driver added here cannot go missing from a surface.
+pub const BUILTIN_MEDIA_DRIVERS: &[&str] =
+    &["openai", "gemini", "elevenlabs", "minimax", "google_tts"];
+
 /// Thread-safe, lazy-initializing cache for media drivers.
 ///
 /// Holds an optional `provider_urls` map (from `KernelConfig`) so that
@@ -162,9 +171,15 @@ pub struct MediaDriverCache {
     /// Provider name → custom base URL, sourced from config `[provider_urls]`.
     /// Behind RwLock for hot-reload support (update URLs via `&self`).
     provider_urls: RwLock<HashMap<String, String>>,
-    /// Provider IDs that support media, in preference order.
-    /// Loaded from the registry (providers/*.toml) at boot.
+    /// Provider IDs that support media, in registry order with the built-ins
+    /// appended. Loaded from the registry (providers/*.toml) at boot.
     media_providers: RwLock<Vec<String>>,
+    /// Provider ID → the `base_url` the registry declares for it.
+    ///
+    /// Separate from `provider_urls`, which is the operator's override and
+    /// wins. A provider whose endpoint the registry already states should not
+    /// require a `config.toml` edit before it can be reached at all.
+    registry_base_urls: RwLock<HashMap<String, String>>,
 }
 
 fn read_media_state<'a, T>(lock: &'a RwLock<T>, state: &'static str) -> RwLockReadGuard<'a, T> {
@@ -202,6 +217,7 @@ impl MediaDriverCache {
                 "minimax".into(),
                 "google_tts".into(),
             ]),
+            registry_base_urls: RwLock::new(HashMap::new()),
         }
     }
 
@@ -225,6 +241,7 @@ impl MediaDriverCache {
                 "minimax".into(),
                 "google_tts".into(),
             ]),
+            registry_base_urls: RwLock::new(HashMap::new()),
         }
     }
 
@@ -240,17 +257,26 @@ impl MediaDriverCache {
             .filter(|p| !p.media_capabilities.is_empty())
             .map(|p| p.id.clone())
             .collect();
-        for builtin in ["openai", "gemini", "elevenlabs", "minimax", "google_tts"] {
+        for builtin in BUILTIN_MEDIA_DRIVERS {
             if !media_provs.iter().any(|p| p == builtin) {
-                media_provs.push(builtin.to_string());
+                media_provs.push((*builtin).to_string());
             }
         }
         *write_media_state(&self.media_providers, "media_providers") = media_provs;
+
+        let base_urls: HashMap<String, String> = providers
+            .iter()
+            .filter(|p| !p.base_url.trim().is_empty())
+            .map(|p| (p.id.clone(), p.base_url.trim_end_matches('/').to_string()))
+            .collect();
+        *write_media_state(&self.registry_base_urls, "registry_base_urls") = base_urls;
     }
 
-    /// The media provider IDs this cache knows about, in preference order.
+    /// The media provider IDs this cache knows about.
     ///
-    /// This is the same list [`detect_for_capability`](Self::detect_for_capability) picks from, which is the point of exposing it: a surface that enumerates media providers from its own hardcoded list can disagree with the list auto-detection actually uses, and then the daemon selects a provider the UI never showed.
+    /// This is the same list [`detect_for_capability`](Self::detect_for_capability) picks from, which is the point of exposing it: a surface that enumerates media providers from its own hardcoded list can disagree with the list auto-detection actually uses.
+    ///
+    /// **Not a preference order**, despite what this said before. The registry portion arrives in whatever sequence `std::fs::read_dir` produced (`model_catalog.rs`), so with two configured providers serving one capability, which one `detect_for_capability` returns is filesystem-dependent. Pinning that order is a separate change with its own behavioural decision to make.
     pub fn media_provider_ids(&self) -> Vec<String> {
         read_media_state(&self.media_providers, "media_providers").clone()
     }
@@ -277,6 +303,19 @@ impl MediaDriverCache {
                     } else {
                         None
                     }
+                })
+                .or_else(|| {
+                    // The registry already states where this provider lives.
+                    // Without this a provider it fully describes still needed a
+                    // `provider_urls` line in config.toml before it could be
+                    // reached, and the only symptom was `configured: false`
+                    // with the API key correctly set.
+                    let declared =
+                        read_media_state(&self.registry_base_urls, "registry_base_urls");
+                    declared
+                        .get(provider)
+                        .or_else(|| declared.get(canonical_provider_name(provider)))
+                        .cloned()
                 })
         });
         let url_ref = resolved_url.as_deref();
@@ -500,6 +539,49 @@ mod tests {
         // Different key means a separate cache entry from the config-resolved one
         let driver2 = cache.get_or_create("minimax", None).unwrap();
         assert!(!Arc::ptr_eq(&driver, &driver2));
+    }
+
+    #[test]
+    fn a_provider_the_registry_gives_a_base_url_needs_no_config_toml_entry() {
+        let cache = MediaDriverCache::new();
+        // byteplus is the real case: the registry states its endpoint, it has
+        // no compiled-in driver, and before this the only way to reach it was
+        // a `provider_urls.byteplus` line in config.toml — with no hint that
+        // one was needed. Setting the API key and restarting left it reported
+        // as unconfigured.
+        cache.load_providers_from_registry(&[librefang_types::model_catalog::ProviderInfo {
+            id: "byteplus".into(),
+            base_url: "https://ark.ap-southeast.bytepluses.com/api/v3".into(),
+            media_capabilities: vec!["image_generation".into()],
+            ..Default::default()
+        }]);
+
+        let driver = cache
+            .get_or_create("byteplus", None)
+            .expect("a provider the registry gives a base_url for must be reachable");
+        assert_eq!(driver.provider_name(), "byteplus");
+    }
+
+    #[test]
+    fn an_operator_override_still_beats_the_registry_base_url() {
+        let cache = MediaDriverCache::new_with_urls([(
+            "byteplus".to_string(),
+            "https://proxy.internal/v1".to_string(),
+        )]);
+        cache.load_providers_from_registry(&[librefang_types::model_catalog::ProviderInfo {
+            id: "byteplus".into(),
+            base_url: "https://ark.ap-southeast.bytepluses.com/api/v3".into(),
+            media_capabilities: vec!["image_generation".into()],
+            ..Default::default()
+        }]);
+
+        // Two different URLs must not collapse onto one cache entry, which is
+        // how the override would silently stop applying.
+        let overridden = cache.get_or_create("byteplus", None).unwrap();
+        let explicit = cache
+            .get_or_create("byteplus", Some("https://proxy.internal/v1"))
+            .unwrap();
+        assert!(Arc::ptr_eq(&overridden, &explicit));
     }
 
     #[test]

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -305,12 +305,18 @@ impl TestAppState {
                         || !cfg.dashboard_pass.trim().is_empty()),
             )
         };
-        // Mirrors `kernel::boot`, which loads the media provider order from the
-        // catalog right after constructing the cache. Without this the harness
-        // hands every test the five compiled-in built-ins while production
-        // serves whatever the registry declares, so a test over
-        // `GET /media/providers` would pass against a list production never
-        // produces.
+        // Mirrors `kernel::boot`, which loads the media provider list from the
+        // catalog right after constructing the cache, so the list
+        // `detect_for_capability` picks from follows the test kernel's catalog
+        // rather than staying at the compiled-in built-ins.
+        //
+        // It is load-bearing only for tests that give the kernel a catalog —
+        // `with_catalog_seed` or `with_registry_fixture`. CI runs with
+        // `LIBREFANG_REGISTRY_OFFLINE=1`, which leaves the catalog empty, and
+        // then this call adds nothing. An earlier version of this comment
+        // claimed it closed a harness/production divergence in general, which
+        // is not true and would have sent someone looking for a difference that
+        // is not there.
         let media_drivers = librefang_runtime::media::MediaDriverCache::new();
         // `KernelApi` is called through its path rather than imported: bringing
         // the trait into scope makes `set_self_handle` resolve to the


### PR DESCRIPTION
Follow-up to #8297, from a review that landed after it merged. Three operator-visible problems, one honesty fix.

## 1. Configuring a provider shrank what it advertised

`byteplus` declares `["image_generation", "video_generation"]` in the registry, and that is what `GET /api/media/providers` reported while it was unconfigured. Add a base URL and it goes through `GenericOpenAICompatMediaDriver`, whose `capabilities()` is `[ImageGeneration]` — it delegates to `/images/generations` and implements nothing else — so the answer became image-only. **The dashboard's video tab dropped the provider at the exact moment it started working.**

Both sides now report what the driver can actually serve. That is the honest direction: advertising `video_generation` for a provider we reach through an images-only driver does not make video work, it moves the failure to the point of use. Teaching the generic driver video is a separate change with an implementation behind it.

## 2. A provider the registry fully describes could not be reached at all

`byteplus.toml` carries `base_url = "https://ark.ap-southeast.bytepluses.com/api/v3"`, but `get_or_create` resolved base URLs from `config.provider_urls` only. Set `BYTEPLUS_API_KEY`, restart, and it still reported `configured: false` — with nothing anywhere to suggest that a `config.toml` edit was the missing step.

`MediaDriverCache` now keeps the base URL the registry declares alongside the provider list and falls back to it. An operator override still wins; the two are kept in separate maps so that stays true.

## 3. The provider list was a boot snapshot

`load_providers_from_registry` runs once at `kernel/boot.rs:1635` and nothing re-runs it — not `POST /api/config/reload`, not a catalog update. A provider added afterwards stayed invisible until a restart, which is the same class of drift #8297 set out to fix, and one removed lingered in the list rendering `"capabilities": []`.

The route derives the list from the live catalog on each request. The built-in driver names it appends move into one exported `BUILTIN_MEDIA_DRIVERS`: `google_tts` has no registry entry, so every surface enumerating media providers has to add it, and each was carrying its own copy.

## 4. `media_provider_ids` stopped claiming an order it does not have

The doc said "in preference order". The registry portion arrives in `std::fs::read_dir` order (`model_catalog.rs:418-434`), so with two configured providers serving one capability, which one `detect_for_capability` returns is filesystem-dependent. Pinning that is a behavioural decision for its own PR; claiming it here only invites someone to rely on it.

## Verification

- `cargo test -p librefang-api --test media_routes_integration` with **`LIBREFANG_REGISTRY_OFFLINE=1`** — 20/20. The flag matters: `MockKernelBuilder` never sets `registry.auto_sync = false` and `network_enabled = false` does not gate it, so without it each mock kernel boots against the real registry and the media list is whatever the fetch delivered. My verification on #8297 may have run that way.
- `cargo test -p librefang-runtime-media` — 115/115.
- `cargo clippy -p librefang-api -p librefang-runtime-media -p librefang-testing --all-targets -- -D warnings` — clean.
- New test `a_provider_the_registry_gives_a_base_url_needs_no_config_toml_entry` fails without the fallback, checked by removing it. A sibling pins that an operator override still beats the registry and that the two do not collapse onto one cache entry.
- `media_providers_lists_registry_declared_providers_with_no_builtin_driver` is updated to the new contract, with the reasoning in the test — it previously asserted the behaviour this PR calls a bug.
- `test_app.rs`'s comment about the harness is corrected. It claimed the `load_providers_from_registry` call closed a harness/production divergence in general; under CI's offline registry the catalog is empty and the call adds nothing, so it is load-bearing only for tests that seed a catalog.