### PR TITLE
fix(dashboard): confirm before restoring a template version

### DIFF
--- a/changelog.d/fixed/8334-confirm-template-restore.md
+++ b/changelog.d/fixed/8334-confirm-template-restore.md
@@ -1,0 +1,3 @@
+Restoring an agent-type version from the dashboard's history panel now asks for confirmation first, and the question names the version it is about to write by its timestamp and change source.
+  It was the one destructive action on that page that fired straight from its button, while Delete and Promote have always gone through a confirmation dialog.
+  Restore overwrites the template's `agent.toml` on disk, and the snapshot the daemon records afterwards holds the restored content rather than the content it replaced — so a mis-click was not undone by the history list it was launched from, and with the rows differing only by a timestamp a mis-click was easy. (#8335) (@DaBlitzStein)

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -4249,6 +4249,7 @@
   },
   "agentTypes": {
     "confirm_delete": "Delete the agent type '{{name}}'? Agents already spawned from it are not affected.",
+    "confirm_restore": "Restore '{{name}}' to the version saved {{timestamp}} ({{source}})? This overwrites the template's current agent.toml; the snapshot recorded afterwards holds the restored content, not the content it replaced.",
     "create_title": "New agent type",
     "created": "Agent type created",
     "delete": "Delete",

--- a/crates/librefang-api/dashboard/src/locales/ko.json
+++ b/crates/librefang-api/dashboard/src/locales/ko.json
@@ -4247,6 +4247,7 @@
   },
   "agentTypes": {
     "confirm_delete": "에이전트 타입 '{{name}}'을(를) 삭제할까요? 이미 스폰된 에이전트에는 영향이 없습니다.",
+    "confirm_restore": "Restore '{{name}}' to the version saved {{timestamp}} ({{source}})? This overwrites the template's current agent.toml; the snapshot recorded afterwards holds the restored content, not the content it replaced.",
     "create_title": "새 에이전트 타입",
     "created": "에이전트 타입을 만들었습니다",
     "delete": "삭제",

--- a/crates/librefang-api/dashboard/src/locales/pl.json
+++ b/crates/librefang-api/dashboard/src/locales/pl.json
@@ -4263,6 +4263,7 @@
   },
   "agentTypes": {
     "confirm_delete": "Usunąć typ agenta '{{name}}'? Agenci już z niego utworzeni pozostaną nienaruszeni.",
+    "confirm_restore": "Restore '{{name}}' to the version saved {{timestamp}} ({{source}})? This overwrites the template's current agent.toml; the snapshot recorded afterwards holds the restored content, not the content it replaced.",
     "create_title": "Nowy typ agenta",
     "created": "Utworzono typ agenta",
     "delete": "Usuń",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -4263,6 +4263,7 @@
   },
   "agentTypes": {
     "confirm_delete": "Видалити тип агента '{{name}}'? Уже створених із нього агентів це не торкнеться.",
+    "confirm_restore": "Restore '{{name}}' to the version saved {{timestamp}} ({{source}})? This overwrites the template's current agent.toml; the snapshot recorded afterwards holds the restored content, not the content it replaced.",
     "create_title": "Новий тип агента",
     "created": "Тип агента створено",
     "delete": "Видалити",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -4248,6 +4248,7 @@
   },
   "agentTypes": {
     "confirm_delete": "删除智能体类型 '{{name}}'？已据此创建的智能体不受影响。",
+    "confirm_restore": "Restore '{{name}}' to the version saved {{timestamp}} ({{source}})? This overwrites the template's current agent.toml; the snapshot recorded afterwards holds the restored content, not the content it replaced.",
     "create_title": "新建智能体类型",
     "created": "已创建智能体类型",
     "delete": "删除",

--- a/crates/librefang-api/dashboard/src/pages/AgentTypesPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentTypesPage.test.tsx
@@ -17,7 +17,7 @@ import * as agentTypeMutations from "../lib/mutations/agentTypes";
 import { ApiError } from "../lib/http/errors";
 import { useUIStore } from "../lib/store";
 import { createTestQueryClient } from "../lib/test/query-client";
-import type { AgentTemplate, AgentTypeDetail } from "../api";
+import type { AgentTemplate, AgentTypeDetail, TemplateVersionEntry } from "../api";
 
 // The promotion flow (#7771) is the part of this page with no net: it opens a
 // pull request against a public registry, so a control that fires the wrong
@@ -140,6 +140,15 @@ const DETAIL: AgentTypeDetail = {
   },
 };
 
+const VERSION: TemplateVersionEntry = {
+  id: 7,
+  template_name: "researcher",
+  // Stored naive-UTC, exactly as the history endpoint returns it.
+  timestamp: "2026-09-01T10:30:00",
+  manifest_toml: 'name = "researcher"\ndescription = "Read papers"\n',
+  change_source: "edit",
+};
+
 const idle = { mutateAsync: vi.fn(), isPending: false };
 
 function mockQuery<T>(data: T) {
@@ -153,8 +162,17 @@ function mockQuery<T>(data: T) {
   };
 }
 
-/** The promote mutation is the only one a test ever varies. */
-function renderPage(promote: { mutateAsync: ReturnType<typeof vi.fn>; isPending: boolean }) {
+type MutationStub = { mutateAsync: ReturnType<typeof vi.fn>; isPending: boolean };
+
+/**
+ * Promotion is the mutation every test varies; restore and the history payload
+ * are opt-in so the tests that do not open the history modal keep reading as
+ * one argument.
+ */
+function renderPage(
+  promote: MutationStub,
+  extras: { restore?: MutationStub; versions?: TemplateVersionEntry[] } = {},
+) {
   vi.mocked(useAgentTypes).mockReturnValue(
     mockQuery([TYPE]) as unknown as ReturnType<typeof useAgentTypes>,
   );
@@ -162,7 +180,9 @@ function renderPage(promote: { mutateAsync: ReturnType<typeof vi.fn>; isPending:
     mockQuery(DETAIL) as unknown as ReturnType<typeof useAgentType>,
   );
   vi.mocked(useAgentTypeHistory).mockReturnValue(
-    mockQuery({ versions: [] }) as unknown as ReturnType<typeof useAgentTypeHistory>,
+    mockQuery({ versions: extras.versions ?? [] }) as unknown as ReturnType<
+      typeof useAgentTypeHistory
+    >,
   );
   vi.mocked(useAgents).mockReturnValue(mockQuery([]) as unknown as ReturnType<typeof useAgents>);
   vi.mocked(useTools).mockReturnValue(mockQuery([]) as unknown as ReturnType<typeof useTools>);
@@ -185,6 +205,11 @@ function renderPage(promote: { mutateAsync: ReturnType<typeof vi.fn>; isPending:
   vi.mocked(usePromoteAgentType).mockReturnValue(
     promote as unknown as ReturnType<typeof usePromoteAgentType>,
   );
+  if (extras.restore) {
+    vi.mocked(useRestoreTemplateVersion).mockReturnValue(
+      extras.restore as unknown as ReturnType<typeof useRestoreTemplateVersion>,
+    );
+  }
 
   return render(
     <QueryClientProvider client={createTestQueryClient()}>
@@ -279,5 +304,59 @@ describe("AgentTypesPage promotion", () => {
     // A refused promotion has opened no pull request, so the success dialog
     // must stay closed.
     expect(screen.queryByRole("link", { name: /View pull request/ })).toBeNull();
+  });
+});
+
+// Restoring rewrites the template's agent.toml on disk, and the snapshot the
+// server records afterwards holds the restored content rather than what it
+// replaced — so the row's Restore button is as destructive as Delete and must
+// reach a confirmation before the mutation fires (#8334).
+describe("AgentTypesPage template history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({ toasts: [] });
+  });
+
+  function openHistory(restore: MutationStub) {
+    renderPage({ mutateAsync: vi.fn(), isPending: false }, { restore, versions: [VERSION] });
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+  }
+
+  it("does not restore a version until the confirmation is accepted", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(DETAIL);
+    openHistory({ mutateAsync, isPending: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    expect(mutateAsync).not.toHaveBeenCalled();
+
+    // The history list is a column of near-identical rows, so the dialog has to
+    // say *which* version it is about to write over the template.
+    const message = screen.getByText(/Restore 'researcher' to the version saved/);
+    // jest-dom collapses the element's whitespace but not the expected string,
+    // and en-US separates the time from AM/PM with U+202F — normalize both sides.
+    const stamp = new Date(VERSION.timestamp + "Z").toLocaleString().replace(/\s+/g, " ");
+    expect(message).toHaveTextContent(stamp);
+    expect(message).toHaveTextContent("(edit)");
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({ name: "researcher", versionId: 7 }),
+    );
+    expect(useUIStore.getState().toasts.map((t) => t.message)).toContain("Version restored");
+  });
+
+  it("writes nothing when the restore confirmation is cancelled", () => {
+    const mutateAsync = vi.fn();
+    openHistory({ mutateAsync, isPending: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Restore 'researcher' to the version saved/)).toBeNull();
+    // The history modal itself stays open — cancelling the dialog is not
+    // cancelling the browse.
+    expect(screen.getByText(/History: researcher/)).toBeInTheDocument();
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/AgentTypesPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentTypesPage.tsx
@@ -2,7 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
 import { Edit2, ExternalLink, History, LayoutTemplate, Lock, Play, Plus, RotateCcw, Share2, ShieldCheck, Trash2 } from "lucide-react";
-import type { AgentTemplate, AgentTypeSpec, SpawnEphemeralResult } from "../api";
+import type {
+  AgentTemplate,
+  AgentTypeSpec,
+  SpawnEphemeralResult,
+  TemplateVersionEntry,
+} from "../api";
 import { useAgentType, useAgentTypes, useAgentTypeHistory } from "../lib/queries/agentTypes";
 import { useAgents, useTools } from "../lib/queries/agents";
 import { useSkills } from "../lib/queries/skills";
@@ -509,6 +514,15 @@ function PromotionPreviewModal({ name, onClose }: { name: string; onClose: () =>
   );
 }
 
+/**
+ * The stored timestamp is naive UTC. The row label and the restore confirmation
+ * must read it identically, or the dialog would name a version the operator
+ * cannot find in the list above it.
+ */
+function versionTimestamp(v: TemplateVersionEntry): string {
+  return new Date(v.timestamp + "Z").toLocaleString();
+}
+
 function TemplateHistoryModal({
   name,
   onClose,
@@ -521,6 +535,24 @@ function TemplateHistoryModal({
   const history = useAgentTypeHistory(name, { enabled: true });
   const restore = useRestoreTemplateVersion();
   const [expanded, setExpanded] = useState<number | null>(null);
+  // Restoring overwrites the template's agent.toml on disk, and the snapshot the
+  // server takes afterwards records the restored content, not the content it
+  // replaced — so the click that starts it gets the same confirmation step as
+  // Delete and Promote on this page (#8334).
+  const [pendingRestore, setPendingRestore] = useState<TemplateVersionEntry | null>(null);
+
+  async function confirmRestore() {
+    if (!pendingRestore) return;
+    try {
+      await restore.mutateAsync({ name, versionId: pendingRestore.id });
+      addToast(t("agentTypes.restored", { defaultValue: "Version restored" }), "success");
+      onClose();
+    } catch (err) {
+      addToast(toastErr(err, t("agentTypes.restore_failed", { defaultValue: "Restore failed" })), "error");
+    } finally {
+      setPendingRestore(null);
+    }
+  }
 
   return (
     <Modal
@@ -552,7 +584,7 @@ function TemplateHistoryModal({
               <div className="flex items-center justify-between gap-2">
                 <div className="min-w-0">
                   <span className="text-[12px] font-medium text-text-main">
-                    {new Date(v.timestamp + "Z").toLocaleString()}
+                    {versionTimestamp(v)}
                   </span>
                   <Badge variant="default" className="ml-2">{v.change_source}</Badge>
                 </div>
@@ -566,15 +598,7 @@ function TemplateHistoryModal({
                   </button>
                   <button
                     type="button"
-                    onClick={async () => {
-                      try {
-                        await restore.mutateAsync({ name, versionId: v.id });
-                        addToast(t("agentTypes.restored", { defaultValue: "Version restored" }), "success");
-                        onClose();
-                      } catch (err) {
-                        addToast(toastErr(err, t("agentTypes.restore_failed", { defaultValue: "Restore failed" })), "error");
-                      }
-                    }}
+                    onClick={() => setPendingRestore(v)}
                     disabled={restore.isPending}
                     className="flex items-center gap-1 rounded-lg px-2 py-1 text-[11px] text-text-dim hover:bg-brand/10 hover:text-brand"
                     title={t("agentTypes.restore", { defaultValue: "Restore this version" })}
@@ -593,6 +617,19 @@ function TemplateHistoryModal({
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={pendingRestore !== null}
+        onClose={() => setPendingRestore(null)}
+        onConfirm={() => void confirmRestore()}
+        title={t("agentTypes.restore", { defaultValue: "Restore this version" })}
+        message={t("agentTypes.confirm_restore", {
+          name,
+          timestamp: pendingRestore ? versionTimestamp(pendingRestore) : "",
+          source: pendingRestore?.change_source ?? "",
+        })}
+        tone="destructive"
+      />
     </Modal>
   );
 }


### PR DESCRIPTION
Closes #8334.

## What changes

- `TemplateHistoryModal`'s Restore button no longer calls `restore.mutateAsync` from its `onClick`.
It sets a `pendingRestore` state and the write happens from a `ConfirmDialog`, the same component, state shape and props that Delete and Promote already use on this page.
- The dialog is `tone="destructive"`, matching Delete: on a destructive dialog `ConfirmDialog` also refuses Enter-to-confirm, so the write needs a deliberate click.
- The confirmation names the version by the timestamp and change source the row itself shows, not "this version" — the history list is a column of near-identical rows.
Row label and dialog label now come from one `versionTimestamp()` helper so they cannot drift.
- New key `agentTypes.confirm_restore` in all five locales.

## Why

Restore was the only destructive action on the Agent Types page without a confirmation step.
It overwrites the template's `agent.toml` on disk via `POST /api/templates/{name}/history/{version_id}/restore`, and the snapshot the server records afterwards (`record_template_version(&state, &name, &rendered, "restore")`, `crates/librefang-api/src/routes/agent_templates.rs:1045`) holds the *restored* content, not the content it replaced — so a mis-click is not undone by the list it was launched from.

## Locales

`en` carries the real text.
`ko`, `pl`, `uk` and `zh` carry the same English string, because that is the existing convention for this key's neighbours: every string of the version-history feature (`agentTypes.restore`, `restore_btn`, `restored`, `restore_failed`, `history`, `history_title`, `history_empty`, `history_empty_desc`) is an untranslated English placeholder in all four locales today.
Inventing a translation for the confirmation alone would leave the dialog reading in one language and the button that opens it in another.
`node scripts/i18n-parity.mjs` reports parity on all four.

## Verification

From `crates/librefang-api/dashboard`, with `LANG=en_US.UTF-8`:

- `npx tsc --noEmit` — clean.
- `npx eslint .` — clean.
- `npx vitest run` — `Test Files  1 failed | 208 passed (209)`, `Tests  1 failed | 1916 passed (1917)`.
The single failure is pre-existing and unrelated: `PromptsExperimentsModal > stops selection when every variant has a traffic bucket` exceeds its 5 s budget.
- `npx pnpm build` — `built in 781ms`.
- `node scripts/i18n-parity.mjs` — all locales in parity with `en.json`.

## The test was seen failing against the unfixed page

Two tests were added to `src/pages/AgentTypesPage.test.tsx`.
With the production change stashed (`git stash push -- crates/librefang-api/dashboard/src/pages/AgentTypesPage.tsx`) and the test plus locales left in place, both fail:

```
× does not restore a version until the confirmation is accepted 47ms
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

× writes nothing when the restore confirmation is cancelled
TestingLibraryElementError: Unable to find an accessible element with the role "button" and name "Cancel"
```

With the change restored, the file is `Test Files  1 passed (1)`, `Tests  6 passed (6)`.

## Seen and not fixed

While the confirmation is open, Escape closes both it and the host history modal instead of only the confirmation.
Reproduced: firing `keydown` Escape with the dialog open leaves `confirm-open: false history-open: false mutation-called: 0`.
The cause is in the shared primitives, not this page — `Modal`'s module-level escape stack calls `event.stopImmediatePropagation()` (`crates/librefang-api/dashboard/src/components/ui/Modal.tsx:106`) and it was registered before `ConfirmDialog`'s own `keydown` listener (`crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx:111`), so the inner handler never runs.
Every nested `ConfirmDialog` in the dashboard behaves this way today; the outcome is safe (nothing is restored), so changing it would mean altering Escape semantics for ~15 other call sites and is left out of this PR deliberately.
