### PR TITLE
test(dashboard): stop the variant cap test spending 2s of a 5s budget

### DIFF
--- a/changelog.d/fixed/8328-prompt-experiments-cap-test-speed.md
+++ b/changelog.d/fixed/8328-prompt-experiments-cap-test-speed.md
@@ -1,3 +1,3 @@
 The dashboard test suite no longer goes red at random on the prompt-experiments variant cap.
 The test drove the production cap of a hundred variants literally — a hundred sequential clicks through a subtree the file's motion mock remounts on every state change — which cost two seconds of vitest's five-second budget on an idle machine and crossed it whenever the rest of the suite was competing for the same cores.
-The cap was already mocked in that file, so it is now mocked low: the assertion is that selection stops at the cap and says so, which is the same behaviour at three variants as at a hundred, and it still fails if the comparison is off by one. (#8328) (@DaBlitzStein)
+The cap was already mocked in that file, so it is now mocked low: the assertion is that selection stops at the cap and says so, which is the same behaviour at three variants as at a hundred, and it still fails if the comparison is off by one. (#8329, #8328) (@DaBlitzStein)

--- a/changelog.d/fixed/8328-prompt-experiments-cap-test-speed.md
+++ b/changelog.d/fixed/8328-prompt-experiments-cap-test-speed.md
@@ -1,0 +1,3 @@
+The dashboard test suite no longer goes red at random on the prompt-experiments variant cap.
+The test drove the production cap of a hundred variants literally — a hundred sequential clicks through a subtree the file's motion mock remounts on every state change — which cost two seconds of vitest's five-second budget on an idle machine and crossed it whenever the rest of the suite was competing for the same cores.
+The cap was already mocked in that file, so it is now mocked low: the assertion is that selection stops at the cap and says so, which is the same behaviour at three variants as at a hundred, and it still fails if the comparison is off by one. (#8328) (@DaBlitzStein)

--- a/crates/librefang-api/dashboard/src/components/PromptsExperimentsModal.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/PromptsExperimentsModal.test.tsx
@@ -55,9 +55,21 @@ vi.mock("../lib/mutations/agents", () => ({
   useDeletePromptVersion: vi.fn().mockReturnValue({ mutate: vi.fn() }),
 }));
 
+/**
+ * The variant cap, mocked deliberately low.
+ *
+ * What the cap test asserts is that selection stops at the cap and says so, which
+ * is the same behaviour at three variants as at a hundred.
+ * Driving the production value meant a hundred sequential clicks through a subtree
+ * the motion mock remounts on every state change, and that is quadratic: two seconds
+ * on an idle machine against vitest's five-second default, so the test failed
+ * whenever the rest of the suite happened to be loading the same cores.
+ */
+const { TEST_VARIANT_CAP } = vi.hoisted(() => ({ TEST_VARIANT_CAP: 3 }));
+
 vi.mock("./trafficSplit", () => ({
   buildEvenTrafficSplit: vi.fn().mockReturnValue([50, 50]),
-  MAX_TRAFFIC_VARIANTS: 100,
+  MAX_TRAFFIC_VARIANTS: TEST_VARIANT_CAP,
 }));
 
 describe("PromptsExperimentsModal", () => {
@@ -220,7 +232,7 @@ describe("PromptsExperimentsModal", () => {
   it("stops selection when every variant has a traffic bucket", async () => {
     const user = userEvent.setup();
     vi.mocked(usePromptVersions).mockReturnValue({
-      data: Array.from({ length: 101 }, (_, index) => ({
+      data: Array.from({ length: TEST_VARIANT_CAP + 1 }, (_, index) => ({
         id: `version-${index}`,
         version: index + 1,
         is_active: false,
@@ -248,7 +260,7 @@ describe("PromptsExperimentsModal", () => {
       }),
     );
 
-    for (let index = 0; index < 100; index += 1) {
+    for (let index = 0; index < TEST_VARIANT_CAP; index += 1) {
       // The lightweight motion mock remounts its host subtree after state
       // changes, so read each current checkbox before clicking it.
       const checkbox = container.querySelectorAll<HTMLInputElement>(
@@ -258,7 +270,9 @@ describe("PromptsExperimentsModal", () => {
     }
 
     expect(
-      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')[100],
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')[
+        TEST_VARIANT_CAP
+      ],
     ).toBeDisabled();
     expect(
       screen.getByText("agents.prompts_experiments.variant_limit"),


### PR DESCRIPTION
Closes #8328.

## What was wrong

`PromptsExperimentsModal > stops selection when every variant has a traffic bucket` failed at random in full dashboard runs and passed when run on its own.
That pattern reads as a race, and it is not one — the test is slow.

Measured on `origin/main` at 310ac4224, alone, on an idle machine: **2016 ms**, against vitest's five-second default.
Any contention from the other 208 files tips it over.

The cost is quadratic and comes from the fixture rather than the component: the test rendered 101 versions and clicked 100 checkboxes one at a time, while the file's own motion mock remounts the host subtree on every state change, so each click re-rendered a list growing toward a hundred rows.

## The change

`MAX_TRAFFIC_VARIANTS` was already mocked inside this test file, so the production cap was never what the test exercised.
It is now mocked at three, and the fixture size and the assertion index both derive from that one constant through `vi.hoisted`, so they cannot drift apart the way two literal `100`s could.

What is asserted is unchanged: selection stops at the cap, and the limit notice appears.

## Verification

- **The test still discriminates.** Turned the component's three `length >=` comparisons into `length >` — an off-by-one that leaves the cap in place but never fires it — and the test went red (`1 failed | 6 passed`). Restored, green.
- 2016 ms → **65 ms** for that test.
- `npx tsc --noEmit` clean; `eslint` clean on the changed file.
- Full suite on this branch: **209 files, 1915 tests, all passing.**

Nothing outside the one test file changes.
