### PR TITLE
fix(llm-drivers): stop retrying a request the provider has already refused

### DIFF
--- a/changelog.d/fixed/8322-no-retry-on-client-error.md
+++ b/changelog.d/fixed/8322-no-retry-on-client-error.md
@@ -1,0 +1,4 @@
+A provider that rejects a request outright is no longer asked the same question two more times before moving on.
+The retry loop treated every ambiguous HTTP failure as worth another attempt, including the ones where the provider has already judged the request itself — those cannot come out differently, since the retry sends exactly the same bytes.
+It mattered most where it was least visible: history compaction handed a summarizer more text than that model could read, and the resulting refusal was retried, failed over, retried again and then repeated per chunk, leaving an agent unresponsive with no error to show for it rather than failing once and plainly.
+Server-side failures keep their retries, as does a request that never finished arriving. (#8322) (@DaBlitzStein)

--- a/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
@@ -97,6 +97,21 @@ pub struct FallbackChain {
     exhaustion_store: Option<ProviderExhaustionStore>,
 }
 
+/// Whether the provider has already decided about *this* request.
+///
+/// A 4xx says the request is wrong, and the retry loop re-sends it byte for
+/// byte, so the answer cannot change. The two exceptions are the statuses that
+/// describe timing rather than content: 408, where the request never finished
+/// arriving, and 429, which is handled as a rate limit and carries its own
+/// backoff.
+fn is_deterministic_client_error(e: &LlmError) -> bool {
+    matches!(
+        e,
+        LlmError::Api { status, .. }
+            if (400..500).contains(status) && *status != 408 && *status != 429
+    )
+}
+
 impl FallbackChain {
     /// Build a chain from an ordered list of entries.
     ///
@@ -174,12 +189,25 @@ impl FallbackChain {
                 Err(e) => {
                     let reason = e.failover_reason();
 
+                    // `HttpError` is the catch-all for statuses the classifier
+                    // calls ambiguous — 400, 403, 404, 500 — and its own comment
+                    // says to "skip to the next provider rather than guessing".
+                    // Retrying the same entry first contradicts that for the 4xx
+                    // half: a client error is the provider's verdict on *this*
+                    // request, and re-sending the identical bytes cannot change
+                    // it. It cost three attempts and two sleeps per provider on
+                    // every one, and turned a summarizer handed 17 914 tokens
+                    // against a 16 384-token context into a retry storm that
+                    // blocked the agent instead of failing once.
+                    //
+                    // 5xx stays retryable: that is the server's state, not the
+                    // request's, and it can differ a second later.
                     let retryable = matches!(
                         reason,
                         FailoverReason::RateLimit(_)
                             | FailoverReason::HttpError
                             | FailoverReason::Timeout
-                    );
+                    ) && !is_deterministic_client_error(&e);
 
                     if retryable && attempts < MAX_RATE_LIMIT_RETRIES {
                         let sleep_ms = match &e {
@@ -860,6 +888,88 @@ mod tests {
             calls_ref.calls.load(std::sync::atomic::Ordering::SeqCst),
             MAX_RATE_LIMIT_RETRIES + 1,
             "should attempt 1 + MAX_RATE_LIMIT_RETRIES times before skipping"
+        );
+    }
+
+    /// A counting driver that always answers with the given HTTP status.
+    struct StatusDriver {
+        status: u16,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmDriver for StatusDriver {
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(LlmError::Api {
+                status: self.status,
+                message: "context length exceeded".to_string(),
+                code: None,
+            })
+        }
+    }
+
+    /// A 400 is the provider's verdict on this exact request, and the retry
+    /// loop re-sends it unchanged, so the answer cannot differ.
+    ///
+    /// This is what turned one over-long summarization payload into a retry
+    /// storm: 17 914 tokens against a 16 384-token context returned 400, and
+    /// every provider in the chain spent three attempts and two sleeps on it
+    /// before moving on, on every compaction attempt.
+    #[tokio::test]
+    async fn a_client_error_fails_over_without_retrying_the_same_provider() {
+        let driver = Arc::new(StatusDriver {
+            status: 400,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let calls_ref = Arc::clone(&driver);
+        let chain = FallbackChain::new(vec![
+            ChainEntry {
+                driver: driver as Arc<dyn LlmDriver>,
+                model_override: String::new(),
+                provider_name: "p1".to_string(),
+            },
+            entry(Arc::new(OkDriver("fallback")), "p2"),
+        ])
+        .with_rate_limit_sleep_ms(0);
+
+        let r = chain.complete(test_request()).await.unwrap();
+        assert_eq!(r.text(), "fallback", "it must still fail over");
+        assert_eq!(
+            calls_ref.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a 400 must be asked exactly once, not MAX_RATE_LIMIT_RETRIES + 1 times"
+        );
+    }
+
+    /// The other half: a 5xx describes the server's state, not the request's,
+    /// and can differ a second later. It keeps its retries.
+    #[tokio::test]
+    async fn a_server_error_still_retries_the_same_provider() {
+        let driver = Arc::new(StatusDriver {
+            status: 500,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let calls_ref = Arc::clone(&driver);
+        let chain = FallbackChain::new(vec![
+            ChainEntry {
+                driver: driver as Arc<dyn LlmDriver>,
+                model_override: String::new(),
+                provider_name: "p1".to_string(),
+            },
+            entry(Arc::new(OkDriver("fallback")), "p2"),
+        ])
+        .with_rate_limit_sleep_ms(0);
+
+        let r = chain.complete(test_request()).await.unwrap();
+        assert_eq!(r.text(), "fallback");
+        assert_eq!(
+            calls_ref.calls.load(std::sync::atomic::Ordering::SeqCst),
+            MAX_RATE_LIMIT_RETRIES + 1,
+            "a 5xx keeps its retries"
         );
     }
 


### PR DESCRIPTION
## What went wrong in production

A daemon stopped answering. The journal, over an hour:

```
WARN FallbackChain: transient error, retrying before failover
     provider=litellm model=Huihui-Qwen3.5-4B attempt=1 sleep_ms=2000 reason=HttpError
WARN FallbackChain: transient error, retrying before failover  attempt=2 sleep_ms=2000
WARN FallbackChain: provider exhausted, trying next
     error=API error (400): ContextWindowExceededError: request (17914 tokens)
     exceeds the available context size (16384 tokens)
WARN Summarization attempt failed, retrying attempt=0
… same shape again, then "Full summarization failed, trying chunked approach",
then a request every ~18s that never terminated
```

History compaction handed its summarizer 17 914 tokens against a 16 384-token context. The 400 that came back is **deterministic** — the same request will produce it every time — and it was retried twice with a two-second sleep, failed over, retried twice more, and then the chunked fallback repeated the whole shape per chunk. One clear failure became a grind that blocked the agent with nothing surfaced to the operator.

## The defect

`FallbackChain::try_entry` classifies retryability like this:

```rust
let retryable = matches!(
    reason,
    FailoverReason::RateLimit(_) | FailoverReason::HttpError | FailoverReason::Timeout
);
```

`FailoverReason::HttpError` is the catch-all for the statuses `failover_reason` calls ambiguous — 400, 403, 404, 500 — and **its own comment says they should "skip to the next provider rather than guessing"**. The retry loop contradicts that for the 4xx half.

A 4xx is the provider's verdict on *this* request, and the loop re-sends it byte for byte. Every attempt after the first is guaranteed waste, multiplied by every entry in the chain.

## The change

A deterministic client error is asked once and failed over. `is_deterministic_client_error` matches `LlmError::Api { status }` in 400..500, excluding:

- **408**, where the request never finished arriving — a retry sends it again and may well succeed;
- **429**, already classified as `RateLimit` with its own backoff.

**5xx keeps its retries.** That describes the server's state rather than the request's and can differ a second later.

Failover is unchanged: a client error still moves to the next provider, which may have a larger context window. What changes is how many times each provider is asked the same unanswerable question.

## Verification

- `a_client_error_fails_over_without_retrying_the_same_provider` — a 400 driver is called **exactly once** and the chain still returns the fallback's answer. Fails without the change (3 calls), checked by reverting.
- `a_server_error_still_retries_the_same_provider` — a 500 keeps `MAX_RATE_LIMIT_RETRIES + 1` calls. Passes either way by design: it is the guard against over-correcting, not a demonstration.
- `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` clean.
- `cargo test -p librefang-llm-drivers --lib`: 694 pass, 1 fails per run — but **a different one each run** (`gemini_cli::complete_returns_json_message_and_usage`, then `codex_cli::complete_pipes_prompt_without_putting_it_in_argv`), both subprocess-spawning CLI driver tests, both passing in isolation and on the unmodified tree. Load-dependent flakiness in that group, not this change.

## What this does not fix

Compaction still hands the summarizer a payload without checking it against that model's context window, and the chunked fallback still has no overall deadline. This PR stops the retry amplification; deciding a payload is too large before sending it is a separate change in `compactor.rs` and belongs with whoever owns the chunking policy.