### PR TITLE
fix(api): tell three bots of one channel type apart in an agent's own view

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1730,6 +1730,50 @@ export async function getAgentMcpServers(
 }
 
 /**
+ * Per-agent channel assignment, returned by `GET /api/agents/{id}/channels`.
+ *
+ * Two different mechanisms, deliberately reported together:
+ *
+ * - `assigned` / `available` / `mode` are the manifest allowlist
+ *   (`agent.toml: channels`), matched against a bare channel **type** —
+ *   `agent_allows_channel` in `librefang-channels` compares
+ *   `channel_type_str(&message.channel)` — so `available` is one entry per
+ *   type, not per configured instance.
+ * - `instances` is the per-instance binding (`[[sidecar_channels]].agent`,
+ *   #6131): which specific bot delivers to which agent. Three Telegram bots
+ *   are three instances of one type, and only this tells them apart.
+ *
+ * Reading both from one place is what lets an agent's own editor answer
+ * "which of these bots is mine?", which previously could only be seen from
+ * the channel's side.
+ */
+export interface AgentChannelInstance {
+  /** `[[sidecar_channels]].name` — unique per instance. */
+  name: string;
+  /** The channel type this instance speaks; several instances share one. */
+  channel_type: string;
+  /** Agent this instance delivers to, or `null` when it has no binding. */
+  agent: string | null;
+  /** True when `agent` is the agent this response is about. */
+  bound_to_this_agent: boolean;
+}
+
+export interface AgentChannelsResponse {
+  assigned: string[];
+  available: string[];
+  instances: AgentChannelInstance[];
+  mode: "all" | "allowlist";
+}
+
+export async function getAgentChannels(
+  agentId: string,
+): Promise<AgentChannelsResponse> {
+  return get<AgentChannelsResponse>(
+    `/api/agents/${encodeURIComponent(agentId)}/channels`,
+  );
+}
+
+/**
  * PUT /api/agents/{id}/skills — replace the agent's skill allowlist.
  *
  * An empty array clears the allowlist, switching the agent back to "all"

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -143,6 +143,7 @@ export {
   getAgentSkills,
   // per-agent MCP server assignment — read (#7713)
   getAgentMcpServers,
+  getAgentChannels,
   getAgentTemplateToml,
   getTemplateHistory,
   // overview

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -15,6 +15,7 @@ import {
   getAgentTools,
   getAgentSkills,
   getAgentMcpServers,
+  getAgentChannels,
 } from "../http/client";
 import { agentKeys, toolKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
@@ -139,6 +140,12 @@ export const agentQueries = {
       queryFn: () => getAgentMcpServers(agentId),
       enabled: !!agentId,
     }),
+  agentChannels: (agentId: string) =>
+    queryOptions({
+      queryKey: agentKeys.channels(agentId),
+      queryFn: () => getAgentChannels(agentId),
+      enabled: !!agentId,
+    }),
   toolsList: () =>
     queryOptions({
       queryKey: toolKeys.list(),
@@ -204,4 +211,8 @@ export function useAgentSkills(agentId: string, options: QueryOverrides = {}) {
 
 export function useAgentMcpServers(agentId: string, options: QueryOverrides = {}) {
   return useQuery(withOverrides(agentQueries.agentMcpServers(agentId), options));
+}
+
+export function useAgentChannels(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.agentChannels(agentId), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -77,6 +77,8 @@ export const agentKeys = {
   // is separate from `tools`: an MCP read must not be invalidated by a tool write.
   mcpServers: (agentId: string) =>
     [...agentKeys.all, "mcpServers", agentId] as const,
+  channels: (agentId: string) =>
+    [...agentKeys.all, "channels", agentId] as const,
 };
 
 // Central prompt repository (#6160). The fleet-wide overview

--- a/crates/librefang-api/src/routes/agents/config.rs
+++ b/crates/librefang-api/src/routes/agents/config.rs
@@ -654,13 +654,44 @@ pub async fn get_agent_channels(
             Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
         );
     }
-    let available: Vec<String> = state
-        .kernel
-        .config_ref()
+    let agent_name = entry.manifest.name.clone();
+    let config = state.kernel.config_ref();
+
+    // The allowlist is matched against a bare channel *type* — `agent_allows_channel`
+    // in `librefang-channels` compares against `channel_type_str(&message.channel)`,
+    // which the `the_roster_key_is_the_bare_channel_type` test pins — so the choices
+    // it offers are types, and one entry per type is the whole list.
+    // This used to map every configured instance to its type, so a host running
+    // three Telegram bots offered "telegram" three times, indistinguishable and
+    // all meaning the same thing.
+    let mut available: Vec<String> = Vec::new();
+    for sc in &config.sidecar_channels {
+        let ty = sc.channel_type.clone().unwrap_or_else(|| sc.name.clone());
+        if !available.contains(&ty) {
+            available.push(ty);
+        }
+    }
+
+    // Which instances exist, and which agent each one delivers to. This is the
+    // per-instance binding from #6131 (`[[sidecar_channels]].agent`), a separate
+    // and finer mechanism than the type allowlist above: the allowlist says which
+    // kinds of channel an agent may serve at all, the binding says which specific
+    // bot's messages arrive at it. Surfacing both from one place is what lets an
+    // agent's own editor answer "which of the three Telegram bots is mine?",
+    // which previously could only be read from the channel's side.
+    let instances: Vec<serde_json::Value> = config
         .sidecar_channels
         .iter()
-        .map(|sc| sc.channel_type.clone().unwrap_or_else(|| sc.name.clone()))
+        .map(|sc| {
+            serde_json::json!({
+                "name": sc.name,
+                "channel_type": sc.channel_type.clone().unwrap_or_else(|| sc.name.clone()),
+                "agent": sc.agent,
+                "bound_to_this_agent": sc.agent.as_deref() == Some(agent_name.as_str()),
+            })
+        })
         .collect();
+
     let mode = if entry.manifest.channels.is_empty() {
         "all"
     } else {
@@ -671,6 +702,7 @@ pub async fn get_agent_channels(
         Json(serde_json::json!({
             "assigned": entry.manifest.channels,
             "available": available,
+            "instances": instances,
             "mode": mode,
         })),
     )

--- a/crates/librefang-api/tests/agent_channels_routes_test.rs
+++ b/crates/librefang-api/tests/agent_channels_routes_test.rs
@@ -74,6 +74,58 @@ async fn boot() -> Harness {
     }
 }
 
+/// Boot with several sidecar instances of the same channel type.
+///
+/// This is the shape a real host takes: three Telegram bots, each delivering
+/// to a different agent, distinguishable only by `name`.
+async fn boot_with_sidecars(instances: &[(&str, &str, Option<&str>)]) -> Harness {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    librefang_kernel::registry_sync::seed_registry_fixture_for_tests(tmp.path());
+
+    // Deserialized rather than built field by field: the type has no `Default`
+    // and a dozen `#[serde(default)]` knobs, and going through serde is also
+    // how a real `[[sidecar_channels]]` block reaches the config.
+    let sidecar_channels = instances
+        .iter()
+        .map(|(name, channel_type, agent)| {
+            serde_json::from_value(serde_json::json!({
+                "name": name,
+                "command": "true",
+                "channel_type": channel_type,
+                "agent": agent,
+            }))
+            .expect("sidecar channel fixture")
+        })
+        .collect();
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        api_key: TEST_TOKEN.to_string(),
+        sidecar_channels,
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::BTreeMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+    let (app, state) = server::build_router(kernel, "127.0.0.1:0".parse().expect("addr")).await;
+    Harness {
+        app,
+        state,
+        _tmp: tmp,
+    }
+}
+
 fn spawn_named(state: &Arc<AppState>, name: &str) -> AgentId {
     let manifest = AgentManifest {
         name: name.to_string(),
@@ -351,5 +403,85 @@ async fn channels_survive_a_reload_from_disk() {
         names,
         vec!["slack", "telegram"],
         "the allowlist must come back off disk, not only out of memory"
+    );
+}
+
+/// Three Telegram bots, told apart.
+///
+/// `available` is the manifest allowlist's choices, and that allowlist is
+/// matched against a bare channel *type* — `agent_allows_channel` in
+/// `librefang-channels` compares `channel_type_str(&message.channel)`, which
+/// `the_roster_key_is_the_bare_channel_type` pins — so one entry per type is
+/// the whole list. It used to map every configured instance to its type, so a
+/// host running three Telegram bots was offered "telegram" three times, three
+/// identical strings all meaning the same thing.
+///
+/// Which specific bot reaches an agent is a different and finer mechanism:
+/// the per-instance binding on `[[sidecar_channels]].agent` (#6131). Reporting
+/// it here is what lets an agent's own editor answer "which of these bots is
+/// mine?", which until now could only be read from the channel's side.
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_distinguishes_instances_of_one_type() {
+    let h = boot_with_sidecars(&[
+        ("telegram", "telegram", Some("deannatroi")),
+        ("laforge", "telegram", Some("LaForge")),
+        ("mercaman", "telegram", Some("Mercaman")),
+    ])
+    .await;
+    let agent_id = spawn_named(&h.state, "Mercaman");
+
+    let (status, body) = send(
+        h.app.clone(),
+        get(&format!("/api/agents/{agent_id}/channels")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got: {body:?}");
+
+    let available: Vec<&str> = body["available"]
+        .as_array()
+        .expect("available array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(
+        available,
+        vec!["telegram"],
+        "the allowlist is per type, so three instances of one type are one choice: {body}"
+    );
+
+    let instances = body["instances"].as_array().expect("instances array");
+    assert_eq!(
+        instances.len(),
+        3,
+        "every configured instance must be listed: {body}"
+    );
+
+    let named: Vec<&str> = instances
+        .iter()
+        .filter_map(|i| i["name"].as_str())
+        .collect();
+    assert_eq!(
+        named,
+        vec!["telegram", "laforge", "mercaman"],
+        "got: {body}"
+    );
+
+    for instance in instances {
+        assert_eq!(
+            instance["channel_type"], "telegram",
+            "each instance carries its type as well as its name: {instance}"
+        );
+    }
+
+    // Exactly the one bound to this agent says so.
+    let bound: Vec<&str> = instances
+        .iter()
+        .filter(|i| i["bound_to_this_agent"] == true)
+        .filter_map(|i| i["name"].as_str())
+        .collect();
+    assert_eq!(
+        bound,
+        vec!["mercaman"],
+        "the agent's own view must say which instance delivers to it: {body}"
     );
 }


### PR DESCRIPTION
## The report

An operator running three Telegram bots opened an agent's channel picker and saw `telegram` three times — indistinguishable — and could not tell which one was assigned to that agent.

## What is actually wrong

`GET /api/agents/{id}/channels` built `available` by mapping every configured sidecar instance to its `channel_type`:

```rust
.map(|sc| sc.channel_type.clone().unwrap_or_else(|| sc.name.clone()))
```

Three instances of one type therefore produced `["telegram", "telegram", "telegram"]`. Measured on a live host, that is exactly what it returns for every agent.

The duplication is a bug on its own terms. That list is the manifest allowlist's set of choices, and the allowlist is matched against a **bare channel type** — `agent_allows_channel` in `librefang-channels` compares `channel_type_str(&message.channel)`, pinned by `the_roster_key_is_the_bare_channel_type` — so one entry per type is the whole list. Repeating it per instance offers three choices that do the same thing.

## What the operator was actually looking for

Which specific bot reaches an agent is a **different and finer** mechanism: the per-instance binding on `[[sidecar_channels]].agent`, shipped in #6131 as Model A of the #5671 RFC. It was readable only from the channel's side, so an agent's own view could not answer "which of these bots is mine?" — which is the question the duplicated list looked like it was answering and was not.

The response now carries `instances`:

```json
{
  "assigned": [],
  "available": ["telegram"],
  "instances": [
    {"name": "telegram", "channel_type": "telegram", "agent": "deannatroi", "bound_to_this_agent": false},
    {"name": "laforge",  "channel_type": "telegram", "agent": "LaForge",    "bound_to_this_agent": false},
    {"name": "mercaman", "channel_type": "telegram", "agent": "Mercaman",   "bound_to_this_agent": true}
  ],
  "mode": "all"
}
```

## Routing is untouched, and that was checked before deciding

I measured every agent on a live host first: none holds an instance name in its allowlist, so nothing was being silently ignored by the type-level match, and the per-instance bindings were correct. This changes what the surface reports, not what the daemon does. Making the allowlist itself instance-granular would add a second mechanism competing with #6131 and is not what the symptom calls for.

## Also here

The dashboard data layer — `getAgentChannels`, its `agentKeys.channels` factory entry, its hook, and the `http/client` re-export. Kept to the data layer so the UI that consumes it is a separate reviewable change rather than a rewrite bundled with a route fix. The TUI's picker (`tui/screens/agents.rs`) reads `available` as `Vec<String>` and is unaffected by the added field; it benefits from the deduplication immediately.

## Verification

- `cargo test -p librefang-api --test agent_channels_routes_test` with `LIBREFANG_REGISTRY_OFFLINE=1` — 8/8.
- New test `channels_distinguishes_instances_of_one_type` builds three Telegram instances bound to three different agents and asserts `available` has one entry, `instances` has three with their names and types, and exactly the bound one reports `bound_to_this_agent`. **Fails against the unfixed handler**, checked by reverting it.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` clean; dashboard `tsc`, `eslint` and `pnpm build` clean.